### PR TITLE
arraylist_dot and qarray types

### DIFF
--- a/doc/nersc.rst
+++ b/doc/nersc.rst
@@ -3,35 +3,19 @@
 Using at NERSC
 ====================
 
-To use TOAST at NERSC, you need to have a Python3 software stack with all dependencies installed.  There are several ways to achieve this.
+To use TOAST at NERSC, you need to have a Python3 software stack with all dependencies installed.  There is already such a software stack installed on edison and cori.
 
+Module Files
+---------------
 
-Temporary Solution
+To get access to the needed module files, add the machine-specific module file location to your search path::
+
+    %> module use /global/common/${NERSC_HOST}/contrib/hpcosmo/modulefiles
+
+Load Dependencies
 --------------------
 
-For now, you can use a python 3.4 software stack built by Ted on edison and cori.  On edison::
+In order to load a full python-3.5 stack, and also all dependencies needed by toast, do::
 
-    %> module use /scratch1/scratchdirs/kisner/software/modulefiles
-    %> module load toast
-
-OR::
-
-    %> module use /scratch1/scratchdirs/kisner/software/modulefiles
     %> module load toast-deps
-
-And then build and install your own copy of toast.  On cori, the path is different::
-
-    %> module use /global/cscratch1/sd/kisner/software/modulefiles
-    %> module load toast
-
-OR::
-
-    %> module use /global/cscratch1/sd/kisner/software/modulefiles
-    %> module load toast-deps
-
-
-NERSC Intel Python / Anaconda
----------------------------------
-
-We will be moving towards a solution using NERSC-supported python3 within a conda environment, with some extra packages.  TBD.
 

--- a/tests/test_qarray.py
+++ b/tests/test_qarray.py
@@ -33,6 +33,17 @@ class QarrayTest(MPITestCase):
         self.rot_by_q2 = np.array([0.8077876, 0.3227185, 0.49328689])
 
 
+    def test_arraylist_dot_onedimarrays(self):
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec, self.vec +1), np.dot(self.vec, self.vec +1))
+
+    def test_arraylist_dot_1dimbymultidim(self):
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec), np.dot(self.vec2,self.vec))
+
+    def test_arraylist_dot_multidim(self):
+        result = np.hstack(np.dot(v1,v2) for v1,v2 in zip(self.vec2, self.vec2+1))
+        np.testing.assert_array_almost_equal(qarray.arraylist_dot(self.vec2, self.vec2 +1), result)
+
+
     def test_inv(self):
         np.testing.assert_array_almost_equal(qarray.inv(self.q1) , self.q1inv)
 

--- a/toast/tod/_qarray.pyx
+++ b/toast/tod/_qarray.pyx
@@ -14,6 +14,7 @@ ctypedef np.int32_t i32_t
 
 
 cdef extern from "pytoast.h":
+    void pytoast_qarraylist_dot(int n, int m, int d, const double* a, const double* b, double* dotprod);
     void pytoast_qinv(int n, double* q)
     void pytoast_qamplitude(int n, int m, int d, const double* v, double* l2)
     void pytoast_qnorm(int n, int m, int d, const double* q_in, double* q_out)
@@ -28,6 +29,14 @@ cdef extern from "pytoast.h":
     void pytoast_to_rotmat(const double* q, double* rotmat)
     void pytoast_from_rotmat(const double* rotmat, double* q)
     void pytoast_from_vectors(const double* vec1, const double* vec2, double* q)
+
+
+def arraylist_dot(int n, int m, int d, np.ndarray[f64_t, ndim=1] a, np.ndarray[f64_t, ndim=1] b):
+    a = np.ascontiguousarray(a)
+    b = np.ascontiguousarray(b)
+    cdef np.ndarray[f64_t, ndim=1, mode='c'] out = np.zeros(n, dtype=f64)
+    pytoast_qarraylist_dot(n, m, d, <double*>a.data, <double*>b.data, <double*>out.data)
+    return out
 
 
 def inv(int n, np.ndarray[f64_t, ndim=1] q):

--- a/toast/tod/qarray.py
+++ b/toast/tod/qarray.py
@@ -8,6 +8,41 @@ import numpy as np
 from . import _qarray as qc
 
 
+def arraylist_dot(a, b):
+    """Dot product of a lists of arrays, returns a column array"""
+    na = None
+    ma = None
+    if a.ndim == 1:
+        na = 1
+        ma = a.shape[0]
+    else:
+        na = a.shape[0]
+        ma = a.shape[1]
+    nb = None
+    mb = None
+    if b.ndim == 1:
+        nb = 1
+        mb = b.shape[0]
+    else:
+        nb = b.shape[0]
+        mb = b.shape[1]
+
+    if ma != mb:
+        raise RuntimeError("vector elements of both arrays must have the same length.")
+    if (na > 1) and (nb > 1) and (na != nb):
+        raise RuntimeError("vector arrays must have length one or matching lengths.")
+    n = np.max([na, nb])
+
+    aa = a
+    if na != n:
+        aa = np.tile(a, n)
+    bb = b
+    if nb != n:
+        bb = np.tile(b, n)
+
+    return qc.arraylist_dot(n, ma, ma, aa.flatten().astype(np.float64, copy=False), bb.flatten().astype(np.float64, copy=False))
+
+
 def inv(q):
     """Inverse of quaternion array q"""
     nq = None
@@ -15,7 +50,7 @@ def inv(q):
         nq = 1
     else:
         nq = q.shape[0]
-    return qc.inv(nq, q.flatten())
+    return qc.inv(nq, q.flatten().astype(np.float64, copy=False))
 
 
 def amplitude(v):
@@ -28,7 +63,7 @@ def amplitude(v):
     else:
         nv = v.shape[0]
         nm = v.shape[1]
-    return qc.amplitude(nv, nm, v.flatten())
+    return qc.amplitude(nv, nm, v.flatten().astype(np.float64, copy=False))
 
 
 def norm(q):
@@ -38,7 +73,7 @@ def norm(q):
         nq = 1
     else:
         nq = q.shape[0]
-    return qc.norm(nq, q.flatten())
+    return qc.norm(nq, q.flatten().astype(np.float64, copy=False))
 
 
 def rotate(q, v):
@@ -69,7 +104,7 @@ def rotate(q, v):
     if nq != n:
         qq = np.tile(q, n)
 
-    return qc.rotate(n, qq.flatten(), vv.flatten())
+    return qc.rotate(n, qq.flatten().astype(np.float64, copy=False), vv.flatten().astype(np.float64, copy=False))
 
 
 def mult(p, q):
@@ -98,12 +133,12 @@ def mult(p, q):
     if nq != n:
         qq = np.tile(q, n)
 
-    return qc.mult(n, pp.flatten(), qq.flatten())
+    return qc.mult(n, pp.flatten().astype(np.float64, copy=False), qq.flatten().astype(np.float64, copy=False))
 
 
 def slerp(targettime, time, q):
     """Slerp, q quaternion array interpolated from time to targettime"""
-    return qc.slerp(targettime, time, q.flatten())
+    return qc.slerp(targettime, time, q.flatten().astype(np.float64, copy=False))
 
 
 def exp(q):
@@ -113,7 +148,7 @@ def exp(q):
         nq = 1
     else:
         nq = q.shape[0]    
-    return qc.exp(nq, q.flatten())
+    return qc.exp(nq, q.flatten().astype(np.float64, copy=False))
 
 
 def ln(q):
@@ -123,7 +158,7 @@ def ln(q):
         nq = 1
     else:
         nq = q.shape[0]    
-    return qc.ln(nq, q.flatten())
+    return qc.ln(nq, q.flatten().astype(np.float64, copy=False))
 
 
 def pow(q, p):
@@ -156,7 +191,7 @@ def pow(q, p):
     if nq != n:
         qq = np.tile(q, n)
 
-    return qc.pow(qq.flatten(), pp.flatten())
+    return qc.pow(qq.flatten().astype(np.float64, copy=False), pp.flatten().astype(np.float64, copy=False))
 
     
 def rotation(axis, angle):
@@ -189,7 +224,7 @@ def rotation(axis, angle):
     else:
         ang = np.tile(angle, n) 
 
-    return qc.rotation(ax.flatten(), ang.flatten())
+    return qc.rotation(ax.flatten().astype(np.float64, copy=False), ang.flatten().astype(np.float64, copy=False))
 
 
 def to_axisangle(q):
@@ -198,18 +233,18 @@ def to_axisangle(q):
         nq = 1
     else:
         nq = q.shape[0]
-    return qc.to_axisangle(nq, q.flatten())
+    return qc.to_axisangle(nq, q.flatten().astype(np.float64, copy=False))
 
 
 def to_rotmat(q):
     """Rotation matrix"""
-    return qc.to_rotmat(q.flatten())
+    return qc.to_rotmat(q.flatten().astype(np.float64, copy=False))
                                 
 
 def from_rotmat(rotmat):
-    return qc.from_rotmat(rotmat.flatten())
+    return qc.from_rotmat(rotmat.flatten().astype(np.float64, copy=False))
 
 
 def from_vectors(v1, v2):
-    return qc.from_vectors(v1.flatten(), v2.flatten())
+    return qc.from_vectors(v1.flatten().astype(np.float64, copy=False), v2.flatten().astype(np.float64, copy=False))
 


### PR DESCRIPTION
Ensure that ndarrays passed to cython code are always type float64.  Add arraylist_dot back into the public API.