### PR TITLE
Tod ground

### DIFF
--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python
+
+import os
+import re
+import argparse
+import pickle
+
+if 'TOAST_NO_MPI' in os.environ.keys():
+    from toast import fakempi as MPI
+else:
+    from mpi4py import MPI
+import numpy as np
+from scipy.constants import degree
+
+import toast
+import toast.tod as tt
+import toast.map as tm
+import toast.tod.qarray as qa
+
+
+XAXIS, YAXIS, ZAXIS = np.eye(3)
+
+
+def view_focalplane(fp, outfile):
+    # To avoid python overhead in large MPI jobs, place the
+    # matplotlib import inside this function, which is only called
+    # when the --debug option is specified.
+    import matplotlib
+    # Force matplotlib to not use any Xwindows backend.
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+
+    # field of view, in degrees
+    width = 10.0
+    height = 10.0
+            
+    fig = plt.figure( figsize=(12,12), dpi=100 )
+    ax = fig.add_subplot(1, 1, 1)
+
+    half_width = 0.5 * width
+    half_height = 0.5 * height
+    ax.set_xlabel('Degrees', fontsize='large')
+    ax.set_ylabel('Degrees', fontsize='large')
+    ax.set_xlim([-half_width, half_width])
+    ax.set_ylim([-half_height, half_height])
+
+    for det in sorted(fp.keys()):
+
+        # radius in degrees
+        detradius = 0.5 * fp[det]['fwhm'] / 60.0
+
+        # rotation from boresight
+        dir = qa.rotate(fp[det]['quat'], ZAXIS).flatten()
+        ang = np.arctan2(dir[1], dir[0])
+
+        orient = qa.rotate(fp[det]['quat'], XAXIS).flatten()
+        polang = np.arctan2(orient[1], orient[0])
+
+        mag = np.arccos(dir[2]) * 180.0 / np.pi
+        xpos = mag * np.cos(ang)
+        ypos = mag * np.sin(ang)
+
+        circ = plt.Circle((xpos, ypos), radius=detradius, fc='white', ec='k')
+        ax.add_artist(circ)
+
+        xtail = xpos - detradius * np.cos(polang)
+        ytail = ypos - detradius * np.sin(polang)
+        dx = 2.0 * detradius * np.cos(polang)
+        dy = 2.0 * detradius * np.sin(polang)    
+
+        detcolor = None
+        if 'color' in fp[det].keys():
+            detcolor = fp[det]['color']
+        ax.arrow(xtail, ytail, dx, dy, width=0.1*detradius,
+                 head_width=0.3*detradius, head_length=0.3*detradius,
+                 fc=detcolor, ec=detcolor, length_includes_head=True)
+
+    plt.savefig(outfile)
+    return
+
+
+def main():
+
+    # This is the 2-level toast communicator.  By default,
+    # there is just one group which spans MPI_COMM_WORLD.
+    comm = toast.Comm()
+
+    if comm.comm_world.rank == 0:
+        print("Running with {} processes".format(comm.comm_world.size))
+
+    global_start = MPI.Wtime()
+
+    parser = argparse.ArgumentParser(description='Simulate ground-based '
+                                     'boresight pointing and make a noise map.')
+    parser.add_argument('--samplerate',
+                        required=False, default=40.0, type=np.float,
+                        help='Detector sample rate (Hz)')
+    parser.add_argument('--site_lon',
+                        required=False, default=10.0,
+                        help='Observing site longitude [pyEphem string]')
+    parser.add_argument('--site_lat',
+                        required=False, default=10.0,
+                        help='Observing site latitude [pyEphem string]')
+    parser.add_argument('--site_alt',
+                        required=False, default=10.0, type=np.float,
+                        help='Observing site altitude [meters]')
+    parser.add_argument('--patch_lon',
+                        required=False, default=30.0,
+                        help='Sky patch longitude [pyEphem string]')
+    parser.add_argument('--patch_lat',
+                        required=False, default=30.0,
+                        help='Sky patch latitude [pyEphem string]')
+    parser.add_argument('--patch_coord',
+                        required=False, default='C',
+                        help='Sky patch coordinate system [C,E,G]')
+    parser.add_argument('--throw',
+                        required=False, default=5.0, type=np.float,
+                        help='Sky patch width in azimuth [degrees]')
+    parser.add_argument('--scanrate',
+                        required=False, default=6.0, type=np.float,
+                        help='Scanning rate [deg / s]')
+    parser.add_argument('--scan_accel',
+                        required=False, default=6.0, type=np.float,
+                        help='Scanning rate change [deg / s^2]')
+    parser.add_argument('--el_min',
+                        required=False, default=0.0, type=np.float,
+                        help='Minimum elevation for a CES')
+    parser.add_argument('--sun_angle_min',
+                        required=False, default=90.0, type=np.float,
+                        help='Minimum angular distance between the Sun and '
+                        'the sky patch')
+    parser.add_argument('--allow_sun_up',
+                        required=False, default=False, action='store_true',
+                        help='If specified, allow day time scans.')
+    parser.add_argument('--hwprpm',
+                        required=False, default=0.0, type=np.float,
+                        help='The rate (in RPM) of the HWP rotation')
+    parser.add_argument('--hwpstep', required=False, default=None,
+                        help='For stepped HWP, the angle in degrees of each step')
+    parser.add_argument('--hwpsteptime',
+                        required=False, default=0.0, type=np.float,
+                        help='For stepped HWP, the the time in seconds between steps')
+    parser.add_argument('--CES_start',
+                        required=False, default=0, type=np.float,
+                        help='Start time of the CES')
+    parser.add_argument('--CES_stop',
+                        required=False, default=1000, type=np.float,
+                        help='Stop time of the CES')
+    parser.add_argument('--outdir',
+                        required=False, default='out',
+                        help='Output directory')
+    parser.add_argument('--debug',
+                        required=False, default=False, action='store_true',
+                        help='Write diagnostics')
+    parser.add_argument('--nside',
+                        required=False, default=1024, type=np.int,
+                        help='Healpix NSIDE')
+    parser.add_argument('--baseline',
+                        required=False, default=60.0, type=np.float,
+                        help='Destriping baseline length (seconds)')
+    parser.add_argument('--noisefilter',
+                        required=False, default=False, action='store_true',
+                        help='Destripe with the noise filter enabled')
+    parser.add_argument('--madam',
+                        required=False, default=False, action='store_true',
+                        help='If specified, use libmadam for map-making')
+    parser.add_argument('--madampar',
+                        required=False, default=None,
+                        help='Madam parameter file')
+    parser.add_argument('--common_flag_mask',
+                        required=False, default=1, type=np.uint8,
+                        help='Common flag mask')
+    parser.add_argument('--MC_start',
+                        required=False, default=0, type=np.int,
+                        help='First Monte Carlo noise realization')
+    parser.add_argument('--MC_count',
+                        required=False, default=1, type=np.int,
+                        help='Number of Monte Carlo noise realizations')
+    parser.add_argument('--fp',
+                        required=False, default=None,
+                        help='Pickle file containing a dictionary of detector '
+                        'properties.  The keys of this dict are the detector '
+                        'names, and each value is also a dictionary with keys '
+                        '"quat" (4 element ndarray), "fwhm" (float, arcmin), '
+                        '"fknee" (float, Hz), "alpha" (float), and '
+                        '"NET" (float).  For optional plotting, the key "color"'
+                        ' can specify a valid matplotlib color string.')
+
+    args = parser.parse_args()
+
+    # get options
+
+    hwprpm = args.hwprpm
+    hwpstep = None
+    if args.hwpstep is not None:
+        hwpstep = float(args.hwpstep)
+    hwpsteptime = args.hwpsteptime
+
+    nside = args.nside
+    npix = 12 * nside * nside
+
+    start = MPI.Wtime()
+
+    fp = None
+
+    # Load focalplane information
+
+    if comm.comm_world.rank == 0:
+        if args.fp is None:
+            # in this case, create a fake detector at the boresight
+            # with a pure white noise spectrum.
+            fake = {}
+            fake['quat'] = np.array([0.0, 0.0, 1.0, 0.0])
+            fake['fwhm'] = 30.0
+            fake['fknee'] = 0.0
+            fake['fmin'] = 1e-9
+            fake['alpha'] = 1.0
+            fake['NET'] = 1.0
+            fake['color'] = 'r'
+            fp = {}
+            # Second detector at 22.5 degree polarization angle
+            fp['bore1'] = fake
+            fake2 = {}
+            zrot = qa.rotation(ZAXIS, 22.5*degree)
+            fake2['quat'] = qa.mult(fake['quat'], zrot)
+            fake2['fwhm'] = 30.0
+            fake2['fknee'] = 0.0
+            fake2['fmin'] = 1e-9
+            fake2['alpha'] = 1.0
+            fake2['NET'] = 1.0
+            fake2['color'] = 'r'
+            fp['bore2'] = fake2
+            # Third detector at 45 degree polarization angle
+            fake3 = {}
+            zrot = qa.rotation(ZAXIS, 45*degree)
+            fake3['quat'] = qa.mult(fake['quat'], zrot)
+            fake3['fwhm'] = 30.0
+            fake3['fknee'] = 0.0
+            fake3['fmin'] = 1e-9
+            fake3['alpha'] = 1.0
+            fake3['NET'] = 1.0
+            fake3['color'] = 'r'
+            fp['bore3'] = fake3
+        else:
+            with open(args.fp, 'rb') as p:
+                fp = pickle.load(p)
+    fp = comm.comm_world.bcast(fp, root=0)
+
+    stop = MPI.Wtime()
+    elapsed = stop - start
+    if comm.comm_world.rank == 0:
+        print('Create focalplane:  {:.2f} seconds'.format(stop-start))
+    start = stop
+
+    if args.debug:
+        if comm.comm_world.rank == 0:
+            outfile = '{}_focalplane.png'.format(args.outdir)
+            view_focalplane(fp, outfile)
+
+    # The distributed timestream data
+
+    data = toast.Data(comm)
+
+    # FIXME: what format will we assume the CES times to be?
+
+    CES_start = args.CES_start
+    CES_stop = args.CES_stop
+
+    totsamples = int((CES_stop - CES_start) * args.samplerate)
+
+    # create the single TOD for this observation
+
+    detectors = sorted(fp.keys())
+    detquats = {}
+    for d in detectors:
+        detquats[d] = fp[d]['quat']
+
+    try:
+        tod = tt.TODGround(
+            mpicomm=comm.comm_group, 
+            detectors=detquats,
+            samples=totsamples,
+            firsttime=CES_start,
+            rate=args.samplerate,
+            site_lon=args.site_lon,
+            site_lat=args.site_lat,
+            site_alt=args.site_alt,
+            patch_lon=args.patch_lon,
+            patch_lat=args.patch_lat,
+            patch_coord=args.patch_coord,
+            throw=args.throw,
+            scanrate=args.scanrate,
+            scan_accel=args.scan_accel,
+            CES_start=None,
+            CES_stop=None,
+            el_min=args.el_min,
+            sun_angle_min=args.sun_angle_min,
+            allow_sun_up=args.allow_sun_up,
+            sizes=None, timedist=False)
+    except RuntimeError as e:
+        print('Failed to create the CES scan: {}'.format(e))
+        return
+
+    # Create the noise model for this observation
+
+    fmin = {}
+    fknee = {}
+    alpha = {}
+    NET = {}
+    rates = {}
+    for d in detectors:
+        rates[d] = args.samplerate
+        fmin[d] = fp[d]['fmin']
+        fknee[d] = fp[d]['fknee']
+        alpha[d] = fp[d]['alpha']
+        NET[d] = fp[d]['NET']
+
+    noise = tt.AnalyticNoise(rate=rates, fmin=fmin, detectors=detectors,
+                             fknee=fknee, alpha=alpha, NET=NET)
+
+    # Create the (single) observation
+
+    ob = {}
+    ob['name'] = 'CES'
+    ob['tod'] = tod
+    ob['intervals'] = None
+    ob['baselines'] = None
+    ob['noise'] = noise
+    ob['id'] = 0
+
+    data.obs.append(ob)
+
+    stop = MPI.Wtime()
+    elapsed = stop - start
+    if comm.comm_world.rank == 0:
+        print('Read parameters, compute data distribution:  {:.2f} seconds'
+              ''.format(stop-start))
+    start = stop
+
+    # make a Healpix pointing matrix.
+
+    pointing = tt.OpPointingHpix(
+        nside=nside, nest=True, mode='IQU', hwprpm=hwprpm, hwpstep=hwpstep,
+        hwpsteptime=hwpsteptime)
+
+    pointing.exec(data)
+
+    comm.comm_world.barrier()
+    stop = MPI.Wtime()
+    elapsed = stop - start
+    if comm.comm_world.rank == 0:
+        print('Pointing generation took {:.3f} s'.format(elapsed))
+    start = stop
+
+    # Mapmaking.  For purposes of this simulation, we use detector noise
+    # weights based on the NET (white noise level).  If the destriping
+    # baseline is too long, this will not be the best choice.
+
+    detweights = {}
+    for d in detectors:
+        net = fp[d]['NET']
+        detweights[d] = 1.0 / (args.samplerate * net * net)
+
+    if not args.madam:
+        if comm.comm_world.rank == 0:
+            print('Not using Madam, will only make a binned map!')
+
+        subnside = 16
+        if subnside > nside:
+            subnside = nside
+        subnpix = 12 * subnside * subnside
+
+        # get locally hit pixels
+        lc = tm.OpLocalPixels()
+        localpix = lc.exec(data)
+
+        # find the locally hit submaps.
+        allsm = np.floor_divide(localpix, subnpix)
+        sm = set(allsm)
+        localsm = np.array(sorted(sm), dtype=np.int64)
+
+        # construct distributed maps to store the covariance,
+        # noise weighted map, and hits
+
+        invnpp = tm.DistPixels(comm=comm.comm_group, size=npix, nnz=6,
+                               dtype=np.float64, submap=subnpix, local=localsm)
+        hits = tm.DistPixels(comm=comm.comm_group, size=npix, nnz=1,
+                             dtype=np.int64, submap=subnpix, local=localsm)
+        zmap = tm.DistPixels(comm=comm.comm_group, size=npix, nnz=3,
+                             dtype=np.float64, submap=subnpix, local=localsm)
+
+        # compute the hits and covariance once, since the pointing and noise
+        # weights are fixed.
+
+        invnpp.data.fill(0.0)
+        hits.data.fill(0)
+
+        build_invnpp = tm.OpAccumDiag(detweights=detweights, invnpp=invnpp,
+                                      hits=hits)
+        build_invnpp.exec(data)
+
+        invnpp.allreduce()
+        hits.allreduce()
+
+        comm.comm_world.barrier()
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        if comm.comm_world.rank == 0:
+            print('Building hits and N_pp^-1 took {:.3f} s'.format(elapsed))
+        start = stop
+
+        hits.write_healpix_fits('{}_hits.fits'.format(args.outdir))
+        invnpp.write_healpix_fits('{}_invnpp.fits'.format(args.outdir))
+
+        comm.comm_world.barrier()
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        if comm.comm_world.rank == 0:
+            print('Writing hits and N_pp^-1 took {:.3f} s'.format(elapsed))
+        start = stop
+
+        # invert it
+        tm.covariance_invert(invnpp.data, 1.0e-3)
+
+        comm.comm_world.barrier()
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        if comm.comm_world.rank == 0:
+            print('Inverting N_pp^-1 took {:.3f} s'.format(elapsed))
+        start = stop
+
+        invnpp.write_healpix_fits('{}_npp.fits'.format(args.outdir))
+
+        comm.comm_world.barrier()
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        if comm.comm_world.rank == 0:
+            print('Writing N_pp took {:.3f} s'.format(elapsed))
+        start = stop
+
+        # in debug mode, print out data distribution information
+        if args.debug:
+            handle = None
+            if comm.comm_world.rank == 0:
+                handle = open('{}_distdata.txt'.format(args.outdir), 'w')
+            data.info(handle)
+            if comm.comm_world.rank == 0:
+                handle.close()
+            
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('Dumping debug data distribution took {:.3f} s'
+                      ''.format(elapsed))
+            start = stop
+
+        mcstart = start
+
+        # Loop over Monte Carlos
+
+        firstmc = int(args.MC_start)
+        nmc = int(args.MC_count)
+
+        for mc in range(firstmc, firstmc+nmc):
+            # create output directory for this realization
+            outpath = '{}_{:03d}'.format(args.outdir, mc)
+            if comm.comm_world.rank == 0:
+                if not os.path.isdir(outpath):
+                    os.makedirs(outpath)
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('Creating output dir {:04d} took {:.3f} s'
+                      ''.format(mc, elapsed))
+            start = stop
+
+            # clear all noise data from the cache, so that we can generate
+            # new noise timestreams.
+            tod.cache.clear('noise_.*')
+
+            # simulate noise
+
+            nse = tt.OpSimNoise(out='noise', realization=mc)
+            nse.exec(data)
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('  Noise simulation {:04d} took {:.3f} s'
+                      ''.format(mc, elapsed))
+            start = stop
+
+            zmap.data.fill(0.0)
+            build_zmap = tm.OpAccumDiag(zmap=zmap, name='noise')
+            build_zmap.exec(data)
+            zmap.allreduce()
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('  Building noise weighted map {:04d} took {:.3f} s'
+                      ''.format(mc, elapsed))
+            start = stop
+
+            tm.covariance_apply(invnpp.data, zmap.data)
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('  Computing binned map {:04d} took {:.3f} s'
+                      ''.format(mc, elapsed))
+            start = stop
+        
+            zmap.write_healpix_fits(os.path.join(outpath, 'binned.fits'))
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('  Writing binned map {:04d} took {:.3f} s'
+                      ''.format(mc, elapsed))
+            elapsed = stop - mcstart
+            if comm.comm_world.rank == 0:
+                print('  Mapmaking {:04d} took {:.3f} s'.format(mc, elapsed))
+            start = stop
+
+    else:
+
+        # Set up MADAM map making.
+
+        pars = {}
+
+        cross = int(nside / 2)
+        submap = 16
+        if submap > nside:
+            submap = nside
+
+        pars[ 'temperature_only' ] = 'F'
+        pars[ 'force_pol' ] = 'T'
+        pars[ 'kfirst' ] = 'T'
+        pars[ 'concatenate_messages' ] = 'T'
+        pars[ 'write_map' ] = 'T'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'T'
+        pars[ 'write_wcov' ] = 'T'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'run_submap_test' ] = 'T'
+        pars[ 'nside_cross' ] = cross
+        pars[ 'nside_submap' ] = submap
+
+        if args.madampar is not None:
+            pat = re.compile(r'\s*(\S+)\s*=\s*(\S+(\s+\S+)*)\s*')
+            comment = re.compile(r'^#.*')
+            with open(args.madampar, 'r') as f:
+                for line in f:
+                    if comment.match(line) is None:
+                        result = pat.match(line)
+                        if result is not None:
+                            key, value = result.group(1), result.group(2)
+                            pars[key] = value
+
+        pars[ 'base_first' ] = args.baseline
+        pars[ 'nside_map' ] = nside
+        if args.noisefilter:
+            pars[ 'kfilter' ] = 'T'
+        else:
+            pars[ 'kfilter' ] = 'F'
+        pars[ 'fsample' ] = args.samplerate
+
+        # Loop over Monte Carlos
+
+        firstmc = int(args.MC_start)
+        nmc = int(args.MC_count)
+
+        for mc in range(firstmc, firstmc+nmc):
+            # clear all noise data from the cache, so that we can generate
+            # new noise timestreams.
+            tod.cache.clear('noise_.*')
+
+            # simulate noise
+
+            nse = tt.OpSimNoise(out='noise', realization=mc)
+            nse.exec(data)
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('Noise simulation took {:.3f} s'.format(elapsed))
+            start = stop
+
+            # create output directory for this realization
+            pars[ 'path_output' ] = '{}_{:03d}'.format(args.outdir, mc)
+            if comm.comm_world.rank == 0:
+                if not os.path.isdir(pars['path_output']):
+                    os.makedirs(pars['path_output'])
+
+            # in debug mode, print out data distribution information
+            if args.debug:
+                handle = None
+                if comm.comm_world.rank == 0:
+                    handle = open(
+                        os.path.join(pars['path_output'], 'distdata.txt'), 'w')
+                data.info(handle)
+                if comm.comm_world.rank == 0:
+                    handle.close()
+
+            madam = tm.OpMadam(params=pars, detweights=detweights, name='noise',
+                               common_flag_mask=args.common_flag_mask)
+            madam.exec(data)
+
+            comm.comm_world.barrier()
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            if comm.comm_world.rank == 0:
+                print('Mapmaking took {:.3f} s'.format(elapsed))
+
+    comm.comm_world.barrier()
+    stop = MPI.Wtime()
+    elapsed = stop - global_start
+    if comm.comm_world.rank == 0:
+        print('Total Time:  {:.2f} seconds'.format(elapsed))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_map_ground.py
+++ b/tests/test_map_ground.py
@@ -64,8 +64,8 @@ class MapGroundTest(MPITestCase):
         self.site_lon = '-67:47:10'
         self.site_lat = '-22:57:30'
         self.site_alt = 5200.
-        self.patch_lon = 15 * degree # '10.0'
-        self.patch_lat = -70 * degree # '-70.0'
+        self.patch_lon = 115 * degree # '10.0'
+        self.patch_lat = -60 * degree # '-70.0'
         self.patch_coord = 'C'
         self.throw = 4.
         self.scanrate = 0.05

--- a/tests/test_map_ground.py
+++ b/tests/test_map_ground.py
@@ -58,9 +58,9 @@ class MapGroundTest(MPITestCase):
         nside = 1024
         self.sim_nside = nside
         #self.totsamp = 400000
-        self.totsamp = 10000
+        self.totsamp = 100000
         self.map_nside = nside
-        self.rate = 4.0
+        self.rate = 40.0
         self.site_lon = '-67:47:10'
         self.site_lat = '-22:57:30'
         self.site_alt = 5200.
@@ -68,9 +68,9 @@ class MapGroundTest(MPITestCase):
         self.patch_lat = -60 * degree # '-70.0'
         self.patch_coord = 'C'
         self.throw = 4.
-        self.scanrate = 0.05
-        self.scan_accel = 0.0001
-        self.CES_start = -1000.
+        self.scanrate = 1.0
+        self.scan_accel = 0.1
+        self.CES_start = None
 
         self.NET = 7.0
 
@@ -93,18 +93,6 @@ class MapGroundTest(MPITestCase):
         # madam only supports a single observation
         nobs = 1
 
-        # in order to make sure that the noise realization is reproducible
-        # all all concurrencies, we set the chunksize to something independent
-        # of the number of ranks.
-
-        nchunk = 10
-        chunksize = int(self.totsamp / nchunk)
-        chunks = np.ones(nchunk, dtype=np.int64)
-        chunks *= chunksize
-        remain = self.totsamp - (nchunk * chunksize)
-        for r in range(remain):
-            chunks[r] += 1
-
         nflagged = 0
 
         for i in range(nobs):
@@ -126,7 +114,8 @@ class MapGroundTest(MPITestCase):
                 scanrate=self.scanrate,
                 scan_accel=self.scan_accel,
                 CES_start=self.CES_start,
-                sizes=chunks)
+                sizes=None)
+                #sizes=chunks)
 
             self.common_flag_mask = tod.TURNAROUND
 
@@ -235,7 +224,6 @@ class MapGroundTest(MPITestCase):
         else:
             print("libmadam not available, skipping tests")
 
-
     def test_noise(self):
         start = MPI.Wtime()
 
@@ -246,6 +234,7 @@ class MapGroundTest(MPITestCase):
         # DEBUG begin
         noise_tod = self.data.obs[0]['tod'].cache.reference('noise_bore')
         #noise_tod[:] = np.random.randn(noise_tod.size)*100
+        #noise_tod[:] = 1
         noise_tod_rms = np.std(noise_tod)
         print('noise_tod_rms = ', noise_tod_rms)
         # DEBUG end

--- a/tests/test_map_ground.py
+++ b/tests/test_map_ground.py
@@ -1,0 +1,650 @@
+# Copyright (c) 2015 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by 
+# a BSD-style license that can be found in the LICENSE file.
+
+
+import sys
+import os
+import shutil
+
+if 'TOAST_NO_MPI' in os.environ.keys():
+    from toast import fakempi as MPI
+else:
+    from mpi4py import MPI
+
+import numpy as np
+import numpy.testing as nt
+import healpy as hp
+from scipy.constants import degree
+
+from toast.tod.tod import *
+from toast.tod.pointing import *
+from toast.tod.sim_tod import *
+from toast.tod.sim_detdata import *
+from toast.tod.sim_noise import *
+from toast.map import *
+
+from toast.mpirunner import MPITestCase
+
+
+class MapGroundTest(MPITestCase):
+
+
+    def setUp(self):
+        self.outdir = "tests_output"
+        if self.comm.rank == 0:
+            if not os.path.isdir(self.outdir):
+                os.mkdir(self.outdir)
+        self.mapdir = os.path.join(self.outdir, "map_ground")
+        if self.comm.rank == 0:
+            if not os.path.isdir(self.mapdir):
+                os.mkdir(self.mapdir)
+
+        # Note: self.comm is set by the test infrastructure
+
+        self.toastcomm = Comm(world=self.comm)
+        self.data = Data(self.toastcomm)
+
+        self.detnames = ['bore']
+        self.dets = {
+            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
+            }
+
+        # this is an unpolarized detector...
+        self.epsilon = {
+            'bore' : 1.0,
+        }
+
+        nside = 1024
+        self.sim_nside = nside
+        #self.totsamp = 400000
+        self.totsamp = 10000
+        self.map_nside = nside
+        self.rate = 4.0
+        self.site_lon = '-67:47:10'
+        self.site_lat = '-22:57:30'
+        self.site_alt = 5200.
+        self.patch_lon = 15 * degree # '10.0'
+        self.patch_lat = -70 * degree # '-70.0'
+        self.patch_coord = 'C'
+        self.throw = 4.
+        self.scanrate = 0.05
+        self.scan_accel = 0.0001
+        self.CES_start = -1000.
+
+        self.NET = 7.0
+
+        self.fmins = {
+            'bore' : 0.0,
+        }
+        self.rates = {
+            'bore' : self.rate,
+        }
+        self.fknee = {
+            'bore' : 0.0,
+        }
+        self.alpha = {
+            'bore' : 1.0,
+        }
+        self.netd = {
+            'bore' : self.NET
+        }
+
+        # madam only supports a single observation
+        nobs = 1
+
+        # in order to make sure that the noise realization is reproducible
+        # all all concurrencies, we set the chunksize to something independent
+        # of the number of ranks.
+
+        nchunk = 10
+        chunksize = int(self.totsamp / nchunk)
+        chunks = np.ones(nchunk, dtype=np.int64)
+        chunks *= chunksize
+        remain = self.totsamp - (nchunk * chunksize)
+        for r in range(remain):
+            chunks[r] += 1
+
+        nflagged = 0
+
+        for i in range(nobs):
+            # create the TOD for this observation
+
+            tod = TODGround(
+                mpicomm=self.toastcomm.comm_group, 
+                detectors=self.dets, 
+                samples=self.totsamp, 
+                firsttime=0.0, 
+                rate=self.rate,
+                site_lon=self.site_lon,
+                site_lat=self.site_lat,
+                site_alt=self.site_alt,
+                patch_lon=self.patch_lon,
+                patch_lat=self.patch_lat,
+                patch_coord=self.patch_coord,
+                throw=self.throw,
+                scanrate=self.scanrate,
+                scan_accel=self.scan_accel,
+                CES_start=self.CES_start,
+                sizes=chunks)
+
+            self.common_flag_mask = tod.TURNAROUND
+
+            common_flags = tod.read_common_flags()
+            nflagged += np.sum((common_flags & self.common_flag_mask) != 0)
+
+            # add analytic noise model with white noise
+
+            nse = AnalyticNoise(
+                rate=self.rates, 
+                fmin=self.fmins,
+                detectors=self.detnames,
+                fknee=self.fknee, 
+                alpha=self.alpha, 
+                NET=self.netd)
+
+            ob = {}
+            ob['name'] = 'test'
+            ob['id'] = 0
+            ob['tod'] = tod
+            ob['intervals'] = None
+            ob['baselines'] = None
+            ob['noise'] = nse
+
+            self.data.obs.append(ob)
+
+        self.nflagged = nflagged
+
+    def test_grad(self):
+        start = MPI.Wtime()
+
+        # add simple sky gradient signal
+        grad = OpSimGradient(nside=self.sim_nside, nest=True, common_flag_mask=self.common_flag_mask)
+        grad.exec(self.data)
+
+        # make a simple pointing matrix
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_ground_grad_info"), "w")
+        self.data.info(handle, common_flag_mask=self.common_flag_mask)
+        if self.comm.rank == 0:
+            handle.close()
+
+        # make a binned map with madam
+        madam_out = os.path.join(self.mapdir, "madam_grad")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
+
+        pars = {}
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = min(8, self.map_nside)
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'F'
+        pars[ 'write_wcov' ] = 'F'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
+
+        madam = OpMadam(params=pars, name='grad', purge=True, common_flag_mask=self.common_flag_mask)
+        if madam.available:
+            madam.exec(self.data)
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            if self.comm.rank == 0:
+                import matplotlib.pyplot as plt
+
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
+
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True)
+
+                outfile = "{}.png".format(binfile)
+                hp.mollview(bins, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to input signal
+
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+
+                sig = grad.sigmap()
+                mask = (bins > -1.0e20)
+                nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
+
+        else:
+            print("libmadam not available, skipping tests")
+
+
+    def test_noise(self):
+        start = MPI.Wtime()
+
+        # generate noise timestreams from the noise model
+        nsig = OpSimNoise()
+        nsig.exec(self.data)
+
+        # DEBUG begin
+        noise_tod = self.data.obs[0]['tod'].cache.reference('noise_bore')
+        #noise_tod[:] = np.random.randn(noise_tod.size)*100
+        noise_tod_rms = np.std(noise_tod)
+        print('noise_tod_rms = ', noise_tod_rms)
+        # DEBUG end
+
+        # make a simple pointing matrix
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_ground_noise_info"), "w")
+        self.data.info(handle, common_flag_mask=self.common_flag_mask)
+        if self.comm.rank == 0:
+            handle.close()
+
+        # For noise weighting in madam, we know we are using an analytic noise
+        # and so we can use noise weights based on the NET.  This is instrument
+        # specific.
+
+        tod = self.data.obs[0]['tod']
+        nse = self.data.obs[0]['noise']
+        detweights = {}
+        for d in tod.local_dets:
+            detweights[d] = 1.0 / (self.rate * nse.NET(d)**2)
+
+        # make a binned map with madam
+        madam_out = os.path.join(self.mapdir, "madam_noise")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
+
+        pars = {}
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = min(8, self.map_nside)
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'F'
+        pars[ 'write_wcov' ] = 'F'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
+
+        madam = OpMadam(params=pars, detweights=detweights, name='noise', common_flag_mask=self.common_flag_mask)
+        if madam.available:
+            madam.exec(self.data)
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            if self.comm.rank == 0:
+                import matplotlib.pyplot as plt
+
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
+
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True)
+
+                outfile = "{}.png".format(binfile)
+                hp.mollview(bins, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # check that pixel rms makes sense given the
+                # number of hits and the timestream rms
+
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                print("tothits = ", tothits)
+
+                mask = (bins > -1.0e20)
+                print("num good pix = ", len(mask))
+                rthits = np.sqrt(hits[mask].astype(np.float64))
+                print("rthits = ", rthits)
+                print("bmap = ", bins[mask])
+                weighted = bins[mask] * rthits
+                print("weighted = ", weighted)
+                pixrms = np.sqrt(np.mean(weighted**2))
+                todrms = self.NET * np.sqrt(self.rate)
+                relerr = np.absolute(pixrms - todrms) / todrms
+                print("pixrms = ", pixrms)
+                print("todrms = ", todrms)
+                print("relerr = ", relerr)
+                self.assertTrue(relerr < 0.02)
+
+        else:
+            print("libmadam not available, skipping tests")
+
+
+    def test_scanmap(self):
+        start = MPI.Wtime()
+
+        # make a simple pointing matrix
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing.exec(self.data)
+
+        # get locally hit pixels
+        lc = OpLocalPixels()
+        localpix = lc.exec(self.data)
+
+        # construct a sky gradient operator, just to get the signal
+        # map- we are not going to use the operator on the data.
+        grad = OpSimGradient(nside=self.sim_nside, nest=True, common_flag_mask=self.common_flag_mask)
+        sig = grad.sigmap()
+
+        # pick a submap size and find the local submaps.
+        submapsize = np.floor_divide(self.sim_nside, 16)
+        allsm = np.floor_divide(localpix, submapsize)
+        sm = set(allsm)
+        localsm = np.array(sorted(sm), dtype=np.int64)
+
+        # construct a distributed map which has the gradient        
+        npix = 12 * self.sim_nside * self.sim_nside
+        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        lsub, lpix = distsig.global_to_local(localpix)
+        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        # create TOD from map
+        scansim = OpSimScan(distmap=distsig)
+        scansim.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_ground_scanmap_info"), "w")
+        self.data.info(handle, common_flag_mask=self.common_flag_mask)
+        if self.comm.rank == 0:
+            handle.close()
+
+        # make a binned map with madam
+        madam_out = os.path.join(self.mapdir, "madam_scansim")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
+
+        pars = {}
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = min(8, self.map_nside)
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'F'
+        pars[ 'write_wcov' ] = 'F'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
+
+        madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
+        if madam.available:
+            madam.exec(self.data)
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            if self.comm.rank == 0:
+                import matplotlib.pyplot as plt
+
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
+
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True)
+
+                outfile = "{}.png".format(binfile)
+                hp.mollview(bins, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to input signal
+
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                mask = (bins > -1.0e20)
+                nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
+
+        else:
+            print("libmadam not available, skipping tests")
+
+
+    def test_hwpfast(self):
+        start = MPI.Wtime()
+
+        # make a pointing matrix with a HWP that rotates 2*PI every sample
+        hwprate = self.rate * 60.0
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwprpm=hwprate)
+        pointing.exec(self.data)
+
+        # get locally hit pixels
+        lc = OpLocalPixels()
+        localpix = lc.exec(self.data)
+
+        # construct a sky gradient operator, just to get the signal
+        # map- we are not going to use the operator on the data.
+        grad = OpSimGradient(nside=self.sim_nside, nest=True)
+        sig = grad.sigmap()
+
+        # pick a submap size and find the local submaps.
+        submapsize = np.floor_divide(self.sim_nside, 16)
+        allsm = np.floor_divide(localpix, submapsize)
+        sm = set(allsm)
+        localsm = np.array(sorted(sm), dtype=np.int64)
+
+        # construct a distributed map which has the gradient        
+        npix = 12 * self.sim_nside * self.sim_nside
+        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        lsub, lpix = distsig.global_to_local(localpix)
+        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        # create TOD from map
+        scansim = OpSimScan(distmap=distsig)
+        scansim.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_ground_hwpfast_info"), "w")
+        self.data.info(handle, common_flag_mask=self.common_flag_mask)
+        if self.comm.rank == 0:
+            handle.close()
+
+        # make a binned map with madam
+        madam_out = os.path.join(self.mapdir, "madam_hwpfast")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
+
+        pars = {}
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = min(8, self.map_nside)
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'F'
+        pars[ 'write_wcov' ] = 'F'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
+
+        madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
+        if madam.available:
+            madam.exec(self.data)
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            if self.comm.rank == 0:
+                import matplotlib.pyplot as plt
+
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
+
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True)
+
+                outfile = "{}.png".format(binfile)
+                hp.mollview(bins, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to input signal
+
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                mask = (bins > -1.0e20)
+                nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
+
+        else:
+            print("libmadam not available, skipping tests")
+
+
+    def test_hwpconst(self):
+        start = MPI.Wtime()
+
+        # make a pointing matrix with a HWP that is constant
+        hwpstep = 2.0 * np.pi
+        hwpsteptime = (self.totsamp / self.rate) / 60.0
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwpstep=hwpstep, hwpsteptime=hwpsteptime)
+        pointing.exec(self.data)
+
+        # get locally hit pixels
+        lc = OpLocalPixels()
+        localpix = lc.exec(self.data)
+
+        # construct a sky gradient operator, just to get the signal
+        # map- we are not going to use the operator on the data.
+        grad = OpSimGradient(nside=self.sim_nside, nest=True)
+        sig = grad.sigmap()
+
+        # pick a submap size and find the local submaps.
+        submapsize = np.floor_divide(self.sim_nside, 16)
+        allsm = np.floor_divide(localpix, submapsize)
+        sm = set(allsm)
+        localsm = np.array(sorted(sm), dtype=np.int64)
+
+        # construct a distributed map which has the gradient        
+        npix = 12 * self.sim_nside * self.sim_nside
+        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        lsub, lpix = distsig.global_to_local(localpix)
+        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        # create TOD from map
+        scansim = OpSimScan(distmap=distsig)
+        scansim.exec(self.data)
+
+        handle = None
+        if self.comm.rank == 0:
+            handle = open(os.path.join(self.outdir,"out_test_ground_hwpconst_info"), "w")
+        self.data.info(handle, common_flag_mask=self.common_flag_mask)
+        if self.comm.rank == 0:
+            handle.close()
+
+        # make a binned map with madam
+        madam_out = os.path.join(self.mapdir, "madam_hwpconst")
+        if self.comm.rank == 0:
+            if os.path.isdir(madam_out):
+                shutil.rmtree(madam_out)
+            os.mkdir(madam_out)
+
+        pars = {}
+        pars[ 'kfirst' ] = 'F'
+        pars[ 'base_first' ] = 1.0
+        pars[ 'fsample' ] = self.rate
+        pars[ 'nside_map' ] = self.map_nside
+        pars[ 'nside_cross' ] = self.map_nside
+        pars[ 'nside_submap' ] = min(8, self.map_nside)
+        pars[ 'write_map' ] = 'F'
+        pars[ 'write_binmap' ] = 'T'
+        pars[ 'write_matrix' ] = 'F'
+        pars[ 'write_wcov' ] = 'F'
+        pars[ 'write_hits' ] = 'T'
+        pars[ 'kfilter' ] = 'F'
+        pars[ 'run_submap_test' ] = 'F'
+        pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
+
+        madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
+        if madam.available:
+            madam.exec(self.data)
+            stop = MPI.Wtime()
+            elapsed = stop - start
+            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            if self.comm.rank == 0:
+                import matplotlib.pyplot as plt
+                
+                hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
+                hits = hp.read_map(hitsfile, nest=True)
+
+                outfile = "{}.png".format(hitsfile)
+                hp.mollview(hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                binfile = os.path.join(madam_out, 'madam_bmap.fits')
+                bins = hp.read_map(binfile, nest=True)
+
+                outfile = "{}.png".format(binfile)
+                hp.mollview(bins, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+
+                # compare binned map to input signal
+
+                tothits = np.sum(hits)
+                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                mask = (bins > -1.0e20)
+                nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
+
+        else:
+            print("libmadam not available, skipping tests")

--- a/tests/test_map_ground.py
+++ b/tests/test_map_ground.py
@@ -64,7 +64,7 @@ class MapGroundTest(MPITestCase):
         self.site_lon = '-67:47:10'
         self.site_lat = '-22:57:30'
         self.site_alt = 5200.
-        self.patch_lon = 115 * degree # '10.0'
+        self.patch_lon = 15 * degree # '10.0'
         self.patch_lat = -60 * degree # '-70.0'
         self.patch_coord = 'C'
         self.throw = 4.

--- a/tests/test_map_ground.py
+++ b/tests/test_map_ground.py
@@ -231,14 +231,6 @@ class MapGroundTest(MPITestCase):
         nsig = OpSimNoise()
         nsig.exec(self.data)
 
-        # DEBUG begin
-        noise_tod = self.data.obs[0]['tod'].cache.reference('noise_bore')
-        #noise_tod[:] = np.random.randn(noise_tod.size)*100
-        #noise_tod[:] = 1
-        noise_tod_rms = np.std(noise_tod)
-        print('noise_tod_rms = ', noise_tod_rms)
-        # DEBUG end
-
         # make a simple pointing matrix
         pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
         pointing.exec(self.data)

--- a/toast/dist.py
+++ b/toast/dist.py
@@ -291,7 +291,7 @@ class Data(object):
         return
 
 
-    def info(self, handle):
+    def info(self, handle, flag_mask=255, common_flag_mask=255):
         """
         Print information about the distributed data to the
         specified file handle.  Only the rank 0 process writes.
@@ -361,7 +361,7 @@ class Data(object):
                     data = tod.read(detector=dt, local_start=0, n=nsamp)
                     flags, common = tod.read_flags(detector=dt, local_start=0, n=nsamp)
                     procstr = "{}      {:.3e} ({}) --> {:.3e} ({})\n".format(procstr, data[0], flags[0], data[-1], flags[-1])
-                    good = np.where((flags | common) == 0)[0]
+                    good = np.where(((flags & flag_mask) | (common & common_flag_mask)) == 0)[0]
                     procstr = "{}        {} good samples\n".format(procstr, len(good))
                     min = np.min(data[good])
                     max = np.max(data[good])

--- a/toast/dist.py
+++ b/toast/dist.py
@@ -250,6 +250,7 @@ def distribute_samples(mpicomm, timedist, detectors, samples, sizes=None):
         dist_detsindx = distribute_uniform(len(detectors), mpicomm.size)[mpicomm.rank]
         dist_dets = detectors[dist_detsindx[0]:dist_detsindx[0]+dist_detsindx[1]]
         dist_samples = [ (0, samples) for x in range(mpicomm.size) ]
+        dist_sizes = [ (0, 1) for x in range(mpicomm.size) ]
 
     return (dist_dets, dist_samples, dist_sizes)
 

--- a/toast/map/madam.py
+++ b/toast/map/madam.py
@@ -245,9 +245,6 @@ class OpMadam(Operator):
                 nsamp += tod.local_samples[1]
         else:
             tod = data.obs[0]['tod']
-            if not tod.timedist:
-                raise RuntimeError(
-                    "Madam requires data to be distributed by time")
             nsamp = tod.local_samples[1]
 
         # Determine the detectors and the pointing matrix non-zeros
@@ -257,9 +254,9 @@ class OpMadam(Operator):
         tod = data.obs[0]['tod']
 
         if self._dets is None:
-            detectors = tod.detectors
+            detectors = tod.local_dets
         else:
-            detectors = [det for det in tod.detectors
+            detectors = [det for det in tod.local_dets
                          if det in self._dets]
 
         detstring = self._dets2detstring(detectors)

--- a/toast/tod/__init__.py
+++ b/toast/tod/__init__.py
@@ -14,7 +14,8 @@ from .interval import Interval
 from .pointing import OpPointingHpix
 
 from .sim_tod import (satellite_scanning, TODHpixSpiral,
-    TODSatellite, slew_precession_axis)
+                      TODSatellite, slew_precession_axis,
+                      TODGround)
 
 from .sim_noise import AnalyticNoise
 

--- a/toast/tod/sim_detdata.py
+++ b/toast/tod/sim_detdata.py
@@ -151,7 +151,7 @@ class OpSimGradient(Operator):
         nest (bool): whether to use NESTED ordering.
     """
 
-    def __init__(self, out='grad', nside=512, min=-100.0, max=100.0, nest=False):
+    def __init__(self, out='grad', nside=512, min=-100.0, max=100.0, nest=False, flag_mask=255, common_flag_mask=255):
         # We call the parent class constructor, which currently does nothing
         super().__init__()
         self._nside = nside
@@ -159,6 +159,8 @@ class OpSimGradient(Operator):
         self._min = min
         self._max = max
         self._nest = nest
+        self._flag_mask = flag_mask
+        self._common_flag_mask = common_flag_mask
 
     def exec(self, data):
         """
@@ -189,8 +191,8 @@ class OpSimGradient(Operator):
                                               n=tod.local_samples[1]))
                 flags, common = tod.read_flags(detector=det, local_start=0,
                                                n=tod.local_samples[1])
-                totflags = np.copy(flags)
-                totflags |= common
+                totflags = flags & self._flag_mask
+                totflags |= (common & self._common_flag_mask)
 
                 pdata[totflags != 0,:] = nullquat
 
@@ -210,6 +212,7 @@ class OpSimGradient(Operator):
                                      (tod.local_samples[1],))
                 ref = tod.cache.reference(cachename)
                 ref[:] += z
+                print('Grad timestream:', ref, np.sum(ref!=0),' non-zeros', flush=True) # DEBUG
 
         return
 


### PR DESCRIPTION
This pull request adds support for constant elevation scans (CES).  When initializing the TOD object, the calling code specifies:
- the start and stop time of the CES. If omitted, will use the TOD time stamp range.
- the start time of the TOD object, the rate and the number of samples. These must define a range that is enclosed by the CES start and stop times.
- location of the observatory on Earth
- location of the observed patch on the sky
- throw (width) of the scan
- scan rate and scan rate acceleration

Earth and sky coordinates can either be (floating point) radians or use the pyEphem coordinate string syntax.

Upon initialization, the TOD object will determine the azimuth and elevation of the target patch midway through the CES and use those to center the scan. If the patch is found to be below the horizon, a runtime error is raised. The TOD object will then simulate the scanning sweeps starting at the CES start time, taking into account the limitations of the scan rate acceleration. A matching set of common flags are created and cached. The TODGround class defines a number of common flag bits that can be checked:

    TURNAROUND = 1
    LEFTRIGHT_SCAN = 2
    RIGHTLEFT_SCAN = 4
    LEFTRIGHT_TURNAROUND = LEFTRIGHT_SCAN + TURNAROUND
    RIGHTLEFT_TURNAROUND = RIGHTLEFT_SCAN + TURNAROUND

These will allow the user to discard (or include) the turnarounds and split the dataset into left and right scans.

Here is a visualization of a simulated CES bore sight pointing in horizontal coordinates

![az](https://cloud.githubusercontent.com/assets/596250/22563428/5cc110fc-e935-11e6-84d9-af13915b9c3a.png)

And here is the resulting scan in equatorial coordinates:

![ra_dec](https://cloud.githubusercontent.com/assets/596250/22563462/78524de0-e935-11e6-8af2-dff693b73b4d.png)

The samples that do not have the TURNAROUND bit raised are indicated in orange. For this simulation, the scan rate and the acceleration were deliberately set to very low values to make the pattern more apparent.