### PR TITLE
Binned map support

### DIFF
--- a/tests/test_binned.py
+++ b/tests/test_binned.py
@@ -54,18 +54,18 @@ class BinnedTest(MPITestCase):
         self.sim_nside = 32
         self.sim_npix = 12 * self.sim_nside**2
 
-        self.totsamp = 200000
+        self.totsamp = 20000000
 
         self.map_nside = 32
         self.map_npix = 12 * self.map_nside**2
         
-        self.rate = 40.0
-        self.spinperiod = 10.0
+        self.rate = 200.0
+        self.spinperiod = 1.0
         self.spinangle = 30.0
-        self.precperiod = 50.0
+        self.precperiod = 5.0
         self.precangle = 65.0
 
-        self.hwprpm = 50
+        self.hwprpm = 100
 
         self.subnside = int(self.map_nside / 4)
         self.subnpix = 12 * self.subnside**2
@@ -154,7 +154,7 @@ class BinnedTest(MPITestCase):
 
         signal = np.random.normal(size=nsamp)
 
-        nh._accumulate_noiseweighted(fakedata, sm, signal, pix, wt, scale, fakehits)
+        nh._accumulate_diagonal(fakedata, 1, fakehits, 1, np.zeros((1,1,1), dtype=np.float64), 0, signal, sm, pix, wt, scale)
 
         for i in range(nsamp):
             checkhits[sm[i], pix[i], 0] += 1
@@ -166,166 +166,294 @@ class BinnedTest(MPITestCase):
         return
 
 
-    # def test_binned(self):
-    #     start = MPI.Wtime()
+    def test_binned(self):
+        start = MPI.Wtime()
 
-    #     # generate noise timestreams from the noise model
-    #     nsig = OpSimNoise(stream=0)
-    #     nsig.exec(self.data)
+        # generate noise timestreams from the noise model
+        nsig = OpSimNoise(stream=0)
+        nsig.exec(self.data)
 
-    #     # make a simple pointing matrix
-    #     pointing = OpPointingHpix(nside=self.map_nside, nest=True, mode='IQU', hwprpm=self.hwprpm)
-    #     pointing.exec(self.data)
+        # make a simple pointing matrix
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, mode='IQU', hwprpm=self.hwprpm)
+        pointing.exec(self.data)
 
-    #     handle = None
-    #     if self.comm.rank == 0:
-    #         handle = open(os.path.join(self.mapdir,"info.txt"), "w")
-    #     self.data.info(handle)
-    #     if self.comm.rank == 0:
-    #         handle.close()
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.mapdir,"info.txt"), "w")
+        self.data.info(handle)
+        if self.comm.rank == 0:
+            handle.close()
 
-    #     # get locally hit pixels
-    #     lc = OpLocalPixels()
-    #     localpix = lc.exec(self.data)
+        # get locally hit pixels
+        lc = OpLocalPixels()
+        localpix = lc.exec(self.data)
 
-    #     # find the locally hit submaps.
-    #     allsm = np.floor_divide(localpix, self.subnpix)
-    #     sm = set(allsm)
-    #     localsm = np.array(sorted(sm), dtype=np.int64)
+        # find the locally hit submaps.
+        allsm = np.floor_divide(localpix, self.subnpix)
+        sm = set(allsm)
+        localsm = np.array(sorted(sm), dtype=np.int64)
 
-    #     # construct distributed maps to store the covariance,
-    #     # noise weighted map, and hits
+        # construct distributed maps to store the covariance,
+        # noise weighted map, and hits
 
-    #     invnpp = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=6, dtype=np.float64, submap=self.subnpix, local=localsm)
-    #     invnpp.data.fill(0.0)
+        invnpp = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=6, dtype=np.float64, submap=self.subnpix, local=localsm)
+        invnpp.data.fill(0.0)
 
-    #     zmap = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=3, dtype=np.float64, submap=self.subnpix, local=localsm)
-    #     zmap.data.fill(0.0)
+        zmap = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=3, dtype=np.float64, submap=self.subnpix, local=localsm)
+        zmap.data.fill(0.0)
 
-    #     hits = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=1, dtype=np.int64, submap=self.subnpix, local=localsm)
-    #     hits.data.fill(0)
+        hits = DistPixels(comm=self.toastcomm.comm_group, size=self.sim_npix, nnz=1, dtype=np.int64, submap=self.subnpix, local=localsm)
+        hits.data.fill(0)
 
-    #     # accumulate the inverse covariance.  Use detector weights
-    #     # based on the analytic NET.
+        # accumulate the inverse covariance and noise weighted map.  
+        # Use detector weights based on the analytic NET.
 
-    #     tod = self.data.obs[0]['tod']
-    #     nse = self.data.obs[0]['noise']
-    #     detweights = {}
-    #     for d in tod.local_dets:
-    #         detweights[d] = 1.0 / (self.rate * nse.NET(d)**2)
+        tod = self.data.obs[0]['tod']
+        nse = self.data.obs[0]['noise']
+        detweights = {}
+        for d in tod.local_dets:
+            detweights[d] = 1.0 / (self.rate * nse.NET(d)**2)
 
-    #     build_invnpp = OpInvCovariance(detweights=detweights, invnpp=invnpp, hits=hits)
-    #     build_invnpp.exec(self.data)
+        build_invnpp = OpAccumDiag(detweights=detweights, invnpp=invnpp, hits=hits, zmap=zmap, name="noise")
+        build_invnpp.exec(self.data)
 
-    #     invnpp.allreduce()
-    #     hits.allreduce()
+        invnpp.allreduce()
+        hits.allreduce()
+        zmap.allreduce()
 
-    #     # invert it
-    #     covariance_invert(invnpp.data, 1.0e-6)
+        hits.write_healpix_fits(os.path.join(self.mapdir, "hits.fits"))
+        invnpp.write_healpix_fits(os.path.join(self.mapdir, "invnpp.fits"))
+        zmap.write_healpix_fits(os.path.join(self.mapdir, "zmap.fits"))
 
-    #     # accumulate the noise weighted map
+        # invert it
+        covariance_invert(invnpp.data, 1.0e-3)
 
-    #     build_zmap = OpNoiseWeighted(zmap=zmap, detweights=detweights, name="noise")
-    #     build_zmap.exec(self.data)
+        invnpp.write_healpix_fits(os.path.join(self.mapdir, "npp.fits"))
 
-    #     zmap.allreduce()
+        # compute the binned map, N_pp x Z
 
-    #     zmap.write_healpix_fits(os.path.join(self.mapdir, "zmap.fits"))
+        covariance_apply(invnpp.data, zmap.data)
+        zmap.write_healpix_fits(os.path.join(self.mapdir, "binned.fits"))
 
-    #     # compute the binned map, N_pp x Z
+        # compare with MADAM
 
-    #     covariance_apply(invnpp.data, zmap.data)
-    #     zmap.write_healpix_fits(os.path.join(self.mapdir, "binned.fits"))
+        madam_out = os.path.join(self.mapdir, "madam")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
 
-    #     # compare with MADAM
+        pars = {}
+        pars[ 'temperature_only' ] = 'F'
+        pars[ 'force_pol' ] = 'T'
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = self.map_nside
+        pars[ 'pixlim_cross' ] = 1.0e-2
+        pars[ 'pixlim_map' ] = 1.0e-3
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'T'
+        pars[ 'write_wcov' ] = 'T'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
 
-    #     madam_out = os.path.join(self.mapdir, "madam")
-    #     if self.comm.rank == 0:
-    #         if os.path.isdir(madam_out):
-    #             shutil.rmtree(madam_out)
-    #         os.mkdir(madam_out)
+        madam = OpMadam(params=pars, detweights=detweights, name="noise")
 
-    #     pars = {}
-    #     pars[ 'temperature_only' ] = 'F'
-    #     pars[ 'force_pol' ] = 'T'
-    #     pars[ 'kfirst' ] = 'F'
-    #     pars[ 'base_first' ] = 1.0
-    #     pars[ 'fsample' ] = self.rate
-    #     pars[ 'nside_map' ] = self.map_nside
-    #     pars[ 'nside_cross' ] = self.map_nside
-    #     pars[ 'nside_submap' ] = self.map_nside
-    #     pars[ 'pixlim_cross' ] = 1.0e-6
-    #     pars[ 'pixlim_map' ] = 1.0e-6
-    #     pars[ 'write_map' ] = 'F'
-    #     pars[ 'write_binmap' ] = 'T'
-    #     pars[ 'write_matrix' ] = 'F'
-    #     pars[ 'write_wcov' ] = 'F'
-    #     pars[ 'write_hits' ] = 'T'
-    #     pars[ 'kfilter' ] = 'F'
-    #     pars[ 'run_submap_test' ] = 'F'
-    #     pars[ 'path_output' ] = madam_out
+        if madam.available:
+            madam.exec(self.data)
 
-    #     madam = OpMadam(params=pars, detweights=detweights, name="noise")
+            if self.comm.rank == 0:
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
 
-    #     if madam.available:
-    #         madam.exec(self.data)
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
-    #         if self.comm.rank == 0:
-    #             hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
-    #             hits = hp.read_map(hitsfile, nest=True)
+                toastfile = os.path.join(self.mapdir, 'hits.fits')
+                toasthits = hp.read_map(toastfile, nest=True)
 
-    #             outfile = "{}.png".format(hitsfile)
-    #             hp.mollview(hits, xsize=1600, nest=True)
-    #             plt.savefig(outfile)
-    #             plt.close()
+                nt.assert_equal(hits, toasthits)
 
-    #             binfile = os.path.join(madam_out, 'madam_bmap.fits')
-    #             bins = hp.read_map(binfile, nest=True)
-    #             mask = hp.mask_bad(bins)
-    #             bins[mask] = 0.0
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp, tothits)
 
-    #             outfile = "{}.png".format(binfile)
-    #             hp.mollview(bins, xsize=1600, nest=True)
-    #             plt.savefig(outfile)
-    #             plt.close()
+                covfile = os.path.join(madam_out, 'madam_wcov_inv.fits')
+                cov = hp.read_map(covfile, nest=True, field=None)
 
-    #             toastfile = os.path.join(self.mapdir, 'binned.fits')
-    #             toastbins = hp.read_map(toastfile, nest=True)
+                toastfile = os.path.join(self.mapdir, 'invnpp.fits')
+                toastcov = hp.read_map(toastfile, nest=True, field=None)
 
-    #             outfile = "{}.png".format(toastfile)
-    #             hp.mollview(toastbins, xsize=1600, nest=True)
-    #             plt.savefig(outfile)
-    #             plt.close()
+                # for p in range(6):
+                #     print("elem {} madam min/max = ".format(p), np.min(cov[p]), " / ", np.max(cov[p]))
+                #     print("elem {} toast min/max = ".format(p), np.min(toastcov[p]), " / ", np.max(toastcov[p]))
+                #     print("elem {} invNpp max diff = ".format(p), np.max(np.absolute(toastcov[p] - cov[p])))
+                #     nt.assert_almost_equal(cov[p], toastcov[p])
 
-    #             zfile = os.path.join(self.mapdir, 'zmap.fits')
-    #             ztoast = hp.read_map(zfile, nest=True)
+                covfile = os.path.join(madam_out, 'madam_wcov.fits')
+                cov = hp.read_map(covfile, nest=True, field=None)
 
-    #             outfile = "{}.png".format(zfile)
-    #             hp.mollview(ztoast, xsize=1600, nest=True)
-    #             plt.savefig(outfile)
-    #             plt.close()
+                toastfile = os.path.join(self.mapdir, 'npp.fits')
+                toastcov = hp.read_map(toastfile, nest=True, field=None)
 
-    #             # compare binned map to madam output
+                # for p in range(6):
+                #     covdiff = toastcov[p] - cov[p]
+                #     print("elem {} madam min/max = ".format(p), np.min(cov[p]), " / ", np.max(cov[p]))
+                #     print("elem {} toast min/max = ".format(p), np.min(toastcov[p]), " / ", np.max(toastcov[p]))
+                #     print("elem {} Npp max diff = ".format(p), np.max(np.absolute(covdiff[p])))
+                #     print("elem {} Npp mean / rms diff = ".format(p), np.mean(covdiff[p]), " / ", np.std(covdiff[p]))
+                #     print("elem {} Npp relative diff mean / rms = ".format(p), np.mean(np.absolute(covdiff[p]/cov[p])), " / ", np.std(np.absolute(covdiff[p]/cov[p])))
+                #     nt.assert_almost_equal(cov[p], toastcov[p])
 
-    #             diffmap = toastbins - bins
-    #             outfile = "{}_diff_madam.png".format(toastfile)
-    #             hp.mollview(diffmap, xsize=1600, nest=True)
-    #             plt.savefig(outfile)
-    #             plt.close()
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True, field=None)
+                mask = hp.mask_bad(bins[0])
+                bins[0][mask] = 0.0
+                mask = hp.mask_bad(bins[1])
+                bins[1][mask] = 0.0
+                mask = hp.mask_bad(bins[2])
+                bins[2][mask] = 0.0
 
-    #             tothits = np.sum(hits)
-    #             nt.assert_equal(self.totsamp, tothits)
+                outfile = "{}_I.png".format(binfile)
+                hp.mollview(bins[0], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
-    #             mask = (bins > -1.0e10)
+                outfile = "{}_Q.png".format(binfile)
+                hp.mollview(bins[1], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
-    #             #nt.assert_almost_equal(bins[mask], toastbins[mask], decimal=4)
+                outfile = "{}_U.png".format(binfile)
+                hp.mollview(bins[2], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                toastfile = os.path.join(self.mapdir, 'binned.fits')
+                toastbins = hp.read_map(toastfile, nest=True, field=None)
+
+                outfile = "{}_I.png".format(toastfile)
+                hp.mollview(toastbins[0], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                outfile = "{}_Q.png".format(toastfile)
+                hp.mollview(toastbins[1], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                outfile = "{}_U.png".format(toastfile)
+                hp.mollview(toastbins[2], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to madam output
+
+                diffmap = toastbins[0] - bins[0]
+                mask = (bins[0] != 0)
+                # print("toast/madam I diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("toast/madam I diff rel ratio min / max = ", np.min(diffmap[mask]/bins[0][mask]), " / ", np.max(diffmap[mask]/bins[0][mask]))
+                outfile = "{}_diff_madam_I.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                #nt.assert_almost_equal(bins[0][mask], binserial[0][mask], decimal=6)
+
+                diffmap = toastbins[1] - bins[1]
+                mask = (bins[1] != 0)
+                # print("toast/madam Q diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("toast/madam Q diff rel ratio min / max = ", np.min(diffmap[mask]/bins[1][mask]), " / ", np.max(diffmap[mask]/bins[1][mask]))
+                outfile = "{}_diff_madam_Q.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                #nt.assert_almost_equal(bins[1][mask], binserial[1][mask], decimal=6)
+
+                diffmap = toastbins[2] - bins[2]
+                mask = (bins[2] != 0)
+                # print("toast/madam U diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("toast/madam U diff rel ratio min / max = ", np.min(diffmap[mask]/bins[2][mask]), " / ", np.max(diffmap[mask]/bins[2][mask]))
+                outfile = "{}_diff_madam_U.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                #nt.assert_almost_equal(bins[2][mask], binserial[2][mask], decimal=6)
 
 
-    #         stop = MPI.Wtime()
-    #         elapsed = stop - start
-    #         self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
-    #     else:
-    #         print("libmadam not available, skipping tests")
+                # compute the binned map serially as a check
 
-    #     return
+                zfile = os.path.join(self.mapdir, 'zmap.fits')
+                ztoast = hp.read_map(zfile, nest=True, field=None)
+
+                binserial = np.copy(ztoast)
+                for p in range(self.map_npix):
+                    binserial[0][p] = toastcov[0][p] * ztoast[0][p] + toastcov[1][p] * ztoast[1][p] + toastcov[2][p] * ztoast[2][p]
+                    binserial[1][p] = toastcov[1][p] * ztoast[0][p] + toastcov[3][p] * ztoast[1][p] + toastcov[4][p] * ztoast[2][p]
+                    binserial[2][p] = toastcov[2][p] * ztoast[0][p] + toastcov[4][p] * ztoast[1][p] + toastcov[5][p] * ztoast[2][p]
+
+                toastfile = os.path.join(self.mapdir, 'binned_serial')
+                outfile = "{}_I.png".format(toastfile)
+                hp.mollview(binserial[0], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                outfile = "{}_Q.png".format(toastfile)
+                hp.mollview(binserial[1], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                outfile = "{}_U.png".format(toastfile)
+                hp.mollview(binserial[2], xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to madam output
+
+                diffmap = binserial[0] - bins[0]
+                mask = (bins[0] != 0)
+                # print("serial/madam I diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("serial/madam I diff rel ratio min / max = ", np.min(diffmap[mask]/bins[0][mask]), " / ", np.max(diffmap[mask]/bins[0][mask]))
+                outfile = "{}_diff_madam_I.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                nt.assert_almost_equal(bins[0][mask], binserial[0][mask], decimal=6)
+
+                diffmap = binserial[1] - bins[1]
+                mask = (bins[1] != 0)
+                # print("serial/madam Q diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("serial/madam Q diff rel ratio min / max = ", np.min(diffmap[mask]/bins[1][mask]), " / ", np.max(diffmap[mask]/bins[1][mask]))
+                outfile = "{}_diff_madam_Q.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                nt.assert_almost_equal(bins[1][mask], binserial[1][mask], decimal=6)
+
+                diffmap = binserial[2] - bins[2]
+                mask = (bins[2] != 0)
+                # print("serial/madam U diff mean / std = ", np.mean(diffmap[mask]), np.std(diffmap[mask]))
+                # print("serial/madam U diff rel ratio min / max = ", np.min(diffmap[mask]/bins[2][mask]), " / ", np.max(diffmap[mask]/bins[2][mask]))
+                outfile = "{}_diff_madam_U.png".format(toastfile)
+                hp.mollview(diffmap, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                nt.assert_almost_equal(bins[2][mask], binserial[2][mask], decimal=6)
+
+
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+        else:
+            print("libmadam not available, skipping tests")
+
+        #self.assertTrue(False)
+
+        return
 

--- a/toast/map/__init__.py
+++ b/toast/map/__init__.py
@@ -9,6 +9,5 @@ from .madam import OpMadam
 
 from .pixels import OpLocalPixels, DistPixels
 
-from .noise import (OpInvCovariance, OpNoiseWeighted,
-    covariance_invert, covariance_rcond, covariance_multiply,
-    covariance_apply)
+from .noise import (OpAccumDiag, covariance_invert, covariance_rcond, 
+    covariance_multiply, covariance_apply)

--- a/toast/map/noise.py
+++ b/toast/map/noise.py
@@ -11,139 +11,31 @@ from ..dist import Comm, Data
 from ..operator import Operator
 from .pixels import DistPixels
 
-from ._noise import (_accumulate_inverse_covariance,
-    _invert_covariance, _cond_covariance, _multiply_covariance,
-    _accumulate_noiseweighted, _apply_covariance)
+from ._noise import (_accumulate_diagonal, _eigendecompose_covariance, 
+    _multiply_covariance, _apply_covariance)
 
 
-class OpInvCovariance(Operator):
+
+class OpAccumDiag(Operator):
     """
-    Operator which computes the diagonal inverse pixel covariance.
+    Operator which accumulates the diagonal covariance and noise weighted map.
 
     This operator requires that the local pointing matrix has already been
-    computed.  Each process has a local piece of the inverse covariance.
+    computed.  Each process has local pieces of the map products.  This
+    operator can optionally accumulate any combination of the hit map,
+    the white noise weighted map, and the diagonal inverse pixel covariance.
+
+    NOTE:  The input DistPixels objects (noise weighted map, hit map, and
+    inverse covariance) are purposefully NOT set to zero at the start.  This
+    allows accumulating multiple instances of the distributed data.  This might
+    be needed (for example) if all desired timestream data does not fit into
+    memory.  You should manually clear the pixel domain objects before
+    accumulation if desired.
 
     Args:
-        invnpp (DistPixels):  The matrix to accumulate.
+        zmap (DistPixels):  (optional) the noise weighted map to accumulate.
         hits (DistPixels):  (optional) the hits to accumulate.
-        detweights (dictionary): individual noise weights to use for each
-            detector.
-        flag_name (str): the name of the cache object (<flag_name>_<detector>) to
-            use for the detector flags.  If None, use the TOD.
-        flag_mask (int): the integer bit mask (0-255) that should be 
-            used with the detector flags in a bitwise AND.
-        common_flag_name (str): the name of the cache object 
-            (<common_flag_name>_<detector>) to use for the common flags.  
-            If None, use the TOD.
-        common_flag_mask (int): the integer bit mask (0-255) that should be 
-            used with the common flags in a bitwise AND.
-        apply_flags (bool): whether to apply flags to the pixel numbers.
-        pixels (str): the name of the cache object (<pixels>_<detector>)
-            containing the pixel indices to use.
-        weights (str): the name of the cache object (<weights>_<detector>)
-            containing the pointing weights to use.
-    """
-
-    def __init__(self, invnpp=None, hits=None, detweights=None, flag_name=None, 
-                flag_mask=255, common_flag_name=None, common_flag_mask=255, 
-                pixels='pixels', weights='weights', apply_flags=True):
-
-        self._flag_name = flag_name
-        self._flag_mask = flag_mask
-        self._common_flag_name = common_flag_name
-        self._common_flag_mask = common_flag_mask
-        self._apply_flags = apply_flags
-        
-        self._pixels = pixels
-        self._weights = weights
-        self._detweights = detweights
-
-        if invnpp is None:
-            raise RuntimeError("you must specify the invnpp to accumulate")
-        self._invnpp = invnpp
-
-        self._hits = hits
-
-        # We call the parent class constructor, which currently does nothing
-        super().__init__()
-
-
-    def exec(self, data):
-        """
-        Iterate over all observations and detectors and accumulate.
-        
-        Args:
-            data (toast.Data): The distributed data.
-        """
-        # the two-level pytoast communicator
-        comm = data.comm
-        # the global communicator
-        cworld = comm.comm_world
-        # the communicator within the group
-        cgroup = comm.comm_group
-        # the communicator with all processes with
-        # the same rank within their group
-        crank = comm.comm_rank
-
-        for obs in data.obs:
-            tod = obs['tod']
-            for det in tod.local_dets:
-
-                # get the pixels and weights from the cache
-
-                pixelsname = "{}_{}".format(self._pixels, det)
-                weightsname = "{}_{}".format(self._weights, det)
-                pixels = tod.cache.reference(pixelsname)
-                weights = tod.cache.reference(weightsname)
-
-                # get flags
-
-                if self._apply_flags:
-                    if self._flag_name is not None:
-                        cacheflagname = "{}_{}".format(self._flag_name, det)
-                        detflags = tod.cache.reference(cacheflagname)
-                        flags = (detflags & self._flag_mask) != 0
-                        if self._common_flag_name is not None:
-                            commonflags = tod.cache.reference(self._common_flag_name)
-                            flags[(commonflags & self._common_flag_mask) != 0] = True
-                    else:
-                        detflags, commonflags = tod.read_flags(detector=det)
-                        flags = np.logical_or((detflags & self._flag_mask) != 0, (commonflags & self._common_flag_mask) != 0)
-
-                    pixels = pixels.copy() # Don't change the cached pixel numbers
-                    pixels[flags] = -1
-
-                # local pointing
-
-                sm, lpix = self._invnpp.global_to_local(pixels)
-                
-                detweight = 1.0
-                
-                if self._detweights is not None:
-                    if det not in self._detweights.keys():
-                        raise RuntimeError("no detector weights found for {}".format(det))
-                    detweight = self._detweights[det]
-                    if detweight == 0:
-                        continue
-
-                if self._hits is not None:
-                    _accumulate_inverse_covariance(self._invnpp.data, sm, lpix, weights, detweight, self._hits.data)
-                else:
-                    fakehits = np.zeros((1,1,1), dtype=np.int64)
-                    _accumulate_inverse_covariance(self._invnpp.data, sm, lpix, weights, detweight, fakehits)
-        return
-
-
-class OpNoiseWeighted(Operator):
-    """
-    Operator which computes the noise-weighted map.
-
-    This operator requires that the local pointing matrix has already been
-    computed.  Each process has a local piece of the noise weighted map.
-
-    Args:
-        zmap (DistPixels):  The map to accumulate.
-        hits (DistPixels):  (optional) the hits to accumulate.
+        invnpp (DistPixels):  (optional) the diagonal covariance matrix.
         detweights (dictionary): individual noise weights to use for each
             detector.
         name (str): the name of the cache object (<name>_<detector>) to
@@ -164,7 +56,7 @@ class OpNoiseWeighted(Operator):
             containing the pointing weights to use.
     """
 
-    def __init__(self, zmap=None, hits=None, detweights=None, name=None, flag_name=None, 
+    def __init__(self, zmap=None, hits=None, invnpp=None, detweights=None, name=None, flag_name=None, 
                 flag_mask=255, common_flag_name=None, common_flag_mask=255, pixels='pixels', 
                 weights='weights', apply_flags=True):
         
@@ -179,11 +71,9 @@ class OpNoiseWeighted(Operator):
         self._weights = weights
         self._detweights = detweights
 
-        if zmap is None:
-            raise RuntimeError("you must specify the map to accumulate")
         self._zmap = zmap
-
         self._hits = hits
+        self._invnpp = invnpp
 
         # We call the parent class constructor, which currently does nothing
         super().__init__()
@@ -206,8 +96,43 @@ class OpNoiseWeighted(Operator):
         # the same rank within their group
         crank = comm.comm_rank
 
+        # since we could get any combination of hits, invnpp, and zmap,
+        # we pick one of them to use for the mapping between global and
+        # local pixels.
+
+        globloc = None
+
+        # set up some helper variables to pass to cython code
+
+        do_hits = 0
+        chits = np.zeros((1,1,1), dtype=np.int64)
+        if self._hits is not None:
+            do_hits = 1
+            chits = self._hits.data
+            if globloc is None:
+                globloc = self._hits
+        
+        do_zmap = 0
+        czmap = np.zeros((1,1,1), dtype=np.float64)
+        if self._zmap is not None:
+            do_zmap = 1
+            czmap = self._zmap.data
+            if globloc is None:
+                globloc = self._zmap
+        
+        do_invnpp = 0
+        cinvnpp = np.zeros((1,1,1), dtype=np.float64)
+        if self._invnpp is not None:
+            do_invnpp = 1
+            cinvnpp = self._invnpp.data
+            if globloc is None:
+                globloc = self._invnpp
+
         for obs in data.obs:
             tod = obs['tod']
+
+            # FIXME:  put this into cython and thread over detectors.
+
             for det in tod.local_dets:
 
                 # get the pixels and weights from the cache
@@ -243,7 +168,7 @@ class OpNoiseWeighted(Operator):
 
                 # local pointing
 
-                sm, lpix = self._zmap.global_to_local(pixels)
+                sm, lpix = globloc.global_to_local(pixels)
                 
                 detweight = 1.0
                 
@@ -254,15 +179,12 @@ class OpNoiseWeighted(Operator):
                     if detweight == 0:
                         continue
 
-                if self._hits is not None:
-                    _accumulate_noiseweighted(self._zmap.data, sm, signal, lpix, weights, detweight, self._hits.data)
-                else:
-                    fakehits = np.zeros((1,1,1), dtype=np.int64)
-                    _accumulate_noiseweighted(self._zmap.data, sm, signal, lpix, weights, detweight, fakehits)
+                _accumulate_diagonal(czmap, do_zmap, chits, do_hits, cinvnpp, do_invnpp, signal, sm, lpix, weights, detweight)
+
         return
 
 
-def covariance_invert(npp, threshold):
+def covariance_invert(npp, threshold, rcond=None):
     """
     Invert the local piece of a diagonal noise covariance.
 
@@ -273,10 +195,14 @@ def covariance_invert(npp, threshold):
     Args:
         npp (3D array): The data member of a distributed covariance.
         threshold (float): The condition number threshold to apply.
+        rcond (3D array): (Optional) the inverse condition number map to fill.
     """
     if len(npp.shape) != 3:
         raise RuntimeError("distributed covariance matrix must have dimensions (number of submaps, pixels per submap, nnz*(nnz+1)/2)")
-    _invert_covariance(npp, threshold)
+    if rcond is None:
+        _eigendecompose_covariance(npp, np.zeros((1,1,1), dtype=np.float64), threshold, 1, 0)
+    else:
+        _eigendecompose_covariance(npp, rcond, threshold, 1, 1)
     return
 
 
@@ -333,5 +259,6 @@ def covariance_rcond(npp):
     if len(npp.shape) != 3:
         raise RuntimeError("distributed covariance matrix must have dimensions (number of submaps, pixels per submap, nnz*(nnz+1)/2)")
     rcond = np.zeros((npp.shape[0], npp.shape[1], 1), dtype=np.float64)
-    _cond_covariance(npp, rcond)
+    threshold = np.finfo(np.float64).eps
+    _eigendecompose_covariance(npp, rcond, threshold, 0, 1)
     return rcond


### PR DESCRIPTION
This includes a reorganization of the toast.map.noise operators into a single operator that can accumulate any of the 3 objects (hits, covariance, noise weighted map).  Also combined the cython code into a single function to avoid repeatedly going through all samples.  Unit tests pass, including a comparison with libmadam.  Pipeline script for example satellite noise sims now supports native binned maps.