### PR TITLE
Working implementation of the mixing matrix noise.

### DIFF
--- a/src/python/tests/ops_simnoise.py
+++ b/src/python/tests/ops_simnoise.py
@@ -1,25 +1,17 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
 
 from ..mpi import MPI
 from .mpi import MPITestCase
 
-import sys
-import os
-
-import numpy as np
-import numpy.testing as nt
-
-import scipy.interpolate as si
-
-from ..tod.tod import *
-from ..tod.pointing import *
-from ..tod.noise import *
-from ..tod.sim_noise import *
-from ..tod.sim_det_noise import *
-from ..tod.sim_tod import *
-
+from ..dist import Comm, Data
+from ..tod import (Noise, sim_noise_timestream, AnalyticNoise,
+                   OpSimNoise, TODHpixSpiral)
 from .. import rng as rng
 
 
@@ -33,19 +25,20 @@ class OpSimNoiseTest(MPITestCase):
 
         # Note: self.comm is set by the test infrastructure
         self.worldsize = self.comm.size
-        if (self.worldsize >= 2):
-            self.groupsize = int( self.worldsize / 2 )
+        if self.worldsize >= 2:
+            self.groupsize = self.worldsize // 2
             self.ngroup = 2
         else:
             self.groupsize = 1
             self.ngroup = 1
         self.toastcomm = Comm(world=self.comm, groupsize=self.groupsize)
-        self.data = Data(self.toastcomm)
+        self.data = Data(self.toastcomm)  # Uncorrelated simulation
+        self.data2 = Data(self.toastcomm)  # Correlated simulation
 
         self.dets = ["f1a", "f1b", "f2a", "f2b", "white", "high"]
-        self.fp = {}
-        for d in self.dets:
-            self.fp[d] = np.array([0.0, 0.0, 1.0, 0.0])
+        self.focalplane = {}
+        for det in self.dets:
+            self.focalplane[det] = np.array([0.0, 0.0, 1.0, 0.0])
 
         self.rate = 20.0
 
@@ -53,108 +46,140 @@ class OpSimNoiseTest(MPITestCase):
         self.fmin = {}
         self.fknee = {}
         self.alpha = {}
-        self.NET = {}
+        self.net = {}
 
         self.rates["f1a"] = self.rate
         self.fmin["f1a"] = 1.0e-5
         self.fknee["f1a"] = 0.15
         self.alpha["f1a"] = 1.0
-        self.NET["f1a"] = 10.0
+        self.net["f1a"] = 10.0
 
         self.rates["f1b"] = self.rate
         self.fmin["f1b"] = 1.0e-5
         self.fknee["f1b"] = 0.1
         self.alpha["f1b"] = 1.0
-        self.NET["f1b"] = 10.0
+        self.net["f1b"] = 10.0
 
         self.rates["f2a"] = self.rate
         self.fmin["f2a"] = 1.0e-5
         self.fknee["f2a"] = 0.05
         self.alpha["f2a"] = 1.0
-        self.NET["f2a"] = 10.0
+        self.net["f2a"] = 10.0
 
         self.rates["f2b"] = self.rate
         self.fmin["f2b"] = 1.0e-5
         self.fknee["f2b"] = 0.001
         self.alpha["f2b"] = 1.0
-        self.NET["f2b"] = 10.0
+        self.net["f2b"] = 10.0
 
         self.rates["white"] = self.rate
         self.fmin["white"] = 0.0
         self.fknee["white"] = 0.0
         self.alpha["white"] = 1.0
-        self.NET["white"] = 10.0
+        self.net["white"] = 10.0
 
         self.rates["high"] = self.rate
         self.fmin["high"] = 1.0e-5
         self.fknee["high"] = 40.0
         self.alpha["high"] = 2.0
-        self.NET["high"] = 10.0
+        self.net["high"] = 10.0
 
         self.totsamp = 100000
 
         self.oversample = 2
 
-        self.MC = 100
+        self.nmc = 100
 
-        # in order to make sure that the noise realization is reproducible
-        # all all concurrencies, we set the chunksize to something independent
-        # of the number of ranks.
+        # in order to make sure that the noise realization is
+        # reproducible all all concurrencies, we set the chunksize to
+        # something independent of the number of ranks.
 
         nchunk = 4
         chunksize = int(self.totsamp / nchunk)
         chunks = np.ones(nchunk, dtype=np.int64)
         chunks *= chunksize
         remain = self.totsamp - (nchunk * chunksize)
-        for r in range(remain):
-            chunks[r] += 1
+        for i in range(remain):
+            chunks[i] += 1
 
         self.chunksize = chunksize
 
         # Construct an empty TOD (no pointing needed)
 
         self.tod = TODHpixSpiral(
-            self.toastcomm.comm_group, 
-            self.fp, 
-            self.totsamp, 
-            firsttime=0.0, 
-            rate=self.rate, 
-            nside=512, 
+            self.toastcomm.comm_group,
+            self.focalplane,
+            self.totsamp,
+            firsttime=0.0,
+            rate=self.rate,
+            nside=512,
             sampsizes=chunks)
 
         # construct an analytic noise model
 
         self.nse = AnalyticNoise(
-            rate=self.rates, 
-            fmin=self.fmin, 
-            detectors=self.dets, 
-            fknee=self.fknee, 
-            alpha=self.alpha, 
-            NET=self.NET
+            rate=self.rates,
+            fmin=self.fmin,
+            detectors=self.dets,
+            fknee=self.fknee,
+            alpha=self.alpha,
+            NET=self.net
         )
 
-        ob = {}
-        ob['name'] = 'noisetest-{}'.format(self.toastcomm.group)
-        ob['id'] = 0
-        ob['tod'] = self.tod
-        ob['intervals'] = None
-        ob['baselines'] = None
-        ob['noise'] = self.nse
+        # And another, correlated noise model
 
-        self.data.obs.append(ob)
+        freqs = {
+            'noise1':self.nse.freq('f1a'),
+            'noise2':self.nse.freq('f1b'),
+            'noise3':self.nse.freq('f2a'),
+            'noise4':self.nse.freq('f2b'),
+            'noise5':self.nse.freq('white'),
+            'noise6':self.nse.freq('high')}
+        psds = {
+            'noise1':self.nse.psd('f1a'),
+            'noise2':self.nse.psd('f1b'),
+            'noise3':self.nse.psd('f2a'),
+            'noise4':self.nse.psd('f2b'),
+            'noise5':self.nse.psd('white'),
+            'noise6':self.nse.psd('high')}
+        mixmatrix = {
+            'f1a':{'noise1':1},
+            'f1b':{'noise2':1},
+            'f2a':{'noise3':1},
+            'f2b':{'noise4':1},
+            'white':{'noise5':1.0},
+            'high':{'noise1':-1, 'noise2':-1, 'noise3':-1, 'noise4':-1,
+                    'noise5':-1}
+        }
+        indices = {
+            'noise1':100, 'noise2':101, 'noise3':103,
+            'noise4':1, 'noise5':2, 'noise6':3}
+        self.nse2 = Noise(detectors=self.dets, freqs=freqs, psds=psds,
+                          mixmatrix=mixmatrix, indices=indices)
 
+        obs = {
+            'name':'noisetest-{}'.format(self.toastcomm.group),
+            'id':0,
+            'tod':self.tod,
+            'intervals':None,
+            'baselines':None,
+            'noise':self.nse}
+        self.data.obs.append(obs)
+
+        obs2 = {
+            'name':'noisetest-{}'.format(self.toastcomm.group),
+            'id':0,
+            'tod':self.tod,
+            'intervals':None,
+            'baselines':None,
+            'noise':self.nse2}
+        self.data2.obs.append(obs2)
+
+        return
 
     def test_gauss(self):
-        # test that the same samples from different calls are reproducible.
+        """Test that the same samples from different calls are reproducible."""
 
-        ob = self.data.obs[0]
-        nse = ob['noise']
-
-        det = self.dets[-1]
-
-        psd = np.ones_like(nse.freq(det))
-        npsd = len(psd)
-        
         detindx = len(self.dets) - 1
         telescope = 5
         realization = 1000
@@ -162,69 +187,82 @@ class OpSimNoiseTest(MPITestCase):
         obsindx = 1234
 
         key1 = realization * 4294967296 + telescope * 65536 + component
-        key2 = obsindx * 4294967296 + detindx 
+        key2 = obsindx * 4294967296 + detindx
         counter1 = 0
 
         compoff = 500
         ncomp = 10
 
         counter2 = 0
-        d1 = rng.random(1000, sampler="gaussian", key=(key1, key2), 
-            counter=(counter1, counter2))
-        print(d1[compoff:compoff+ncomp])
+        data1 = rng.random(1000, sampler="gaussian", key=(key1, key2),
+                           counter=(counter1, counter2))
+        print(data1[compoff:compoff+ncomp])
 
         counter2 = 100
-        d2 = rng.random(1000, sampler="gaussian", key=(key1, key2), 
-            counter=(counter1, counter2))
-        print(d2[compoff-100:compoff-100+ncomp])
+        data2 = rng.random(1000, sampler="gaussian", key=(key1, key2),
+                           counter=(counter1, counter2))
+        print(data2[compoff-100:compoff-100+ncomp])
 
         counter2 = 300
-        d3 = rng.random(1000, sampler="gaussian", key=(key1, key2), 
-            counter=(counter1, counter2))
-        print(d3[compoff-300:compoff-300+ncomp])
+        data3 = rng.random(1000, sampler="gaussian", key=(key1, key2),
+                           counter=(counter1, counter2))
+        print(data3[compoff-300:compoff-300+ncomp])
 
-        np.testing.assert_array_almost_equal(d1[compoff:compoff+ncomp], d2[compoff-100:compoff-100+ncomp])
-        np.testing.assert_array_almost_equal(d1[compoff:compoff+ncomp], d3[compoff-300:compoff-300+ncomp])
-
+        np.testing.assert_array_almost_equal(
+            data1[compoff:compoff+ncomp], data2[compoff-100:compoff-100+ncomp])
+        np.testing.assert_array_almost_equal(
+            data1[compoff:compoff+ncomp], data3[compoff-300:compoff-300+ncomp])
+        return
 
     def test_sim(self):
+        """Test the uncorrelated noise generation."""
         start = MPI.Wtime()
 
-        ob = self.data.obs[0]
-        tod = ob['tod']
-        nse = ob['noise']
+        obs = self.data.obs[0]
+        tod = obs['tod']
+        nse = obs['noise']
 
-        # verify that the white noise part of the spectrum is normalized correctly
+        # verify that the white noise part of the spectrum is normalized
+        # correctly
 
         for det in tod.local_dets:
             fsamp = nse.rate(det)
             cutoff = 0.95 * (fsamp / 2.0)
             indx = np.where(nse.freq(det) > cutoff)
 
-            NET = nse.NET(det)
-            knee = nse.fknee(det)
+            net = nse.NET(det)
             avg = np.mean(nse.psd(det)[indx])
-            NETsq = NET*NET
-            print("det {} NETsq = {}, average white noise level = {}".format(det, NETsq, avg))
+            netsq = net*net
+            print("det {} NETsq = {}, average white noise level = {}"
+                  "".format(det, netsq, avg))
             if det != "high":
-                self.assertTrue((np.absolute(avg - NETsq)/NETsq) < 0.02)
+                self.assertTrue((np.absolute(avg - netsq)/netsq) < 0.02)
 
         if self.comm.rank == 0:
             import matplotlib.pyplot as plt
 
             for det in tod.local_dets:
-                savefile = os.path.join(self.outdir, "out_test_simnoise_rawpsd_{}.txt".format(det))
-                np.savetxt(savefile, np.transpose([nse.freq(det), nse.psd(det)]), delimiter=' ')
+                savefile = os.path.join(
+                    self.outdir, "out_test_simnoise_rawpsd_{}.txt".format(det))
+                np.savetxt(savefile,
+                           np.transpose([nse.freq(det), nse.psd(det)]),
+                           delimiter=' ')
 
-                fig = plt.figure(figsize=(12,8), dpi=72)
+                fig = plt.figure(figsize=(12, 8), dpi=72)
                 ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                ax.loglog(nse.freq(det), nse.psd(det), marker='o', c="red", label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, fmin={:0.4f}'.format(det, self.rates[det], self.NET[det], self.fknee[det], self.fmin[det]))
+                ax.loglog(nse.freq(det), nse.psd(det), marker='o', c="red",
+                          label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, '
+                          'fmin={:0.4f}'.format(
+                              det, self.rates[det], self.net[det],
+                              self.fknee[det], self.fmin[det]))
+
                 cur_ylim = ax.get_ylim()
                 ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
                 ax.legend(loc=1)
                 plt.title("Simulated PSD from toast.AnalyticNoise")
 
-                savefile = os.path.join(self.outdir, "out_test_simnoise_rawpsd_{}.png".format(det))
+                savefile = os.path.join(
+                    self.outdir, "out_test_simnoise_rawpsd_{}.png".format(det))
                 plt.savefig(savefile)
                 plt.close()
 
@@ -273,16 +311,18 @@ class OpSimNoiseTest(MPITestCase):
         idet = 0
         for det in tod.local_dets:
 
-            df = nse.rate(det) / float(fftlen)
+            dfreq = nse.rate(det) / float(fftlen)
 
-            (temp, freqs[det], psds[det]) = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
+            (_, freqs[det], psds[det]) = sim_noise_timestream(
+                0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize,
+                self.oversample, nse.freq(det), nse.psd(det))
 
             # Factor of 2 comes from the negative frequency values.
-            psdnorm[det] = 2.0 * np.sum(psds[det] * df)
+            psdnorm[det] = 2.0 * np.sum(psds[det] * dfreq)
             print("psd[{}] integral = {}".format(det, psdnorm[det]))
 
-            todvar[det] = np.zeros(self.MC, dtype=np.float64)
-            checkpsd[det] = np.zeros((nbins-1, self.MC), dtype=np.float64)
+            todvar[det] = np.zeros(self.nmc, dtype=np.float64)
+            checkpsd[det] = np.zeros((nbins-1, self.nmc), dtype=np.float64)
 
             idet += 1
 
@@ -290,18 +330,28 @@ class OpSimNoiseTest(MPITestCase):
             import matplotlib.pyplot as plt
 
             for det in tod.local_dets:
-                savefile = os.path.join(self.outdir, "out_test_simnoise_psd_{}.txt".format(det))
-                np.savetxt(savefile, np.transpose([freqs[det], psds[det]]), delimiter=' ')
+                savefile = os.path.join(
+                    self.outdir, "out_test_simnoise_psd_{}.txt".format(det))
+                np.savetxt(savefile, np.transpose([freqs[det], psds[det]]),
+                           delimiter=' ')
 
-                fig = plt.figure(figsize=(12,8), dpi=72)
+                fig = plt.figure(figsize=(12, 8), dpi=72)
                 ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                ax.loglog(freqs[det], psds[det], marker='+', c="blue", label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, fmin={:0.4f}'.format(det, self.rates[det], self.NET[det], self.fknee[det], self.fmin[det]))
+                ax.loglog(freqs[det], psds[det], marker='+', c="blue",
+                          label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, '
+                          'fmin={:0.4f}'.format(
+                              det, self.rates[det], self.net[det],
+                              self.fknee[det], self.fmin[det]))
+
                 cur_ylim = ax.get_ylim()
                 ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
                 ax.legend(loc=1)
-                plt.title("Interpolated PSD with High-pass from {:0.1f} second Simulation Interval".format((float(self.totsamp)/self.rate)))
+                plt.title("Interpolated PSD with High-pass from {:0.1f} "
+                          "second Simulation Interval".format(
+                              (float(self.totsamp)/self.rate)))
 
-                savefile = os.path.join(self.outdir, "out_test_simnoise_psd_{}.png".format(det))
+                savefile = os.path.join(
+                    self.outdir, "out_test_simnoise_psd_{}.png".format(det))
                 plt.savefig(savefile)
                 plt.close()
 
@@ -321,30 +371,33 @@ class OpSimNoiseTest(MPITestCase):
                     # just write the first realization as usual
                     hpy = None
 
-        # if we have the h5py module and a special environment variable is set, 
-        # then process zero will dump out its full timestream data for more 
-        # extensive sharing / tests.  Just dump a few detectors to keep the 
+        # if we have the h5py module and a special environment variable is set,
+        # then process zero will dump out its full timestream data for more
+        # extensive sharing / tests.  Just dump a few detectors to keep the
         # file size reasonable.
 
-        hf = None
+        hfile = None
         dset = {}
         if hpy is not None:
-            hf = hpy.File(os.path.join(self.outdir, "out_test_simnoise_tod.hdf5"), "w")
+            hfile = hpy.File(
+                os.path.join(self.outdir, "out_test_simnoise_tod.hdf5"), "w")
             for det in ['white', 'f1a', 'f2a']:
-                dset[det] = hf.create_dataset(det, (self.MC, self.totsamp), dtype="float64")
+                dset[det] = hfile.create_dataset(
+                    det, (self.nmc, self.totsamp), dtype="float64")
 
         # Run both the numpy FFT case and the toast FFT case.
 
         for case in ['npFFT', 'toastFFT']:
 
-            for r in range(self.MC):
+            for realization in range(self.nmc):
 
                 # generate timestreams
 
-                op = OpSimNoise(realization=r, altFFT=(case == 'toastFFT'))
-                op.exec(self.data)
+                opnoise = OpSimNoise(realization=realization,
+                                     altFFT=(case == 'toastFFT'))
+                opnoise.exec(self.data)
 
-                if r == 0:
+                if realization == 0:
                     # write timestreams to disk for debugging
 
                     if self.comm.rank == 0:
@@ -354,107 +407,148 @@ class OpSimNoiseTest(MPITestCase):
 
                             check = tod.cache.reference("noise_{}".format(det))
 
-                            savefile = os.path.join(self.outdir, "out_{}_test_simnoise_tod_mc0_{}.txt".format(case, det))
-                            np.savetxt(savefile, np.transpose([check]), delimiter=' ')
+                            savefile = os.path.join(
+                                self.outdir,
+                                "out_{}_test_simnoise_tod_mc0_{}.txt"
+                                "".format(case, det))
+                            np.savetxt(savefile, np.transpose([check]),
+                                       delimiter=' ')
 
-                            fig = plt.figure(figsize=(12,8), dpi=72)
+                            fig = plt.figure(figsize=(12, 8), dpi=72)
                             ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                            ax.plot(np.arange(len(check)), check, c="black", label='Det {}'.format(det))
+                            ax.plot(np.arange(len(check)), check, c="black",
+                                    label='Det {}'.format(det))
                             ax.legend(loc=1)
-                            plt.title("First Realization of Simulated TOD from toast.sim_noise_timestream()")
+                            plt.title("First Realization of Simulated TOD "
+                                      "from toast.sim_noise_timestream()")
 
-                            savefile = os.path.join(self.outdir, "out_{}_test_simnoise_tod_mc0_{}.png".format(case, det))
+                            savefile = os.path.join(
+                                self.outdir,
+                                "out_{}_test_simnoise_tod_mc0_{}.png"
+                                "".format(case, det))
                             plt.savefig(savefile)
                             plt.close()
 
                 for det in tod.local_dets:
                     # compute the TOD variance
-                    td = tod.cache.reference("noise_{}".format(det))
-                    dclevel = np.mean(td)
-                    variance = np.vdot(td-dclevel, td-dclevel) / ntod
-                    todvar[det][r] = variance
+                    ref = tod.cache.reference("noise_{}".format(det))
+                    dclevel = np.mean(ref)
+                    variance = np.vdot(ref-dclevel, ref-dclevel) / ntod
+                    todvar[det][realization] = variance
 
-                    if hf is not None and case == "toastFFT":
+                    if hfile is not None and case == "toastFFT":
                         if det in dset:
-                            dset[det][r,:] = td[:]
+                            dset[det][realization, :] = ref[:]
 
                     # compute the PSD
                     buffer = np.zeros(cfftlen, dtype=np.float64)
-                    offset = (cfftlen - len(td)) // 2
-                    buffer[offset:offset+len(td)] = td
+                    offset = (cfftlen - len(ref)) // 2
+                    buffer[offset:offset+len(ref)] = ref
                     rawpsd = np.fft.rfft(buffer)
                     norm = 1.0 / (self.rate * self.totsamp)
                     rawpsd = norm * np.abs(rawpsd**2)
                     bpsd = np.bincount(checkbinmap, weights=rawpsd)
                     good = (bcount > 0)
                     bpsd[good] /= bcount[good]
-                    checkpsd[det][:,r] = bpsd[:]
+                    checkpsd[det][:, realization] = bpsd[:]
 
                 tod.cache.clear()
 
-            if hf is not None:
-                hf.close()
+            if hfile is not None:
+                hfile.close()
 
             if self.comm.rank == 0:
-                np.savetxt(os.path.join(self.outdir,"out_{}_test_simnoise_tod_var.txt".format(case)), np.transpose([todvar[self.dets[0]], todvar[self.dets[1]], todvar[self.dets[2]], todvar[self.dets[3]], todvar[self.dets[4]]]), delimiter=' ')
+                np.savetxt(
+                    os.path.join(
+                        self.outdir,
+                        "out_{}_test_simnoise_tod_var.txt".format(case)),
+                    np.transpose(
+                        [todvar[self.dets[0]], todvar[self.dets[1]],
+                         todvar[self.dets[2]], todvar[self.dets[3]],
+                         todvar[self.dets[4]]]),
+                    delimiter=' ')
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
 
                 for det in tod.local_dets:
-                    savefile = os.path.join(self.outdir, "out_{}_test_simnoise_tod_var_{}.txt".format(case, det))
-                    np.savetxt(savefile, np.transpose([todvar[det]]), delimiter=' ')
+                    savefile = os.path.join(
+                        self.outdir,
+                        "out_{}_test_simnoise_tod_var_{}.txt".format(case, det))
+                    np.savetxt(savefile, np.transpose([todvar[det]]),
+                               delimiter=' ')
 
                     sig = np.mean(todvar[det]) * np.sqrt(2.0/(self.chunksize-1))
                     histrange = 5.0 * sig
                     histmin = psdnorm[det] - histrange
                     histmax = psdnorm[det] + histrange
 
-                    fig = plt.figure(figsize=(12,8), dpi=72)
+                    fig = plt.figure(figsize=(12, 8), dpi=72)
 
                     ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                    hn, hbins, hpatches = plt.hist(todvar[det], 10, range=(histmin, histmax), facecolor="magenta", alpha=0.75, label="{}:  PSD integral = {:0.1f} expected sigma = {:0.1f}".format(det, psdnorm[det], sig))
+                    plt.hist(
+                        todvar[det], 10, range=(histmin, histmax),
+                        facecolor="magenta", alpha=0.75,
+                        label="{}:  PSD integral = {:0.1f} expected sigma = "
+                        "{:0.1f}".format(det, psdnorm[det], sig))
                     ax.legend(loc=1)
-                    plt.title("Distribution of TOD Variance for {} Realizations".format(self.MC))
+                    plt.title("Distribution of TOD Variance for {} "
+                              "Realizations".format(self.nmc))
 
-                    savefile = os.path.join(self.outdir, "out_{}_test_simnoise_tod_var_{}.png".format(case, det))
+                    savefile = os.path.join(
+                        self.outdir,
+                        "out_{}_test_simnoise_tod_var_{}.png".format(case, det))
                     plt.savefig(savefile)
                     plt.close()
 
-                    meanpsd = np.asarray([ np.mean(checkpsd[det][x,:]) for x in range(nbins-1) ])
+                    meanpsd = np.asarray(
+                        [np.mean(checkpsd[det][x, :]) for x in range(nbins-1)])
 
-                    fig = plt.figure(figsize=(12,8), dpi=72)
+                    fig = plt.figure(figsize=(12, 8), dpi=72)
 
                     ax = fig.add_subplot(1, 1, 1, aspect='auto')
                     ax.plot(bins, bintruth[det], c='k', label="Input Truth")
-                    ax.plot(bins, meanpsd, c='b', marker="o", label="Mean Binned PSD")
-                    ax.scatter(np.repeat(bins, self.MC), checkpsd[det].flatten(), marker='x', color='r', label="Binned PSD")
+                    ax.plot(bins, meanpsd, c='b', marker="o",
+                            label="Mean Binned PSD")
+                    ax.scatter(np.repeat(bins, self.nmc),
+                               checkpsd[det].flatten(), marker='x', color='r',
+                               label="Binned PSD")
                     #ax.set_xscale('log')
                     #ax.set_yscale('log')
                     ax.legend(loc=1)
-                    plt.title("Detector {} Binned PSDs for {} Realizations".format(det, self.MC))
+                    plt.title(
+                        "Detector {} Binned PSDs for {} Realizations"
+                        "".format(det, self.nmc))
 
-                    savefile = os.path.join(self.outdir, "out_{}_test_simnoise_binpsd_dist_{}.png".format(case, det))
+                    savefile = os.path.join(
+                        self.outdir,
+                        "out_{}_test_simnoise_binpsd_dist_{}.png"
+                        "".format(case, det))
                     plt.savefig(savefile)
                     plt.close()
 
-                    # The data will likely not be gaussian distributed.  Just check that the mean
-                    # is "close enough" to the truth.
+                    # The data will likely not be gaussian distributed.
+                    # Just check that the mean is "close enough" to the truth.
                     errest = np.absolute(np.mean((meanpsd - tpsd) / tpsd))
                     print("Det {} avg rel error = {}".format(det, errest))
                     if self.fknee[det] < 0.1:
                         self.assertTrue(errest < 0.1)
 
 
-            # Verify that Parseval's theorem holds- that the variance of the TOD
-            # equals the integral of the PSD.  We do this for an ensemble of realizations
-            # and compare the TOD variance to the integral of the PSD accounting
-            # for the error on the variance due to finite numbers of samples.
+            # Verify that Parseval's theorem holds- that the variance of
+            # the TOD equals the integral of the PSD.  We do this for an
+            # ensemble of realizations
+            #
+            # and compare the TOD variance to the integral of the PSD
+            # accounting for the error on the variance due to finite
+            # numbers of samples.
+            #
 
             for det in tod.local_dets:
                 sig = np.mean(todvar[det]) * np.sqrt(2.0/(self.chunksize-1))
-                over3sig = np.where(np.absolute(todvar[det] - psdnorm[det]) > 3.0*sig)[0]
-                overfrac = float(len(over3sig)) / self.MC
+                over3sig = np.where(
+                    np.absolute(todvar[det] - psdnorm[det]) > 3.0*sig)[0]
+                overfrac = float(len(over3sig)) / self.nmc
                 print(det, " : ", overfrac)
                 if self.fknee[det] < 0.1:
                     self.assertTrue(overfrac < 0.1)
@@ -464,3 +558,33 @@ class OpSimNoiseTest(MPITestCase):
         elapsed = stop - start
         self.print_in_turns("simnoise test took {:.3f} s".format(elapsed))
 
+        return
+
+    def test_sim_correlated(self):
+        """Test the correlated noise generation."""
+        start = MPI.Wtime()
+
+        obs = self.data2.obs[0]
+        tod = obs['tod']
+
+        opnoise = OpSimNoise(realization=0)
+        opnoise.exec(self.data2)
+
+        total = None
+        for det in tod.local_dets:
+            # compute the TOD variance
+            ref = tod.cache.reference("noise_{}".format(det))
+            self.assertTrue(np.std(ref) > 0)
+            if total is None:
+                total = ref.copy()
+            else:
+                total += ref
+            del ref
+
+        np.testing.assert_almost_equal(np.std(total), 0)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        self.print_in_turns("simnoise test took {:.3f} s".format(elapsed))
+
+        return

--- a/src/python/tod/noise.py
+++ b/src/python/tod/noise.py
@@ -42,24 +42,24 @@ class Noise(object):
     """
 
     def __init__(self, *, detectors, freqs, psds, mixmatrix=None, indices=None):
-        self.detectors = list(sorted(detectors))
+        self._dets = list(sorted(detectors))
         if mixmatrix is None:
             # Default diagonal mixing matrix
-            self.keys = self.detectors
+            self._keys = self._dets
             self._mixmatrix = None
         else:
             # Assemble the list of keys needed for the specified detectors
             keys = set()
             self._mixmatrix = {}
-            for det in self.detectors:
+            for det in self._dets:
                 self._mixmatrix[det] = {}
                 for key, weight in mixmatrix[det].items():
                     keys.add(key)
                     self._mixmatrix[det][key] = weight
-            self.keys = list(sorted(keys))
+            self._keys = list(sorted(keys))
         if indices is None:
             self._indices = {}
-            for i, key in enumerate(self.keys):
+            for i, key in enumerate(self._keys):
                 self._indices[key] = i
         else:
             self._indices = dict(indices)
@@ -67,7 +67,7 @@ class Noise(object):
         self._psds = {}
         self._rates = {}
 
-        for key in self.keys:
+        for key in self._keys:
             if psds[key].shape[0] != freqs[key].shape[0]:
                 raise ValueError(
                     'PSD length must match the number of frequencies')
@@ -75,6 +75,20 @@ class Noise(object):
             self._psds[key] = np.copy(psds[key])
             # last frequency point should be Nyquist
             self._rates[key] = 2.0 * self._freqs[key][-1]
+
+    @property
+    def detectors(self):
+        """
+        (list): list of strings containing the detector names.
+        """
+        return self._dets
+
+    @property
+    def keys(self):
+        """
+        (list): list of strings containing the PSD names.
+        """
+        return self._keys
 
     def multiply_ntt(self, key, data):
         """Filter the data with noise covariance."""

--- a/src/python/tod/noise.py
+++ b/src/python/tod/noise.py
@@ -1,102 +1,147 @@
 # Copyright (c) 2015 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+"""
+noise.py implements the Noise class for storing noise PSDs.
+
+"""
 
 import numpy as np
 
 
 class Noise(object):
     """
-    Base class for an object that describes the noise properties of all
-    detectors for a single observation.
+    Noise objects act as containers for noise PSDs.
+
+    Noise is a base class for an object that describes the noise
+    properties of all detectors for a single observation.
 
     Args:
-        detectors (list): names of detectors we have
-        freqs (dict): dictionary of array of frequencies for our PSDs
-        psds (dict): dictionary of arrays which contains the PSD values
-            for each detector.
+        detectors (list): Names of detectors.
+        freqs (dict): Dictionary of arrays of frequencies for `psds`.
+        psds (dict): Dictionary of arrays which contain the PSD values
+            for each detector or `mixmatrix` key.
+        mixmatrix (dict): Mixing matrix describing how the PSDs should
+            be combined for detector noise.  If provided, must contain
+            entries for every detector, and every key specified for a
+            detector must be defined in `freqs` and `psds`.
+        indices (dict):  Integer index for every PSD, useful for
+            generating indepedendent and repeateable noise realizations.
+            If absent, runnign indices will be assigned and provided.
+
+    Attributes:
+        detectors (list): List of detector names
+        keys (list): List of PSD names
+
+    Raises:
+        KeyError: If `freqs`, `psds`, `mixmatrix` or `indices` do not
+            include all relevant entries.
+        ValueError: If vector lengths in `freqs` and `psds` do not match.
+
     """
 
-    def __init__(self, detectors=None, freqs=None, psds=None):
-        self._dets = []
+    def __init__(self, *, detectors, freqs, psds, mixmatrix=None, indices=None):
+        self.detectors = list(sorted(detectors))
+        if mixmatrix is None:
+            # Default diagonal mixing matrix
+            self.keys = self.detectors
+            self._mixmatrix = None
+        else:
+            # Assemble the list of keys needed for the specified detectors
+            keys = set()
+            self._mixmatrix = {}
+            for det in self.detectors:
+                self._mixmatrix[det] = {}
+                for key, weight in mixmatrix[det].items():
+                    keys.add(key)
+                    self._mixmatrix[det][key] = weight
+            self.keys = list(sorted(keys))
+        if indices is None:
+            self._indices = {}
+            for i, key in enumerate(self.keys):
+                self._indices[key] = i
+        else:
+            self._indices = dict(indices)
         self._freqs = {}
         self._psds = {}
-        self._weights = {}
-        self._rate = {}
+        self._rates = {}
 
-        if detectors is not None:
-            self._dets = detectors
-            if psds is None:
-                raise RutimeError("you must provide a dictionary of PSD arrays for all detectors")
-            if freqs is None:
-                raise RutimeError("you must provide a dictionary of frequency arrays for all detectors")
-            for det in self._dets:
-                if det not in psds:
-                    raise RuntimeError("no PSD specified for detector {}".format(det))
-                if det not in freqs:
-                    raise RuntimeError("no frequency array specified for detector {}".format(det))
-                if psds[det].shape[0] != freqs[det].shape[0]:
-                    raise RuntimeError("PSD length must match the number of frequencies")
-                self._freqs[det] = np.copy(freqs[det])
-                self._psds[det] = np.copy(psds[det])
-                # last frequency point should be Nyquist
-                self._rate[det] = 2.0 * self._freqs[det][-1]
+        for key in self.keys:
+            if psds[key].shape[0] != freqs[key].shape[0]:
+                raise ValueError(
+                    'PSD length must match the number of frequencies')
+            self._freqs[key] = np.copy(freqs[key])
+            self._psds[key] = np.copy(psds[key])
+            # last frequency point should be Nyquist
+            self._rates[key] = 2.0 * self._freqs[key][-1]
 
+    def multiply_ntt(self, key, data):
+        """Filter the data with noise covariance."""
+        raise NotImplementedError('multiply_ntt not yet implemented')
 
-    @property
-    def detectors(self):
-        """
-        (list): list of strings containing the detector names.
-        """
-        return self._dets
+    def multiply_invntt(self, key, data):
+        """Filter the data with inverse noise covariance."""
+        raise NotImplementedError('multiply_invntt not yet implemented')
 
-
-    def multiply_ntt(self, detector, data):
-        pass
-
-
-    def multiply_invntt(self, detector, data):
-        pass
-
-
-    def freq(self, detector):
-        """
-        Get the frequencies for a detector.
+    def weight(self, det, key):
+        """Return the mixing weight for noise `key` in `det`.
 
         Args:
-            detector (str): the detector name.
-
+            det (str): Detector name
+            key (std): Mixing matrix key.
         Returns:
-            (array): the frequency bins that are used for the PSD.
-        """
-        return self._freqs[detector]
+            weight (float): Mixing matrix weight
 
-
-    def rate(self, detector):
         """
-        Get the sample rate for a detector.
+        weight = 0
+        if self._mixmatrix is None:
+            if det == key:
+                weight = 1
+        elif key in self._mixmatrix[det]:
+            weight = self._mixmatrix[det][key]
+        return weight
+
+    def index(self, key):
+        """Return the PSD index for `key`
 
         Args:
-            detector (str): the detector name.
+            key (std): Detector name or mixing matrix key.
+        Returns:
+            index (int): PSD index.
 
+        """
+        return self._indices[key]
+
+    def freq(self, key):
+        """Get the frequencies corresponding to `key`.
+
+        Args:
+            key (str): Detector name or mixing matrix key.
+        Returns:
+            (array): Frequency bins that are used for the PSD.
+
+        """
+        return self._freqs[key]
+
+    def rate(self, key):
+        """Get the sample rate for `key`.
+
+        Args:
+            key (str): the detector name or mixing matrix key.
         Returns:
             (float): the sample rate in Hz.
-        """
-        return self._rate[detector]
 
-
-    def psd(self, detector):
         """
-        Get the PSD for a detector.
+        return self._rates[key]
+
+    def psd(self, key):
+        """Get the PSD corresponding to `key`.
 
         Args:
-            detector (str): the detector name.
-
+            key (str): Detector name or mixing matrix key.
         Returns:
-            (array): an array containing the PSD for the detector.
-        """
-        if detector not in self._dets:
-            raise RuntimeError("psd for detector {} not found".format(detector))
-        return self._psds[detector]
+            (array): PSD matching the key.
 
+        """
+        return self._psds[key]

--- a/src/python/tod/sim_det_noise.py
+++ b/src/python/tod/sim_det_noise.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+"""
+sim_det_noise.py implements the noise simulation operator, OpSimNoise.
+
+"""
 
 import numpy as np
-
-from .tod import TOD
-
-from .noise import Noise
 
 from ..op import Operator
 
@@ -23,7 +23,7 @@ class OpSimNoise(Operator):
     include a unique 'ID' used in the random number generation.  The
     observation dictionary can optionally include a 'global_offset' member
     that might be useful if you are splitting observations and want to
-    enforce reproducibility of a given sample, even when using 
+    enforce reproducibility of a given sample, even when using
     different-sized observations.
 
     Args:
@@ -33,11 +33,12 @@ class OpSimNoise(Operator):
             index.
         component (int): the component index to use for this noise simulation.
         noise (str): PSD key in the observation dictionary.
+
     """
 
     def __init__(self, out='noise', realization=0, component=0, noise='noise',
                  rate=None, altFFT=False):
-        
+
         # We call the parent class constructor, which currently does nothing
         super().__init__()
 
@@ -59,8 +60,13 @@ class OpSimNoise(Operator):
 
         Args:
             data (toast.Data): The distributed data.
+
+        Raises:
+            KeyError: If an observation in data does not have noise
+                object defined under given key.
+            RuntimeError: If observations are not split into chunks.
+
         """
-        comm = data.comm
 
         for obs in data.obs:
             obsindx = 0
@@ -81,8 +87,8 @@ class OpSimNoise(Operator):
             if self._noisekey in obs:
                 nse = obs[self._noisekey]
             else:
-                raise RuntimeError('Observation does not contain noise under '
-                                   '"{}"'.format(self._noisekey))
+                raise KeyError('Observation does not contain noise under '
+                               '"{}"'.format(self._noisekey))
             if tod.local_chunks is None:
                 raise RuntimeError('noise simulation for uniform distributed '
                                    'samples not implemented')
@@ -90,54 +96,79 @@ class OpSimNoise(Operator):
             # eventually we'll redistribute, to allow long correlations...
 
             if self._rate is None:
-                times = tod.read_times(local_start=0, n=tod.local_samples[1])
+                times = tod.read_times(
+                    local_start=0, n=tod.local_samples[1])
+            else:
+                times = None
 
             # Iterate over each chunk.
 
-            tod_first = tod.local_samples[0]
-            chunk_first = tod_first
-
+            chunk_first = tod.local_samples[0]
             for curchunk in range(tod.local_chunks[1]):
-                abschunk = tod.local_chunks[0] + curchunk
-                chunk_samp = tod.total_chunks[abschunk]
-                local_offset = chunk_first - tod_first
-
-                if self._rate is None:
-                    # compute effective sample rate
-                    dt = np.median(np.diff(
-                            times[local_offset:local_offset+chunk_samp]))
-                    rate = 1.0 / dt
-                else:
-                    rate = self._rate
-
-                idet = 0
-                for det in tod.local_dets:
-
-                    detindx = tod.detindx[det]
-
-                    (nsedata, freq, psd) = sim_noise_timestream(
-                        self._realization, telescope, self._component, obsindx,
-                        detindx, rate, chunk_first + global_offset, chunk_samp,
-                        self._oversample, nse.freq(det), nse.psd(det), 
-                        self._altfft)
-
-                    # write to cache
-
-                    cachename = "{}_{}".format(self._out, det)
-
-                    ref = None
-                    if tod.cache.exists(cachename):
-                        ref = tod.cache.reference(cachename)
-                    else:
-                        ref = tod.cache.create(cachename, np.float64,
-                                    (tod.local_samples[1],))
-
-                    ref[local_offset:local_offset+chunk_samp] += nsedata
-                    del ref
-
-                    idet += 1
-
-                chunk_first += chunk_samp
+                chunk_first += self.simulate_chunk(
+                    tod=tod, nse=nse,
+                    curchunk=curchunk, chunk_first=chunk_first,
+                    obsindx=obsindx, times=times,
+                    telescope=telescope, global_offset=global_offset)
 
         return
 
+    def simulate_chunk(self, *, tod, nse, curchunk, chunk_first,
+                       obsindx, times, telescope, global_offset):
+        """
+        Simulate one chunk of noise for all detectors.
+
+        Args:
+            tod (toast.tod.TOD): TOD object for the observation.
+            nse (toast.tod.Noise): Noise object for the observation.
+            curchunk (int): The local index of the chunk to simulate.
+            chunk_first (int): First global sample index of the chunk.
+            obsindx (int): Observation index for random number stream.
+            times (int): Timestamps for effective sample rate.
+            telescope (int): Telescope index for random number stream.
+            global_offset (int): Global offset for random number stream.
+
+        Returns:
+            chunk_samp (int): Number of simulated samples
+
+        """
+        chunk_samp = tod.total_chunks[tod.local_chunks[0] + curchunk]
+        local_offset = chunk_first - tod.local_samples[0]
+
+        if self._rate is None:
+            # compute effective sample rate
+            rate = 1 / np.median(np.diff(
+                times[local_offset : local_offset+chunk_samp]))
+        else:
+            rate = self._rate
+
+        for key in nse.keys:
+            # Check if noise matching this PSD key is needed
+            weight = 0.
+            for det in tod.local_dets:
+                weight += np.abs(nse.weight(det, key))
+            if weight == 0:
+                continue
+
+            # Simulate the noise matching this key
+            nsedata = sim_noise_timestream(
+                self._realization, telescope, self._component, obsindx,
+                nse.index(key), rate, chunk_first+global_offset, chunk_samp,
+                self._oversample, nse.freq(key), nse.psd(key),
+                self._altfft)[0]
+
+            # Add the noise to all detectors that have nonzero weights
+            for det in tod.local_dets:
+                weight = nse.weight(det, key)
+                if weight == 0:
+                    continue
+                cachename = '{}_{}'.format(self._out, det)
+                if tod.cache.exists(cachename):
+                    ref = tod.cache.reference(cachename)
+                else:
+                    ref = tod.cache.create(cachename, np.float64,
+                                           (tod.local_samples[1],))
+                ref[local_offset : local_offset+chunk_samp] += weight*nsedata
+                del ref
+
+        return chunk_samp

--- a/src/python/tod/sim_noise.py
+++ b/src/python/tod/sim_noise.py
@@ -21,29 +21,17 @@ class AnalyticNoise(Noise):
     minimum frequency, etc.
 
     Args:
-        detectors (list): list of detectors.
-        rate (dict): dictionary of sample rates in Hertz.
-        fmin (dict): dictionary of minimum frequencies for high pass
-        fknee (dict): dictionary of knee frequencies.
-        alpha (dict): dictionary of alpha exponents (positive, not negative!).
-        NET (dict): dictionary of detector NETs.
+        detectors (list): List of detectors.
+        rate (dict): Dictionary of sample rates in Hertz.
+        fmin (dict): Dictionary of minimum frequencies for high pass
+        fknee (dict): Dictionary of knee frequencies.
+        alpha (dict): Dictionary of alpha exponents (positive, not negative!).
+        NET (dict): Dictionary of detector NETs.
+
     """
 
-    def __init__(self, detectors=None, rate=None, fmin=None, fknee=None, alpha=None, NET=None):
-        if detectors is None:
-            raise RuntimeError("you must specify the detector list")
-        if rate is None:
-            raise RuntimeError("you must specify the sample rates")
-        if fmin is None:
-            raise RuntimeError("you must specify the frequencies for high pass")
-        if fknee is None:
-            raise RuntimeError("you must specify the knee frequencies")
-        if alpha is None:
-            raise RuntimeError("you must specify the exponents")
-        if NET is None:
-            raise RuntimeError("you must specify the NET")
+    def __init__(self, *, detectors, rate, fmin, fknee, alpha, NET):
 
-        self._detectors = detectors
         self._rate = rate
         self._fmin = fmin
         self._fknee = fknee
@@ -52,16 +40,18 @@ class AnalyticNoise(Noise):
 
         for d in detectors:
             if self._alpha[d] < 0.0:
-                raise RuntimeError("alpha exponents should be positive in this formalism")
+                raise RuntimeError(
+                    "alpha exponents should be positive in this formalism")
 
         freqs = {}
         psds = {}
 
         last_nyquist = None
 
-        for d in self._detectors:
+        for d in detectors:
             if (self._fknee[d] > 0.0) and (self._fknee[d] < self._fmin[d]):
-                raise RuntimeError("If knee frequency is non-zero, it must be greater than f_min")
+                raise RuntimeError("If knee frequency is non-zero, it must "
+                                   "be greater than f_min")
 
             nyquist = self._rate[d] / 2.0
             if nyquist != last_nyquist:

--- a/src/python/tod/tod.py
+++ b/src/python/tod/tod.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -24,31 +24,34 @@ class TOD(object):
     are called.  A TOD base class should never be directly instantiated.
 
     Args:
-        mpicomm (mpi4py.MPI.Comm): the MPI communicator over which the data is distributed.
+        mpicomm (mpi4py.MPI.Comm): the MPI communicator over which the
+            data is distributed.
         detectors (list):  The list of detector names.
         samples (int):  The total number of samples.
-        detindx (dict): the detector indices for use in simulations.  Default is 
+        detindx (dict): the detector indices for use in simulations.  Default is
             { x[0] : x[1] for x in zip(detectors, range(len(detectors))) }.
         detranks (int):  The dimension of the process grid in the detector
             direction.  The MPI communicator size must be evenly divisible
             by this number.
         detbreaks (list):  Optional list of hard breaks in the detector
             distribution.
-        sampsizes (list):  Optional list of sample chunk sizes which 
-            cannot be split.    
-        sampbreaks (list):  Optional list of hard breaks in the sample 
+        sampsizes (list):  Optional list of sample chunk sizes which
+            cannot be split.
+        sampbreaks (list):  Optional list of hard breaks in the sample
             distribution.
 
     """
-    def __init__(self, mpicomm, detectors, samples, detindx=None, detranks=1, 
+    def __init__(self, mpicomm, detectors, samples, detindx=None, detranks=1,
         detbreaks=None, sampsizes=None, sampbreaks=None):
 
         self._mpicomm = mpicomm
         self._detranks = detranks
 
         if mpicomm.size % detranks != 0:
-            raise RuntimeError("The number of detranks ({}) does not divide evenly into the communicator size ({})".format(detranks, mpicomm.size))
-        
+            raise RuntimeError(
+                "The number of detranks ({}) does not divide evenly into the "
+                "communicator size ({})".format(detranks, mpicomm.size))
+
         self._sampranks = mpicomm.size // detranks
 
         self._rank_det = mpicomm.rank // self._sampranks
@@ -63,25 +66,31 @@ class TOD(object):
         if detindx is not None:
             for d in self._dets:
                 if d not in detindx:
-                    raise RuntimeError("detindx must have a value for every detector")
+                    raise RuntimeError(
+                        "detindx must have a value for every detector")
             self._detindx = detindx
         else:
-            self._detindx = { x[0] : x[1] for x in zip(detectors, range(len(detectors))) }
+            self._detindx = { x[0] : x[1] for x in zip(
+                detectors, range(len(detectors))) }
 
         # if sizes is specified, it must be consistent with
         # the total number of samples.
         if self._sizes is not None:
             test = np.sum(self._sizes)
             if samples != test:
-                raise RuntimeError("Sum of sampsizes ({}) does not equal total samples ({})".format(test, samples))
+                raise RuntimeError(
+                    "Sum of sampsizes ({}) does not equal total samples ({})"
+                    "".format(test, samples))
 
-        (self._dist_dets, self._dist_samples, self._dist_sizes) = distribute_samples(
-            self._mpicomm, self._dets, self._nsamp, detranks=self._detranks, 
-            detbreaks=detbreaks, sampsizes=sampsizes, sampbreaks=sampbreaks)
+        (self._dist_dets, self._dist_samples,
+         self._dist_sizes) = distribute_samples(
+             self._mpicomm, self._dets, self._nsamp, detranks=self._detranks,
+             detbreaks=detbreaks, sampsizes=sampsizes, sampbreaks=sampbreaks)
 
         if self._sizes is None:
             # in this case, the chunks just come from the uniform distribution.
-            self._sizes = [ self._dist_samples[x][1] for x in range(self._sampranks) ]
+            self._sizes = [
+                self._dist_samples[x][1] for x in range(self._sampranks)]
 
         if self._mpicomm.rank == 0:
             # check that all processes have some data, otherwise print warning
@@ -101,7 +110,6 @@ class TOD(object):
 
     def __del__(self):
         self.cache.clear()
-
 
     @property
     def detectors(self):
@@ -127,7 +135,7 @@ class TOD(object):
     @property
     def total_chunks(self):
         """
-        (list): the full list of sample chunk sizes that were used in the 
+        (list): the full list of sample chunk sizes that were used in the
             data distribution.
         """
         return self._sizes
@@ -136,7 +144,7 @@ class TOD(object):
     def dist_chunks(self):
         """
         (list): this is a list of 2-tuples, one for each column of the process
-        grid.  Each element of the list is the same as the information returned 
+        grid.  Each element of the list is the same as the information returned
         by the "local_chunks" member for a given process column.
         """
         return self._dist_sizes
@@ -144,7 +152,7 @@ class TOD(object):
     @property
     def local_chunks(self):
         """
-        (2-tuple): the first element of the tuple is the index of the 
+        (2-tuple): the first element of the tuple is the index of the
         first chunk assigned to this process (i.e. the index in the list
         given by the "total_chunks" member).  The second element of the
         tuple is the number of chunks assigned to this process.
@@ -162,8 +170,8 @@ class TOD(object):
     def dist_samples(self):
         """
         (list): This is a list of 2-tuples, with one element per column
-            of the process grid.  Each tuple is the same information 
-            returned by the "local_samples" member for the corresponding 
+            of the process grid.  Each tuple is the same information
+            returned by the "local_samples" member for the corresponding
             process grid column rank.
         """
         return self._dist_samples
@@ -192,7 +200,7 @@ class TOD(object):
             directions.
         """
         return (self._detranks, self._sampranks)
-    
+
     @property
     def grid_ranks(self):
         """
@@ -201,76 +209,73 @@ class TOD(object):
         """
         return (self._rank_det, self._rank_samp)
 
-
     def _get(self, detector, start, n):
-        raise RuntimeError("Fell through to TOD._get base class method")
+        raise NotImplementedError("Fell through to TOD._get base class method")
         return None
-
 
     def _put(self, detector, start, data):
-        raise RuntimeError("Fell through to TOD._put base class method")
+        raise NotImplementedError("Fell through to TOD._put base class method")
         return
-
 
     def _get_pntg(self, detector, start, n):
-        raise RuntimeError("Fell through to TOD._get_pntg base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_pntg base class method")
         return None
-
 
     def _put_pntg(self, detector, start, data):
-        raise RuntimeError("Fell through to TOD._put_pntg base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_pntg base class method")
         return
-
 
     def _get_flags(self, detector, start, n):
-        raise RuntimeError("Fell through to TOD._get_flags base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_flags base class method")
         return None
-
 
     def _put_det_flags(self, detector, start, flags):
-        raise RuntimeError("Fell through to TOD._put_det_flags base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_det_flags base class method")
         return
-
 
     def _get_common_flags(self, start, n):
-        raise RuntimeError("Fell through to TOD._get_common_flags base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_common_flags base class method")
         return None
-
 
     def _put_common_flags(self, start, flags):
-        raise RuntimeError("Fell through to TOD._put_common_flags base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_common_flags base class method")
         return
-
 
     def _get_times(self, start, n):
-        raise RuntimeError("Fell through to TOD._get_times base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_times base class method")
         return None
-
 
     def _put_times(self, start, stamps):
-        raise RuntimeError("Fell through to TOD._put_times base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_times base class method")
         return None
-
 
     def _get_position(self, start, n):
-        raise RuntimeError("Fell through to TOD._get_position base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_position base class method")
         return None
-
 
     def _put_position(self, start, pos):
-        raise RuntimeError("Fell through to TOD._put_position base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_position base class method")
         return
-
 
     def _get_velocity(self, start, n):
-        raise RuntimeError("Fell through to TOD._get_velocity base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._get_velocity base class method")
         return None
 
-    
     def _put_velocity(self, start, vel):
-        raise RuntimeError("Fell through to TOD._put_velocity base class method")
+        raise NotImplementedError(
+            "Fell through to TOD._put_velocity base class method")
         return
-
 
     # Read and write the common timestamps
 
@@ -292,9 +297,11 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read times- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read times- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError('local sample range {} - {} is invalid'
+                             ''.format(local_start, local_start+n-1))
         return self._get_times(local_start, n, **kwargs)
 
 
@@ -313,12 +320,15 @@ class TOD(object):
         if stamps is None:
             raise ValueError('you must specify the vector of time stamps')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write times- process has no assigned local samples')
-        if (local_start < 0) or (local_start + stamps.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+stamps.shape[0]-1))
+            raise RuntimeError(
+                'cannot write times- process has no assigned local samples')
+        if (local_start < 0) \
+           or (local_start + stamps.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+stamps.shape[0]-1))
         self._put_times(local_start, stamps, **kwargs)
         return
-
 
     # Read and write detector data
 
@@ -344,11 +354,13 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get(detector, local_start, n, **kwargs)
-        
 
     def write(self, detector=None, local_start=0, data=None, **kwargs):
         """
@@ -369,12 +381,15 @@ class TOD(object):
         if data is None:
             raise ValueError('data array must be specified')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write- process has no assigned local samples')
-        if (local_start < 0) or (local_start + data.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+data.shape[0]-1))
+            raise RuntimeError(
+                'cannot write- process has no assigned local samples')
+        if (local_start < 0) \
+           or (local_start + data.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+data.shape[0]-1))
         self._put(detector, local_start, data, **kwargs)
         return
-
 
     # Read and write detector quaternion pointing
 
@@ -400,11 +415,13 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read pntg- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read pntg- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get_pntg(detector, local_start, n, **kwargs)
-
 
     def write_pntg(self, detector=None, local_start=0, data=None, **kwargs):
         """
@@ -429,12 +446,13 @@ class TOD(object):
         if data.shape[1] != 4:
             raise ValueError('data should have second dimension of size 4')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write pntg- process has no assigned local samples')
-        if (local_start < 0) or (local_start + data.shape[0] > self.local_samples[1]):
+            raise RuntimeError(
+                'cannot write pntg- process has no assigned local samples')
+        if (local_start < 0) \
+           or (local_start + data.shape[0] > self.local_samples[1]):
             raise ValueError('local sample range is invalid')
         self._put_pntg(detector, local_start, data, **kwargs)
         return
-
 
     # Read and write detector flags
 
@@ -461,11 +479,13 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read flags- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read flags- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get_flags(detector, local_start, n, **kwargs)
-
 
     def read_common_flags(self, local_start=0, n=0, **kwargs):
         """
@@ -483,13 +503,15 @@ class TOD(object):
             (array): a numpy array containing the flags.
         """
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read common flags- process has no assigned local samples')
+            raise RuntimeError('cannot read common flags- process has no '
+                               'assigned local samples')
         if n == 0:
             n = self.local_samples[1] - local_start
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get_common_flags(local_start, n, **kwargs)
-
 
     def write_common_flags(self, local_start=0, flags=None, **kwargs):
         """
@@ -506,14 +528,19 @@ class TOD(object):
         if flags is None:
             raise ValueError('flags must be specified')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write common flags- process has no assigned local samples')
-        if (local_start < 0) or (local_start + flags.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+flags.shape[0]-1))
+            raise RuntimeError('cannot write common flags- process has no '
+                               'assigned local samples')
+
+        if (local_start < 0) \
+           or (local_start + flags.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+flags.shape[0]-1))
         self._put_common_flags(local_start, flags, **kwargs)
         return
 
-
-    def write_det_flags(self, detector=None, local_start=0, flags=None, **kwargs):
+    def write_det_flags(self, detector=None, local_start=0, flags=None,
+                        **kwargs):
         """
         Write detector flags.
 
@@ -532,12 +559,15 @@ class TOD(object):
         if flags is None:
             raise ValueError('flags must be specified')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write flags- process has no assigned local samples')
-        if (local_start < 0) or (local_start + flags.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+flags.shape[0]-1))
+            raise RuntimeError('cannot write flags- process has no assigned '
+                               'local samples')
+        if (local_start < 0) \
+           or (local_start + flags.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+flags.shape[0]-1))
         self._put_det_flags(detector, local_start, flags, **kwargs)
         return
-
 
     # Read and write telescope position
 
@@ -545,7 +575,7 @@ class TOD(object):
         """
         Read telescope position.
 
-        This reads the telescope position in solar system barycenter 
+        This reads the telescope position in solar system barycenter
         coordinates (in Kilometers).
 
         Args:
@@ -560,11 +590,13 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read position- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read position- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get_position(local_start, n, **kwargs)
-
 
     def write_position(self, local_start=0, pos=None, **kwargs):
         """
@@ -581,12 +613,15 @@ class TOD(object):
         if pos is None:
             raise ValueError('you must specify the array of coordinates')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write position- process has no assigned local samples')
-        if (local_start < 0) or (local_start + pos.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+pos.shape[0]-1))
+            raise RuntimeError(
+                'cannot write position- process has no assigned local samples')
+        if (local_start < 0) \
+           or (local_start + pos.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+pos.shape[0]-1))
         self._put_position(local_start, pos, **kwargs)
         return
-
 
     # Read and write telescope velocity
 
@@ -594,7 +629,7 @@ class TOD(object):
         """
         Read telescope velocity.
 
-        This reads the telescope velocity in solar system barycenter 
+        This reads the telescope velocity in solar system barycenter
         coordinates (in Kilometers/s).
 
         Args:
@@ -609,11 +644,13 @@ class TOD(object):
         if n == 0:
             n = self.local_samples[1] - local_start
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot read position- process has no assigned local samples')
+            raise RuntimeError(
+                'cannot read position- process has no assigned local samples')
         if (local_start < 0) or (local_start + n > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+n-1))
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+n-1))
         return self._get_velocity(local_start, n, **kwargs)
-
 
     def write_velocity(self, local_start=0, vel=None, **kwargs):
         """
@@ -631,12 +668,15 @@ class TOD(object):
         if vel is None:
             raise ValueError('you must specify the array of velocities.')
         if self.local_samples[1] <= 0:
-            raise RuntimeError('cannot write times- process has no assigned local samples')
-        if (local_start < 0) or (local_start + vel.shape[0] > self.local_samples[1]):
-            raise ValueError('local sample range {} - {} is invalid'.format(local_start, local_start+vel.shape[0]-1))
+            raise RuntimeError(
+                'cannot write times- process has no assigned local samples')
+        if (local_start < 0) \
+           or (local_start + vel.shape[0] > self.local_samples[1]):
+            raise ValueError(
+                'local sample range {} - {} is invalid'
+                ''.format(local_start, local_start+vel.shape[0]-1))
         self._put_velocity(local_start, vel, **kwargs)
         return
-
 
 
 class TODCache(TOD):
@@ -647,28 +687,28 @@ class TODCache(TOD):
     ordered data.  You must "write" the data before you can "read" it.
 
     Args:
-        mpicomm (mpi4py.MPI.Comm): the MPI communicator over which the data is distributed.
+        mpicomm (mpi4py.MPI.Comm): the MPI communicator over which the
+            data is distributed.
         detectors (list):  The list of detector names.
         samples (int):  The total number of samples.
-        detindx (dict): the detector indices for use in simulations.  Default is 
+        detindx (dict): the detector indices for use in simulations.  Default is
             { x[0] : x[1] for x in zip(detectors, range(len(detectors))) }.
         detranks (int):  The dimension of the process grid in the detector
             direction.  The MPI communicator size must be evenly divisible
             by this number.
         detbreaks (list):  Optional list of hard breaks in the detector
             distribution.
-        sampsizes (list):  Optional list of sample chunk sizes which 
-            cannot be split.    
-        sampbreaks (list):  Optional list of hard breaks in the sample 
+        sampsizes (list):  Optional list of sample chunk sizes which
+            cannot be split.
+        sampbreaks (list):  Optional list of hard breaks in the sample
             distribution.
-
     """
 
-    def __init__(self, mpicomm, detectors, samples, detindx=None, detranks=1, 
+    def __init__(self, mpicomm, detectors, samples, detindx=None, detranks=1,
         detbreaks=None, sampsizes=None, sampbreaks=None):
 
-        super().__init__(mpicomm, detectors, samples, detindx=detindx, 
-            detranks=detranks, detbreaks=detbreaks, sampsizes=sampsizes, 
+        super().__init__(mpicomm, detectors, samples, detindx=detindx,
+            detranks=detranks, detbreaks=detbreaks, sampsizes=sampsizes,
             sampbreaks=sampbreaks)
 
         self._pref_detdata = 'toast_tod_detdata_'
@@ -682,47 +722,49 @@ class TODCache(TOD):
     def __del__(self):
         self.cache.clear()
 
-
     # This class just use a Cache object to store things.
 
     def _get(self, detector, start, n):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cachedata = "{}{}".format(self._pref_detdata, detector)
         if not self.cache.exists(cachedata):
-            raise ValueError('detector {} data not yet written'.format(detector))
+            raise ValueError(
+                'detector {} data not yet written'.format(detector))
         dataref = self.cache.reference(cachedata)[start:start+n]
         return dataref
 
-
     def _put(self, detector, start, data):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cachedata = "{}{}".format(self._pref_detdata, detector)
-        
+
         if not self.cache.exists(cachedata):
             self.cache.create(cachedata, np.float64, (self.local_samples[1],))
-        
+
         n = data.shape[0]
         refdata = self.cache.reference(cachedata)[start:start+n]
 
         refdata[:] = data
         return
 
-
     def _get_pntg(self, detector, start, n):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cachepntg = "{}{}".format(self._pref_detpntg, detector)
         if not self.cache.exists(cachepntg):
-            raise ValueError('detector {} pointing data not yet written'.format(detector))
+            raise ValueError(
+                'detector {} pointing data not yet written'.format(detector))
         pntgref = self.cache.reference(cachepntg)[start:start+n,:]
         return pntgref
 
-
     def _put_pntg(self, detector, start, data):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cachepntg = "{}{}".format(self._pref_detpntg, detector)
         if not self.cache.exists(cachepntg):
             self.cache.create(cachepntg, np.float64, (self.local_samples[1],4))
@@ -730,41 +772,40 @@ class TODCache(TOD):
         pntgref[:] = data
         return
 
-
     def _get_flags(self, detector, start, n):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cacheflags = "{}{}".format(self._pref_detflags, detector)
         if not self.cache.exists(cacheflags):
-            raise ValueError('detector {} flags not yet written'.format(detector))
+            raise ValueError(
+                'detector {} flags not yet written'.format(detector))
         if not self.cache.exists(self._common):
             raise ValueError('common flags not yet written')
         flagsref = self.cache.reference(cacheflags)[start:start+n]
         comref = self.cache.reference(self._common)[start:start+n]
         return flagsref, comref
 
-
     def _put_det_flags(self, detector, start, flags):
         if detector not in self.local_dets:
-            raise ValueError('detector {} not assigned to local process'.format(detector))
+            raise ValueError(
+                'detector {} not assigned to local process'.format(detector))
         cacheflags = "{}{}".format(self._pref_detflags, detector)
-        
+
         if not self.cache.exists(cacheflags):
             self.cache.create(cacheflags, np.uint8, (self.local_samples[1],))
-        
+
         n = flags.shape[0]
         refflags = self.cache.reference(cacheflags)[start:start+n]
 
         refflags[:] = flags
         return
 
-
     def _get_common_flags(self, start, n):
         if not self.cache.exists(self._common):
             raise ValueError('common flags not yet written')
         comref = self.cache.reference(self._common)[start:start+n]
         return comref
-
 
     def _put_common_flags(self, start, flags):
         if not self.cache.exists(self._common):
@@ -774,29 +815,26 @@ class TODCache(TOD):
         comref[:] = flags
         return
 
-
     def _get_times(self, start, n):
         if not self.cache.exists(self._stamps):
             raise ValueError('timestamps not yet written')
         ref = self.cache.reference(self._stamps)[start:start+n]
         return ref
 
-
     def _put_times(self, start, stamps):
         if not self.cache.exists(self._stamps):
-            self.cache.create(self._stamps, np.float64, (self.local_samples[1],))
+            self.cache.create(self._stamps, np.float64,
+                              (self.local_samples[1],))
         n = stamps.shape[0]
         ref = self.cache.reference(self._stamps)[start:start+n]
         ref[:] = stamps
         return
-
 
     def _get_position(self, start, n):
         if not self.cache.exists(self._pos):
             raise ValueError('telescope position not yet written')
         ref = self.cache.reference(self._pos)[start:start+n]
         return ref
-
 
     def _put_position(self, start, pos):
         if not self.cache.exists(self._pos):
@@ -806,14 +844,12 @@ class TODCache(TOD):
         ref[:,:] = pos
         return
 
-
     def _get_velocity(self, start, n):
         if not self.cache.exists(self._vel):
             raise ValueError('telescope velocity not yet written')
         ref = self.cache.reference(self._vel)[start:start+n]
         return ref
 
-    
     def _put_velocity(self, start, vel):
         if not self.cache.exists(self._vel):
             self.cache.create(self._vel, np.float64, (self.local_samples[1], 3))
@@ -821,6 +857,3 @@ class TODCache(TOD):
         ref = self.cache.reference(self._vel)[start:start+n,:]
         ref[:,:] = vel
         return
-
-
-


### PR DESCRIPTION
The noise stream index (earlier detector index) is stored in the Noise class instead of the TOD class. In a correlated noise simulation it would be confusing having to get the indices for every noise mode from the TOD object. This implies a required change in pipelines that have been setting the detector indices.

Also:
- Tweaking the type of raised Exceptions to better reflect the errors encountered
- Improve the docstrings in the affected files
- replace accessor functions with public members where the accessor added no value.
- number of tweaks (white space, variable naming) of the source to improve readability and conform to the style guide.
- Use a python3 feature to enforce setting named method arguments. This feature should probably be used everywhere where we require all keyword arguments to be set (instead of checking them explicitly)