### PR TITLE
Fix ctypes loading in case of no MPI

### DIFF
--- a/pipelines/toast_cov_invert.py
+++ b/pipelines/toast_cov_invert.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/pipelines/toast_cov_rcond.py
+++ b/pipelines/toast_cov_rcond.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_cov.py
+++ b/tests/test_cov.py
@@ -7,7 +7,7 @@ import sys
 import os
 import shutil
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_map_satellite.py
+++ b/tests/test_map_satellite.py
@@ -7,7 +7,7 @@ import sys
 import os
 import shutil
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_ops_madam.py
+++ b/tests/test_ops_madam.py
@@ -7,7 +7,7 @@ import sys
 import os
 import shutil
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_ops_pmat.py
+++ b/tests/test_ops_pmat.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_ops_simnoise.py
+++ b/tests/test_ops_simnoise.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_psd_math.py
+++ b/tests/test_psd_math.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/tests/test_tod.py
+++ b/tests/test_tod.py
@@ -6,7 +6,7 @@
 import sys
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/dist.py
+++ b/toast/dist.py
@@ -5,7 +5,7 @@
 
 import os
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from . import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/fod/psd_math.py
+++ b/toast/fod/psd_math.py
@@ -3,7 +3,7 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from toast import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/map/madam.py
+++ b/toast/map/madam.py
@@ -4,7 +4,7 @@
 
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from .. import fakempi as MPI
 else:
     from mpi4py import MPI
@@ -22,15 +22,14 @@ from ..operator import Operator
 from ..tod import TOD
 from ..tod import Interval
 
-
-try:
-    libmadam = ct.CDLL('libmadam.so')
-except:
-    path = find_library('madam')
-    if path is not None:
-        libmadam = ct.CDLL(path)
-    else:
-        libmadam = None
+libmadam = None
+if 'TOAST_NO_MPI' not in os.environ.keys():
+    try:
+        libmadam = ct.CDLL('libmadam.so')
+    except:
+        path = find_library('madam')
+        if path is not None:
+            libmadam = ct.CDLL(path)
 
 if libmadam is not None:
     libmadam.destripe.restype = None

--- a/toast/map/pixels.py
+++ b/toast/map/pixels.py
@@ -4,7 +4,7 @@
 
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from .. import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/mpirunner.py
+++ b/toast/mpirunner.py
@@ -11,7 +11,7 @@ from unittest import TestCase
 from unittest import TextTestRunner
 from unittest import TestResult, TextTestResult
 
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from . import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/tod/conviqt.py
+++ b/toast/tod/conviqt.py
@@ -4,7 +4,7 @@
 
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from .. import fakempi as MPI
 else:
     from mpi4py import MPI
@@ -37,14 +37,14 @@ try:
 except Exception as e:
     raise Exception('Failed to set the portable MPI communicator datatype. MPI4py is probably too old. You need to have at least version 2.0. ({})'.format(e))
 
-try:
-    libconviqt = ct.CDLL('libconviqt.so')
-except:
-    path = find_library('conviqt')
-    if path is not None:
-        libconviqt = ct.CDLL(path)
-    else:
-        libconviqt = None
+libconviqt = None
+if 'TOAST_NO_MPI' not in os.environ.keys():
+    try:
+        libconviqt = ct.CDLL('libconviqt.so')
+    except:
+        path = find_library('conviqt')
+        if path is not None:
+            libconviqt = ct.CDLL(path)
 
 if libconviqt is not None:
     # Beam functions

--- a/toast/tod/sim_tod.py
+++ b/toast/tod/sim_tod.py
@@ -4,7 +4,7 @@
 
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from .. import fakempi as MPI
 else:
     from mpi4py import MPI

--- a/toast/tod/tod.py
+++ b/toast/tod/tod.py
@@ -4,7 +4,7 @@
 
 
 import os
-if 'PYTOAST_NOMPI' in os.environ.keys():
+if 'TOAST_NO_MPI' in os.environ.keys():
     from .. import fakempi as MPI
 else:
     from mpi4py import MPI


### PR DESCRIPTION
This avoids loading libmadam and libconviqt (both MPI libraries) if no MPI is in use.  Also, the environment variable that controls this has been changed to "TOAST_NO_MPI".