### PR TITLE
Separate valid intervals from data distribution

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -182,18 +182,27 @@ def main():
 
     data = toast.Data(comm)
 
-    # construct the list of intervals
+    # construct the list of valid data intervals
+
+    intervals = tt.regular_intervals(int(args.numobs), 0.0, 0, samplerate, 3600*float(args.obs), 3600*float(args.gap))
+
+    # now divide the data up for distribution
 
     obschunks = int(args.obschunks)
+    if len(intervals) > 1:
+        itsamp = intervals[1].first - intervals[0].first
+    else:
+        itsamp = intervals[0].last - intervals[0].first + 1
 
-    intervals = tt.regular_intervals(int(args.numobs), 0.0, 0, samplerate, 3600*float(args.obs), 3600*float(args.gap), chunks=obschunks)
+    chnks = toast.distribute_uniform(itsamp, obschunks)
 
     distsizes = []
     for it in intervals:
-        distsizes.append(it.last - it.first + 1)
+        for c in chnks:
+            distsizes.append(c[1])
 
     totsamples = np.sum(distsizes)
-
+    
     # create the single TOD for this observation
 
     detectors = sorted(fp.keys())

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -11,6 +11,9 @@ if 'TOAST_NO_MPI' in os.environ.keys():
 else:
     from mpi4py import MPI
 
+import numpy as np
+import numpy.testing as nt
+
 from toast.dist import *
 from toast.tod.interval import *
 from toast.tod.sim_interval import *
@@ -29,7 +32,6 @@ class IntervalTest(MPITestCase):
         self.rate = 123.456
         self.duration = 24 * 3601.23
         self.gap = 3600.0
-        self.chunks = 24
         self.start = 5432.1
         self.first = 10
         self.nint = 3
@@ -38,18 +40,17 @@ class IntervalTest(MPITestCase):
     def test_regular(self):
         start = MPI.Wtime()
         
-        intrvls = regular_intervals(self.nint, self.start, self.first, self.rate, self.duration, self.gap, chunks=self.chunks)
+        intrvls = regular_intervals(self.nint, self.start, self.first, self.rate, self.duration, self.gap)
 
-        totsamp = self.duration + self.gap
+        goodsamp = self.nint * ( int(0.5 + self.duration * self.rate) + 1 )
 
-        # for i in range(len(intrvls)):
-        #     print("--- {} ---".format(i))
-        #     print(intrvls[i].first)
-        #     print(intrvls[i].last)
-        #     print(intrvls[i].start)
-        #     print(intrvls[i].stop)
+        check = 0
 
-        #self.assertTrue(False)
+        for it in intrvls:
+            print(it.first," ",it.last," ",it.start," ",it.stop)
+            check += it.last - it.first + 1
+
+        nt.assert_equal(check, goodsamp)
 
         stop = MPI.Wtime()
         elapsed = stop - start

--- a/toast/map/madam.py
+++ b/toast/map/madam.py
@@ -103,8 +103,7 @@ class OpMadam(Operator):
         flag_mask (int): the integer bit mask (0-255) that should be 
             used with the detector flags in a bitwise AND.
         common_flag_name (str): the name of the cache object 
-            (<common_flag_name>_<detector>) to use for the common flags.  
-            If None, use the TOD.
+            to use for the common flags.  If None, use the TOD.
         common_flag_mask (int): the integer bit mask (0-255) that should
             be used with the common flags in a bitwise AND.
         apply_flags (bool): whether to apply flags to the pixel numbers.

--- a/toast/tod/sim_interval.py
+++ b/toast/tod/sim_interval.py
@@ -13,7 +13,7 @@ from .interval import Interval
 
 
 
-def regular_intervals(n, start, first, rate, duration, gap, chunks=1):
+def regular_intervals(n, start, first, rate, duration, gap):
     """
     Function to generate regular intervals.
 
@@ -22,7 +22,7 @@ def regular_intervals(n, start, first, rate, duration, gap, chunks=1):
     length of the interval and the gap are rounded to the nearest sample
     and all intervals in the list are created using those lengths.
 
-    Optionally, the valid data span can be subdivided into some number
+    Optionally, the full data span can be subdivided into some number
     of contiguous subchunks.
 
     Args:
@@ -32,18 +32,16 @@ def regular_intervals(n, start, first, rate, duration, gap, chunks=1):
         rate (float): the sample rate in Hz.
         duration (float): the length of the interval in seconds.
         gap (float): the length of the gap in seconds.
-        chunks (int): divide the valid data in "duration" into this
-            number of contiguous chunks.
 
     Returns:
         (list): a list of Interval objects.
     """
     invrate = 1.0 / rate
 
-    # Compute the whole number of samples that fit completely within the
-    # requested time span.
-    totsamples = int((duration + gap) * rate) + 1
-    dursamples = int(duration * rate) + 1
+    # Compute the whole number of samples that fit within the
+    # requested time span (rounded to nearest sample).
+    totsamples = int(0.5 + (duration + gap) * rate) + 1
+    dursamples = int(0.5 + duration * rate) + 1
     gapsamples = totsamples - dursamples
 
     # Compute the actual time span for this number of samples
@@ -51,20 +49,14 @@ def regular_intervals(n, start, first, rate, duration, gap, chunks=1):
     durtime = (dursamples - 1) * invrate
     gaptime = tottime - durtime
 
-    # If we have sub-chunks, compute them now
-    chnks = distribute_uniform(dursamples, chunks)
-
     intervals = []
 
     for i in range(n):
         ifirst = first + i * totsamples
+        ilast = ifirst + dursamples - 1
         istart = start + i * tottime
-        for c in chnks:
-            cfirst = ifirst + c[0]
-            clast = cfirst + c[1] - 1
-            cstart = istart + (c[0] * invrate)
-            cstop = istart + ((c[0] + c[1] - 1) * invrate)
-            intervals.append(Interval(start=cstart, stop=cstop, first=cfirst, last=clast))
+        istop = istart + (dursamples - 1) * invrate
+        intervals.append(Interval(start=istart, stop=istop, first=ifirst, last=ilast))
 
     return intervals
 


### PR DESCRIPTION
Change regular_interval function to only return a list of whole intervals (no subchunks).  Change pipelines and unit tests to separately specify the distribution chunks independent of the valid data intervals.  Add an operator to flag samples in between valid intervals.  These flags can be used in the madam and noise accumulation operators.