### PR TITLE
Make internal quaternion and RNG operations the default

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
-import mpi4py.MPI as MPI
-
 import os
+if 'PYTOAST_NOMPI' in os.environ.keys():
+    from toast import fakempi as MPI
+else:
+    from mpi4py import MPI
+
 import re
 import argparse
 

--- a/setup.py
+++ b/setup.py
@@ -75,10 +75,10 @@ ext_rng = Extension (
 )
 
 ext_qarray = Extension (
-    'toast.tod.qarray',
+    'toast.tod._qarray',
     include_dirs = [np.get_include(), ctoast_dir],
     sources = [
-        'toast/tod/qarray.pyx'
+        'toast/tod/_qarray.pyx'
     ]
 )
 

--- a/tests/test_map_satellite.py
+++ b/tests/test_map_satellite.py
@@ -107,7 +107,9 @@ class MapSatelliteTest(MPITestCase):
                 precangle=self.precangle, 
                 sizes=chunks)
 
-            tod.set_prec_axis()
+            precquat = slew_precession_axis(nsim=self.totsamp, firstsamp=0, samplerate=self.rate, degday=1.0)
+
+            tod.set_prec_axis(qprec=precquat)
 
             # add analytic noise model with white noise
 

--- a/tests/test_map_satellite.py
+++ b/tests/test_map_satellite.py
@@ -139,6 +139,9 @@ class MapSatelliteTest(MPITestCase):
 
         borequat = satellite_scanning(nsim=1000, qprec=None, samplerate=100.0, spinperiod=1.0, spinangle=0.0, precperiod=20.0, precangle=0.0)
 
+        print("borequat dims = ",borequat.shape)
+        print(borequat)
+
         data = qa.rotate(borequat, np.tile(zaxis, nsim).reshape(-1,3))
 
         np.testing.assert_almost_equal(data, np.tile(np.array([1.0, 0.0, 0.0]), nsim).reshape(-1,3))

--- a/tests/test_map_satellite.py
+++ b/tests/test_map_satellite.py
@@ -57,7 +57,7 @@ class MapSatelliteTest(MPITestCase):
         }
 
         self.sim_nside = 64
-        self.totsamp = 200000
+        self.totsamp = 400000
         self.map_nside = 64
         self.rate = 40.0
         self.spinperiod = 10.0
@@ -320,7 +320,7 @@ class MapSatelliteTest(MPITestCase):
                 print("pixrms = ", pixrms)
                 print("todrms = ", todrms)
                 print("relerr = ", relerr)
-                self.assertTrue(relerr < 0.01)
+                self.assertTrue(relerr < 0.02)
 
         else:
             print("libmadam not available, skipping tests")

--- a/tests/test_ops_pmat.py
+++ b/tests/test_ops_pmat.py
@@ -94,3 +94,22 @@ class OpPointingHpixTest(MPITestCase):
         elapsed = stop - start
         self.print_in_turns("pmat test took {:.3f} s".format(elapsed))
 
+
+    def test_hpix_hwpnull(self):
+        start = MPI.Wtime()
+
+        op = OpPointingHpix(mode='IQU')
+        op.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_hpix_hwpnull_info"), "w")
+        self.data.info(handle)
+        if self.comm.rank == 0:
+            handle.close()
+        
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        self.print_in_turns("pmat test took {:.3f} s".format(elapsed))
+
+

--- a/tests/test_ops_simnoise.py
+++ b/tests/test_ops_simnoise.py
@@ -107,7 +107,7 @@ class OpSimNoiseTest(MPITestCase):
 
         # generate timestreams
 
-        op = OpSimNoise(stream=123456)
+        op = OpSimNoise(stream=123456, realization=10)
         op.exec(self.data)
 
         ob = self.data.obs[0]
@@ -144,7 +144,7 @@ class OpSimNoiseTest(MPITestCase):
         check4 = tod.cache.reference("noise_{}".format(self.dets[3]))
 
         if self.comm.rank == 0:
-            np.savetxt(os.path.join(self.outdir,"out_test_simnoise_tod.txt"), np.transpose([check1, check2, check3, check4]), delimiter='\n')
+            np.savetxt(os.path.join(self.outdir,"out_test_simnoise_tod.txt"), np.transpose([check1, check2, check3, check4]), delimiter=' ')
 
         # verify that timestreams with the same PSD *DO NOT* have the same
         # values (this is a crude test that the random seeds are being incremented)

--- a/tests/test_ops_simnoise.py
+++ b/tests/test_ops_simnoise.py
@@ -107,7 +107,7 @@ class OpSimNoiseTest(MPITestCase):
 
         # generate timestreams
 
-        op = OpSimNoise(stream=123456, realization=10)
+        op = OpSimNoise(stream=0)
         op.exec(self.data)
 
         ob = self.data.obs[0]

--- a/tests/test_qarray.py
+++ b/tests/test_qarray.py
@@ -16,144 +16,287 @@ import toast.tod.qarray as qarray
 
 class QarrayTest(MPITestCase):
 
+
     def setUp(self):
         #data
-        self.q1 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857]])
-        self.q1inv = np.array([[ -0.50487417,  -0.61426059,  -0.60118994,  0.07972857]])
-        self.q2 = np.array([[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
-        self.q1_2 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857],[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
+        self.q1 = np.array([ 0.50487417,  0.61426059,  0.60118994,  0.07972857])
+        self.q1inv = np.array([ -0.50487417,  -0.61426059,  -0.60118994,  0.07972857])
+        self.q2 = np.array([ 0.43561544,  0.33647027,  0.40417115,  0.73052901])
         self.qtonormalize = np.array([[1.,2,3,4],[2,3,4,5]])
         self.qnormalized = np.array([[0.18257419,  0.36514837,  0.54772256,  0.73029674],[ 0.27216553,  0.40824829,  0.54433105,  0.68041382]])
         self.vec = np.array([ 0.57734543,  0.30271255,  0.75831218])
-        self.vec_2d = np.array([[ 0.57734543,  0.30271255,  0.75831218]]) # 2d array required
-        self.vec2 = np.array([[ 0.57734543,  8.30271255,  5.75831218, 0.87937215],[ 1.57734543,  3.30271255,  0.75831218, 0.67128248]])
+        self.vec2 = np.array([[ 0.57734543,  8.30271255,  5.75831218],[ 1.57734543,  3.30271255,  0.75831218]])
         self.qeasy = np.array([[.3,.3,.1,.9],[.3,.3,.1,.9]])
         #results from Quaternion CHANGED SIGN TO COMPLY WITH THE ONLINE QUATERNION CALCULATOR
         self.mult_result = -1*np.array([[-0.44954009, -0.53339352, -0.37370443,  0.61135101]])
         self.rot_by_q1 = np.array([[0.4176698, 0.84203849, 0.34135482]])
         self.rot_by_q2 = np.array([[0.8077876, 0.3227185, 0.49328689]])
 
-        
+
     def test_arraylist_dot_onedimarrays(self):
-        q_result = qarray.arraylist_dot(self.vec_2d, (self.vec_2d +1))
-        np.testing.assert_array_almost_equal(q_result, np.dot(self.vec, self.vec +1)) 
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec, self.vec +1), np.dot(self.vec, self.vec +1)) 
+
+
+    def test_arraylist_dot_1dimbymultidim(self):
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec), np.dot(self.vec2,self.vec)) 
+
 
     def test_arraylist_dot_multidim(self):
-        q_result = qarray.arraylist_dot(self.vec2, (self.vec2 +1))
         result = np.hstack(np.dot(v1,v2) for v1,v2 in zip(self.vec2, self.vec2+1))
-        np.testing.assert_array_almost_equal(q_result.flatten(), result.flatten()) 
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec2 +1), result) 
+
 
     def test_inv(self):
-        q_result = qarray.inv(self.q1)
-        np.testing.assert_array_almost_equal(q_result, self.q1inv)
+        np.testing.assert_array_almost_equal(qarray.inv(self.q1) , self.q1inv)
+
 
     def test_norm(self):
-        q_result1 = qarray.norm(self.q1)
-        q_result2 = qarray.norm(self.qtonormalize)
-        np.testing.assert_array_almost_equal(q_result1, self.q1/np.linalg.norm(self.q1))
-        np.testing.assert_array_almost_equal(q_result2, self.qnormalized)
+        np.testing.assert_array_almost_equal(qarray.norm(self.q1), self.q1/np.linalg.norm(self.q1))
+        np.testing.assert_array_almost_equal(qarray.norm(self.qtonormalize) , self.qnormalized)
 
-    def test_norm_inplace(self):
-        q1 = self.q1
-        qarray.norm_inplace(q1)
-        qarray.norm_inplace(self.qtonormalize)
-        np.testing.assert_array_almost_equal(q1, q1/np.linalg.norm(q1))
-        np.testing.assert_array_almost_equal(self.qtonormalize , self.qnormalized)
 
     def test_mult_onequaternion(self):
-        q_result = qarray.mult(self.q1, self.q2)
-        self.assertEquals( q_result.shape[0], 1)
-        self.assertEquals( q_result.shape[1], 4)
-        np.testing.assert_array_almost_equal(q_result , self.mult_result)
+        my_mult_result = qarray.mult(self.q1, self.q2)
+        self.assertEquals( my_mult_result.shape[0], 1)
+        self.assertEquals( my_mult_result.shape[1], 4)
+        np.testing.assert_array_almost_equal(my_mult_result , self.mult_result)
+
 
     def test_mult_qarray(self):
         dim = (3, 1)
         qarray1 = np.tile(self.q1, dim)
         qarray2 = np.tile(self.q2, dim)
-        q_result = qarray.mult(qarray1, qarray2)
-        np.testing.assert_array_almost_equal(q_result , np.tile(self.mult_result,dim))
+        my_mult_result = qarray.mult(qarray1, qarray2)
+        np.testing.assert_array_almost_equal(my_mult_result , np.tile(self.mult_result,dim))
+
 
     def test_rotate_onequaternion(self):
-        vec_result = qarray.rotate(self.q1, self.vec_2d)
-        np.testing.assert_array_almost_equal(vec_result , self.rot_by_q1)
+        my_rot_result = qarray.rotate(self.q1, self.vec)
+        np.testing.assert_array_almost_equal(my_rot_result , self.rot_by_q1)
+
         
     def test_rotate_qarray(self):
-        vec_result = qarray.rotate(np.vstack([self.q1,self.q2]), np.vstack([self.vec_2d, self.vec_2d]))
-        np.testing.assert_array_almost_equal(vec_result , np.vstack([self.rot_by_q1, self.rot_by_q2]))
+        my_rot_result = qarray.rotate(np.vstack([self.q1,self.q2]), self.vec)
+        np.testing.assert_array_almost_equal(my_rot_result , np.vstack([self.rot_by_q1, self.rot_by_q2]))
+
 
     def test_slerp(self):
         q = qarray.norm(np.array([[2., 3, 4, 5],
-                      [6, 7, 8, 9]]))
-        time = np.array([0., 9])
+                      [6., 7, 8, 9]]))
+        time = np.array([0., 9]) 
         targettime = np.array([0, 3, 4.5, 9])
         q_interp = qarray.slerp(targettime, time, q)
-        self.assertEquals(q_interp.shape[1], 4)
-
+        self.assertEquals(len(q_interp), 4)
         np.testing.assert_array_almost_equal(q_interp[0], q[0])
         np.testing.assert_array_almost_equal(q_interp[-1], q[-1])
-        np.testing.assert_array_almost_equal(q_interp[1], qarray.norm( ( (q[0]*2 + q[1])/3 ).reshape(1,4) )[0], decimal=4 )
-        np.testing.assert_array_almost_equal(q_interp[2], qarray.norm( ( (q[0] + q[1])/2 ).reshape(1,4) )[0], decimal=4 )
+        np.testing.assert_array_almost_equal(q_interp[1], qarray.norm(q[0] * 2/3 + q[1]/3), decimal=4)
+        np.testing.assert_array_almost_equal(q_interp[2], qarray.norm((q[0] + q[1])/2), decimal=4)
+
 
     def test_rotation(self):
-        q_result = qarray.rotation(np.array([[0.,0.,1.]]), np.array([np.radians(30)]))
         np.testing.assert_array_almost_equal(
-            q_result,  np.array([[0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]])
+            qarray.rotation(np.array([0.0, 0.0, 1.0]), np.radians(30)),  np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))])
             )
 
-    def test_exp(self):
-        """Exponential test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-        q_result = qarray.exp(self.qeasy)
-        np.testing.assert_array_almost_equal(
-            q_result,  np.array([[ 0.71473568,  0.71473568,  0.23824523,  2.22961712],[ 0.71473568,  0.71473568,  0.23824523,  2.22961712]])
-            )
-
-    def test_ln(self):
-        """Log test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-        q_result = qarray.ln(self.qeasy)
-        np.testing.assert_array_almost_equal(
-            q_result,  np.array([[ 0.31041794,  0.31041794,  0.10347265,  0.        ],[ 0.31041794,  0.31041794,  0.10347265,  0.        ]])
-            )
-
-    def test_pow(self):
-        """Pow test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-        pow_index = np.array([3.,3.])
-        q_result = qarray.pow(self.qeasy, pow_index)
-        np.testing.assert_array_almost_equal(
-            q_result, np.array([[ 0.672,  0.672,  0.224,  0.216],[ 0.672,  0.672,  0.224,  0.216]])
-            )
-        pow_index = np.array([.1,.1])
-        q_result = qarray.pow(self.qeasy, pow_index)
-        np.testing.assert_array_almost_equal(
-            q_result, np.array([[ 0.03103127,  0.03103127,  0.01034376,  0.99898305],[ 0.03103127,  0.03103127,  0.01034376,  0.99898305]])
-            )
 
     def test_toaxisangle(self):
-        axis = np.array([0.,0.,1.])
-        angle = np.radians(30)
+        axis = np.array([0.0, 0.0, 1.0])
+        angle = np.radians(30.0)
         q = np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))])
         qaxis, qangle = qarray.to_axisangle(q)
         np.testing.assert_array_almost_equal(axis, qaxis)
         self.assertAlmostEqual(angle, qangle)
 
+
+    def test_exp(self):
+        """Exponential test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+        np.testing.assert_array_almost_equal(
+            qarray.exp(self.qeasy),  np.array([[ 0.71473568,  0.71473568,  0.23824523,  2.22961712],[ 0.71473568,  0.71473568,  0.23824523,  2.22961712]])
+            )
+
+
+    def test_ln(self):
+        """Log test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+        np.testing.assert_array_almost_equal(
+            qarray.ln(self.qeasy),  np.array([[ 0.31041794,  0.31041794,  0.10347265,  0.        ],[ 0.31041794,  0.31041794,  0.10347265,  0.        ]])
+            )
+
+
+    def test_pow(self):
+        """Pow test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+        np.testing.assert_array_almost_equal(
+            qarray.pow(self.qeasy, 3.0), np.array([[ 0.672,  0.672,  0.224,  0.216],[ 0.672,  0.672,  0.224,  0.216]])
+            )
+        np.testing.assert_array_almost_equal(
+            qarray.pow(self.qeasy, 0.1), np.array([[ 0.03103127,  0.03103127,  0.01034376,  0.99898305],[ 0.03103127,  0.03103127,  0.01034376,  0.99898305]])
+            )
+
+
     def test_torotmat(self):
         """Rotmat test from Quaternion"""
-        rotmat = qarray.to_rotmat(self.qeasy[0])
-        np.testing.assert_array_almost_equal(rotmat,
+        np.testing.assert_array_almost_equal(qarray.to_rotmat(self.qeasy[0]),
                                             np.array([[  8.00000000e-01,  -2.77555756e-17,   6.00000000e-01],
                                                    [  3.60000000e-01,   8.00000000e-01,  -4.80000000e-01],
                                                    [ -4.80000000e-01,   6.00000000e-01,   6.40000000e-01]])
         )
 
+
     def test_fromrotmat(self):
-        rotmat = qarray.to_rotmat(self.qeasy[0])
-        q_result = qarray.from_rotmat(rotmat)
-        np.testing.assert_array_almost_equal(self.qeasy[0], q_result)
+        np.testing.assert_array_almost_equal(
+            self.qeasy[0], qarray.from_rotmat(qarray.to_rotmat(self.qeasy[0]))
+        )
+
 
     def test_fromvectors(self):
         axis = np.array([0,0,1])
         angle = np.radians(30)
-        v1 = np.array([1., 0, 0])
+
+        v1 = np.array([1.0, 0.0, 0.0])
         v2 = np.array([np.cos(angle), np.sin(angle), 0])
-        q_result = qarray.from_vectors(v1, v2)
-        np.testing.assert_array_almost_equal(q_result, np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
+        np.testing.assert_array_almost_equal(qarray.from_vectors(v1, v2), np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
+
+
+
+# class QarrayTest(MPITestCase):
+
+#     def setUp(self):
+#         #data
+#         self.q1 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857]])
+#         self.q1inv = np.array([[ -0.50487417,  -0.61426059,  -0.60118994,  0.07972857]])
+#         self.q2 = np.array([[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
+#         self.q1_2 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857],[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
+#         self.qtonormalize = np.array([[1.,2,3,4],[2,3,4,5]])
+#         self.qnormalized = np.array([[0.18257419,  0.36514837,  0.54772256,  0.73029674],[ 0.27216553,  0.40824829,  0.54433105,  0.68041382]])
+#         self.vec = np.array([ 0.57734543,  0.30271255,  0.75831218])
+#         self.vec_2d = np.array([[ 0.57734543,  0.30271255,  0.75831218]]) # 2d array required
+#         self.vec2 = np.array([[ 0.57734543,  8.30271255,  5.75831218, 0.87937215],[ 1.57734543,  3.30271255,  0.75831218, 0.67128248]])
+#         self.qeasy = np.array([[.3,.3,.1,.9],[.3,.3,.1,.9]])
+#         #results from Quaternion CHANGED SIGN TO COMPLY WITH THE ONLINE QUATERNION CALCULATOR
+#         self.mult_result = -1*np.array([[-0.44954009, -0.53339352, -0.37370443,  0.61135101]])
+#         self.rot_by_q1 = np.array([[0.4176698, 0.84203849, 0.34135482]])
+#         self.rot_by_q2 = np.array([[0.8077876, 0.3227185, 0.49328689]])
+
+        
+#     def test_arraylist_dot_onedimarrays(self):
+#         q_result = qarray.arraylist_dot(self.vec_2d, (self.vec_2d +1))
+#         np.testing.assert_array_almost_equal(q_result, np.dot(self.vec, self.vec +1)) 
+
+#     def test_arraylist_dot_multidim(self):
+#         q_result = qarray.arraylist_dot(self.vec2, (self.vec2 +1))
+#         result = np.hstack(np.dot(v1,v2) for v1,v2 in zip(self.vec2, self.vec2+1))
+#         np.testing.assert_array_almost_equal(q_result.flatten(), result.flatten()) 
+
+#     def test_inv(self):
+#         q_result = qarray.inv(self.q1)
+#         np.testing.assert_array_almost_equal(q_result, self.q1inv)
+
+#     def test_norm(self):
+#         q_result1 = qarray.norm(self.q1)
+#         q_result2 = qarray.norm(self.qtonormalize)
+#         np.testing.assert_array_almost_equal(q_result1, self.q1/np.linalg.norm(self.q1))
+#         np.testing.assert_array_almost_equal(q_result2, self.qnormalized)
+
+#     def test_norm_inplace(self):
+#         q1 = self.q1
+#         qarray.norm_inplace(q1)
+#         qarray.norm_inplace(self.qtonormalize)
+#         np.testing.assert_array_almost_equal(q1, q1/np.linalg.norm(q1))
+#         np.testing.assert_array_almost_equal(self.qtonormalize , self.qnormalized)
+
+#     def test_mult_onequaternion(self):
+#         q_result = qarray.mult(self.q1, self.q2)
+#         self.assertEquals( q_result.shape[0], 1)
+#         self.assertEquals( q_result.shape[1], 4)
+#         np.testing.assert_array_almost_equal(q_result , self.mult_result)
+
+#     def test_mult_qarray(self):
+#         dim = (3, 1)
+#         qarray1 = np.tile(self.q1, dim)
+#         qarray2 = np.tile(self.q2, dim)
+#         q_result = qarray.mult(qarray1, qarray2)
+#         np.testing.assert_array_almost_equal(q_result , np.tile(self.mult_result,dim))
+
+#     def test_rotate_onequaternion(self):
+#         vec_result = qarray.rotate(self.q1, self.vec_2d)
+#         np.testing.assert_array_almost_equal(vec_result , self.rot_by_q1)
+        
+#     def test_rotate_qarray(self):
+#         vec_result = qarray.rotate(np.vstack([self.q1,self.q2]), np.vstack([self.vec_2d, self.vec_2d]))
+#         np.testing.assert_array_almost_equal(vec_result , np.vstack([self.rot_by_q1, self.rot_by_q2]))
+
+#     def test_slerp(self):
+#         q = qarray.norm(np.array([[2., 3, 4, 5],
+#                       [6, 7, 8, 9]]))
+#         time = np.array([0., 9])
+#         targettime = np.array([0, 3, 4.5, 9])
+#         q_interp = qarray.slerp(targettime, time, q)
+#         self.assertEquals(q_interp.shape[1], 4)
+
+#         np.testing.assert_array_almost_equal(q_interp[0], q[0])
+#         np.testing.assert_array_almost_equal(q_interp[-1], q[-1])
+#         np.testing.assert_array_almost_equal(q_interp[1], qarray.norm( ( (q[0]*2 + q[1])/3 ).reshape(1,4) )[0], decimal=4 )
+#         np.testing.assert_array_almost_equal(q_interp[2], qarray.norm( ( (q[0] + q[1])/2 ).reshape(1,4) )[0], decimal=4 )
+
+#     def test_rotation(self):
+#         q_result = qarray.rotation(np.array([[0.,0.,1.]]), np.array([np.radians(30)]))
+#         np.testing.assert_array_almost_equal(
+#             q_result,  np.array([[0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]])
+#             )
+
+#     def test_exp(self):
+#         """Exponential test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+#         q_result = qarray.exp(self.qeasy)
+#         np.testing.assert_array_almost_equal(
+#             q_result,  np.array([[ 0.71473568,  0.71473568,  0.23824523,  2.22961712],[ 0.71473568,  0.71473568,  0.23824523,  2.22961712]])
+#             )
+
+#     def test_ln(self):
+#         """Log test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+#         q_result = qarray.ln(self.qeasy)
+#         np.testing.assert_array_almost_equal(
+#             q_result,  np.array([[ 0.31041794,  0.31041794,  0.10347265,  0.        ],[ 0.31041794,  0.31041794,  0.10347265,  0.        ]])
+#             )
+
+#     def test_pow(self):
+#         """Pow test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
+#         pow_index = np.array([3.,3.])
+#         q_result = qarray.pow(self.qeasy, pow_index)
+#         np.testing.assert_array_almost_equal(
+#             q_result, np.array([[ 0.672,  0.672,  0.224,  0.216],[ 0.672,  0.672,  0.224,  0.216]])
+#             )
+#         pow_index = np.array([.1,.1])
+#         q_result = qarray.pow(self.qeasy, pow_index)
+#         np.testing.assert_array_almost_equal(
+#             q_result, np.array([[ 0.03103127,  0.03103127,  0.01034376,  0.99898305],[ 0.03103127,  0.03103127,  0.01034376,  0.99898305]])
+#             )
+
+#     def test_toaxisangle(self):
+#         axis = np.array([0.,0.,1.])
+#         angle = np.radians(30)
+#         q = np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))])
+#         qaxis, qangle = qarray.to_axisangle(q)
+#         np.testing.assert_array_almost_equal(axis, qaxis)
+#         self.assertAlmostEqual(angle, qangle)
+
+#     def test_torotmat(self):
+#         """Rotmat test from Quaternion"""
+#         rotmat = qarray.to_rotmat(self.qeasy[0])
+#         np.testing.assert_array_almost_equal(rotmat,
+#                                             np.array([[  8.00000000e-01,  -2.77555756e-17,   6.00000000e-01],
+#                                                    [  3.60000000e-01,   8.00000000e-01,  -4.80000000e-01],
+#                                                    [ -4.80000000e-01,   6.00000000e-01,   6.40000000e-01]])
+#         )
+
+#     def test_fromrotmat(self):
+#         rotmat = qarray.to_rotmat(self.qeasy[0])
+#         q_result = qarray.from_rotmat(rotmat)
+#         np.testing.assert_array_almost_equal(self.qeasy[0], q_result)
+
+#     def test_fromvectors(self):
+#         axis = np.array([0,0,1])
+#         angle = np.radians(30)
+#         v1 = np.array([1., 0, 0])
+#         v2 = np.array([np.cos(angle), np.sin(angle), 0])
+#         q_result = qarray.from_vectors(v1, v2)
+#         np.testing.assert_array_almost_equal(q_result, np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
 

--- a/tests/test_qarray.py
+++ b/tests/test_qarray.py
@@ -156,147 +156,24 @@ class QarrayTest(MPITestCase):
         np.testing.assert_array_almost_equal(qarray.from_vectors(v1, v2), np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
 
 
+    def test_fp(self):
+        xaxis = np.array([1,0,0], dtype=np.float64)
+        yaxis = np.array([0,1,0], dtype=np.float64)
+        zaxis = np.array([0,0,1], dtype=np.float64)
 
-# class QarrayTest(MPITestCase):
+        radius = np.deg2rad(10.0)
+        rot = np.deg2rad(25.0)
 
-#     def setUp(self):
-#         #data
-#         self.q1 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857]])
-#         self.q1inv = np.array([[ -0.50487417,  -0.61426059,  -0.60118994,  0.07972857]])
-#         self.q2 = np.array([[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
-#         self.q1_2 = np.array([[ 0.50487417,  0.61426059,  0.60118994,  0.07972857],[ 0.43561544,  0.33647027,  0.40417115,  0.73052901]])
-#         self.qtonormalize = np.array([[1.,2,3,4],[2,3,4,5]])
-#         self.qnormalized = np.array([[0.18257419,  0.36514837,  0.54772256,  0.73029674],[ 0.27216553,  0.40824829,  0.54433105,  0.68041382]])
-#         self.vec = np.array([ 0.57734543,  0.30271255,  0.75831218])
-#         self.vec_2d = np.array([[ 0.57734543,  0.30271255,  0.75831218]]) # 2d array required
-#         self.vec2 = np.array([[ 0.57734543,  8.30271255,  5.75831218, 0.87937215],[ 1.57734543,  3.30271255,  0.75831218, 0.67128248]])
-#         self.qeasy = np.array([[.3,.3,.1,.9],[.3,.3,.1,.9]])
-#         #results from Quaternion CHANGED SIGN TO COMPLY WITH THE ONLINE QUATERNION CALCULATOR
-#         self.mult_result = -1*np.array([[-0.44954009, -0.53339352, -0.37370443,  0.61135101]])
-#         self.rot_by_q1 = np.array([[0.4176698, 0.84203849, 0.34135482]])
-#         self.rot_by_q2 = np.array([[0.8077876, 0.3227185, 0.49328689]])
+        for pos in range(6):
+            posang = np.deg2rad(pos * 60.0)
+            posrot = qarray.rotation(zaxis, posang+np.pi/2.0)
+            radrot = qarray.rotation(xaxis, radius)
+            detrot = qarray.mult(posrot, radrot)
 
-        
-#     def test_arraylist_dot_onedimarrays(self):
-#         q_result = qarray.arraylist_dot(self.vec_2d, (self.vec_2d +1))
-#         np.testing.assert_array_almost_equal(q_result, np.dot(self.vec, self.vec +1)) 
+            detdir = qarray.rotate(detrot, zaxis)
 
-#     def test_arraylist_dot_multidim(self):
-#         q_result = qarray.arraylist_dot(self.vec2, (self.vec2 +1))
-#         result = np.hstack(np.dot(v1,v2) for v1,v2 in zip(self.vec2, self.vec2+1))
-#         np.testing.assert_array_almost_equal(q_result.flatten(), result.flatten()) 
+            check = np.dot(detdir, zaxis)[0]
 
-#     def test_inv(self):
-#         q_result = qarray.inv(self.q1)
-#         np.testing.assert_array_almost_equal(q_result, self.q1inv)
+            np.testing.assert_almost_equal(check, np.cos(radius))
 
-#     def test_norm(self):
-#         q_result1 = qarray.norm(self.q1)
-#         q_result2 = qarray.norm(self.qtonormalize)
-#         np.testing.assert_array_almost_equal(q_result1, self.q1/np.linalg.norm(self.q1))
-#         np.testing.assert_array_almost_equal(q_result2, self.qnormalized)
-
-#     def test_norm_inplace(self):
-#         q1 = self.q1
-#         qarray.norm_inplace(q1)
-#         qarray.norm_inplace(self.qtonormalize)
-#         np.testing.assert_array_almost_equal(q1, q1/np.linalg.norm(q1))
-#         np.testing.assert_array_almost_equal(self.qtonormalize , self.qnormalized)
-
-#     def test_mult_onequaternion(self):
-#         q_result = qarray.mult(self.q1, self.q2)
-#         self.assertEquals( q_result.shape[0], 1)
-#         self.assertEquals( q_result.shape[1], 4)
-#         np.testing.assert_array_almost_equal(q_result , self.mult_result)
-
-#     def test_mult_qarray(self):
-#         dim = (3, 1)
-#         qarray1 = np.tile(self.q1, dim)
-#         qarray2 = np.tile(self.q2, dim)
-#         q_result = qarray.mult(qarray1, qarray2)
-#         np.testing.assert_array_almost_equal(q_result , np.tile(self.mult_result,dim))
-
-#     def test_rotate_onequaternion(self):
-#         vec_result = qarray.rotate(self.q1, self.vec_2d)
-#         np.testing.assert_array_almost_equal(vec_result , self.rot_by_q1)
-        
-#     def test_rotate_qarray(self):
-#         vec_result = qarray.rotate(np.vstack([self.q1,self.q2]), np.vstack([self.vec_2d, self.vec_2d]))
-#         np.testing.assert_array_almost_equal(vec_result , np.vstack([self.rot_by_q1, self.rot_by_q2]))
-
-#     def test_slerp(self):
-#         q = qarray.norm(np.array([[2., 3, 4, 5],
-#                       [6, 7, 8, 9]]))
-#         time = np.array([0., 9])
-#         targettime = np.array([0, 3, 4.5, 9])
-#         q_interp = qarray.slerp(targettime, time, q)
-#         self.assertEquals(q_interp.shape[1], 4)
-
-#         np.testing.assert_array_almost_equal(q_interp[0], q[0])
-#         np.testing.assert_array_almost_equal(q_interp[-1], q[-1])
-#         np.testing.assert_array_almost_equal(q_interp[1], qarray.norm( ( (q[0]*2 + q[1])/3 ).reshape(1,4) )[0], decimal=4 )
-#         np.testing.assert_array_almost_equal(q_interp[2], qarray.norm( ( (q[0] + q[1])/2 ).reshape(1,4) )[0], decimal=4 )
-
-#     def test_rotation(self):
-#         q_result = qarray.rotation(np.array([[0.,0.,1.]]), np.array([np.radians(30)]))
-#         np.testing.assert_array_almost_equal(
-#             q_result,  np.array([[0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]])
-#             )
-
-#     def test_exp(self):
-#         """Exponential test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-#         q_result = qarray.exp(self.qeasy)
-#         np.testing.assert_array_almost_equal(
-#             q_result,  np.array([[ 0.71473568,  0.71473568,  0.23824523,  2.22961712],[ 0.71473568,  0.71473568,  0.23824523,  2.22961712]])
-#             )
-
-#     def test_ln(self):
-#         """Log test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-#         q_result = qarray.ln(self.qeasy)
-#         np.testing.assert_array_almost_equal(
-#             q_result,  np.array([[ 0.31041794,  0.31041794,  0.10347265,  0.        ],[ 0.31041794,  0.31041794,  0.10347265,  0.        ]])
-#             )
-
-#     def test_pow(self):
-#         """Pow test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html"""
-#         pow_index = np.array([3.,3.])
-#         q_result = qarray.pow(self.qeasy, pow_index)
-#         np.testing.assert_array_almost_equal(
-#             q_result, np.array([[ 0.672,  0.672,  0.224,  0.216],[ 0.672,  0.672,  0.224,  0.216]])
-#             )
-#         pow_index = np.array([.1,.1])
-#         q_result = qarray.pow(self.qeasy, pow_index)
-#         np.testing.assert_array_almost_equal(
-#             q_result, np.array([[ 0.03103127,  0.03103127,  0.01034376,  0.99898305],[ 0.03103127,  0.03103127,  0.01034376,  0.99898305]])
-#             )
-
-#     def test_toaxisangle(self):
-#         axis = np.array([0.,0.,1.])
-#         angle = np.radians(30)
-#         q = np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))])
-#         qaxis, qangle = qarray.to_axisangle(q)
-#         np.testing.assert_array_almost_equal(axis, qaxis)
-#         self.assertAlmostEqual(angle, qangle)
-
-#     def test_torotmat(self):
-#         """Rotmat test from Quaternion"""
-#         rotmat = qarray.to_rotmat(self.qeasy[0])
-#         np.testing.assert_array_almost_equal(rotmat,
-#                                             np.array([[  8.00000000e-01,  -2.77555756e-17,   6.00000000e-01],
-#                                                    [  3.60000000e-01,   8.00000000e-01,  -4.80000000e-01],
-#                                                    [ -4.80000000e-01,   6.00000000e-01,   6.40000000e-01]])
-#         )
-
-#     def test_fromrotmat(self):
-#         rotmat = qarray.to_rotmat(self.qeasy[0])
-#         q_result = qarray.from_rotmat(rotmat)
-#         np.testing.assert_array_almost_equal(self.qeasy[0], q_result)
-
-#     def test_fromvectors(self):
-#         axis = np.array([0,0,1])
-#         angle = np.radians(30)
-#         v1 = np.array([1., 0, 0])
-#         v2 = np.array([np.cos(angle), np.sin(angle), 0])
-#         q_result = qarray.from_vectors(v1, v2)
-#         np.testing.assert_array_almost_equal(q_result, np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
 

--- a/tests/test_qarray.py
+++ b/tests/test_qarray.py
@@ -28,22 +28,9 @@ class QarrayTest(MPITestCase):
         self.vec2 = np.array([[ 0.57734543,  8.30271255,  5.75831218],[ 1.57734543,  3.30271255,  0.75831218]])
         self.qeasy = np.array([[.3,.3,.1,.9],[.3,.3,.1,.9]])
         #results from Quaternion CHANGED SIGN TO COMPLY WITH THE ONLINE QUATERNION CALCULATOR
-        self.mult_result = -1*np.array([[-0.44954009, -0.53339352, -0.37370443,  0.61135101]])
-        self.rot_by_q1 = np.array([[0.4176698, 0.84203849, 0.34135482]])
-        self.rot_by_q2 = np.array([[0.8077876, 0.3227185, 0.49328689]])
-
-
-    def test_arraylist_dot_onedimarrays(self):
-        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec, self.vec +1), np.dot(self.vec, self.vec +1)) 
-
-
-    def test_arraylist_dot_1dimbymultidim(self):
-        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec), np.dot(self.vec2,self.vec)) 
-
-
-    def test_arraylist_dot_multidim(self):
-        result = np.hstack(np.dot(v1,v2) for v1,v2 in zip(self.vec2, self.vec2+1))
-        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec2 +1), result) 
+        self.mult_result = -1*np.array([-0.44954009, -0.53339352, -0.37370443,  0.61135101])
+        self.rot_by_q1 = np.array([0.4176698, 0.84203849, 0.34135482])
+        self.rot_by_q2 = np.array([0.8077876, 0.3227185, 0.49328689])
 
 
     def test_inv(self):
@@ -57,8 +44,6 @@ class QarrayTest(MPITestCase):
 
     def test_mult_onequaternion(self):
         my_mult_result = qarray.mult(self.q1, self.q2)
-        self.assertEquals( my_mult_result.shape[0], 1)
-        self.assertEquals( my_mult_result.shape[1], 4)
         np.testing.assert_array_almost_equal(my_mult_result , self.mult_result)
 
 
@@ -69,6 +54,15 @@ class QarrayTest(MPITestCase):
         my_mult_result = qarray.mult(qarray1, qarray2)
         np.testing.assert_array_almost_equal(my_mult_result , np.tile(self.mult_result,dim))
 
+        check = qarray.mult(self.q1, self.q2)
+        res = qarray.mult(np.tile(self.q1, 10).reshape((-1, 4)), self.q2)
+        np.testing.assert_array_almost_equal(res, np.tile(check, 10).reshape((-1, 4)))
+
+        nulquat = np.array([0.0, 0.0, 0.0, 1.0])
+        check = qarray.mult(self.q1, nulquat)
+        res = qarray.mult(np.tile(self.q1, 10).reshape((-1, 4)), nulquat)
+        np.testing.assert_array_almost_equal(res, np.tile(check, 10).reshape((-1, 4)))
+
 
     def test_rotate_onequaternion(self):
         my_rot_result = qarray.rotate(self.q1, self.vec)
@@ -77,7 +71,7 @@ class QarrayTest(MPITestCase):
         
     def test_rotate_qarray(self):
         my_rot_result = qarray.rotate(np.vstack([self.q1,self.q2]), self.vec)
-        np.testing.assert_array_almost_equal(my_rot_result , np.vstack([self.rot_by_q1, self.rot_by_q2]))
+        np.testing.assert_array_almost_equal(my_rot_result , np.vstack([self.rot_by_q1, self.rot_by_q2]).reshape((2, 3)))
 
 
     def test_slerp(self):
@@ -177,7 +171,7 @@ class QarrayTest(MPITestCase):
 
             detdir = qarray.rotate(detrot, zaxis)
 
-            check = np.dot(detdir, zaxis)[0]
+            check = np.dot(detdir, zaxis)
 
             np.testing.assert_almost_equal(check, np.cos(radius))
 

--- a/tests/test_qarray.py
+++ b/tests/test_qarray.py
@@ -155,6 +155,11 @@ class QarrayTest(MPITestCase):
         v2 = np.array([np.cos(angle), np.sin(angle), 0])
         np.testing.assert_array_almost_equal(qarray.from_vectors(v1, v2), np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
 
+        nulquat = np.array([0.0, 0.0, 0.0, 1.0])
+        zaxis = np.array([0.0, 0.0, 1.0])
+        check = qarray.from_vectors(zaxis, zaxis)
+        np.testing.assert_array_almost_equal(check, nulquat)
+
 
     def test_fp(self):
         xaxis = np.array([1,0,0], dtype=np.float64)

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -18,7 +18,6 @@ class RNGTest(MPITestCase):
     def setUp(self):
         #data
         self.size = 6
-        self.array = np.zeros(self.size)
         self.counter = [1357111317,888118218888]
         self.key = [0xfeedbead,0xbaadcafe]
         self.counter00 = [0,0]
@@ -39,46 +38,44 @@ class RNGTest(MPITestCase):
 
     def test_rng_gaussian(self):
         # Testing with any counter and any key
-        CBRNG.random(array=self.array,counter=self.counter,key=self.key)
-        self.assertTrue((self.array > -10).all() and (self.array < 10).all())
-        np.testing.assert_array_almost_equal(self.array, self.array_gaussian)
+        result = random(self.size, counter=self.counter, key=self.key)
+        self.assertTrue((result > -10).all() and (result < 10).all())
+        np.testing.assert_array_almost_equal(result, self.array_gaussian)
 
         # Testing with counter=[0,0] and key=[0,0]
-        CBRNG.random(array=self.array,counter=self.counter00,key=self.key00)
-        self.assertTrue((self.array > -10).all() and (self.array < 10).all())
-        np.testing.assert_array_almost_equal(self.array, self.array00_gaussian)
+        result = random(self.size, counter=self.counter00, key=self.key00)
+        self.assertTrue((result > -10).all() and (result < 10).all())
+        np.testing.assert_array_almost_equal(result, self.array00_gaussian)
 
     def test_rng_m11(self):
         # Testing with any counter and any key
-        CBRNG.random(array=self.array,counter=self.counter,sampler="uniform_m11",key=self.key)
-        self.assertTrue((self.array > -1).all() and (self.array < 1).all())
-        np.testing.assert_array_almost_equal(self.array, self.array_m11)
+        result = random(self.size, counter=self.counter, sampler="uniform_m11", key=self.key)
+        self.assertTrue((result > -1).all() and (result < 1).all())
+        np.testing.assert_array_almost_equal(result, self.array_m11)
 
         # Testing with counter=[0,0] and key=[0,0]
-        CBRNG.random(array=self.array,counter=self.counter00,sampler="uniform_m11",key=self.key00)
-        self.assertTrue((self.array > -1).all() and (self.array < 1).all())
-        np.testing.assert_array_almost_equal(self.array, self.array00_m11)
+        result = random(self.size, counter=self.counter00, sampler="uniform_m11", key=self.key00)
+        self.assertTrue((result > -1).all() and (result < 1).all())
+        np.testing.assert_array_almost_equal(result, self.array00_m11)
 
     def test_rng_01(self):
         # Testing with any counter and any key
-        CBRNG.random(array=self.array,counter=self.counter,sampler="uniform_01",key=self.key)
-        self.assertTrue((self.array > 0).all() and (self.array < 1).all())
-        np.testing.assert_array_almost_equal(self.array, self.array_01)
+        result = random(self.size, counter=self.counter, sampler="uniform_01", key=self.key)
+        self.assertTrue((result > 0).all() and (result < 1).all())
+        np.testing.assert_array_almost_equal(result, self.array_01)
 
         # Testing with counter=[0,0] and key=[0,0]
-        CBRNG.random(array=self.array,counter=self.counter00,sampler="uniform_01",key=self.key00)
-        self.assertTrue((self.array > 0).all() and (self.array < 1).all())
-        np.testing.assert_array_almost_equal(self.array, self.array00_01)
+        result = random(self.size, counter=self.counter00, sampler="uniform_01", key=self.key00)
+        self.assertTrue((result > 0).all() and (result < 1).all())
+        np.testing.assert_array_almost_equal(result, self.array00_01)
 
     def test_rng_uint64(self):
         # Testing with any counter and any key
-        self.array = np.zeros(self.size,dtype=np.uint64)
-        CBRNG.random(array=self.array,counter=self.counter,sampler="uniform_uint64",key=self.key)
-        self.assertTrue(type(self.array[0]) == np.uint64)
-        np.testing.assert_array_almost_equal(self.array, self.array_uint64)
+        result = random(self.size, counter=self.counter, sampler="uniform_uint64", key=self.key)
+        self.assertTrue(type(result[0]) == np.uint64)
+        np.testing.assert_array_equal(result, self.array_uint64)
 
         # Testing with counter=[0,0] and key=[0,0]
-        self.array = np.zeros(self.size,dtype=np.uint64)
-        CBRNG.random(array=self.array,counter=self.counter00,sampler="uniform_uint64",key=self.key00)
-        self.assertTrue(type(self.array[0]) == np.uint64)
-        np.testing.assert_array_almost_equal(self.array, self.array00_uint64)
+        result = random(self.size, counter=self.counter00, sampler="uniform_uint64", key=self.key00)
+        self.assertTrue(type(result[0]) == np.uint64)
+        np.testing.assert_array_equal(result, self.array00_uint64)

--- a/toast/ctoast/pytoast.h
+++ b/toast/ctoast/pytoast.h
@@ -39,9 +39,8 @@ void pytoast_mem_aligned_free(void * mem);
 
 /*
 Dot product of a lists of arrays, returns a column array
-Arrays a and b must be n by 4, but only the m first columns will be used for the dot product (n-array)
 */
-void pytoast_qarraylist_dot(int n, int m, const double* a, const double* b, double* dotprod);
+void pytoast_qarraylist_dot(int n, int m, int d, const double* a, const double* b, double* dotprod);
 
 /*
 Inverse of quaternion array q
@@ -51,25 +50,21 @@ void pytoast_qinv(int n, double* q);
 
 /*
 Norm of quaternion array list
-v must be a n by 4 array, only the first m rows will be considered, l2 is a n-array
 */
-void pytoast_qamplitude(int n, int m, const double* v, double* l2);
+void pytoast_qamplitude(int n, int m, int d, const double* v, double* l2);
 
 /*
 Normalize quaternion array q or array list to unit quaternions
-q_in must be a n by 4 arrray, only the first m rows will be considered, results are output to q_out
 */
-void pytoast_qnorm(int n, int m, const double* q_in, double* q_out);
+void pytoast_qnorm(int n, int m, int d, const double* q_in, double* q_out);
 
 /*
 Normalize quaternion array q or array list to unit quaternions
-q must be a n by 4 arrray, only the first m rows will be considered, results are written to q
 */
-void pytoast_qnorm_inplace(int n, int m, double* q);
+void pytoast_qnorm_inplace(int n, int m, int d, double* q);
 
 /*
 Rotate vector v by n-quaternion array q and returns array with rotate n-vectors
-v is a 3D-vector and q is a n by 4 array, v_out is a n by 3 array.
 */
 void pytoast_qrotate(int n, const double* v, const double* q_in, double* v_out);
 

--- a/toast/ctoast/pytoast.h
+++ b/toast/ctoast/pytoast.h
@@ -104,10 +104,9 @@ axis is an n by 3 array, angle is a n-array, q_out is a n by 4 array
 void pytoast_from_axisangle(int n, const double* axis, const double* angle, double* q_out);
 
 /*
-Returns the axis and angle of rotation of a quaternion
-q is a 4-array, axis is a 3-array, angle is 1-array
+Returns the axes and angles of rotation of a quaternion array.
 */
-void pytoast_to_axisangle(const double* q, double* axis, double* angle);
+void pytoast_to_axisangle(int n, const double* q, double* axis, double* angle);
 
 /*
 Creates the rotation matrix corresponding to a quaternion

--- a/toast/ctoast/pytoast_qarray.c
+++ b/toast/ctoast/pytoast_qarray.c
@@ -326,19 +326,26 @@ void pytoast_from_axisangle(int n, const double* axis, const double* angle, doub
 Returns the axis and angle of rotation of a quaternion
 q is a 4-array, axis is a 3-array, angle is 1-array
 */
-void pytoast_to_axisangle(const double* q, double* axis, double* angle) {
+void pytoast_to_axisangle(int n, const double* q, double* axis, double* angle) {
     double tmp;
+    int i;
+    int vf;
+    int qf;
 
-    angle[0] = 2 * acos(q[3]);
-    if (angle[0] < 1e-4) {
-        axis[0] = 0;
-        axis[1] = 0;
-        axis[2] = 0;
-    } else {
-        tmp = sin(angle[0]/2.);
-        axis[0] = q[0]/tmp;
-        axis[1] = q[1]/tmp;
-        axis[2] = q[2]/tmp;
+    for (i = 0; i < n; ++i) {
+        qf = 4 * i;
+        vf = 3 * i;
+        angle[i] = 2 * acos(q[qf+3]);
+        if (angle[i] < 1e-4) {
+            axis[vf+0] = 0;
+            axis[vf+1] = 0;
+            axis[vf+2] = 0;
+        } else {
+            tmp = sin(angle[i]/2.);
+            axis[vf+0] = q[qf+0]/tmp;
+            axis[vf+1] = q[qf+1]/tmp;
+            axis[vf+2] = q[qf+2]/tmp;
+        }
     }
     return;
 }

--- a/toast/ctoast/pytoast_qarray.c
+++ b/toast/ctoast/pytoast_qarray.c
@@ -415,20 +415,20 @@ void pytoast_from_vectors(const double* vec1, const double* vec2, double* q) {
     double dotprod = vec1[0]*vec2[0] + vec1[1]*vec2[1] + vec1[2]*vec2[2];
     double vec1prod = vec1[0]*vec1[0] + vec1[1]*vec1[1] + vec1[2]*vec1[2];
     double vec2prod = vec2[0]*vec2[0] + vec2[1]*vec2[1] + vec2[2]*vec2[2];
-    /*
-    if (dotprod < -0.999999) {
-        
-    } else if (dotprod > 0.999999) {
-        
+
+    /* shortcut for coincident vectors */
+    if (fabs(dotprod) < 1.0e-12) {
+        q[0] = 0.0;
+        q[1] = 0.0;
+        q[2] = 0.0;
+        q[3] = 1.0;
     } else {
-        
+        q[0] = vec1[1]*vec2[2] - vec1[2]*vec2[1];
+        q[1] = vec1[2]*vec2[0] - vec1[0]*vec2[2];
+        q[2] = vec1[0]*vec2[1] - vec1[1]*vec2[0];
+        q[3] = sqrt(vec1prod * vec2prod) + dotprod;
+        pytoast_qnorm_inplace(1, 4, 4, q);
     }
-    */
-    q[0] = vec1[1]*vec2[2] - vec1[2]*vec2[1];
-    q[1] = vec1[0]*vec2[2] - vec1[2]*vec2[0];
-    q[2] = vec1[0]*vec2[1] - vec1[1]*vec2[0];
-    q[3] = sqrt(vec1prod * vec2prod) + dotprod;
-    pytoast_qnorm_inplace(1, 4, 4, q);
 
     return;
 }

--- a/toast/ctoast/pytoast_rng.c
+++ b/toast/ctoast/pytoast_rng.c
@@ -56,7 +56,7 @@ double uneg11(uint64_t in) {
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
 void generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
-    int i;
+    uint64_t i;
     threefry2x64_ctr_t rand;
 
     /* Box-Muller transform variables */
@@ -90,7 +90,7 @@ void generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t co
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
 void generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
-    int i;
+    uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};
@@ -114,7 +114,7 @@ void generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
 void generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
-    int i;
+    uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};
@@ -139,7 +139,7 @@ void generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t c
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
 void generate_uint64rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, uint64_t* rand_array) {
-    int i;
+    uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};

--- a/toast/dist.py
+++ b/toast/dist.py
@@ -369,6 +369,15 @@ class Data(object):
                     rms = np.std(data[good])
                     procstr = "{}        min = {:.4e}, max = {:.4e}, mean = {:.4e}, rms = {:.4e}\n".format(procstr, min, max, mean, rms)
 
+                for cname in tod.cache.keys():
+                    procstr = "{}    cache {}:\n".format(procstr, cname)
+                    ref = tod.cache.reference(cname)
+                    min = np.min(ref)
+                    max = np.max(ref)
+                    mean = np.mean(ref)
+                    rms = np.std(ref)
+                    procstr = "{}        min = {:.4e}, max = {:.4e}, mean = {:.4e}, rms = {:.4e}\n".format(procstr, min, max, mean, rms)
+
             recvstr = ""
             if gcomm.rank == 0:
                 groupstr = "{}{}".format(groupstr, procstr)

--- a/toast/rng.py
+++ b/toast/rng.py
@@ -8,25 +8,38 @@ import numpy as np
 from ._rng import *
 
 
-# define a more pythonic class here to represent the random
-# number generator, which uses stuff from _rng.
-
-class CBRNG:
+def random(samples, counter, sampler="gaussian", key=(0xcafebead,0xbaadfeed)):
     """
-    Counter-based random number generator class
+    High level interface to internal Random123 library.
 
+    This provides an interface for calling the internal functions to generate
+    random values from common distributions.
 
+    Args:
+        samples (int): The number of samples to return.
+        counter (tuple): Two uint64 values which (along with the key) define
+            the state of the generator.
+        sampler (string): The distribution to sample from.  Allowed values are
+            "gaussian", "uniform_01", "uniform_m11", and "uniform_uint64".
+        key (tuple): Two uint64 values which (along with the counter) define
+            the state of the generator.
+    Returns:
+        array: The random values of appropriate type for the sampler.
     """
+    ret = None
+    if sampler == "gaussian":
+        ret = np.zeros(samples, dtype=np.float64)
+        cbrng_normal(samples, 0, counter[0], counter[1], key[0], key[1], ret)
+    elif sampler == "uniform_01":
+        ret = np.zeros(samples, dtype=np.float64)
+        cbrng_uniform_01_f64(samples, 0, counter[0], counter[1], key[0], key[1], ret)
+    elif sampler == "uniform_m11":
+        ret = np.zeros(samples, dtype=np.float64)
+        cbrng_uniform_m11_f64(samples, 0, counter[0], counter[1], key[0], key[1], ret)
+    elif sampler == "uniform_uint64":
+        ret = np.zeros(samples, dtype=np.uint64)
+        cbrng_uniform_uint64(samples, 0, counter[0], counter[1], key[0], key[1], ret)
+    else:
+        raise ValueError("Undefined sampler. Choose among: gaussian, uniform_01, uniform_m11, uniform_uint64")
+    return ret
 
-    def random(array, counter, sampler="gaussian" , key=[0xcafebead,0xbaadfeed]):
-        if sampler == "gaussian":
-            cbrng_normal(np.shape(array)[0], 0, counter[0], counter[1], key[0], key[1], array)
-        elif sampler == "uniform_01":
-            cbrng_uniform_01_f64(np.shape(array)[0], 0, counter[0], counter[1], key[0], key[1], array)
-        elif sampler == "uniform_m11":
-            cbrng_uniform_m11_f64(np.shape(array)[0], 0, counter[0], counter[1], key[0], key[1], array)
-        elif sampler == "uniform_uint64":
-            cbrng_uniform_uint64(np.shape(array)[0], 0, counter[0], counter[1], key[0], key[1], array)
-        else:
-            print("Undefined sampler. Choose among: gaussian, uniform_01, uniform_m11, uniform_uint64")
-        return

--- a/toast/tod/__init__.py
+++ b/toast/tod/__init__.py
@@ -5,6 +5,8 @@
 
 # import functions in our public API
 
+from . import qarray as qarray
+
 from .tod import TOD
 
 from .interval import Interval

--- a/toast/tod/_qarray.pyx
+++ b/toast/tod/_qarray.pyx
@@ -14,7 +14,6 @@ ctypedef np.int32_t i32_t
 
 
 cdef extern from "pytoast.h":
-    void pytoast_qarraylist_dot(int n, int m, int d, const double* a, const double* b, double* dotprod)
     void pytoast_qinv(int n, double* q)
     void pytoast_qamplitude(int n, int m, int d, const double* v, double* l2)
     void pytoast_qnorm(int n, int m, int d, const double* q_in, double* q_out)
@@ -25,139 +24,137 @@ cdef extern from "pytoast.h":
     void pytoast_qln(int n, const double* q_in, double* q_out)
     void pytoast_qpow(int n, const double* p, const double* q_in, double* q_out)
     void pytoast_from_axisangle(int n, const double* axis, const double* angle, double* q_out)
-    void pytoast_to_axisangle(const double* q, double* axis, double* angle)
+    void pytoast_to_axisangle(int n, const double* q, double* axis, double* angle)
     void pytoast_to_rotmat(const double* q, double* rotmat)
     void pytoast_from_rotmat(const double* rotmat, double* q)
     void pytoast_from_vectors(const double* vec1, const double* vec2, double* q)
 
 
-def arraylist_dot(np.ndarray[f64_t, ndim=2] a, np.ndarray[f64_t, ndim=2] b):
-    '''Dot product of a lists of arrays, returns a column array'''
-    cdef int n = a.shape[0]
-    cdef int m = a.shape[1]
-    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n, dtype=f64)
-    a = np.ascontiguousarray(a)
-    b = np.ascontiguousarray(b)
-    pytoast_qarraylist_dot(n, m, m, <double*>a.data, <double*>b.data, <double*>out.data)
-    return out
-
-
-def inv(np.ndarray[f64_t, ndim=2] q):
-    """Inverse of quaternion array q"""
-    cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
+def inv(int n, np.ndarray[f64_t, ndim=1] q):
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.copy(q)
     pytoast_qinv(n, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def amplitude(np.ndarray[f64_t, ndim=2] v):
-    cdef int n = v.shape[0]
-    cdef int m = v.shape[1]
+def amplitude(int n, int m, np.ndarray[f64_t, ndim=1] v):
     v = np.ascontiguousarray(v)
-    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zero(n, dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n, dtype=f64)
     pytoast_qamplitude(n, m, m, <double*>v.data, <double*>out.data)
     return out
 
 
-def norm(np.ndarray[f64_t, ndim=2] q):
-    """Normalize quaternion array q or array list to unit quaternions"""
-    cdef int n = q.shape[0]
-    cdef int m = q.shape[1]
+def norm(int n, np.ndarray[f64_t, ndim=1] q):
     q = np.ascontiguousarray(q)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
-    pytoast_qnorm(n, m, m, <double*>q.data, <double*>out.data)
-    return out
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(4*n, dtype=f64)
+    pytoast_qnorm(n, 4, 4, <double*>q.data, <double*>out.data)
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def rotate(np.ndarray[f64_t, ndim=2] q, np.ndarray[f64_t, ndim=2] v):
-    """Rotate vector or array of vectors v by quaternion q"""
-    cdef int n = q.shape[0]
+def rotate(int n, np.ndarray[f64_t, ndim=1] q, np.ndarray[f64_t, ndim=1] v):
     q = np.ascontiguousarray(q)
     v = np.ascontiguousarray(v)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(v)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(3*n, dtype=f64)
     pytoast_qrotate(n, <double*>v.data, <double*>q.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 3))
 
 
-def mult(np.ndarray[f64_t, ndim=2] p, np.ndarray[f64_t, ndim=2] q):
-    """Multiply arrays of quaternions, see:
-    http://en.wikipedia.org/wiki/Quaternions#Quaternions_and_the_geometry_of_R3
-    """
-    cdef int n = q.shape[0]
+def mult(int n, np.ndarray[f64_t, ndim=1] p, np.ndarray[f64_t, ndim=1] q):
     p = np.ascontiguousarray(p)
     q = np.ascontiguousarray(q)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(4*n, dtype=f64)
     pytoast_qmult(n, <double*>p.data, <double*>q.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def slerp(np.ndarray[f64_t, ndim=1] targettime, np.ndarray[f64_t, ndim=1] time, np.ndarray[f64_t, ndim=2] q):
-    """Slerp, q quaternion array interpolated from time to targettime"""
+def slerp(np.ndarray[f64_t, ndim=1] targettime, np.ndarray[f64_t, ndim=1] time, np.ndarray[f64_t, ndim=1] q):
     cdef int ntime = time.shape[0]
     cdef int ntarget = targettime.shape[0]
     time = np.ascontiguousarray(time)
     targettime = np.ascontiguousarray(targettime)
     q = np.ascontiguousarray(q)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros((ntarget, 4), dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(ntarget*4, dtype=f64)
     pytoast_slerp(ntime, ntarget, <double*>time.data, <double*>targettime.data, <double*>q.data, <double*>out.data)
-    return out
+    if ntarget == 1:
+        return out
+    else:
+        return out.reshape((ntarget, 4))
 
 
-def exp(np.ndarray[f64_t, ndim=2] q):
-    """Exponential of a quaternion array"""
-    cdef int n = q.shape[0]
+def exp(int n, np.ndarray[f64_t, ndim=1] q):
     q = np.ascontiguousarray(q)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(4*n, dtype=f64)
     pytoast_qexp(n, <double*>q.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def ln(np.ndarray[f64_t, ndim=2] q):
-    """Natural logarithm of a quaternion array"""
-    cdef int n = q.shape[0]
+def ln(int n, np.ndarray[f64_t, ndim=1] q):
     q = np.ascontiguousarray(q)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(4*n, dtype=f64)
     pytoast_qln(n, <double*>q.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def pow(np.ndarray[f64_t, ndim=2] q, np.ndarray[f64_t, ndim=1] p):
-    """Real power of a quaternion array"""
-    cdef int n = q.shape[0]
+def pow(np.ndarray[f64_t, ndim=1] q, np.ndarray[f64_t, ndim=1] p):
+    cdef int n = p.shape[0]
     q = np.ascontiguousarray(q)
     p = np.ascontiguousarray(p)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n*4, dtype=f64)
     pytoast_qpow(n, <double*>p.data, <double*>q.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
     
 
-def rotation(np.ndarray[f64_t, ndim=2] axis, np.ndarray[f64_t, ndim=1] angle):
-    """Rotation quaternions of angles [rad] around axes [already normalized]"""
-    cdef int n = axis.shape[0]
+def rotation(np.ndarray[f64_t, ndim=1] axis, np.ndarray[f64_t, ndim=1] angle):
+    cdef int n = angle.shape[0]
     axis = np.ascontiguousarray(axis)
     angle = np.ascontiguousarray(angle)
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros((n,4), dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n*4, dtype=f64)
     pytoast_from_axisangle(n, <double*>axis.data, <double*>angle.data, <double*>out.data)
-    return out
+    if n == 1:
+        return out
+    else:
+        return out.reshape((n, 4))
 
 
-def to_axisangle(np.ndarray[f64_t, ndim=1] q):
-    cdef f64_t angle
-    cdef np.ndarray[f64_t, ndim=1, mode='c'] axis = np.zeros(3, dtype=f64)
+def to_axisangle(int n, np.ndarray[f64_t, ndim=1] q):
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] angle = np.zeros(n, dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] axis = np.zeros(3*n, dtype=f64)
     q = np.ascontiguousarray(q)
-    pytoast_to_axisangle(<double*>q.data, <double*>axis.data, <double*>&angle)
-    return axis, angle
+    pytoast_to_axisangle(n, <double*>q.data, <double*>axis.data, <double*>angle.data)
+    if n == 1:
+        return axis, angle[0]
+    else:
+        return axis.reshape((n, 3)), angle
 
 
 def to_rotmat(np.ndarray[f64_t, ndim=1] q):
-    """Rotation matrix"""
-    cdef np.ndarray[f64_t, ndim=2, mode='c'] rot = np.zeros((3,3), dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] rot = np.zeros(9, dtype=f64)
     q = np.ascontiguousarray(q)
     pytoast_to_rotmat(<double*>q.data, <double*>rot.data)
-    return rot
+    return rot.reshape((3,3))
 
 
-def from_rotmat(np.ndarray[f64_t, ndim=2] rotmat):
+def from_rotmat(np.ndarray[f64_t, ndim=1] rotmat):
     cdef np.ndarray[f64_t, ndim=1, mode='c'] q = np.zeros(4, dtype=f64)
     rotmat = np.ascontiguousarray(rotmat)
     pytoast_from_rotmat(<double*>rotmat.data, <double*>q.data)

--- a/toast/tod/_qarray.pyx
+++ b/toast/tod/_qarray.pyx
@@ -14,11 +14,10 @@ ctypedef np.int32_t i32_t
 
 
 cdef extern from "pytoast.h":
-    void pytoast_qarraylist_dot(int n, int m, const double* a, const double* b, double* dotprod)
+    void pytoast_qarraylist_dot(int n, int m, int d, const double* a, const double* b, double* dotprod)
     void pytoast_qinv(int n, double* q)
-    void pytoast_qamplitude(int n, const int m, const double* v, double* l2)
-    void pytoast_qnorm(int n, int m, const double* q_in, double* q_out)
-    void pytoast_qnorm_inplace(int n, int m, double* q)
+    void pytoast_qamplitude(int n, int m, int d, const double* v, double* l2)
+    void pytoast_qnorm(int n, int m, int d, const double* q_in, double* q_out)
     void pytoast_qrotate(int n, const double* v, const double* q_in, double* v_out)
     void pytoast_qmult(int n, const double* p, const double* q, double* r)
     void pytoast_slerp(int n_time, int n_targettime, const double* time, const double* targettime, const double* q_in, double* q_interp)
@@ -36,15 +35,17 @@ def arraylist_dot(np.ndarray[f64_t, ndim=2] a, np.ndarray[f64_t, ndim=2] b):
     '''Dot product of a lists of arrays, returns a column array'''
     cdef int n = a.shape[0]
     cdef int m = a.shape[1]
-    cdef np.ndarray[f64_t, ndim=1] out = np.zeros(n, dtype=f64)
-    pytoast_qarraylist_dot(n, m, <double*>a.data, <double*>b.data, <double*>out.data)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n, dtype=f64)
+    a = np.ascontiguousarray(a)
+    b = np.ascontiguousarray(b)
+    pytoast_qarraylist_dot(n, m, m, <double*>a.data, <double*>b.data, <double*>out.data)
     return out
 
 
 def inv(np.ndarray[f64_t, ndim=2] q):
     """Inverse of quaternion array q"""
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.copy(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
     pytoast_qinv(n, <double*>out.data)
     return out
 
@@ -52,8 +53,9 @@ def inv(np.ndarray[f64_t, ndim=2] q):
 def amplitude(np.ndarray[f64_t, ndim=2] v):
     cdef int n = v.shape[0]
     cdef int m = v.shape[1]
-    cdef np.ndarray[f64_t, ndim=1] out = np.zeros(n, dtype=f64)
-    pytoast_qamplitude(n, m, <double*>v.data, <double*>out.data)
+    v = np.ascontiguousarray(v)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zero(n, dtype=f64)
+    pytoast_qamplitude(n, m, m, <double*>v.data, <double*>out.data)
     return out
 
 
@@ -61,34 +63,30 @@ def norm(np.ndarray[f64_t, ndim=2] q):
     """Normalize quaternion array q or array list to unit quaternions"""
     cdef int n = q.shape[0]
     cdef int m = q.shape[1]
-    cdef np.ndarray[f64_t, ndim=2] out = np.copy(q)
-    pytoast_qnorm(n, m, <double*>q.data, <double*>out.data)
+    q = np.ascontiguousarray(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
+    pytoast_qnorm(n, m, m, <double*>q.data, <double*>out.data)
     return out
-
-
-def norm_inplace(np.ndarray[f64_t, ndim=2] q):
-    """Normalize quaternion array q or array list to unit quaternions"""
-    cdef int n = q.shape[0]
-    cdef int m = q.shape[1]
-    pytoast_qnorm_inplace(n, m, <double*>q.data)
-    return
 
 
 def rotate(np.ndarray[f64_t, ndim=2] q, np.ndarray[f64_t, ndim=2] v):
     """Rotate vector or array of vectors v by quaternion q"""
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.zeros_like(v)
+    q = np.ascontiguousarray(q)
+    v = np.ascontiguousarray(v)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(v)
     pytoast_qrotate(n, <double*>v.data, <double*>q.data, <double*>out.data)
     return out
 
 
 def mult(np.ndarray[f64_t, ndim=2] p, np.ndarray[f64_t, ndim=2] q):
-    """Multiply arrays of quaternions,
-    see:
+    """Multiply arrays of quaternions, see:
     http://en.wikipedia.org/wiki/Quaternions#Quaternions_and_the_geometry_of_R3
     """
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.zeros_like(q)
+    p = np.ascontiguousarray(p)
+    q = np.ascontiguousarray(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
     pytoast_qmult(n, <double*>p.data, <double*>q.data, <double*>out.data)
     return out
 
@@ -97,7 +95,10 @@ def slerp(np.ndarray[f64_t, ndim=1] targettime, np.ndarray[f64_t, ndim=1] time, 
     """Slerp, q quaternion array interpolated from time to targettime"""
     cdef int ntime = time.shape[0]
     cdef int ntarget = targettime.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.zeros((ntarget, 4), dtype=f64)
+    time = np.ascontiguousarray(time)
+    targettime = np.ascontiguousarray(targettime)
+    q = np.ascontiguousarray(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros((ntarget, 4), dtype=f64)
     pytoast_slerp(ntime, ntarget, <double*>time.data, <double*>targettime.data, <double*>q.data, <double*>out.data)
     return out
 
@@ -105,7 +106,8 @@ def slerp(np.ndarray[f64_t, ndim=1] targettime, np.ndarray[f64_t, ndim=1] time, 
 def exp(np.ndarray[f64_t, ndim=2] q):
     """Exponential of a quaternion array"""
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.copy(q)
+    q = np.ascontiguousarray(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros_like(q)
     pytoast_qexp(n, <double*>q.data, <double*>out.data)
     return out
 
@@ -113,7 +115,8 @@ def exp(np.ndarray[f64_t, ndim=2] q):
 def ln(np.ndarray[f64_t, ndim=2] q):
     """Natural logarithm of a quaternion array"""
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.copy(q)
+    q = np.ascontiguousarray(q)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
     pytoast_qln(n, <double*>q.data, <double*>out.data)
     return out
 
@@ -121,7 +124,9 @@ def ln(np.ndarray[f64_t, ndim=2] q):
 def pow(np.ndarray[f64_t, ndim=2] q, np.ndarray[f64_t, ndim=1] p):
     """Real power of a quaternion array"""
     cdef int n = q.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.copy(q)
+    q = np.ascontiguousarray(q)
+    p = np.ascontiguousarray(p)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.copy(q)
     pytoast_qpow(n, <double*>p.data, <double*>q.data, <double*>out.data)
     return out
     
@@ -129,33 +134,40 @@ def pow(np.ndarray[f64_t, ndim=2] q, np.ndarray[f64_t, ndim=1] p):
 def rotation(np.ndarray[f64_t, ndim=2] axis, np.ndarray[f64_t, ndim=1] angle):
     """Rotation quaternions of angles [rad] around axes [already normalized]"""
     cdef int n = axis.shape[0]
-    cdef np.ndarray[f64_t, ndim=2] out = np.zeros((n,4), dtype=f64)
+    axis = np.ascontiguousarray(axis)
+    angle = np.ascontiguousarray(angle)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] out = np.zeros((n,4), dtype=f64)
     pytoast_from_axisangle(n, <double*>axis.data, <double*>angle.data, <double*>out.data)
     return out
 
 
 def to_axisangle(np.ndarray[f64_t, ndim=1] q):
     cdef f64_t angle
-    cdef np.ndarray[f64_t, ndim=1] axis = np.zeros(3, dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] axis = np.zeros(3, dtype=f64)
+    q = np.ascontiguousarray(q)
     pytoast_to_axisangle(<double*>q.data, <double*>axis.data, <double*>&angle)
     return axis, angle
 
 
 def to_rotmat(np.ndarray[f64_t, ndim=1] q):
     """Rotation matrix"""
-    cdef np.ndarray[f64_t, ndim=2] rot = np.zeros((3,3), dtype=f64)
+    cdef np.ndarray[f64_t, ndim=2, mode='c'] rot = np.zeros((3,3), dtype=f64)
+    q = np.ascontiguousarray(q)
     pytoast_to_rotmat(<double*>q.data, <double*>rot.data)
     return rot
-                                
+
 
 def from_rotmat(np.ndarray[f64_t, ndim=2] rotmat):
-    cdef np.ndarray[f64_t, ndim=1] q = np.zeros(4, dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] q = np.zeros(4, dtype=f64)
+    rotmat = np.ascontiguousarray(rotmat)
     pytoast_from_rotmat(<double*>rotmat.data, <double*>q.data)
     return q
 
 
 def from_vectors(np.ndarray[f64_t, ndim=1] v1, np.ndarray[f64_t, ndim=1] v2):
-    cdef np.ndarray[f64_t, ndim=1] q = np.zeros(4, dtype=f64)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] q = np.zeros(4, dtype=f64)
+    v1 = np.ascontiguousarray(v1)
+    v2 = np.ascontiguousarray(v2)
     pytoast_from_vectors(<double*>v1.data, <double*>v2.data, <double*>q.data)
     return q
 

--- a/toast/tod/conviqt.py
+++ b/toast/tod/conviqt.py
@@ -19,7 +19,7 @@ import healpy as hp
 import numpy as np
 import numpy.ctypeslib as npc
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from ..dist import Comm, Data
 from ..operator import Operator

--- a/toast/tod/pointing.py
+++ b/toast/tod/pointing.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import healpy as hp
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from ..operator import Operator
 from ..dist import Comm, Data

--- a/toast/tod/pointing_math.py
+++ b/toast/tod/pointing_math.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import healpy as hp
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from scipy.constants import c
 

--- a/toast/tod/qarray.py
+++ b/toast/tod/qarray.py
@@ -1,0 +1,193 @@
+# Copyright (c) 2015 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by 
+# a BSD-style license that can be found in the LICENSE file.
+
+
+import numpy as np
+
+from . import _qarray as qc
+
+
+def arraylist_dot(a, b):
+    '''Dot product of a lists of arrays, returns a column array'''
+    na = 1
+    if a.ndim > 1:
+        na = a.shape[0]
+    nb = 1
+    if b.ndim > 1:
+        nb = b.shape[0]
+    if (na > 1) and (nb > 1) and (na != nb):
+        raise RuntimeError("quaternion arrays must have length one or matching lengths.")
+    n = np.max([na, nb])
+
+    aa = a
+    if a.ndim == 1:
+        aa = np.tile(a, n).reshape((-1, a.shape[0]))
+    bb = b
+    if b.ndim == 1:
+        bb = np.tile(b, n).reshape((-1, b.shape[0]))
+
+    return qc.arraylist_dot(aa, bb)
+
+
+def inv(q):
+    """Inverse of quaternion array q"""
+    qq = q
+    if q.ndim == 1:
+        qq = q.reshape((1, q.shape[0]))
+    res = qc.inv(qq)
+    if q.ndim == 1:
+        return res.flatten()
+    else:
+        return res
+
+
+def amplitude(v):
+    vv = v
+    if v.ndim == 1:
+        vv = v.reshape((1, v.shape[0]))
+    res = qc.amplitude(vv)
+    if v.ndim == 1:
+        return res.flatten()
+    else:
+        return res
+
+
+def norm(q):
+    """Normalize quaternion array q or array list to unit quaternions"""
+    qq = q
+    if q.ndim == 1:
+        qq = q.reshape((1, q.shape[0]))
+    res = qc.norm(qq)
+    if q.ndim == 1:
+        return res.flatten()
+    else:
+        return res
+
+
+def rotate(q, v):
+    """
+    Use a quaternion or array of quaternions (q) to rotate a vector or 
+    array of vectors (v).  If the dimensions of both q and v are 2, then
+    they must have the same leading dimension.
+    """
+    nq = 1
+    if q.ndim > 1:
+        nq = q.shape[0]
+    nv = 1
+    if v.ndim > 1:
+        nv = v.shape[0]
+    if (nq > 1) and (nv > 1) and (nq != nv):
+        raise RuntimeError("quaternion and vector arrays must have length one or matching lengths.")
+    n = np.max([nq, nv])
+
+    vv = v
+    if v.ndim == 1:
+        vv = np.tile(v, n).reshape((-1, 3))
+    qq = q
+    if q.ndim == 1:
+        qq = np.tile(q, n).reshape((-1, 4))
+
+    return qc.rotate(qq, vv)
+
+
+def mult(p, q):
+    """Multiply arrays of quaternions, see:
+    http://en.wikipedia.org/wiki/Quaternions#Quaternions_and_the_geometry_of_R3
+    """
+    qn = 1
+    if q.ndim > 1:
+        qn = q.shape[0]
+    pn = 1
+    if p.ndim > 1:
+        pn = p.shape[0]
+    if (qn > 1) and (pn > 1) and (qn != pn):
+        raise RuntimeError("quaternion arrays must have length one or matching lengths.")
+    n = np.max([qn, pn])
+
+    pp = p
+    if p.ndim == 1:
+        pp = np.tile(p, n).reshape((-1, 4))
+    qq = q
+    if q.ndim == 1:
+        qq = np.tile(q, n).reshape((-1, 4))
+
+    return qc.mult(pp, qq)
+
+
+def slerp(targettime, time, q):
+    """Slerp, q quaternion array interpolated from time to targettime"""
+    return qc.slerp(targettime, time, q)
+
+
+def exp(q):
+    """Exponential of a quaternion array"""
+    qq = q
+    if q.ndim == 1:
+        qq = q.reshape((1, q.shape[0]))
+    print(qq)
+    return qc.exp(qq)
+
+
+def ln(q):
+    """Natural logarithm of a quaternion array"""
+    qq = q
+    if q.ndim == 1:
+        qq = q.reshape((1, q.shape[0]))
+    return qc.ln(qq)
+
+
+def pow(q, p):
+    """Real power of a quaternion array"""
+    qq = q
+    if q.ndim == 1:
+        qq = q.reshape((1, q.shape[0]))
+    pp = p
+    if not isinstance(p, np.ndarray):
+        pp = np.tile(p, qq.shape[0])
+    return qc.pow(qq, pp)
+
+    
+def rotation(axis, angle):
+    """Rotation quaternions of angles [rad] around axes [already normalized]"""
+    nax = 1
+    if axis.ndim > 1:
+        nax = axis.shape[0]
+    nang = 1
+    if isinstance(angle, np.ndarray):
+        # we have more than one angle
+        nang = angle.shape[0]
+    if (nax > 1) and (nang > 1) and (nax != nang):
+        raise RuntimeError("axis and angle arrays must have length one or matching lengths.")
+    n = np.max([nax, nang])
+
+    ax = axis
+    if axis.ndim == 1:
+        ax = np.tile(axis, n).reshape((-1, 3))
+    ang = angle
+    if nang == 1:
+        ang = np.tile(angle, n)
+
+    res = qc.rotation(ax, ang)
+    if n == 1:
+        return res.flatten()
+    else:
+        return res
+
+
+def to_axisangle(q):
+    return qc.to_axisangle(q)
+
+
+def to_rotmat(q):
+    """Rotation matrix"""
+    return qc.to_rotmat(q)
+                                
+
+def from_rotmat(rotmat):
+    return qc.from_rotmat(rotmat)
+
+
+def from_vectors(v1, v2):
+    return qc.from_vectors(v1, v2)
+

--- a/toast/tod/qarray.py
+++ b/toast/tod/qarray.py
@@ -8,186 +8,208 @@ import numpy as np
 from . import _qarray as qc
 
 
-def arraylist_dot(a, b):
-    '''Dot product of a lists of arrays, returns a column array'''
-    na = 1
-    if a.ndim > 1:
-        na = a.shape[0]
-    nb = 1
-    if b.ndim > 1:
-        nb = b.shape[0]
-    if (na > 1) and (nb > 1) and (na != nb):
-        raise RuntimeError("quaternion arrays must have length one or matching lengths.")
-    n = np.max([na, nb])
-
-    aa = a
-    if a.ndim == 1:
-        aa = np.tile(a, n).reshape((-1, a.shape[0]))
-    bb = b
-    if b.ndim == 1:
-        bb = np.tile(b, n).reshape((-1, b.shape[0]))
-
-    return qc.arraylist_dot(aa, bb)
-
-
 def inv(q):
     """Inverse of quaternion array q"""
-    qq = q
+    nq = None
     if q.ndim == 1:
-        qq = q.reshape((1, q.shape[0]))
-    res = qc.inv(qq)
-    if q.ndim == 1:
-        return res.flatten()
+        nq = 1
     else:
-        return res
+        nq = q.shape[0]
+    return qc.inv(nq, q.flatten())
 
 
 def amplitude(v):
-    vv = v
+    """Amplitude of a vector array"""
+    nv = None
+    nm = None
     if v.ndim == 1:
-        vv = v.reshape((1, v.shape[0]))
-    res = qc.amplitude(vv)
-    if v.ndim == 1:
-        return res.flatten()
+        nv = 1
+        nm = v.shape[0]
     else:
-        return res
+        nv = v.shape[0]
+        nm = v.shape[1]
+    return qc.amplitude(nv, nm, v.flatten())
 
 
 def norm(q):
-    """Normalize quaternion array q or array list to unit quaternions"""
-    qq = q
+    """Normalize quaternion array to unit quaternions"""
+    nq = None
     if q.ndim == 1:
-        qq = q.reshape((1, q.shape[0]))
-    res = qc.norm(qq)
-    if q.ndim == 1:
-        return res.flatten()
+        nq = 1
     else:
-        return res
+        nq = q.shape[0]
+    return qc.norm(nq, q.flatten())
 
 
 def rotate(q, v):
     """
     Use a quaternion or array of quaternions (q) to rotate a vector or 
-    array of vectors (v).  If the dimensions of both q and v are 2, then
-    they must have the same leading dimension.
+    array of vectors (v).  If the number of dimensions of both q and v 
+    are 2, then they must have the same leading dimension.
     """
-    nq = 1
-    if q.ndim > 1:
+    nq = None
+    if q.ndim == 1:
+        nq = 1
+    else:
         nq = q.shape[0]
-    nv = 1
-    if v.ndim > 1:
+    nv = None
+    if v.ndim == 1:
+        nv = 1
+    else:
         nv = v.shape[0]
+
     if (nq > 1) and (nv > 1) and (nq != nv):
         raise RuntimeError("quaternion and vector arrays must have length one or matching lengths.")
     n = np.max([nq, nv])
 
     vv = v
-    if v.ndim == 1:
-        vv = np.tile(v, n).reshape((-1, 3))
+    if nv != n:
+        vv = np.tile(v, n)
     qq = q
-    if q.ndim == 1:
-        qq = np.tile(q, n).reshape((-1, 4))
+    if nq != n:
+        qq = np.tile(q, n)
 
-    return qc.rotate(qq, vv)
+    return qc.rotate(n, qq.flatten(), vv.flatten())
 
 
 def mult(p, q):
     """Multiply arrays of quaternions, see:
     http://en.wikipedia.org/wiki/Quaternions#Quaternions_and_the_geometry_of_R3
     """
-    qn = 1
-    if q.ndim > 1:
-        qn = q.shape[0]
-    pn = 1
-    if p.ndim > 1:
+    nq = None
+    if q.ndim == 1:
+        nq = 1
+    else:
+        nq = q.shape[0]
+    pn = None
+    if p.ndim == 1:
+        pn = 1
+    else:
         pn = p.shape[0]
-    if (qn > 1) and (pn > 1) and (qn != pn):
+
+    if (nq > 1) and (pn > 1) and (nq != pn):
         raise RuntimeError("quaternion arrays must have length one or matching lengths.")
-    n = np.max([qn, pn])
+    n = np.max([nq, pn])
 
     pp = p
-    if p.ndim == 1:
-        pp = np.tile(p, n).reshape((-1, 4))
+    if pn != n:
+        pp = np.tile(p, n)
     qq = q
-    if q.ndim == 1:
-        qq = np.tile(q, n).reshape((-1, 4))
+    if nq != n:
+        qq = np.tile(q, n)
 
-    return qc.mult(pp, qq)
+    return qc.mult(n, pp.flatten(), qq.flatten())
 
 
 def slerp(targettime, time, q):
     """Slerp, q quaternion array interpolated from time to targettime"""
-    return qc.slerp(targettime, time, q)
+    return qc.slerp(targettime, time, q.flatten())
 
 
 def exp(q):
     """Exponential of a quaternion array"""
-    qq = q
+    nq = None
     if q.ndim == 1:
-        qq = q.reshape((1, q.shape[0]))
-    print(qq)
-    return qc.exp(qq)
+        nq = 1
+    else:
+        nq = q.shape[0]    
+    return qc.exp(nq, q.flatten())
 
 
 def ln(q):
     """Natural logarithm of a quaternion array"""
-    qq = q
+    nq = None
     if q.ndim == 1:
-        qq = q.reshape((1, q.shape[0]))
-    return qc.ln(qq)
+        nq = 1
+    else:
+        nq = q.shape[0]    
+    return qc.ln(nq, q.flatten())
 
 
 def pow(q, p):
     """Real power of a quaternion array"""
-    qq = q
+    nq = None
     if q.ndim == 1:
-        qq = q.reshape((1, q.shape[0]))
-    pp = p
-    if not isinstance(p, np.ndarray):
-        pp = np.tile(p, qq.shape[0])
-    return qc.pow(qq, pp)
+        nq = 1
+    else:
+        nq = q.shape[0]
+    pn = None
+    if isinstance(p, np.ndarray):
+        pn = p.shape[0]
+    else:
+        pn = 1
+
+    if (nq > 1) and (pn > 1) and (nq != pn):
+        raise RuntimeError("quaternion array and power must have length one or matching lengths.")
+    n = np.max([nq, pn])
+
+    pp = None
+    if isinstance(p, np.ndarray):
+        if pn != n:
+            pp = np.tile(p, n)
+        else:
+            pp = p
+    else:
+        pp = np.tile(p, n)
+
+    qq = q
+    if nq != n:
+        qq = np.tile(q, n)
+
+    return qc.pow(qq.flatten(), pp.flatten())
 
     
 def rotation(axis, angle):
     """Rotation quaternions of angles [rad] around axes [already normalized]"""
-    nax = 1
-    if axis.ndim > 1:
+    nax = None
+    if axis.ndim == 1:
+        nax = 1
+    else:
         nax = axis.shape[0]
-    nang = 1
+    nang = None
     if isinstance(angle, np.ndarray):
-        # we have more than one angle
         nang = angle.shape[0]
+    else:
+        nang = 1
+
     if (nax > 1) and (nang > 1) and (nax != nang):
         raise RuntimeError("axis and angle arrays must have length one or matching lengths.")
     n = np.max([nax, nang])
 
     ax = axis
-    if axis.ndim == 1:
-        ax = np.tile(axis, n).reshape((-1, 3))
-    ang = angle
-    if nang == 1:
-        ang = np.tile(angle, n)
+    if nax != n:
+        ax = np.tile(axis, n)
 
-    res = qc.rotation(ax, ang)
-    if n == 1:
-        return res.flatten()
+    ang = None
+    if isinstance(angle, np.ndarray):
+        if nang != n:
+            ang = np.tile(angle, n)
+        else:
+            ang = angle
     else:
-        return res
+        ang = np.tile(angle, n) 
+
+    return qc.rotation(ax.flatten(), ang.flatten())
 
 
 def to_axisangle(q):
-    return qc.to_axisangle(q)
+    nq = None
+    if q.ndim == 1:
+        nq = 1
+    else:
+        nq = q.shape[0]
+    return qc.to_axisangle(nq, q.flatten())
 
 
 def to_rotmat(q):
     """Rotation matrix"""
-    return qc.to_rotmat(q)
+    return qc.to_rotmat(q.flatten())
                                 
 
 def from_rotmat(rotmat):
-    return qc.from_rotmat(rotmat)
+    return qc.from_rotmat(rotmat.flatten())
 
 
 def from_vectors(v1, v2):
-    return qc.from_vectors(v1, v2)
+    return qc.from_vectors(v1.flatten(), v2.flatten())
 

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -13,7 +13,7 @@ import scipy.sparse as sp
 
 import healpy as hp
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from .tod import TOD
 

--- a/toast/tod/sim_noise.py
+++ b/toast/tod/sim_noise.py
@@ -13,7 +13,7 @@ import scipy.sparse as sp
 
 import healpy as hp
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from .tod import TOD
 

--- a/toast/tod/sim_tod.py
+++ b/toast/tod/sim_tod.py
@@ -19,7 +19,7 @@ import scipy.sparse as sp
 
 import healpy as hp
 
-import quaternionarray as qa
+from . import qarray as qa
 
 from .tod import TOD
 


### PR DESCRIPTION
This switches the codebase to using the internal C quaternion operations and the internal python interface around the Random123 library.  Unit tests pass, as well as demonstrated consistency with litebird-like and Core noise simulations.