### PR TITLE
TIDAS data support

### DIFF
--- a/external/conf/cori-haswell-intel
+++ b/external/conf/cori-haswell-intel
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/conf/cori-knl-intel
+++ b/external/conf/cori-knl-intel
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/conf/edison-intel
+++ b/external/conf/edison-intel
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/conf/linux-intel
+++ b/external/conf/linux-intel
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/conf/tacc-knl-intel
+++ b/external/conf/tacc-knl-intel
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/conf/tacc-knl-intel-cross
+++ b/external/conf/tacc-knl-intel-cross
@@ -1,6 +1,7 @@
 
 # Serial compilers
 
+INTEL_COMP = yes
 CC = icc
 CXX = icpc
 FC = ifort

--- a/external/rules/boost.sh
+++ b/external/rules/boost.sh
@@ -1,7 +1,7 @@
-curl -SL https://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.bz2/download \
-    -o boost_1_63_0.tar.bz2 \
-    && tar xjf boost_1_63_0.tar.bz2 \
-    && cd boost_1_63_0 \
+curl -SL https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.bz2 \
+    -o boost_1_64_0.tar.bz2 \
+    && tar xjf boost_1_64_0.tar.bz2 \
+    && cd boost_1_64_0 \
     && echo "" > tools/build/user-config.jam \
     && echo 'using @BOOSTCHAIN@ : : @CXX@ : <cflags>"@CFLAGS@" <cxxflags>"@CXXFLAGS@" ;' >> tools/build/user-config.jam \
     && echo 'using mpi : @MPICXX@ : <include>"@MPI_CPPFLAGS@" <library-path>"@MPI_LDFLAGS@" <find-shared-library>"@MPI_CXXLIB@" <find-shared-library>"@MPI_LIB@" ;' >> tools/build/user-config.jam \

--- a/external/rules/conda_pkgs.sh
+++ b/external/rules/conda_pkgs.sh
@@ -11,7 +11,6 @@ conda install --copy --yes \
     ephem \
     virtualenv \
     memory_profiler \
-    && conda install --copy --yes -c defaults \
-    ipython ipython-notebook \
+    ipython \
     && python -c "import matplotlib.font_manager" \
     && rm -rf @CONDA_PREFIX@/pkgs/*

--- a/external/rules/hdf5.sh
+++ b/external/rules/hdf5.sh
@@ -1,12 +1,14 @@
 curl -SL https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.19.tar.bz2 \
     | tar xjf - \
     && cd hdf5-1.8.19 \
-    && CC="@CC@" CFLAGS="@CFLAGS@" \
-    CXX="@CXX@" CXXFLAGS="@CXXFLAGS@" \
+    && CC="@CC@" CFLAGS=$(if [ "x@CROSS@" = x ]; then echo "@CFLAGS@"; \
+       else echo "-O3"; fi) \
+    CXX="@CXX@" CXXFLAGS=$(if [ "x@CROSS@" = x ]; then echo "@CXXFLAGS@"; \
+       else echo "-O3"; fi) \
     ./configure --disable-fortran --disable-fortran2003 \
     --disable-silent-rules \
     --disable-parallel \
-    --enable-cxx @CROSS@ \
+    --enable-cxx \
     --prefix="@AUX_PREFIX@" \
     && make -j 4 && make install \
     && cd .. \

--- a/external/rules/openblas.sh
+++ b/external/rules/openblas.sh
@@ -1,0 +1,9 @@
+curl -SL http://github.com/xianyi/OpenBLAS/archive/v0.2.20.tar.gz \
+    | tar xzf - \
+    && cd OpenBLAS-0.2.20 \
+    && make USE_OPENMP=1 NO_SHARED=1 \
+    FC="@FC@" FCFLAGS="@FCFLAGS@" \
+    CC="@CC@" CFLAGS="@CFLAGS@" \
+    && make NO_SHARED=1 PREFIX="@AUX_PREFIX@" install \
+    && cd .. \
+    && rm -rf OpenBLAS*

--- a/external/rules/tidas.sh
+++ b/external/rules/tidas.sh
@@ -1,5 +1,6 @@
 git clone https://github.com/hpc4cmb/tidas.git \
     && cd tidas \
+    && ./autogen.sh \
     && CC="@CC@" CFLAGS="@CFLAGS@" \
     CXX="@CXX@" CXXFLAGS="@CXXFLAGS@" \
     FC="@FC@" FCFLAGS="@FCFLAGS@" \

--- a/external/tools/install.in
+++ b/external/tools/install.in
@@ -86,7 +86,9 @@ fi
 
 # Install OpenBLAS
 
+if [ "x@INTEL_COMP@" != "xyes"]; then
 @openblas@
+fi
 
 # Install wcslib
 

--- a/external/tools/install.in
+++ b/external/tools/install.in
@@ -84,6 +84,10 @@ fi
 
 @cfitsio@
 
+# Install OpenBLAS
+
+@openblas@
+
 # Install wcslib
 
 @wcslib@

--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -552,9 +552,13 @@ def expand_pointing(args, comm, data, counter):
         hwprpm=hwprpm, hwpstep=hwpstep, hwpsteptime=hwpsteptime)
 
     pointing.exec(data)
-    for ob in data.obs:
-        tod = ob['tod']
-        tod.free_radec_quats()
+
+    # Only purge the pointing if we are NOT going to export the
+    # data to a TIDAS volume
+    if args.tidas is None:
+        for ob in data.obs:
+            tod = ob['tod']
+            tod.free_radec_quats()
 
     comm.comm_world.barrier()
     stop = MPI.Wtime()

--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -224,8 +224,15 @@ def parse_arguments(comm):
                         required=False, default=1, type=np.int,
                         help='Number of frequencies with identical focal '
                         'planes')
+    parser.add_argument('--tidas',
+                        required=False, default=None,
+                        help='Output TIDAS export path')
 
     args = parser.parse_args()
+
+    if args.tidas is not None:
+        if not tt.tidas_available:
+            raise RuntimeError("TIDAS not found- cannot export")
 
     if comm.comm_world.rank == 0:
         print('\nAll parameters:')
@@ -1347,6 +1354,17 @@ def main():
                            totalname_freq)
 
             scramble_gains(args, comm, data, mc+mcoffset, counter)
+
+            if (mc == firstmc) and (ifreq == 0):
+                # For the first realization and frequency, optionally 
+                # export the timestream data to a TIDAS volume.
+                if args.tidas is not None:
+                    from toast.tod.tidas import OpTidasExport
+                    tidas_path = os.path.abspath(args.tidas)
+                    export = OpTidasExport(tidas_path, name=totalname, 
+                        common_flag_name=common_flag_name, 
+                        flag_name=flag_name, usedist=True)
+                    export.exec(data)
 
             outpath = setup_output(args, comm, mc+mcoffset)
 

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -103,8 +103,16 @@ def main():
         "(float, arcmin), \"fknee\" (float, Hz), \"alpha\" (float), and \"NET\" "
         "(float).  For optional plotting, the key \"color\" can specify a "
         "valid matplotlib color string." )
+
+    parser.add_argument('--tidas',
+                        required=False, default=None,
+                        help='Output TIDAS export path')
     
     args = parser.parse_args()
+
+    if args.tidas is not None:
+        if not tt.tidas_available:
+            raise RuntimeError("TIDAS not found- cannot export")
 
     groupsize = args.groupsize
     if groupsize == 0:
@@ -421,6 +429,15 @@ def main():
 
             nse = tt.OpSimNoise(out="noise", realization=mc)
             nse.exec(data)
+
+            if mc == firstmc:
+                # For the first realization, optionally export the 
+                # timestream data to a TIDAS volume.
+                if args.tidas is not None:
+                    from toast.tod.tidas import OpTidasExport
+                    tidas_path = os.path.abspath(args.tidas)
+                    export = OpTidasExport(tidas_path, name="noise")
+                    export.exec(data)
 
             comm.comm_world.barrier()
             stop = MPI.Wtime()

--- a/platforms/cori-gcc_nomkl.sh
+++ b/platforms/cori-gcc_nomkl.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script assumes that the "toast-deps" module has been loaded.
+# To install to my scratch directory, I might run this script with:
+#
+# $> ./platforms/cori-gcc_mkl.sh \
+#    --prefix=$SCRATCH/software/toast-gcc
+#
+
+OPTS="$@"
+
+export CC=cc
+export CXX=CC
+export MPICC=cc
+export MPICXX=CC
+export CFLAGS="-O3 -g -fPIC"
+export CXXFLAGS="-O3 -g -fPIC"
+export OPENMP_CFLAGS="-fopenmp"
+export OPENMP_CXXFLAGS="-fopenmp"
+
+./configure ${OPTS} \
+    --without-mkl \
+    --with-blas="-lopenblas -fopenmp"
+

--- a/platforms/osx-clang-condaforge.sh
+++ b/platforms/osx-clang-condaforge.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# This config assumes use of clang and Anaconda python,
+# using mpich, mpi4py, cfitsio, and fftw from the 
+# conda-forge channel.
+# 
+# 1.  Install miniconda / anaconda
+#
+# 2.  Edit ~/.condarc to look like this:
+#
+#     channels:
+#         - conda-forge
+#         - defaults
+#
+# 3.  Install numpy, mpich, mpi4py, cfitsio, fftw
+#
+# 4.  In order to link against the relocatable shared
+#     libraries installed by conda packages (which have
+#     relative @rpaths), you must add the conda
+#     environment lib directory to $DYLD_LIBRARY_PATH.
+#     This is needed (for example) to use FFTW and CFITSIO
+#     libraries installed by conda packages.
+#
+
+OPTS="$@"
+
+condabin=$(dirname $(which python))
+
+export CC=mpicc
+export CXX=mpicxx
+export MPICC=mpicc
+export MPICXX=mpicxx
+export CFLAGS="-O3 -g"
+export CXXFLAGS="-O3 -g"
+
+./configure ${OPTS} \
+--without-mkl
+

--- a/src/libtoast/math/toast_qarray.cpp
+++ b/src/libtoast/math/toast_qarray.cpp
@@ -26,7 +26,10 @@ const static int toast_qarray_ompthresh = 100;
 void toast::qarray::list_dot ( size_t n, size_t m, size_t d, double const * a, 
     double const * b, double * dotprod ) {
 
-    int nt = omp_get_num_threads();
+    int nt = 1;
+    #ifdef _OPENMP
+    nt = omp_get_num_threads();
+    #endif
     
     if ( n < toast_qarray_ompthresh * nt ) {
         for ( size_t i = 0; i < n; ++i ) {
@@ -87,7 +90,10 @@ void toast::qarray::normalize ( size_t n, size_t m, size_t d, double const * q_i
 
     toast::qarray::amplitude ( n, m, d, q_in, norm );
 
-    int nt = omp_get_num_threads();
+    int nt = 1;
+    #ifdef _OPENMP
+    nt = omp_get_num_threads();
+    #endif
 
     if ( n < toast_qarray_ompthresh * nt ) {
         for ( size_t i = 0; i < n; ++i ) {
@@ -119,7 +125,10 @@ void toast::qarray::normalize_inplace ( size_t n, size_t m, size_t d, double * q
 
     toast::qarray::amplitude ( n, m, d, q, norm );
 
-    int nt = omp_get_num_threads();
+    int nt = 1;
+    #ifdef _OPENMP
+    nt = omp_get_num_threads();
+    #endif
 
     if ( n < toast_qarray_ompthresh * nt ) {
         for ( size_t i = 0; i < n; ++i ) {
@@ -163,7 +172,10 @@ void toast::qarray::rotate ( size_t nq, double const * q, size_t nv, double cons
     size_t qf;
     double xw, yw, zw, x2, xy, xz, y2, yz, z2;
 
-    int nt = omp_get_num_threads();
+    int nt = 1;
+    #ifdef _OPENMP
+    nt = omp_get_num_threads();
+    #endif
 
     // this is to avoid branching inside the for loop.
     size_t chv;
@@ -298,7 +310,10 @@ void toast::qarray::rotate ( size_t nq, double const * q, size_t nv, double cons
 
 void toast::qarray::mult ( size_t np, double const * p, size_t nq, double const * q, double * r ) {
 
-    int nt = omp_get_num_threads();
+    int nt = 1;
+    #ifdef _OPENMP
+    nt = omp_get_num_threads();
+    #endif
 
     size_t n = np;
     if ( nq > n ) {

--- a/src/python/mpi.py.in
+++ b/src/python/mpi.py.in
@@ -5,6 +5,8 @@
 import sys
 import ctypes as ct
 
+import numpy as np
+
 # open ctoast library
 
 library_path = "@LIBTOAST_PATH@"
@@ -64,5 +66,488 @@ except Exception as e:
         'Failed to set the portable MPI communicator datatype. MPI4py is '
         'probably too old. You need to have at least version 2.0. ({})'
         ''.format(e))
+
+
+class MPILock(object):
+    """
+    Manage a lock using MPI shared memory.
+
+    The lock is created across the given communicator.  This simply uses
+    a single-element integer buffer as a way of controlling process flow.
+    Nothing is actually written to or read from the buffer.
+
+    Args:
+        comm (MPI.Comm): the full communicator to use.
+    """
+    def __init__(self, comm):
+        self._comm = comm
+        self._rank = 0
+        self._procs = 1
+        if self._comm is not None:
+            self._rank = self._comm.rank
+            self._procs = self._comm.size
+
+        if self._rank == 0:
+            self._nlocal = 1
+        else:
+            self._nlocal = 0
+
+        # Allocate the shared memory buffer.
+
+        self._mpitype = None
+        self._win = None
+
+        if self._comm is not None:
+            # We are actually using MPI, so we need to ensure that
+            # our specified numpy dtype has a corresponding MPI datatype.
+            status = 0
+            try:
+                # Technically this is an internal variable, but online
+                # forum posts from the developers indicate this is stable
+                # at least until a public interface is created.
+                self._mpitype = MPI._typedict[np.dtype("int32").char]
+            except:
+                status = 1
+            self._checkabort(self._comm, status,
+                "numpy to MPI type conversion")
+
+            # Number of bytes in our buffer
+            dsize = self._mpitype.Get_size()
+            nbytes = self._nlocal * dsize
+
+            # Rank zero allocates the buffer
+            status = 0
+            try:
+                self._win = MPI.Win.Allocate_shared(nbytes, dsize, 
+                    comm=self._comm)
+            except:
+                status = 1
+            self._checkabort(self._comm, status, 
+                "shared memory allocation")
+
+
+    @property
+    def comm(self):
+        """
+        The communicator.
+        """
+        return self._comm
+
+
+    def _checkabort(self, comm, status, msg):
+        failed = comm.allreduce(status, op=MPI.SUM)
+        if failed > 0:
+            if comm.rank == 0:
+                print("MPIShared: one or more processes failed: {}".format(
+                    msg))
+                sys.stdout.flush()
+                comm.Abort()
+        return
+
+
+    def lock(self):
+        """
+        Request the lock and wait.
+
+        This call blocks until lock is available.
+        """
+        self._win.Lock(self._rank, MPI.LOCK_EXCLUSIVE)
+        return
+
+
+    def unlock(self):
+        """
+        Unlock and return.
+        """
+        self._win.Unlock(self._rank)
+        return
+
+
+class MPIShared(object):
+    """
+    Create a shared memory buffer that is replicated across nodes.
+
+    For the given array dimensions and datatype, the original communicator
+    is split into groups of processes that can share memory (i.e. that are
+    on the same node).
+
+    The values of the memory buffer can be set by one process at a time.
+    When the set() method is called the data passed by the specified
+    process is replicated to all nodes and then copied into the desired
+    place in the shared memory buffer on each node.  This way the shared
+    buffer on each node is identical.
+
+    All processes across all nodes may do read-only access to their node-
+    local copy of the buffer, simply by using the standard array indexing
+    notation ("[]") on the object itself.
+
+    Args:
+        shape (tuple): the dimensions of the array.
+        dtype (np.dtype): the data type of the array.
+        comm (MPI.Comm): the full communicator to use.  This may span
+            multiple nodes, and each node will have a copy.
+    """
+    def __init__(self, shape, dtype, comm):
+        self._shape = shape
+        self._dtype = dtype
+
+        # Global communicator.
+        
+        self._comm = comm
+        self._rank = 0
+        self._procs = 1
+        if self._comm is not None:
+            self._rank = self._comm.rank
+            self._procs = self._comm.size
+        
+        # Compute the flat-packed buffer size.
+
+        self._n = 1
+        for d in self._shape:
+            self._n *= d
+
+        # Split our communicator into groups on the same node.  Also
+        # create an inter-node communicator between corresponding
+        # processes on all nodes (for use in "setting" slices of the
+        # buffer.
+        
+        self._nodecomm = None
+        self._rankcomm = None
+        self._noderank = 0
+        self._nodeprocs = 1
+        self._nodes = 1
+        self._mynode = 0
+        if self._comm is not None:
+            self._nodecomm = self._comm.Split_type(MPI.COMM_TYPE_SHARED, 0)
+            self._noderank = self._nodecomm.rank
+            self._nodeprocs = self._nodecomm.size
+            self._nodes = self._procs // self._nodeprocs
+            if self._nodes * self._nodeprocs < self._procs:
+                self._nodes += 1
+            self._mynode = self._rank // self._nodeprocs
+            self._rankcomm = self._comm.Split(self._noderank, self._mynode)
+
+        # Consider a corner case of the previous calculation.  Imagine that
+        # the number of processes is not evenly divisible by the number of
+        # processes per node.  In that case, when we later use the set()
+        # method, the rank-wise communicator may not have a member on the
+        # final node.  Here we compute the "highest" rank within a node which
+        # is present on all nodes.  That sets the possible allowed processes
+        # which may call the set() method.
+
+        dist = self._disthelper(self._procs, self._nodes)
+        self._maxsetrank = dist[-1][1] - 1
+
+        # Divide up the total memory size among the processes on each
+        # node.  For reasonable NUMA settings, this should spread the
+        # allocated memory to locations across the node.
+
+        # FIXME: the above statement works fine for allocating the window,
+        # and it is also great in C/C++ where the pointer to the start of 
+        # the buffer is all you need.  In mpi4py, querying the rank-0 buffer
+        # returns a buffer-interface-compatible object, not just a pointer.
+        # And this "buffer object" has the size of just the rank-0 allocated
+        # data.  SO, for now, disable this and have rank 0 allocate the whole
+        # thing.  We should change this back once we figure out how to
+        # take the raw pointer from rank zero and present it to numpy as the
+        # the full buffer.
+
+        # dist = self._disthelper(self._n, self._nodeprocs)
+        # self._localoffset, self._nlocal = dist[self._noderank]
+        if self._noderank == 0:
+            self._localoffset = 0
+            self._nlocal = self._n
+        else:
+            self._localoffset = 0
+            self._nlocal = 0
+
+        # Allocate the shared memory buffer and wrap it in a 
+        # numpy array.  If the communicator is None, just make
+        # a normal numpy array.
+
+        self._mpitype = None
+        self._win = None
+        self._buffer = None
+        self._dbuf = None
+        self._flat = None
+        self._data = None
+
+        if self._comm is not None:
+            # We are actually using MPI, so we need to ensure that
+            # our specified numpy dtype has a corresponding MPI datatype.
+            status = 0
+            try:
+                # Technically this is an internal variable, but online
+                # forum posts from the developers indicate this is stable
+                # at least until a public interface is created.
+                self._mpitype = MPI._typedict[self._dtype.char]
+            except:
+                status = 1
+            self._checkabort(self._comm, status, 
+                "numpy to MPI type conversion")
+
+            # Number of bytes in our buffer
+            dsize = self._mpitype.Get_size()
+            nbytes = self._nlocal * dsize
+
+            # Every process allocates a piece of the buffer.  The per-
+            # process pieces are guaranteed to be contiguous.
+            status = 0
+            try:
+                self._win = MPI.Win.Allocate_shared(nbytes, dsize, 
+                    comm=self._nodecomm)
+            except:
+                status = 1
+            self._checkabort(self._nodecomm, status, 
+                "shared memory allocation")
+
+            # Every process looks up the memory address of rank zero's piece,
+            # which is the start of the contiguous shared buffer.
+            status = 0
+            try:
+                self._buffer, dsize = self._win.Shared_query(0)
+            except:
+                status = 1
+            self._checkabort(self._nodecomm, status, "shared memory query")
+
+            # Create a numpy array which acts as a "view" of the buffer.
+            self._dbuf = np.array(self._buffer, dtype="B", copy=False)
+            self._flat = self._dbuf.view(self._dtype)
+            self._data = self._flat.reshape(self._shape)
+
+            # Initialize to zero.  Any of the processes could do this to the
+            # whole buffer, but it is safe and easy for each process to just
+            # initialize its local piece.
+
+            # FIXME: change this back once every process is allocating a 
+            # piece of the buffer.            
+            # self._flat[self._localoffset:self._localoffset + self._nlocal] = 0
+            if self._noderank == 0:
+                self._flat[:] = 0
+
+        else:
+            self._data = np.zeros(_n, dtype=_dtype).reshape(_shape)
+
+
+    def __del__(self):
+        self.close()
+        
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, tb):
+        self.close()
+        return False
+
+
+    def close(self):
+        # The shared memory window is automatically freed
+        # when the class instance is garbage collected.
+        # This function is for any other clean up on destruction.
+        return
+
+
+    @property
+    def shape(self):
+        """
+        The tuple of dimensions of the shared array.
+        """
+        return self._shape
+
+
+    @property
+    def dtype(self):
+        """
+        The numpy datatype of the shared array.
+        """
+        return self._dtype
+
+
+    @property
+    def comm(self):
+        """
+        The full communicator.
+        """
+        return self._comm
+
+
+    @property
+    def nodecomm(self):
+        """
+        The node-local communicator.
+        """
+        return self._nodecomm
+
+
+    def _disthelper(self, n, groups):
+        dist = []
+        for i in range(groups):
+            myn = n // groups
+            first = 0
+            leftover = n % groups
+            if i < leftover:
+                myn += 1
+                first = i * myn
+            else:
+                first = ((myn + 1) * leftover) + (myn * (i - leftover))
+            dist.append( (first, myn) )
+        return dist
+
+
+    def _checkabort(self, comm, status, msg):
+        failed = comm.allreduce(status, op=MPI.SUM)
+        if failed > 0:
+            if comm.rank == 0:
+                print("MPIShared: one or more processes failed: {}".format(
+                    msg))
+            comm.Abort()
+        return
+
+
+    def set(self, data, offset, fromrank=0):
+        """
+        Set the values of a slice of the shared array.
+
+        This call is collective across the full communicator, but only the
+        data input from process "fromrank" is meaningful.  The offset 
+        specifies the starting element along each dimension when copying
+        the data into the shared array.  Regardless of which node the 
+        "fromrank" process is on, the data will be replicated to the
+        shared memory buffer on all nodes.
+
+        Args:
+            data (array): a numpy array with the same number of dimensions
+                as the full array.
+            offset (tuple): the starting offset along each dimension, which
+                determines where the input data should be inserted into the
+                shared array.
+            fromrank (int): the process rank of the full communicator which
+                is passing in the data.
+
+        Returns:
+            Nothing
+        """
+        # Explicit barrier here, to ensure that we don't try to update
+        # data while other processes are reading.
+        if self._comm is not None:
+            self._comm.barrier()
+
+        # First check that the dimensions of the data and the offset tuple
+        # match the shape of the data.
+
+        if self._rank == fromrank:
+            if len(data.shape) != len(self._shape):
+                msg = "data has incompatible number of dimensions"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+            if len(offset) != len(self._shape):
+                msg = "offset tuple has incompatible number of dimensions"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+            if data.dtype != self._dtype:
+                msg = "input data has different type than shared array"
+                if self._comm is not None:
+                    print(msg)
+                    sys.stdout.flush()
+                    #self._comm.Abort()
+                else:
+                    raise RuntimeError(msg)
+
+        # The input data is coming from exactly one process on one node.
+        # First, we broadcast the data from this process to the same node-rank
+        # process on each of the nodes.
+
+        if self._comm is not None:
+            target_noderank = self._comm.bcast(self._noderank, root=fromrank)
+            fromnode = self._comm.bcast(self._mynode, root=fromrank)
+
+            # Verify that the node rank with the data actually has a member on
+            # every node (see notes in the constructor).
+            if target_noderank > self._maxsetrank:
+                if self._rank == 0:
+                    print("set() called with data from a node rank which does"
+                        " not exist on all nodes")
+                    self._comm.Abort()
+
+            if self._noderank == target_noderank:
+                # We are the lucky process on this node that gets to write
+                # the data into shared memory!
+
+                # Broadcast the offsets of the input slice
+                copyoffset = None
+                if self._mynode == fromnode:
+                    copyoffset = offset
+                copyoffset = self._rankcomm.bcast(copyoffset, root=fromnode)
+
+                # Pre-allocate buffer, so that we can use the low-level
+                # (and faster) Bcast method.
+                datashape = None
+                if self._mynode == fromnode:
+                    datashape = data.shape
+                datashape = self._rankcomm.bcast(datashape, root=fromnode)
+                
+                nodedata = None
+                if self._mynode == fromnode:
+                    nodedata = np.copy(data)
+                else:
+                    nodedata = np.zeros(datashape, dtype=self._dtype)
+
+                # Broadcast the data buffer
+                self._rankcomm.Bcast(nodedata, root=fromnode)
+
+                # Now one process on every node has a copy of the data, and
+                # can copy it into the shared memory buffer.
+
+                dslice = []
+                ndims = len(nodedata.shape)
+                for d in range(ndims):
+                    dslice.append( slice(copyoffset[d], 
+                        copyoffset[d]+nodedata.shape[d], 1) )
+                slc = tuple(dslice)
+
+                # Get a write-lock on the shared memory
+                self._win.Lock(self._noderank, MPI.LOCK_EXCLUSIVE)
+
+                # Copy data slice
+                self._data[slc] = nodedata
+
+                # Release the write-lock
+                self._win.Unlock(self._noderank)
+
+        else:
+            # We are just copying to a numpy array...
+            dslice = []
+            ndims = len(data.shape)
+            for d in range(ndims):
+                dslice.append( slice(offset[d], offset[d]+data.shape[d], 1) )
+            slc = tuple(dslice)
+
+            self._data[slc] = data
+
+        # Explicit barrier here, to ensure that other processes do not try
+        # reading data before the writing processes have finished.
+        if self._comm is not None:
+            self._comm.barrier()
+
+        return
+
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+    def __setitem__(self, key, value):
+        raise NotImplementedError("Setting individual array elements not"
+            " supported.  Use the set() method instead.")
 
 

--- a/src/python/mpi.py.in
+++ b/src/python/mpi.py.in
@@ -151,7 +151,7 @@ class MPILock(object):
 
         This call blocks until lock is available.
         """
-        self._win.Lock(self._rank, MPI.LOCK_EXCLUSIVE)
+        self._win.Lock(0, MPI.LOCK_EXCLUSIVE)
         return
 
 
@@ -159,7 +159,7 @@ class MPILock(object):
         """
         Unlock and return.
         """
-        self._win.Unlock(self._rank)
+        self._win.Unlock(0)
         return
 
 

--- a/src/python/tests/Makefile.am
+++ b/src/python/tests/Makefile.am
@@ -44,7 +44,8 @@ qarray.py \
 rng.py \
 fft.py \
 runner.py \
-tod.py
+tod.py \
+tidas.py
 
 
 clean-local :

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -38,6 +38,7 @@ from . import ops_madam as testopsmadam
 from . import map_satellite as testmapsatellite
 from . import map_ground as testmapground
 from . import binned as testbinned
+from . import tidas as testtidas
 
 
 def test(name=None):
@@ -77,6 +78,7 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testpsdmath) )
         suite.addTest( loader.loadTestsFromModule(testintervals) )
         suite.addTest( loader.loadTestsFromModule(testopspmat) )
+        suite.addTest( loader.loadTestsFromModule(testtidas) )
         suite.addTest( loader.loadTestsFromModule(testcov) )
         suite.addTest( loader.loadTestsFromModule(testopsdipole) )
         suite.addTest( loader.loadTestsFromModule(testopssimnoise) )

--- a/src/python/tests/tidas.py
+++ b/src/python/tests/tidas.py
@@ -1,0 +1,414 @@
+# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by 
+# a BSD-style license that can be found in the LICENSE file.
+
+from ..mpi import MPI
+from .mpi import MPITestCase
+
+import sys
+import os
+import re
+import shutil
+
+import unittest
+
+import numpy as np
+import numpy.testing as nt
+
+from ..dist import *
+
+from .. import qarray as qa
+
+from ..tod import tidas_available
+from ..tod import Interval
+
+if tidas_available:
+    import tidas as tds
+    from tidas.mpi_volume import MPIVolume
+    from ..tod import tidas as tt
+
+
+class TidasTest(MPITestCase):
+
+    def setUp(self):
+        self.outdir = "toast_test_output"
+        if self.comm.rank == 0:
+            if not os.path.isdir(self.outdir):
+                os.mkdir(self.outdir)
+        self.outvol = os.path.join(self.outdir, "test_tidas")
+        self.export = os.path.join(self.outdir, "export_tidas")
+        self.rate = 20.0
+
+        # Properties of the observations
+        self.nobs = 6
+        self.obslen = 3600.0
+        self.obsgap = 600.0
+
+        self.obstotalsamp = int(0.5 + (self.obslen + self.obsgap) 
+            * self.rate) + 1
+        self.obssamp = int(0.5 + self.obslen * self.rate) + 1
+        self.obsgapsamp = self.obstotalsamp - self.obssamp
+
+        self.obstotal = (self.obstotalsamp - 1) / self.rate
+        self.obslen = (self.obssamp - 1) / self.rate
+        self.obsgap = (self.obsgapsamp - 1) / self.rate
+        
+        # Properties of the intervals within an observation
+        self.nsub = 5
+        self.subtotsamp = self.obssamp // self.nsub
+        self.subgapsamp = 0
+        self.subsamp = self.subtotsamp - self.subgapsamp
+
+        # Detectors
+        self.dets = [
+            "d100-1a",
+            "d100-1b",
+            "d145-2a",
+            "d145-2b",
+            "d220-3a",
+            "d220-3b"
+        ]
+
+        self.detquats = {}
+        for d in self.dets:
+            self.detquats[d] = np.array([0,0,0,1], dtype=np.float64)
+
+        # Skip the rest of the setup if we don't have tidas.
+        if not tidas_available:
+            return
+
+        # Group schema
+        self.schm = tt.create_tidas_schema(self.dets, "float64", "volts")
+
+
+    def tearDown(self):
+        pass
+        
+
+    def meta_setup(self):
+        ret = {}
+        ret["string"] = "blahblahblah"
+        ret["double"] = -123456789.0123
+        ret["float"] = -123456789.0123
+        ret["int8"] = -100
+        ret["uint8"] = 100
+        ret["int16"] = -10000
+        ret["uint16"] = 10000
+        ret["int32"] = -1000000000
+        ret["uint32"] = 1000000000
+        ret["int64"] = -100000000000
+        ret["uint64"] = 100000000000
+        return ret
+
+
+    def meta_verify(self, dct):
+        nt.assert_equal(dct["string"], "blahblahblah")
+        nt.assert_equal(dct["int8"], -100)
+        nt.assert_equal(dct["uint8"], 100)
+        nt.assert_equal(dct["int16"], -10000)
+        nt.assert_equal(dct["uint16"], 10000)
+        nt.assert_equal(dct["int32"], -1000000000)
+        nt.assert_equal(dct["uint32"], 1000000000)
+        nt.assert_equal(dct["int64"], -100000000000)
+        nt.assert_equal(dct["uint64"], 100000000000)
+        nt.assert_almost_equal(dct["float"], -123456789.0123)
+        nt.assert_almost_equal(dct["double"], -123456789.0123)
+        return
+
+
+    def create_intervals(self, start, first):
+        ret = []
+        for i in range(self.nsub):
+            ifirst = i * self.subtotsamp
+            if i == self.nsub - 1:
+                ilast = self.obssamp - 1
+            else:
+                ilast = (i+1) * self.subtotsamp - 1
+            istart = float(ifirst) / self.rate
+            istop = float(ilast) / self.rate
+            ret.append(Interval(
+                start=(start + istart),
+                stop=(start + istop), 
+                first=(first + ifirst), 
+                last=(first + ilast)))
+        return ret
+
+
+    def intervals_init(self, start, first):
+        return self.create_intervals(start, first)
+
+
+    def intervals_verify(self, ilist, start, first):
+        reg = self.create_intervals(start, first)
+        nt.assert_equal(len(ilist), len(reg))
+        for i in range(len(ilist)):
+            nt.assert_almost_equal(ilist[i].start, reg[i].start)
+            nt.assert_equal(ilist[i].first, reg[i].first)
+        return
+
+
+    def create_bore(self, total, local):
+        theta_incr = (0.5*np.pi) / (total - 1)
+        phi_incr = (2.0*np.pi) / (total - 1)
+
+        theta_start = local[0] * theta_incr
+        phi_start = local[0] * phi_incr
+
+        theta_stop = theta_start + (local[1] - 1) * theta_incr
+        phi_stop = phi_start + (local[1] - 1) * phi_incr
+
+        theta = np.linspace(theta_start, theta_stop, num=local[1], 
+            endpoint=True, dtype=np.float64)
+        phi = np.linspace(phi_start, phi_stop, num=local[1], 
+            endpoint=True, dtype=np.float64)
+        pa = np.zeros(local[1], dtype=np.float64)
+
+        return qa.from_angles(theta, phi, pa)
+
+
+    def obs_init(self, vol, parent, name, start, first):
+
+        # fake metadata
+        props = self.meta_setup()
+        props = tt.encode_tidas_quats(self.detquats, props=props)
+
+        # create intervals
+        ilist = self.intervals_init(start, 0)
+
+        # create the observation within the TIDAS volume
+
+        obs = tt.create_tidas_obs(vol, parent, name, 
+            groups={
+                "detectors" : (self.schm, self.obssamp, props)
+            }, 
+            intervals={
+                "chunks" : (len(ilist), dict())
+            })
+
+        # write the intervals that will be used for data distribution
+        if vol.comm.rank == 0:
+            obs.intervals_get("chunks").write(ilist)
+
+        # instantiate a TOD for this observation
+
+        tod = tt.TODTidas(vol.comm, vol, "{}/{}".format(parent, name), 
+            detgroup="detectors", distintervals="chunks")
+
+        # Now write the data.  For this test, we simple write the detector
+        # index (as a float) to the detector timestream.  We also flag every
+        # other sample.  For the boresight pointing, we create a fake spiral
+        # pattern.
+
+        if vol.comm.rank == 0:
+            # number of samples
+            n = tod.total_samples
+
+            # Write some simple timestamps
+            incr = 1.0 / self.rate
+            stamps = np.arange(n, dtype=np.float64)
+            stamps *= incr
+            stamps += start
+
+            tod.write_times(stamps=stamps)
+
+            # boresight
+            boresight = self.create_bore(n, (0,n))
+            tod.write_boresight(data=boresight)
+
+            # flags.  We use this for both the common and all the detector
+            # flags just to check write/read roundtrip.
+            flags = np.zeros(n, dtype=np.uint8)
+            flags[::2] = 1
+
+            tod.write_common_flags(flags=flags)
+
+            # detector data
+            fakedata = np.empty(n, dtype=np.float64)
+            for d in tod.detectors:
+                # get unique detector index and convert to float
+                indx = float(tod.detindx[d])
+                # write this to all local elements
+                fakedata[:] = indx
+                tod.write(detector=d, data=fakedata)
+                # write detector flags
+                tod.write_det_flags(detector=d, flags=flags)
+
+        # FIXME: consider doing this in parallel once either TIDAS supports
+        # that or there is a toast-specific workaround to serialize I/O to a
+        # single HDF5 file.
+        #
+        # # number of local samples
+        # nlocal = tod.local_samples[1]
+
+        # # Write some simple timestamps
+        # stamps = np.arange(nlocal, dtype=np.float64)
+        # stamps /= self.rate
+        # stamps += start + (tod.local_samples[0] / self.rate)
+
+        # tod.write_times(stamps=stamps)
+
+        # # boresight
+        # boresight = self.create_bore(tod.total_samples, tod.local_samples)
+        # tod.write_boresight(boresight)
+
+        # # flags.  We use this for both the common and all the detector
+        # # flags just to check write/read roundtrip.
+        # flags = np.zeros(nlocal, dtype=np.uint8)
+        # flags[::2] = 1
+
+        # tod.write_common_flags(flags=flags)
+
+        # # detector data
+        # fakedata = np.empty(nlocal, dtype=np.float64)
+        # for d in range(len(self.dets)):
+        #     # get unique detector index and convert to float
+        #     indx = float(tod.detindx[d])
+        #     # write this to all local elements
+        #     fakedata[:] = indx
+        #     tod.write(detector=self.dets[d], data=fakedata)
+        #     # write detector flags
+        #     tod.write_det_flags(detector=self.dets[d], flags=flags)
+
+        return
+
+
+    def obs_verify(self, tod, start, first):
+        nlocal = tod.local_samples[1]
+        odd = False
+        if tod.local_samples[0] % 2 != 0:
+            odd = True
+
+        # Read the intervals and compare
+
+        intr = tod.block.intervals_get("chunks")
+        ilist = intr.read()
+        self.intervals_verify(ilist, start, 0)
+
+        # Verify group properties
+
+        self.meta_verify(tod.group.props)
+
+        # Read and compare timestamps
+
+        compstamps = np.arange(nlocal, dtype=np.float64)
+        compstamps /= self.rate
+        compstamps += start + (tod.local_samples[0] / self.rate)
+
+        stamps = tod.read_times()
+
+        nt.assert_almost_equal(stamps, compstamps)
+
+        # Read and compare boresight
+
+        compbore = self.create_bore(tod.total_samples, tod.local_samples)
+        boresight = tod.read_boresight()
+
+        nt.assert_almost_equal(boresight, compbore)
+
+        # flags.  We use this for both the common and all the detector
+        # flags just to check write/read roundtrip.
+
+        compflags = np.zeros(nlocal, dtype=np.uint8)
+        if odd:
+            compflags[1::2] = 1
+        else:
+            compflags[::2] = 1
+
+        flags = tod.read_common_flags()
+
+        nt.assert_equal(flags, compflags)
+
+        # detector data
+
+        compdata = np.empty(nlocal, dtype=np.float64)
+        for d in tod.local_dets:
+            # get unique detector index and convert to float
+            indx = float(tod.detindx[d])
+            # comparison values
+            compdata[:] = indx
+            # read and check
+            data = tod.read(detector=d)
+            nt.assert_almost_equal(data, compdata)
+            # check detector flags
+            flags, cflags = tod.read_flags(detector=d)
+            nt.assert_equal(flags, compflags)
+
+        return
+
+
+    def volume_init(self, path):
+        if self.comm.rank == 0:
+            if os.path.isdir(path):
+                shutil.rmtree(path)
+        self.comm.barrier()
+
+        with MPIVolume(self.comm, path, backend="hdf5", comp="none") as vol:
+            # Usually for real data we will have a hierarchy of blocks 
+            # (year, month, season, etc).  For this test we just add generic
+            # observations to the root block.
+            for ob in range(self.nobs):
+                obsname = "obs_{:02d}".format(ob)
+                start = ob * self.obstotal
+                first = ob * self.obstotalsamp
+                self.obs_init(vol, "", obsname, start, first)
+        return
+
+ 
+    def volume_verify(self, path):
+        with MPIVolume(self.comm, path) as vol:
+            root = vol.root()
+            for ob in range(self.nobs):
+                obsname = "obs_{:02d}".format(ob)
+                obs = root.block_get(obsname)
+                start = ob * self.obstotal
+                first = ob * self.obstotalsamp
+                tod = tt.TODTidas(self.comm, vol, "/{}".format(obsname), 
+                    detgroup="detectors", distintervals="chunks")
+                self.obs_verify(tod, start, first)
+        return
+
+
+    @unittest.skipIf(not tidas_available, "TIDAS not found")
+    def test_io(self):
+        start = MPI.Wtime()
+
+        self.volume_init(self.outvol)
+        self.volume_verify(self.outvol)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
+
+
+    @unittest.skipIf(not tidas_available, "TIDAS not found")
+    def test_export(self):
+        start = MPI.Wtime()
+
+        self.volume_init(self.outvol)
+
+        worldsize = self.comm.size
+        if (worldsize >= 2):
+            groupsize = int( worldsize / 2 )
+            ngroup = 2
+        else:
+            groupsize = 1
+            ngroup = 1
+        toastcomm = Comm(self.comm, groupsize=groupsize)
+
+        distdata = tt.load_tidas(toastcomm, self.outvol, mode="r",
+            distintervals="chunks")
+
+        if self.comm.rank == 0:
+            if os.path.isdir(self.export):
+                shutil.rmtree(self.export)
+        self.comm.barrier()
+
+        dumper = tt.OpTidasExport(self.export, usedist=True)
+        dumper.exec(distdata)
+
+        self.volume_verify(self.export)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
+

--- a/src/python/tests/tidas.py
+++ b/src/python/tests/tidas.py
@@ -23,7 +23,6 @@ from ..tod import tidas_available
 from ..tod import Interval
 
 if tidas_available:
-    import tidas as tds
     from tidas.mpi_volume import MPIVolume
     from ..tod import tidas as tt
 

--- a/src/python/tests/tod.py
+++ b/src/python/tests/tod.py
@@ -22,7 +22,7 @@ class TODTest(MPITestCase):
                 os.mkdir(self.outdir)
             
         # Note: self.comm is set by the test infrastructure
-        self.dets = ['1a', '1b', '2a', '2b']
+        self.dets = ["1a", "1b", "2a", "2b"]
         self.mynsamp = 10
         self.myoff = self.mynsamp * self.comm.rank
         self.totsamp = self.mynsamp * self.comm.size
@@ -54,7 +54,7 @@ class TODTest(MPITestCase):
 
         stop = MPI.Wtime()
         elapsed = stop - start
-        #print('Proc {}:  test took {:.4f} s'.format( MPI.COMM_WORLD.rank, elapsed ))
+        #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
 
 
     def test_read(self):
@@ -69,7 +69,7 @@ class TODTest(MPITestCase):
 
         stop = MPI.Wtime()
         elapsed = stop - start
-        #print('Proc {}:  test took {:.4f} s'.format( MPI.COMM_WORLD.rank, elapsed ))
+        #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
 
 
     def test_read_pntg(self):

--- a/src/python/tod/Makefile.am
+++ b/src/python/tod/Makefile.am
@@ -38,7 +38,8 @@ sim_det_noise.py \
 sim_det_map.py \
 sim_det_dipole.py \
 sim_det_atm.py \
-sim_focalplane.py
+sim_focalplane.py \
+tidas.py
 
 
 if HAVE_AM_MPI

--- a/src/python/tod/__init__.py
+++ b/src/python/tod/__init__.py
@@ -44,3 +44,6 @@ from .tod_math import (calibrate, dipole, sim_noise_timestream,
                        OpCacheCopy, OpCacheClear)
 
 from .conviqt import OpSimConviqt
+
+from .tidas import available as tidas_available
+

--- a/src/python/tod/tidas.py
+++ b/src/python/tod/tidas.py
@@ -1,0 +1,968 @@
+# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by 
+# a BSD-style license that can be found in the LICENSE file.
+
+from ..mpi import MPI, MPILock
+
+import sys
+import os
+import re
+
+import numpy as np
+
+from .. import qarray as qa
+
+from ..dist import Data, distribute_discrete
+from ..op import Operator
+
+from .tod import TOD
+from .interval import Interval
+
+available = True
+try:
+    import tidas as tds
+    from tidas.mpi_volume import MPIVolume
+except:
+    available = False
+
+
+# Module-level constants
+
+STR_QUAT = "QUAT"
+STR_FLAG = "FLAG"
+STR_COMMON = "COMMON"
+STR_BORE = "BORE"
+STR_POS = "POS"
+STR_VEL = "VEL"
+STR_DISTINTR = "chunks"
+STR_DETGROUP = "detectors"
+
+
+def create_tidas_schema(detlist, typestr, units):
+    """
+    Create a schema for a list of detectors.
+
+    All detector timestreams will be set to the same type and units.  A flag
+    field will be created for each detector.  Additional built-in fields will
+    also be added to the schema.
+
+    Args:
+        detlist (list): a list of detector names
+        typestr (str): the tidas datatype assigned to all data fields.
+        units (str): the units string assigned to all data fields.
+
+    Returns (dict):
+        Schema dictionary containing the data and flag fields. 
+    """
+    schm = {}
+    for c in ["X", "Y", "Z", "W"]:
+        field = "{}_{}{}".format(STR_BORE, STR_QUAT, c)
+        schm[field] = ("float64", "NA")
+
+    for c in ["X", "Y", "Z"]:
+        field = "{}{}".format(STR_POS, c)
+        schm[field] = ("float64", "NA")
+
+    for c in ["X", "Y", "Z"]:
+        field = "{}{}".format(STR_VEL, c)
+        schm[field] = ("float64", "NA")
+
+    schm["{}_{}".format(STR_FLAG, STR_COMMON)] = ("uint8", "NA")
+
+    for d in detlist:
+        schm[d] = (typestr, units)
+        schm["{}_{}".format(STR_FLAG, d)] = ("uint8", "NA")
+    return schm
+
+
+def create_tidas_obs(vol, parent, name, groups=None, intervals=None):
+    """
+    Create a single TIDAS block that represents an observation.
+
+    This creates a new block to represent an observation, and then creates
+    zero or more groups and intervals inside that block.  When writing to a
+    new TIDAS volume, this function can be used in the pipeline script 
+    to set up the "leaf nodes" of the volume, each of which is a single
+    observation.
+
+    The detector group will have additional fields added to the schema
+    that are expected by the TODTidas class for boresight pointing and
+    telescope position / velocity.
+
+    Args:
+        vol (tidas.MPIVolume):  the volume.
+        parent (str):  the path to the parent block.
+        name (str):  the name of the observation block.
+        groups (dict):  dictionary where the key is the group name and the
+            value is a tuple containing the (schema, size, properties) of
+            the group.  The objects in the tuple are exactly the arguments
+            to the constructor of the tidas.Group object.
+        intervals (dict):  dictionary where the key is the intervals name 
+            and the value is a tuple containing the (size, properties) of
+            the intervals.  The objects in the tuple are exactly the arguments
+            to the constructor of the tidas.Intervals object.
+        detgroup (str):  The name of the TIDAS group containing detector 
+            and other telescope information at the detector sample rate.
+            If there is only one data group, then this is optional.
+
+    Returns (tidas.Block):
+        The newly created block.
+    """
+    if not available:
+        raise RuntimeError("tidas is not available")
+        return
+    
+    # The root block
+    root = vol.root()
+
+    # Only create these objects on one process
+    if vol.comm.rank == 0:
+        
+        # Descend tree to the parent node
+        parentnodes = parent.split("/")
+        par = root
+        for pn in parentnodes:
+            if pn != "":
+                par = par.block_get(pn)
+
+        # Create the observation block
+        obs = par.block_add(name)
+
+        # Create the groups
+        if groups is not None:
+            for grp, args in groups.items():
+                g = tds.Group(schema=args[0], size=args[1], props=args[2])
+                g = obs.group_add(grp, g)
+
+        # Create the intrvals
+        if intervals is not None:
+            for intrvl, args in intervals.items():
+                intr = tds.Intervals(size=args[0], props=args[1])
+                intr = obs.intervals_add(intrvl, intr)
+
+    # Sync metadata
+    vol.meta_sync()
+
+    # Get fresh handle to the observation block on all processes
+    parentnodes = parent.split("/")
+    par = root
+    for pn in parentnodes:
+        if pn != "":
+            par = par.block_get(pn)
+    obs = par.block_get(name)
+
+    return obs
+
+
+def decode_tidas_quats(props):
+    """
+    Read detector quaternions from a TIDAS property dictionary.
+
+    This extracts and assembles the quaternion offsets for each detector from
+    the metadata properties from a TIDAS group.
+
+    Args:
+        props (dict):  the dictionary of properties associated with a TIDAS
+            detector group.
+
+    Returns (dict):
+        a dictionary of detectors and their quaternions, each stored as a 4
+        element numpy array.
+    """
+    quatpat = re.compile(r"(.*)_{}([XYZW])".format(STR_QUAT))
+    loc = {"X":0, "Y":1, "Z":2, "W":3}
+    quats = {}
+
+    # Extract all quaternions from the properties based on the key names
+    for key, val in props.items():
+        mat = quatpat.match(key)
+        if mat is not None:
+            det = mat.group(1)
+            comp = mat.group(2)
+            if det not in quats:
+                quats[det] = np.zeros(4, dtype=np.float64)
+            quats[det][loc[comp]] = float(val)
+
+    return quats
+
+
+def encode_tidas_quats(detquats, props=None):
+    """
+    Append detector quaternions to a dictionary.
+
+    This takes a dictionary of detector quaternions and encodes the elements
+    into named dictionary values suitable for creating a TIDAS group.  The
+    entries are merged with the input dictionary and the result is returned.
+
+    This extracts and assembles the quaternion offsets for each detector from
+    the metadata of a particular group (the one containing the detector data).
+
+    Args:
+        detquats (dict):  a dictionary with keys of detector names and values
+            containing 4-element numpy arrays with the quaternion.
+        props (dict):  the starting dictionary of properties.  The updated
+            properties are returned.
+
+    Returns (dict):
+        a dictionary of detector quaternion values appended to the input.
+    """
+    ret = props
+    if ret is None:
+        ret = {}
+
+    qname = ["X", "Y", "Z", "W"]
+    for det, quat in detquats.items():
+        for q in range(4):
+            key = "{}_{}{}".format(det, STR_QUAT, qname[q])
+            ret[key] = float(quat[q])
+
+    return ret
+
+
+class TODTidas(TOD):
+    """
+    This class provides an interface to a single TIDAS data block.
+
+    An instance of this class reads and writes to a single TIDAS block which
+    represents a TOAST observation.  The volume and specific block should
+    already exist.  Groups and intervals within the observation may already
+    exist or may be created with the provided helper methods.  All groups
+    and intervals must exist prior to reading or writing from them.
+
+    Detector pointing offsets from the boresight are given as quaternions,
+    and are expected to be contained in the dictionary of properties 
+    found in the TIDAS group containing detector timestreams.
+
+    Args:
+        mpicomm (mpi4py.MPI.Comm): the MPI communicator over which this
+            observation data is distributed.
+        vol (tidas.MPIVolume):  the volume.
+        path (str):  the path to this observation block.
+        detranks (int):  The dimension of the process grid in the detector
+            direction.  The MPI communicator size must be evenly divisible
+            by this number.
+        detbreaks (list):  Optional list of hard breaks in the detector
+            distribution.
+        detgroup (str):  The name of the TIDAS group containing detector 
+            and other telescope information at the detector sample rate.
+            If there is only one data group, then this is optional.
+        distintervals (str):  Optional name of the TIDAS intervals that
+            determines how the data should be distributed along the time
+            axis.  Default is to distribute only by detector.
+    
+    """
+
+    # FIXME: currently the data flags are stored in the same group as
+    # the data.  Once TIDAS supports per-group backend options like
+    # compression, we should move the flags to a separate group:
+    #   https://github.com/hpc4cmb/tidas/issues/13
+
+    def __init__(self, mpicomm, vol, path, detranks=1, detbreaks=None, 
+        detgroup=None, distintervals=None):
+
+        if not available:
+            raise RuntimeError("tidas is not available")
+
+        # The root block
+        root = vol.root()
+
+        # Descend tree to the observation node
+        nodes = path.split("/")
+        blk = root
+        for nd in nodes:
+            if nd != "":
+                sys.stdout.flush()
+                blk = blk.block_get(nd)
+
+        self._block = blk
+
+        # Get the detector group
+        self._dgrpname = None
+        self._dgrp = None
+        grpnames = self._block.group_names()
+
+        if len(grpnames) == 1:
+            self._dgrpname = grpnames[0]
+            self._dgrp = self._block.group_get(grpnames[0])
+        else:
+            if detgroup is None:
+                raise RuntimeError("You must specify the detector group if "
+                    "multiple groups exist")
+            else:
+                self._dgrpname = detgroup
+                self._dgrp = self._block.group_get(detgroup)
+
+        # Get the detector quaternion offsets
+        self._detquats = decode_tidas_quats(self._dgrp.props)
+        self._detlist = sorted(list(self._detquats.keys()))
+
+        # We need to assign a unique integer index to each detector.  This
+        # is used when seeding the streamed RNG in order to simulate
+        # timestreams.  For simplicity, and assuming that detector names
+        # are not too long, we can convert the detector name to bytes and
+        # then to an integer.
+
+        self._detindx = {}
+        for det in self._detlist:
+            bdet = det.encode("utf-8")
+            ind = None
+            try:
+                ind = int.from_bytes(bdet, byteorder="little")
+            except:
+                raise RuntimeError("Cannot convert detector name {} to a "
+                    "unique integer- maybe it is too long?".format(det))
+            self.detindx[det] = ind
+
+        # Create an MPI lock to use for writing to the TIDAS volume.  We must
+        # have only one writing process at a time.  Note that this lock is over
+        # the communicator for this single observation (TIDAS block).
+        # Processes writing to separate blocks have no restrictions.
+
+        self._writelock = MPILock(mpicomm)
+
+        # read intervals and set up distribution chunks.
+
+        sampsizes = None
+        self._distintervals = None
+        self._intervals = None
+        self._distint = None
+
+        if distintervals is not None:
+            self._distintervals = distintervals
+            self._distint = self._block.intervals_get(distintervals)
+            # Rank zero process reads and broadcasts intervals
+            if vol.comm.rank == 0:
+                self._intervals = self._distint.read()
+            self._intervals = vol.comm.bcast(self._intervals, root=0)
+            # Compute the contiguous spans of time for data distribution
+            # based on the starting points of all intervals.
+            sampsizes = [ (x[1].first - x[0].first) for x in 
+                zip(self._intervals[:-1], self._intervals[1:]) ]
+            sampsizes.append( self._dgrp.size - 
+                self._intervals[-1].first )
+        
+        # call base class constructor to distribute data
+        super().__init__(vol.comm, self._detlist, self._dgrp.size, 
+            detindx=self._detindx, detranks=detranks, detbreaks=detbreaks,
+            sampsizes=sampsizes, meta=self._dgrp.props)
+
+
+    @property
+    def block(self):
+        """
+        The TIDAS block for this TOD.
+
+        This can be used for arbitrary access to other groups and intervals
+        associated with this observation.
+        """
+        return self._block
+
+
+    @property
+    def group(self):
+        """
+        The TIDAS group for the detectors in this TOD.
+        """
+        return self._dgrp
+
+
+    @property
+    def groupname(self):
+        """
+        The TIDAS group name for the detectors in this TOD.
+        """
+        return self._dgrpname
+
+
+    def detoffset(self):
+        """
+        Return dictionary of detector quaternions.
+
+        This returns a dictionary with the detector names as the keys and the
+        values are 4-element numpy arrays containing the quaternion offset 
+        from the boresight.
+
+        Args:
+            None
+
+        Returns (dict):
+            the dictionary of quaternions.
+        """
+        return dict(self._detquats)
+
+
+    def _read_cache_helper(self, prefix, comps, start, n, usecache):
+        """
+        Helper function to read multi-component data, pack into an
+        array, optionally cache it, and return.
+        """
+        # Number of components we have
+        ncomp = len(comps)
+
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+
+        if self.cache.exists(prefix):
+            return self.cache.reference(prefix)[start:start+n,:]
+        else:
+            if usecache:
+                # We cache the whole observation, regardless of what sample
+                # range we will return.
+                data = self.cache.create(prefix, np.float64, 
+                    (self.local_samples[1], ncomp))
+                for c in range(ncomp):
+                    field = "{}{}".format(prefix, comps[c])
+                    d = self._dgrp.read(field, offset, self.local_samples[1])
+                    data[:,c] = d
+                # Return just the desired slice
+                return data[start:start+n,:]
+            else:
+                # Read and return just the slice we want
+                data = np.zeros((n, ncomp), dtype=np.float64)
+                for c in range(ncomp):
+                    field = "{}{}".format(prefix, comps[c])
+                    d = self._dgrp.read(field, offset, n)
+                    dat[:,c] = d
+                return data
+
+
+    def _write_helper(self, data, prefix, comps, start):
+        """
+        Helper function to write multi-component data.  
+        """
+        # Number of components we have
+        ncomp = len(comps)
+
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+
+        tmpdata = np.empty(data.shape[0], dtype=data.dtype, order="C")
+        for c in range(ncomp):
+            field = "{}{}".format(prefix, comps[c])
+            tmpdata[:] = data[:,c]
+            self._dgrp.write(field, offset, tmpdata)
+
+        return
+    
+
+    def _get_boresight(self, start, n, usecache=True):
+        # Cache name
+        cachebore = "{}_{}".format(STR_BORE, STR_QUAT)
+        # Read and optionally cache the boresight pointing.
+        return self._read_cache_helper(cachebore, ["X", "Y", "Z", "W"], 
+            start, n, usecache)
+
+
+    def _put_boresight(self, start, data):
+        # Data name
+        borename = "{}_{}".format(STR_BORE, STR_QUAT)
+        # Write data
+        self._writelock.lock()
+        self._write_helper(data, borename, ["X", "Y", "Z", "W"], 
+            start)
+        self._writelock.unlock()
+        return
+
+
+    def _get(self, detector, start, n):
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Read from the data group and return
+        return self._dgrp.read(detector, offset, n)
+
+
+    def _put(self, detector, start, data):
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Write to the data group
+        self._writelock.lock()
+        self._dgrp.write(detector, offset, data)
+        self._writelock.unlock()
+        return
+
+
+    def _get_flags(self, detector, start, n):
+        # Field name
+        field = "{}_{}".format(STR_FLAG, detector)
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Read from the data group and return
+        cflags = self._get_common_flags(start, n)
+        return (self._dgrp.read(field, offset, n), cflags)
+
+
+    def _put_det_flags(self, detector, start, flags):
+        # Field name
+        field = "{}_{}".format(STR_FLAG, detector)
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Write to the data group
+        self._writelock.lock()
+        self._dgrp.write(field, offset, flags)
+        self._writelock.unlock()
+        return
+
+
+    def _get_common_flags(self, start, n):
+        # Field name
+        field = "{}_{}".format(STR_FLAG, STR_COMMON)
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Read from the data group and return
+        return self._dgrp.read(field, offset, n)
+
+
+    def _put_common_flags(self, start, flags):
+        # Field name
+        field = "{}_{}".format(STR_FLAG, STR_COMMON)
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Write to the data group
+        self._writelock.lock()
+        self._dgrp.write(field, offset, flags)
+        self._writelock.unlock()
+        return
+
+
+    def _get_times(self, start, n):
+        # FIXME: as soon as the TIDAS group interface supports partial reading
+        # of time stamps, change this to use that interface:
+        #   https://github.com/hpc4cmb/tidas/issues/17
+        # until then, workaround here by reading the timestamps as a normal
+        # field.
+        field = "TIDAS_TIME"
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Read from the data group and return
+        return self._dgrp.read(field, offset, n)
+
+
+    def _put_times(self, start, stamps):
+        # FIXME: as soon as the TIDAS group interface supports partial reading
+        # of time stamps, change this to use that interface:
+        #   https://github.com/hpc4cmb/tidas/issues/17
+        # until then, workaround here by reading the timestamps as a normal
+        # field.
+        field = "TIDAS_TIME"
+        # Compute the sample offset of our local data
+        offset = self.local_samples[0] + start
+        # Write to the data group
+        self._writelock.lock()
+        self._dgrp.write(field, offset, stamps)
+        self._writelock.unlock()
+        return
+
+
+    def _get_pntg(self, detector, start, n):
+        # Get boresight pointing (from disk or cache)
+        bore = self._get_boresight(start, n)
+        # Apply detector quaternion and return
+        return qa.mult(bore, self._detquats[detector])
+
+
+    def _put_pntg(self, detector, start, data):
+        raise RuntimeError("TODTidas computes detector pointing on the fly."
+            " Use the write_boresight() method instead.")
+        return
+
+
+    def _get_position(self, start, n, usecache=False):
+        # Read and optionally cache the telescope position.
+        return self._read_cache(STR_POS, ["X", "Y", "Z"], start, n, usecache)
+
+
+    def _put_position(self, start, pos):
+        self._writelock.lock()
+        self._write_helper(pos, STR_POS, ["X", "Y", "Z"], start)
+        self._writelock.unlock()
+        return
+
+
+    def _get_velocity(self, start, n, usecache=False):
+        # Read and optionally cache the telescope velocity.
+        return self._read_cache(STR_VEL, ["X", "Y", "Z"], start, n, usecache)
+
+    
+    def _put_velocity(self, start, vel):
+        self._writelock.lock()
+        self._write_helper(vel, STR_VEL, ["X", "Y", "Z"], start)
+        self._writelock.unlock()
+        return
+
+
+def load_tidas(comm, path, mode="r", detranks=1, detbreaks=None, detgroup=None,
+    distintervals=None):
+    """
+    Loads an existing TOAST dataset in TIDAS format.
+
+    This takes a 2-level TOAST communicator and opens an existing TIDAS
+    volume using the global communicator.  The opened volume handle is stored 
+    in the observation dictionary with the "tidas" key.  Similarly, the 
+    metadata path to the block within the volume is stored in the 
+    "tidas_block" key.
+    
+    The leaf nodes of the hierarchy are assumed to be the "observations".
+    the observations are assigned to the process groups in a load-balanced
+    way based on the number of samples in each detector group.
+
+    For each observation, the TOD data distribution parameters and the group
+    communicator are passed to the TODTidas class.
+
+    Args:
+        comm (toast.Comm): the toast Comm class for distributing the data.
+        path (str):  the TIDAS volume path.
+        mode (string): whether to open the file in read-only ("r") or
+                       read-write ("w") mode.  Default is read-only.
+        detranks (int):  The dimension of the process grid in the detector
+            direction.  The MPI group communicator size must be evenly
+            divisible by this number.
+        detbreaks (list):  Optional list of hard breaks in the detector
+            distribution.
+        detgroup (str):  The name of the TIDAS group containing detector 
+            and other telescope information at the detector sample rate.
+            If there is only one data group, then this is optional.
+        distintervals (str):  Optional name of the TIDAS intervals that
+            determines how the data should be distributed along the time
+            axis.  Default is to distribute only by detector.
+
+    Returns (toast.Data):
+        The distributed data object.
+    """
+    if not available:
+        raise RuntimeError("tidas is not available")
+        return None
+    # the global communicator
+    cworld = comm.comm_world
+    # the communicator within the group
+    cgroup = comm.comm_group
+    # the communicator with all processes with
+    # the same rank within their group
+    crank = comm.comm_rank
+
+    # Collectively open the volume.  We cannot use a context manager here, 
+    # since we are keeping a handle to the volume around for future use.
+    # This means the volume will remain open for the life of the program,
+    # or (hopefully) will get closed if the distributed data object is
+    # destroyed.
+
+    vol = MPIVolume(cworld, path, mode=mode)
+
+    # Traverse the blocks of the volume and get the properties of the
+    # observations so we can distribute them.
+
+    obslist = []
+    obspath = {}
+    obssize = {}
+
+    def procblock(pth, nm, current):
+        subs = current.block_names()
+        pthnm = "{}/{}".format(pth, nm)
+        for s in subs:
+            chld = current.block_get(s)
+            procblock(pthnm, s, chld)
+        if len(subs) == 0:
+            # this is a leaf node
+            obslist.append(nm)
+            obspath[nm] = pthnm
+            grpnames = current.group_names()
+            grpnm = detgroup
+            if len(grpnames) == 1:
+                grpnm = grpnames[0]
+            grp = current.group_get(grpnm)
+            obssize[nm] = grp.size
+        return
+
+    if cworld.rank == 0:
+        root = vol.root()
+        toplist = root.block_names()
+        for b in toplist:
+            bk = root.block_get(b)
+            procblock("", b, bk)
+
+    obslist = cworld.bcast(obslist, root=0)
+    obspath = cworld.bcast(obspath, root=0)
+    obssize = cworld.bcast(obssize, root=0)
+
+    # Distribute the observations among groups
+
+    obssizelist = [ obssize[x] for x in obslist ]
+    distobs = distribute_discrete(obssizelist, comm.ngroups)
+
+    # Distributed data
+
+    data = Data(comm)
+
+    # Now every group adds its observations to the list
+
+    firstobs = distobs[comm.group][0]
+    nobs = distobs[comm.group][1]
+    for ob in range(firstobs, firstobs+nobs):
+        obs = {}
+        obs["name"] = obslist[ob]
+        obs["tidas"] = vol
+        obs["tidas_block"] = obspath[obslist[ob]]
+        obs["tod"] = TODTidas(cgroup, vol, obspath[obslist[ob]], 
+            detranks=detranks, detgroup=detgroup, distintervals=distintervals)
+        if "obs_id" in obs["tod"].group.props:
+            obs["id"] = obs["tod"].group.props["obs_id"]
+        if "obs_telescope" in obs["tod"].group.props:
+            obs["telescope"] = obs["tod"].group.props["obs_telescope"]
+        
+        obs["intervals"] = None
+        if distintervals is not None:
+            tilist = []
+            if cgroup.rank == 0:
+                blk = obs["tod"].block
+                intr = blk.intervals_get(distintervals)
+                ilist = intr.read()
+                tilist = [ Interval(start=x.start, stop=x.stop, first=x.first,
+                    last=x.last) for x in ilist ]
+            tilist = cgroup.bcast(tilist, root=0)
+            obs["intervals"] = tilist
+
+        data.obs.append(obs)
+    
+    vol.meta_sync()
+
+    return data
+
+
+class OpTidasExport(Operator):
+    """
+    Operator which writes data to a TIDAS volume.
+
+    The volume is created at construction time, and the full metadata
+    path inside the volume can be given for each observation.  If not given,
+    all observations are exported to TIDAS blocks under the root block.
+
+    Timestream data, flags, and boresight pointing are read from the
+    current TOD for the observation and written to the TIDAS TOD.  Data can
+    be read directly or copied from the cache.
+
+    Args:
+        path (str): the output TIDAS volume path (must not exist).
+        backend (str): the TIDAS backend type.
+        comp (str): the TIDAS compression type.
+        backopts (dict): extra options to the TIDAS backend.
+        obspath (dict): (optional) each observation has a "name" and these
+            should be the keys of this dictionary.  The values of the dict
+            should be the metadata parent path of the observation inside
+            the volume.
+        name (str): the name of the cache object (<name>_<detector>) to
+            use for the detector timestream.  If None, use the TOD.
+        common_flag_name (str):  the name of the cache object to use for
+            common flags.  If None, use the TOD.
+        flag_name (str):  the name of the cache object (<name>_<detector>) to
+            use for the detector flags.  If None, use the TOD.
+        units (str):  the units of the detector timestreams.
+        usedist (bool):  if True, use the TOD total_chunks() method to get
+            the chunking used for data distribution and replicate that as a
+            set of TIDAS intervals.  Otherwise do not write any intervals
+            to the output.
+    """
+    def __init__(self, path, backend="hdf5", comp="none", backopts=None, 
+        obspath=None, name=None, common_flag_name=None, flag_name=None, 
+        units="unknown", usedist=False):
+
+        if not available:
+            raise RuntimeError("tidas is not available")
+
+        self._path = path.rstrip("/")
+        self._backend = backend
+        self._comp = comp
+        self._backopts = backopts
+        self._obspath = obspath
+        self._cachename = name
+        self._cachecomm = common_flag_name
+        self._cacheflag = flag_name
+        self._usedist = usedist
+        self._units = units
+
+        # We call the parent class constructor
+        super().__init__()
+
+
+    def exec(self, data):
+        """
+        Export data to a TIDAS volume.
+
+        Each group will write its list of observations as TIDAS blocks.
+
+        For errors that prevent the export, this function will directly call
+        MPI Abort() rather than raise exceptions.  This could be changed in
+        the future if additional logic is implemented to ensure that all
+        processes raise an exception when one process encounters an error.
+
+        Args:
+            data (toast.Data): The distributed data.
+        """
+
+        # the two-level toast communicator
+        comm = data.comm
+        # the global communicator
+        cworld = comm.comm_world
+        # the communicator within the group
+        cgroup = comm.comm_group
+        # the communicator with all processes with
+        # the same rank within their group
+        crank = comm.comm_rank
+
+        # One process checks that the path is OK
+        if cworld.rank == 0:
+            dname = os.path.dirname(self._path)
+            if not os.path.isdir(dname):
+                print("Directory for exported TIDAS volume ({}) does not "
+                    "exist".format(dname))
+                cworld.Abort()
+            if os.path.exists(self._path):
+                print("Path for exported TIDAS volume ({}) already "
+                    "exists".format(self._path))
+                cworld.Abort()
+        cworld.barrier()
+
+        # Collectively open the volume
+
+        with MPIVolume(cworld, self._path, backend=self._backend, 
+            comp=self._comp) as vol:
+
+            # Groups iterate over their observations
+
+            for obs in data.obs:
+                # Get the name
+                if "name" not in obs:
+                    print("observation does not have a name, cannot export")
+                    cworld.Abort()
+                obsname = obs["name"]
+
+                # Get the metadata path
+                blockpath = ""
+                if self._obspath is not None:
+                    blockpath = self._obspath[obsname]
+
+                # The existing TOD
+                tod = obs["tod"]
+                detranks, sampranks = tod.grid_size
+                rankdet, ranksamp = tod.grid_ranks
+                metadata = tod.meta()
+
+                # Get the observation ID (used for RNG)
+                obsid = 0
+                if "id" in obs:
+                    metadata["obs_id"] = obs["id"]
+
+                # Get the telescope ID (used for RNG)
+                obstele = 0
+                if "telescope" in obs:
+                    metadata["obs_telescope"] = obs["telescope"]
+
+                # Optionally setup intervals for future data distribution 
+                intervals = None
+                if self._usedist:
+                    # This means that the distribution chunks in the time 
+                    # direction were intentional (not just the boundaries of
+                    # some uniform distribution), and we want to write them 
+                    # out to tidas intervals so that we can use them for data
+                    # distribution when this volume is read in later.
+                    intervals = {STR_DISTINTR : (len(tod.total_chunks), 
+                        dict())}
+
+                # Get detector quaternions and encode them for use in the 
+                # properties of the tidas group.  Combine this with the 
+                # existing observation properties into a single dictionary.
+
+                props = encode_tidas_quats(tod.detoffset(), props=metadata)
+
+                # Configure the detector group
+
+                schm = create_tidas_schema(tod.detectors, "float64", 
+                    self._units)
+                groups = {STR_DETGROUP : (schm, tod.total_samples, props)}
+
+                # Create the block in the volume that corresponds to this
+                # observation.  Get handles to the tidas group and intervals.
+
+                blk = create_tidas_obs(vol, blockpath, obsname, groups=groups, 
+                    intervals=intervals)
+
+                intr = None
+                if self._usedist:
+                    intr = blk.intervals_get(STR_DISTINTR)
+                grp = blk.group_get(STR_DETGROUP)
+
+                # Instantiate a TIDAS TOD to wrap this block
+
+                distintervals = None
+                if self._usedist:
+                    distintervals = STR_DISTINTR
+                tidastod = TODTidas(tod.mpicomm, vol, "{}/{}".format(blockpath,
+                    obsname), detranks=detranks, detgroup=STR_DETGROUP,
+                    distintervals=distintervals)
+
+                # Some data is common across all processes that share the same
+                # time span (timestamps, boresight pointing, common flags).
+                # Since we only need to write these once, we let the first
+                # process row handle that.
+
+                # We are going to gather the timestamps to a single process
+                # since we need them to convert between the existing TOD 
+                # chunks and times for the intervals.  The interval list is
+                # common between all processes.
+
+                if rankdet == 0:
+                    # Only the first row of the process grid does this...
+                    # First process timestamps
+                    rowdata = tod.grid_comm_row.gather(tod.read_times(), 
+                        root=0)
+                    if ranksamp == 0:
+                        full = np.concatenate(rowdata)
+                        grp.write_times(full)
+                        if self._usedist:
+                            ilist = []
+                            off = 0
+                            for sz in tod.total_chunks:
+                                ilist.append(tds.Intrvl(start=full[off], 
+                                    stop=full[off+sz-1], first=off, 
+                                    last=(off+sz-1)))
+                                off += sz
+                            intr.write(ilist)
+                        del full
+                    del rowdata
+                    
+                    # Next the boresight data
+                    tidastod.write_boresight(data=tod.read_boresight())
+
+                    # Common flags
+                    if self._cachecomm is not None:
+                        ref = tod.cache.reference(self._cachecomm)
+                        tidastod.write_common_flags(flags=ref)
+                        del ref
+                    else:
+                        tidastod.write_common_flags(
+                            flags=tod.read_common_flags())
+
+                tod.mpicomm.barrier()
+
+                # Now each process can write their unique data slice
+
+                for det in tod.local_dets:
+                    if self._cachename is not None:
+                        ref = tod.cache.reference(
+                            "{}_{}".format(self._cachename, det))
+                        tidastod.write(detector=det, data=ref)
+                        del ref
+                    else:
+                        tidastod.write(detector=det, 
+                            data=tod.read(detector=det))
+                    if self._cacheflag is not None:
+                        ref = tod.cache.reference(
+                            "{}_{}".format(self._cacheflag, det))
+                        tidastod.write_det_flags(detector=det, flags=ref)
+                        del ref
+                    else:
+                        flg, cflg = tod.read_flags(detector=det)
+                        tidastod.write_det_flags(detector=det, flags=flg)
+
+        return
+
+
+


### PR DESCRIPTION
This branch adds basic support for writing and reading TIDAS data format.  This includes a TOD class that wraps a single block within the volume (representing an observation), as well as an operator to dump existing distributed data to a new volume and a function to load and distribute an existing volume.

There is still some missing functionality, the main one being allowing TOD classes to provide a customized export method and also to provide an alternate load method that takes a TIDAS block.  I'll open separate issues to track that later.

This pull request is to open up discussion and testing.  It should not be merged without trying a more detailed export of simulated ground telescope data.