### PR TITLE
Fix issue with FFT

### DIFF
--- a/tests/test_psd_math.py
+++ b/tests/test_psd_math.py
@@ -190,7 +190,7 @@ class PSDTest(MPITestCase):
 
             (temp, freqs[det], psds[det]) = sim_noise_timestream(0, idet, nse.rate(det), self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
 
-            if True:
+            if False:
                 psdfreq = freqs[det]
                 psd = psds[det]
 
@@ -208,6 +208,10 @@ class PSDTest(MPITestCase):
                 #print(noisetod[:100])
             else:
                 noisetod = tod.cache.reference("noise_{}".format(det))
+
+            noisetod2 = noisetod.copy()
+            for i in range(1,noisetod.size):
+                noisetod[i] = .999*( noisetod[i-1] + noisetod2[i] - noisetod2[i-1] )
             
             autocovs = autocov_psd(np.arange(ntod)/fsamp, noisetod, np.zeros(ntod,dtype=np.bool), self.lagmax, self.stationary_period, fsamp, comm=self.comm)
             #autocovs = autocov_psd(np.arange(ntod)/fsamp, noisetod, np.zeros(ntod,dtype=np.bool), 10, self.stationary_period, fsamp, comm=self.comm)

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -30,7 +30,7 @@ def sim_noise_timestream(realization, stream, rate, samples, oversample, freq, p
     while fftlen <= (oversample * samples):
         fftlen *= 2
     npsd = fftlen // 2 + 1
-    norm = rate * float(npsd)
+    norm = rate * float(npsd - 1)
 
     interp_freq = np.fft.rfftfreq( fftlen, 1/rate )
     if interp_freq.size != npsd:
@@ -85,7 +85,6 @@ def sim_noise_timestream(realization, stream, rate, samples, oversample, freq, p
     # scale by PSD
 
     scale = np.sqrt(interp_psd * norm)
-    scale[-1] *= np.sqrt(2)
 
     fdata *= scale
 

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -50,7 +50,7 @@ def sim_noise_timestream(realization, stream, rate, samples, oversample, freq, p
 
     # gaussian Re/Im randoms
 
-    fdata = rng.random(interp_psd.size, sampler="gaussian", key=(realization, stream), counter=(0,0)) + 1j*rng.random(interp_psd.size, sampler="gaussian", key=(realization, stream), counter=(0,0))
+    fdata = rng.random(interp_psd.size, sampler="gaussian", key=(realization, stream), counter=(0,0)) + 1j*rng.random(interp_psd.size, sampler="gaussian", key=(realization, stream), counter=(interp_psd.size,0))
 
     # scale by PSD
 


### PR DESCRIPTION
Replace scipy fft calls with numpy rfft. Use np.fft.rfftfreq. Disable dysfunctional high pass filter. Use basic interpolation rather than loglog-interpolation for the PSD.