### PR TITLE
Fix use of the RNG for noise generation

### DIFF
--- a/tests/test_ops_simnoise.py
+++ b/tests/test_ops_simnoise.py
@@ -190,8 +190,7 @@ class OpSimNoiseTest(MPITestCase):
             print("det {} PSD integral = {}".format(det, psum))
             err = variance * np.sqrt(2.0/(ntod-1))
             print("det {} expected error on variance = {}".format(det, err))
-            #self.assertTrue(np.absolute(psum - variance) < err)
-        self.assertTrue(False)
+            self.assertTrue(np.absolute(psum - variance) < err)
         
         stop = MPI.Wtime()
         elapsed = stop - start

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -17,23 +17,23 @@ class RNGTest(MPITestCase):
 
     def setUp(self):
         #data
-        self.size = 6
+        self.size = 11
         self.counter = [1357111317,888118218888]
-        self.key = [0xfeedbead,0xbaadcafe]
+        self.key = [3405692589,3131965165]
         self.counter00 = [0,0]
         self.key00 = [0,0]
 
-        # C test output with counter=[1357111317,888118218888] and key=[0xfeedbead,0xbaadcafe]
-        self.array_gaussian = np.array([ 2.275196 , -1.671555 , -0.389303 , -1.649345 , -0.123563 , -0.675699 ], np.float64)
-        self.array_m11 = np.array([ 0.701690 , 0.037174 , -0.926218 , 0.475780 , -0.942428 , -0.420310 ], np.float64)
-        self.array_01 = np.array([ 0.350845 , 0.018587 , 0.536891 , 0.237890 , 0.528786 , 0.789845 ], np.float64)
-        self.array_uint64 = np.array([ 6471948635099375789 , 342865335310108017 , 9903888746739875372 , 4388295497737174248 , 9754383911267064809 , 14570067135682199833 ], np.uint64)
+        # C test output with counter=[1357111317,888118218888] and key=[3405692589,3131965165]
+        self.array_gaussian = np.array([-0.602799, 2.141513, -0.433604, 0.493275, -0.037459, -0.926340, -0.536562, -0.064849, -0.662582, -1.024292, -0.170119], np.float64)
+        self.array_m11 = np.array([-0.951008, 0.112014, -0.391117, 0.858437, -0.232332, -0.929797, 0.513278, -0.722889, -0.439833, 0.814677, 0.466897], np.float64)
+        self.array_01 = np.array([0.524496, 0.056007, 0.804442, 0.429218, 0.883834, 0.535102, 0.256639, 0.638556, 0.780084, 0.407338, 0.233448], np.float64)
+        self.array_uint64 = np.array([9675248043493244317, 1033143684219887964, 14839328367301273822, 7917682351778602270, 16303863741333868668, 9870884412429777903, 4734154306332135586, 11779270208507399991, 14390002533568630569, 7514066637753215609, 4306362335420736255], np.uint64)
 
         # C test output with counter=[0,0] and key=[0,0]
-        self.array00_gaussian = np.array([ -1.286392 , 0.085829 , -1.131298 , -0.845273 , 1.076501 , -0.115413 ], np.float64)
-        self.array00_m11 = np.array([ -0.478794 , 0.871153 , -0.704256 , 0.737851 , 0.533997 , -0.886999 ], np.float64)
-        self.array00_01 = np.array([ 0.760603 , 0.435576 , 0.647872 , 0.368925 , 0.266998 , 0.556500 ], np.float64)
-        self.array00_uint64 = np.array([ 14030652003081164901 , 8034964082011408461 , 11951131804325250240 , 6805473726779904618 , 4925249918008276254 , 10265621268231006908 ], np.uint64)
+        self.array00_gaussian = np.array([-0.680004, -0.633214, -1.523790, -1.847484, -0.427139, 0.991348, 0.601200, 0.481707, -0.085967, 0.110980, -1.220734], np.float64)
+        self.array00_m11 = np.array([-0.478794, -0.704256, 0.533997, 0.004571, 0.392376, -0.785938, -0.373569, 0.866371, 0.325575, -0.266422, 0.937621], np.float64)
+        self.array00_01 = np.array([0.760603, 0.647872, 0.266998, 0.002285, 0.196188, 0.607031, 0.813215, 0.433185, 0.162788, 0.866789, 0.468810], np.float64)
+        self.array00_uint64 = np.array([14030652003081164901, 11951131804325250240, 4925249918008276254, 42156276261651215, 3619028682724454876, 11197741606642300638, 15001177968947004470, 7990859118804543502, 3002902877118036975, 15989435820833075781, 8648023362736035120], np.uint64)
 
 
     def test_rng_gaussian(self):
@@ -46,6 +46,11 @@ class RNGTest(MPITestCase):
         result = random(self.size, counter=self.counter00, key=self.key00)
         self.assertTrue((result > -10).all() and (result < 10).all())
         np.testing.assert_array_almost_equal(result, self.array00_gaussian)
+
+        # Test reproducibility
+        result1 = random(20, counter=[0,0], key=[0,0])
+        result2 = random(20, counter=[0,5], key=[0,0])
+        np.testing.assert_array_almost_equal(result1[5:], result2[:-5])
 
     def test_rng_m11(self):
         # Testing with any counter and any key

--- a/toast/_rng.pyx
+++ b/toast/_rng.pyx
@@ -9,48 +9,44 @@ ctypedef np.int64_t i64_t
 ctypedef np.uint64_t u64_t
 
 cdef extern from "pytoast.h":
-    void generate_grv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
-    void generate_neg11rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
-    void generate_01rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
-    void generate_uint64rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, u64_t* rand_array)
+    void pytoast_generate_grv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
+    void pytoast_generate_neg11rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
+    void pytoast_generate_01rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, f64_t* rand_array)
+    void pytoast_generate_uint64rv(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, u64_t* rand_array)
 
 
 def cbrng_normal(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, np.ndarray[f64_t, ndim=1] rand_array):
     """Returns an array of gaussian random variables based on the threefry2x64 counter-based random number generator"""
-    size = size - size%2
     # Perform array boundary check
     if np.shape(rand_array)[0] < (size+offset):
         print("Specified size & offset is out of array bounds")
         return
-    generate_grv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
+    pytoast_generate_grv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
     return
 
 def cbrng_uniform_01_f64(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, np.ndarray[f64_t, ndim=1] rand_array):
     """Returns an array of uniform random variables in (0,1) based on the threefry2x64 counter-based random number generator"""
-    size = size - size%2
     # Perform array boundary check
     if np.shape(rand_array)[0] < (size+offset):
         print("Specified size & offset is out of array bounds")
         return
-    generate_01rv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
+    pytoast_generate_01rv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
     return
 
 def cbrng_uniform_m11_f64(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, np.ndarray[f64_t, ndim=1] rand_array):
     """Returns an array of uniform random variables in (0,1) based on the threefry2x64 counter-based random number generator"""
-    size = size - size%2
     # Perform array boundary check
     if np.shape(rand_array)[0] < (size+offset):
         print("Specified size & offset is out of array bounds")
         return
-    generate_neg11rv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
+    pytoast_generate_neg11rv(size, offset, counter1, counter2, key1, key2, <f64_t*>rand_array.data)
     return
 
 def cbrng_uniform_uint64(u64_t size, u64_t offset, u64_t counter1, u64_t counter2, u64_t key1, u64_t key2, np.ndarray[u64_t, ndim=1] rand_array):
     """Returns an array of natural random variables in (unsigned 64-bit integer) based on the threefry2x64 counter-based random number generator"""
-    size = size - size%2
     # Perform array boundary check
     if np.shape(rand_array)[0] < (size+offset):
         print("Specified size & offset is out of array bounds")
         return
-    generate_uint64rv(size, offset, counter1, counter2, key1, key2, <u64_t*>rand_array.data)
+    pytoast_generate_uint64rv(size, offset, counter1, counter2, key1, key2, <u64_t*>rand_array.data)
     return

--- a/toast/ctoast/Makefile
+++ b/toast/ctoast/Makefile
@@ -12,14 +12,14 @@ HEADERS = pytoast.h
 
 LIBOBJ = pytoast_mem.o pytoast_qarray.o pytoast_rng.o
 
-all : test_mem test_qarray test_rng
+all : test_mem test_rng
 
 
 test_mem : test_mem.o libctoast.a
 	$(CC) -o test_mem test_mem.o libctoast.a $(LIBS)
 
-test_qarray : test_qarray.o libctoast.a
-	$(CC) -o test_qarray test_qarray.o libctoast.a $(LIBS)
+# test_qarray : test_qarray.o libctoast.a
+# 	$(CC) -o test_qarray test_qarray.o libctoast.a $(LIBS)
 
 test_rng : test_rng.o
 	$(CC) -o test_rng test_rng.o libctoast.a $(LIBS)

--- a/toast/ctoast/pytoast.h
+++ b/toast/ctoast/pytoast.h
@@ -129,26 +129,17 @@ void pytoast_from_vectors(const double* vec1, const double* vec2, double* q);
 
 /* counter-based random number generation with Random123 library */
 
-#if !defined(NO_SINCOS) && defined(__APPLE__)
-/* MacOS X 10.10.5 (2015) doesn't have sincos */
-#define NO_SINCOS 1
-#endif
+double pytoast_uneg11(uint64_t in);
 
-#if NO_SINCOS /* enable this if sincos are not in the math library */
-void sincos(double x, double *s, double *c);
-#endif /* sincos is not in the math library */
+double pytoast_u01(uint64_t in);
 
-double uneg11(uint64_t in);
+void pytoast_generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
 
-double u01(uint64_t in);
+void pytoast_generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
 
-void generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
+void pytoast_generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
 
-void generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
-
-void generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array);
-
-void generate_uint64rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, uint64_t* rand_array);
+void pytoast_generate_uint64rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, uint64_t* rand_array);
 
 
 #endif

--- a/toast/ctoast/pytoast_rng.c
+++ b/toast/ctoast/pytoast_rng.c
@@ -6,32 +6,19 @@ a BSD-style license that can be found in the LICENSE file.
 
 
 /* Interface function for counter-based random number generation */
-
+#include <stdio.h>
 #include <stdint.h>
 #include <math.h>
 
 #include <threefry.h>
 #include <pytoast.h>
 
-/* We might consider implementing a version returning 4 random number per rng call (using threefry4x64) for better efficiency */
-
-/* 
- * Some versions of OS X do not have sincos in the standard math library.
- * Also, some versions of the math library on Linux requre GNU extensions
- * to be enabled to access this function.  Rather than get into complicated
- * logic to detect OS features, we just define our own function.  If this
- * really becomes a performance issue, we can investigate at that time.
- */
-void rng_sincos(double x, double *s, double *c) {
-    *s = sin(x);
-    *c = cos(x);
-}
 
 /*
  * Converts unsigned 64-bit integer to double.
  * Output is as dense as possible in (0,1), never 0.0.
  */
-double u01(uint64_t in) {
+double pytoast_u01(uint64_t in) {
     double factor = 1. / (UINT64_MAX + 1.);
     double halffactor = 0.5 * factor;
     return (in * factor + halffactor);
@@ -41,7 +28,7 @@ double u01(uint64_t in) {
  * Converts unsigned 64-bit integer to double.
  * Output is as dense as possible in (-1,1), never 0.0.
  */
-double uneg11(uint64_t in) {
+double pytoast_uneg11(uint64_t in) {
     double factor = 1. / (INT64_MAX + 1.);
     double halffactor = 0.5 * factor;
     return (((int64_t)in) * factor + halffactor);
@@ -55,30 +42,22 @@ double uneg11(uint64_t in) {
  * counter1 and counter2: first and second 64-bit component of the counter
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
-void generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
+void pytoast_generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
     uint64_t i;
     threefry2x64_ctr_t rand;
 
     /* Box-Muller transform variables */
-    const double PI = 3.1415926535897932;
-    double x, y, r;
+    double twoPI = 2.0 * 3.1415926535897932;
 
     threefry2x64_key_t key={{key1, key2}};
     threefry2x64_ctr_t ctr={{counter1, counter2}};
 
-    for (i = 0; i < (size - (size%2)); i+=2) {
+    for (i = 0; i < size; i++) {
         rand = threefry2x64(ctr, key);
-        rand_array[i+offset] = rand.v[0];
-        rand_array[i+1+offset] = rand.v[1];
-
-        rng_sincos(PI*uneg11(rand_array[i+offset]), &x, &y);
-        r = sqrt(-2. * log(u01(rand_array[i+1+offset])));
-
-        rand_array[i+offset] = x * r;
-        rand_array[i+1+offset] = y * r;
-
+        rand_array[i+offset] = sqrt(-2.0 * log(pytoast_u01(rand.v[0]))) * cos(twoPI * pytoast_u01(rand.v[1]));
         ctr.v[1]++;
     }
+    return;
 }
 
 /*
@@ -89,20 +68,19 @@ void generate_grv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t co
  * counter1 and counter2: first and second 64-bit component of the counter
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
-void generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
+void pytoast_generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
     uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};
     threefry2x64_ctr_t ctr={{counter1, counter2}};
 
-    for (i = 0; i < (size - (size%2)); i+=2) {
+    for (i = 0; i < size; i++) {
         rand = threefry2x64(ctr, key);
-        rand_array[i+offset] = uneg11(rand.v[0]);
-        rand_array[i+1+offset] = uneg11(rand.v[1]);
-
+        rand_array[i+offset] = pytoast_uneg11(rand.v[0]);
         ctr.v[1]++;
     }
+    return;
 }
 
 /*
@@ -113,20 +91,19 @@ void generate_neg11rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_
  * counter1 and counter2: first and second 64-bit component of the counter
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
-void generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
+void pytoast_generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, double* rand_array) {
     uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};
     threefry2x64_ctr_t ctr={{counter1, counter2}};
 
-    for (i = 0; i < (size - (size%2)); i+=2) {
+    for (i = 0; i < size; i++) {
         rand = threefry2x64(ctr, key);
-        rand_array[i+offset] = u01(rand.v[0]);
-        rand_array[i+1+offset] = u01(rand.v[1]);
-
+        rand_array[i+offset] = pytoast_u01(rand.v[0]);
         ctr.v[1]++;
     }
+    return;
 }
 
 
@@ -138,19 +115,18 @@ void generate_01rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t c
  * counter1 and counter2: first and second 64-bit component of the counter
  * rand_array: array of size at least [offset+size] where the random variables are written
  */
-void generate_uint64rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, uint64_t* rand_array) {
+void pytoast_generate_uint64rv(uint64_t size, uint64_t offset, uint64_t counter1, uint64_t counter2, uint64_t key1, uint64_t key2, uint64_t* rand_array) {
     uint64_t i;
     threefry2x64_ctr_t rand;
 
     threefry2x64_key_t key={{key1, key2}};
     threefry2x64_ctr_t ctr={{counter1, counter2}};
 
-    for (i = 0; i < (size - (size%2)); i+=2) {
+    for (i = 0; i < size; i++) {
         rand = threefry2x64(ctr, key);
         rand_array[i+offset] = rand.v[0];
-        rand_array[i+1+offset] = rand.v[1];
-
         ctr.v[1]++;
     }
+    return;
 }
 

--- a/toast/ctoast/test_rng.c
+++ b/toast/ctoast/test_rng.c
@@ -11,43 +11,68 @@ test the implementation of quaternion arrays.
 int main(int argc, char const *argv[])
 {
     int i;
-    int n = 11, offset = 2;
+    int n = 11, offset = 1;
     uint64_t counter1 = 1357111317, counter2 = 888118218888;
-    uint64_t key1 = 0xcafebead, key2 = 0xbaadfeed;
-    if(argc>1) counter1 = atoi(argv[1]);
-    if(argc>2) counter2 = atoi(argv[2]);
-    if(argc>3) key1 = atoi(argv[3]);
-    if(argc>4) key2 = atoi(argv[4]);
-    double * array_f64 = malloc( (n + 2 * offset) * sizeof(double) );
-    uint64_t * array_uint64 = malloc( (n + 2 * offset) * sizeof(uint64_t) );
+    uint64_t key1 = 3405692589, key2 = 3131965165;
 
-    generate_grv(n, offset, counter1, counter2, key1, key2, array_f64);
+    double * array_f64 = malloc( (n + offset) * sizeof(double) );
+    uint64_t * array_uint64 = malloc( (n + offset) * sizeof(uint64_t) );
 
-    printf("x_gaussian = [ %f ", array_f64[0]);
-    for (i = 1; i < (n + 2 * offset); ++i) printf(", %f ", array_f64[i]);
-    printf("];\n");
+    pytoast_generate_grv(n, offset, counter1, counter2, key1, key2, array_f64);
 
+    printf("x_gaussian = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
 
-    generate_neg11rv(n, offset, counter1, counter2, key1, key2, array_f64);
+    pytoast_generate_neg11rv(n, offset, counter1, counter2, key1, key2, array_f64);
 
-    printf("x_m11 = [ %f ", array_f64[0]);
-    for (i = 1; i < (n + 2 * offset); ++i) printf(", %f ", array_f64[i]);
-    printf("];\n");
+    printf("x_m11 = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
 
- 
-    generate_01rv(n, offset, counter1, counter2, key1, key2, array_f64);
+    pytoast_generate_01rv(n, offset, counter1, counter2, key1, key2, array_f64);
 
-    printf("x_01 = [ %f ", array_f64[0]);
-    for (i = 1; i < (n + 2 * offset); ++i) printf(", %f ", array_f64[i]);
-    printf("];\n");
+    printf("x_01 = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
 
+    pytoast_generate_uint64rv(n, offset, counter1, counter2, key1, key2, array_uint64);
 
-    generate_uint64rv(n, offset, counter1, counter2, key1, key2, array_uint64);
+    printf("x_uint64 = [");
+    for (i = 0; i < n; ++i) printf("%lu, ", (long unsigned)array_uint64[offset+i]);
+    printf("]\n");
 
-    printf("x_uint64 = [ %lu ", (long unsigned)array_uint64[0]);
-    for (i = 1; i < (n + 2 * offset); ++i) printf(", %lu ", (long unsigned)array_uint64[i]);
-    printf("];\n");
+    counter1 = 0;
+    counter2 = 0;
+    key1 = 0;
+    key2 = 0;
 
+    pytoast_generate_grv(n, offset, counter1, counter2, key1, key2, array_f64);
+
+    printf("x_gaussian = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
+
+    pytoast_generate_neg11rv(n, offset, counter1, counter2, key1, key2, array_f64);
+
+    printf("x_m11 = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
+
+    pytoast_generate_01rv(n, offset, counter1, counter2, key1, key2, array_f64);
+
+    printf("x_01 = [");
+    for (i = 0; i < n; ++i) printf("%f, ", array_f64[offset+i]);
+    printf("]\n");
+
+    pytoast_generate_uint64rv(n, offset, counter1, counter2, key1, key2, array_uint64);
+
+    printf("x_uint64 = [");
+    for (i = 0; i < n; ++i) printf("%lu, ", (long unsigned)array_uint64[offset+i]);
+    printf("]\n");
+
+    free(array_f64);
+    free(array_uint64);
 
     return 0;
 }

--- a/toast/rng.py
+++ b/toast/rng.py
@@ -8,7 +8,7 @@ import numpy as np
 from ._rng import *
 
 
-def random(samples, counter, sampler="gaussian", key=(0xcafebead,0xbaadfeed)):
+def random(samples, counter=(0,0), sampler="gaussian", key=(0,0)):
     """
     High level interface to internal Random123 library.
 
@@ -18,11 +18,11 @@ def random(samples, counter, sampler="gaussian", key=(0xcafebead,0xbaadfeed)):
     Args:
         samples (int): The number of samples to return.
         counter (tuple): Two uint64 values which (along with the key) define
-            the state of the generator.
+            the starting state of the generator.
         sampler (string): The distribution to sample from.  Allowed values are
             "gaussian", "uniform_01", "uniform_m11", and "uniform_uint64".
         key (tuple): Two uint64 values which (along with the counter) define
-            the state of the generator.
+            the starting state of the generator.
     Returns:
         array: The random values of appropriate type for the sampler.
     """

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -169,7 +169,7 @@ class OpSimNoise(Operator):
 
                     detstream = self._rngstream + rngobs + (abschunk * ndet) + idet
 
-                    fdata = rng.random(fftlen, (detstream, self._realization), sampler="gaussian")
+                    fdata = rng.random(fftlen, sampler="gaussian", key=(self._realization, detstream), counter=(0,0))
 
                     # scale by PSD
 

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -114,7 +114,7 @@ class OpSimNoise(Operator):
                 while fftlen <= (self._oversample * chksamp):
                     fftlen *= 2
                 half = int(fftlen / 2)
-                norm = rate * half;
+                norm = 0.5 * rate * float(half)
                 df = rate / fftlen
 
                 freq = np.linspace(df, df*half, num=half, endpoint=True)
@@ -175,9 +175,9 @@ class OpSimNoise(Operator):
 
                     scale = np.sqrt(psd * norm)
 
-                    fdata[0] *= 0.0
+                    fdata[0] *= np.sqrt(2.0) * scale[0]
                     fdata[1:half] *= scale[0:-1]
-                    fdata[half] *= np.sqrt(2 * scale[-1])
+                    fdata[half] *= np.sqrt(2.0) * scale[-1]
                     fdata[half+1:] *= scale[-2::-1]
 
                     #np.savetxt("out_simnoise_fdata.txt", fdata, delimiter='\n')

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -88,7 +88,7 @@ class OpSimNoise(Operator):
             if tod.local_chunks is None:
                 raise RuntimeError('noise simulation for uniform distributed samples not implemented')
 
-            # for purposes of incrementing the random seed, find
+            # for purposes of incrementing the random stream, find
             # the number of detectors
             alldets = tod.detectors
             ndet = len(alldets)

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -114,7 +114,7 @@ class OpSimNoise(Operator):
                 while fftlen <= (self._oversample * chksamp):
                     fftlen *= 2
                 half = int(fftlen / 2)
-                norm = 0.5 * rate * float(half)
+                norm = rate * float(half)
                 df = rate / fftlen
 
                 freq = np.linspace(df, df*half, num=half, endpoint=True)


### PR DESCRIPTION
When using wrapped Random123 functions, use the MC index and stream as the key to select the generating function.  One element of the counter is used for the sample index.  Only use one returned value from the generator when creating uniform randoms, which ensures reproducibility of a given sample.  Use both returned values when generating a single normal distributed sample with Box-Mueller.  Also add much more extensive tests of the noise TOD normalization. 