### PR TITLE
cleanup `external/rules/mpi4py.sh`

### DIFF
--- a/external/rules/mpi4py.sh
+++ b/external/rules/mpi4py.sh
@@ -1,6 +1,5 @@
 curl -SL https://pypi.python.org/packages/ee/b8/f443e1de0b6495479fc73c5863b7b5272a4ece5122e3589db6cd3bb57eeb/mpi4py-2.0.0.tar.gz#md5=4f7d8126d7367c239fd67615680990e3 \
-    -o mpi4py-2.0.0.tar.gz \
-    && tar xzf mpi4py-2.0.0.tar.gz \
+    | tar xzf - \
     && cd mpi4py-2.0.0 \
     && echo $'\n\
 [toast]\n\

--- a/external/rules/mpi4py.sh
+++ b/external/rules/mpi4py.sh
@@ -1,18 +1,18 @@
 curl -SL https://pypi.python.org/packages/ee/b8/f443e1de0b6495479fc73c5863b7b5272a4ece5122e3589db6cd3bb57eeb/mpi4py-2.0.0.tar.gz#md5=4f7d8126d7367c239fd67615680990e3 \
     | tar xzf - \
     && cd mpi4py-2.0.0 \
-    && echo $'\n\
-[toast]\n\
-mpicc = @MPICC@\n\
-mpicxx = @MPICXX@\n\
-include_dirs = @MPI_CPPFLAGS@\n\
-library_dirs = @MPI_LDFLAGS@\n\
-runtime_library_dirs = @MPI_LDFLAGS@\n\
-libraries = @MPI_LIB@\n\
-extra_compile_args = @MPI_EXTRA_COMP@\n\
-extra_link_args = @MPI_EXTRA_LINK@\n\
-' > mpi.cfg \
-    && python setup.py build --mpi=toast \
+    && cat << EOF > mpi.cfg &&
+[toast]
+mpicc = @MPICC@
+mpicxx = @MPICXX@
+include_dirs = @MPI_CPPFLAGS@
+library_dirs = @MPI_LDFLAGS@
+runtime_library_dirs = @MPI_LDFLAGS@
+libraries = @MPI_LIB@
+extra_compile_args = @MPI_EXTRA_COMP@
+extra_link_args = @MPI_EXTRA_LINK@
+EOF
+    python setup.py build --mpi=toast \
     && python setup.py install --prefix=@CONDA_PREFIX@ \
     && cd .. \
     && rm -rf mpi4py*

--- a/external/rules/mpi4py.sh
+++ b/external/rules/mpi4py.sh
@@ -1,5 +1,5 @@
-curl -SL https://pypi.python.org/packages/ee/b8/f443e1de0b6495479fc73c5863b7b5272a4ece5122e3589db6cd3bb57eeb/mpi4py-2.0.0.tar.gz#md5=4f7d8126d7367c239fd67615680990e3 \
-    | tar xzf - &&
+curl -SL https://pypi.python.org/packages/ee/b8/f443e1de0b6495479fc73c5863b7b5272a4ece5122e3589db6cd3bb57eeb/mpi4py-2.0.0.tar.gz#md5=4f7d8126d7367c239fd67615680990e3 |
+    tar xzf - &&
     cd mpi4py-2.0.0 &&
     cat << EOF > mpi.cfg &&
 [toast]

--- a/external/rules/mpi4py.sh
+++ b/external/rules/mpi4py.sh
@@ -1,7 +1,7 @@
 curl -SL https://pypi.python.org/packages/ee/b8/f443e1de0b6495479fc73c5863b7b5272a4ece5122e3589db6cd3bb57eeb/mpi4py-2.0.0.tar.gz#md5=4f7d8126d7367c239fd67615680990e3 \
-    | tar xzf - \
-    && cd mpi4py-2.0.0 \
-    && cat << EOF > mpi.cfg &&
+    | tar xzf - &&
+    cd mpi4py-2.0.0 &&
+    cat << EOF > mpi.cfg &&
 [toast]
 mpicc = @MPICC@
 mpicxx = @MPICXX@
@@ -12,7 +12,7 @@ libraries = @MPI_LIB@
 extra_compile_args = @MPI_EXTRA_COMP@
 extra_link_args = @MPI_EXTRA_LINK@
 EOF
-    python setup.py build --mpi=toast \
-    && python setup.py install --prefix=@CONDA_PREFIX@ \
-    && cd .. \
-    && rm -rf mpi4py*
+    python setup.py build --mpi=toast &&
+    python setup.py install --prefix=@CONDA_PREFIX@ &&
+    cd .. &&
+    rm -rf mpi4py*


### PR DESCRIPTION
There seems to be a bug here. Out of the 4 commits here, c6dd0d4 is a bug fix and others are "cosmetic".

Before commit c6dd0d4, the `mpi.cfg` written looks something like this:

```
mpicc = @MPICC@
\
mpicxx = @MPICXX@
\
...
```

Here-doc is used to avoid this and made the syntax looks more readable.

I suspect similar things might happened elsewhere, I could take a look at other similar files if you want to.