### PR TITLE
Do not use MKL with GNU compilers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,11 @@ AX_PROG_CXX_MPI([test "$toast_mpi" = yes], [toast_mpi=yes], [
 ])
 AM_CONDITIONAL([HAVE_AM_MPI], [test $toast_mpi = yes])
 
+dnl +------------------------------------------------
+dnl | Check for compiler vendor
+dnl +------------------------------------------------
+AX_COMPILER_VENDOR
+
 dnl +-------------------------
 dnl | Shared library extension
 dnl +-------------------------
@@ -122,7 +127,11 @@ dnl | Check for MKL
 dnl +------------------------------------------------
 AC_LANG_PUSH([C])
 ax_have_mkl=no
-ACX_MKL([ax_have_mkl=yes;AC_DEFINE(HAVE_MKL,1,[Define if using Intel MKL])], [])
+if test x"$ax_cv_c_compiler_vendor" = x"intel"; then
+  ACX_MKL([ax_have_mkl=yes;AC_DEFINE(HAVE_MKL,1,[Define if using Intel MKL])], [])
+else
+  echo "**** Skipping MKL checks since we are not using Intel compilers."
+fi
 AC_LANG_POP([C])
 AM_CONDITIONAL([HAVE_AM_MKL], [test $ax_have_mkl = yes])
 

--- a/external/conf/cori-gcc
+++ b/external/conf/cori-gcc
@@ -37,9 +37,9 @@ INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 PYVERSION = 3.5
 
-# For BLAS/LAPACK, we use MKL
+# For BLAS/LAPACK, we use our own openblas
 
-BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -lm -ldl
+BLAS = -lopenblas
 LAPACK = 
 
 # Boost toolchain name

--- a/external/conf/cori-gcc
+++ b/external/conf/cori-gcc
@@ -35,7 +35,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, we use our own openblas
 

--- a/external/conf/cori-gcc.module
+++ b/external/conf/cori-gcc.module
@@ -10,7 +10,6 @@ if [ module-info mode load ] {
     }
   }
   module swap gcc gcc/6.3.0
-  module load intel/17.0.2.174
   module load git
   module load cmake
   setenv CRAYPE_LINK_TYPE dynamic

--- a/external/conf/cori-gcc.sh
+++ b/external/conf/cori-gcc.sh
@@ -11,7 +11,6 @@ if [ "x${loadedgnu}" = x ]; then
     fi
 fi
 module swap gcc gcc/6.3.0
-module load intel/17.0.2.174
 module load git
 module load cmake
 export CRAYPE_LINK_TYPE=dynamic

--- a/external/conf/cori-haswell-intel
+++ b/external/conf/cori-haswell-intel
@@ -19,9 +19,9 @@ MPI_EXTRA_LINK =
 
 # Compile flags
 
-CFLAGS = -O3 -g -fPIC -xAVX -pthread
-CXXFLAGS = -O3 -g -fPIC -xAVX -pthread
-FCFLAGS = -O3 -g -fPIC -xAVX -fexceptions -pthread
+CFLAGS = -O3 -g -fPIC -xcore-avx2 -pthread
+CXXFLAGS = -O3 -g -fPIC -xcore-avx2 -pthread
+FCFLAGS = -O3 -g -fPIC -xcore-avx2 -fexceptions -pthread
 
 OPENMP_CFLAGS = -qopenmp
 OPENMP_CXXFLAGS = -qopenmp
@@ -35,11 +35,11 @@ CROSS =
 
 INTEL_CONDA = yes
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, use MKL
 
-BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -lmemkind -lm -ldl
+BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -liomp5 -lpthread -limf -ldl
 LAPACK = 
 
 # Boost toolchain name

--- a/external/conf/cori-knl-intel
+++ b/external/conf/cori-knl-intel
@@ -19,9 +19,9 @@ MPI_EXTRA_LINK =
 
 # Compile flags
 
-CFLAGS = -O3 -g -fPIC -xMIC-AVX512 -pthread
-CXXFLAGS = -O3 -g -fPIC -xMIC-AVX512 -pthread
-FCFLAGS = -O3 -g -fPIC -xMIC-AVX512 -fexceptions -pthread
+CFLAGS = -O3 -g -fPIC -xmic-avx512 -pthread
+CXXFLAGS = -O3 -g -fPIC -xmic-avx512 -pthread
+FCFLAGS = -O3 -g -fPIC -xmic-avx512 -fexceptions -pthread
 
 OPENMP_CFLAGS = -qopenmp
 OPENMP_CXXFLAGS = -qopenmp
@@ -35,11 +35,11 @@ CROSS = --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu
 
 INTEL_CONDA = yes
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, use MKL
 
-BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -lmemkind -lm -ldl
+BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -liomp5 -lpthread -lmemkind -limf -ldl
 LAPACK = 
 
 # Boost toolchain name

--- a/external/conf/docker-gcc
+++ b/external/conf/docker-gcc
@@ -23,7 +23,7 @@ LDFLAGS = -lpthread -fopenmp
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 CROSS =
 

--- a/external/conf/edison-gcc
+++ b/external/conf/edison-gcc
@@ -37,9 +37,9 @@ INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 PYVERSION = 3.5
 
-# For BLAS/LAPACK, we use MKL
+# For BLAS/LAPACK, we use our own openblas
 
-BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -lm -ldl
+BLAS = -lopenblas
 LAPACK = 
 
 # Boost toolchain name

--- a/external/conf/edison-gcc
+++ b/external/conf/edison-gcc
@@ -35,7 +35,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, we use our own openblas
 

--- a/external/conf/edison-gcc.module
+++ b/external/conf/edison-gcc.module
@@ -10,7 +10,6 @@ if [ module-info mode load ] {
     }
   }
   module swap gcc gcc/6.3.0
-  module load intel/17.0.2.174
   module load git
   module load cmake
   setenv CRAYPE_LINK_TYPE dynamic

--- a/external/conf/edison-gcc.sh
+++ b/external/conf/edison-gcc.sh
@@ -11,7 +11,6 @@ if [ "x${loadedgnu}" = x ]; then
     fi
 fi
 module swap gcc gcc/6.3.0
-module load intel/17.0.2.174
 module load git
 module load cmake
 export CRAYPE_LINK_TYPE=dynamic

--- a/external/conf/edison-intel
+++ b/external/conf/edison-intel
@@ -19,9 +19,9 @@ MPI_EXTRA_LINK =
 
 # Compile flags
 
-CFLAGS = -O3 -g -fPIC -xAVX -pthread
-CXXFLAGS = -O3 -g -fPIC -xAVX -pthread
-FCFLAGS = -O3 -g -fPIC -xAVX -fexceptions -pthread
+CFLAGS = -O3 -g -fPIC -xavx -pthread
+CXXFLAGS = -O3 -g -fPIC -xavx -pthread
+FCFLAGS = -O3 -g -fPIC -xavx -fexceptions -pthread
 
 OPENMP_CFLAGS = -qopenmp
 OPENMP_CXXFLAGS = -qopenmp
@@ -35,11 +35,11 @@ CROSS =
 
 INTEL_CONDA = yes
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, use MKL
 
-BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -fopenmp -lpthread -lm -ldl
+BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -liomp5 -lpthread -limf -ldl
 LAPACK = 
 
 # Boost toolchain name

--- a/external/conf/linux-gcc
+++ b/external/conf/linux-gcc
@@ -35,7 +35,7 @@ CROSS =
 
 INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, we use openblas
 

--- a/external/conf/linux-gcc
+++ b/external/conf/linux-gcc
@@ -37,9 +37,9 @@ INTEL_CONDA = no
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 PYVERSION = 3.5
 
-# For BLAS/LAPACK, we use the conda-installed MKL
+# For BLAS/LAPACK, we use openblas
 
-BLAS = -L@CONDA_PREFIX@/lib -lmkl_rt -fopenmp -lpthread -lm -ldl
+BLAS = -lopenblas
 LAPACK =
 
 # Boost toolchain name

--- a/external/conf/linux-intel
+++ b/external/conf/linux-intel
@@ -1,0 +1,52 @@
+
+# Serial compilers
+
+CC = icc
+CXX = icpc
+FC = ifort
+
+# MPI compilers
+
+MPICC = mpiicc
+MPICXX = mpiicpc
+MPIFC = mpiifort
+MPI_CPPFLAGS = ${I_MPI_ROOT}/include64
+MPI_LDFLAGS = ${I_MPI_ROOT}/lib64
+MPI_CXXLIB = mpicxx
+MPI_LIB = mpi
+MPI_EXTRA_COMP =
+MPI_EXTRA_LINK =
+
+# Compile flags
+
+CFLAGS = -O3 -g -fPIC -xcore-avx2 -pthread
+CXXFLAGS = -O3 -g -fPIC -xcore-avx2 -pthread
+FCFLAGS = -O3 -g -fPIC -xcore-avx2 -fexceptions -pthread
+
+OPENMP_CFLAGS = -qopenmp
+OPENMP_CXXFLAGS = -qopenmp
+LDFLAGS = -lpthread -liomp5
+
+# Are we doing a cross-compile?
+
+CROSS =
+
+# Miniconda install
+
+INTEL_CONDA = yes
+MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+PYVERSION = 3.6
+
+# For BLAS/LAPACK, we use MKL
+
+BLAS = -L${MKLROOT}/lib/intel64 -lmkl_rt -liomp5 -lpthread -limf -ldl
+LAPACK =
+
+# Boost toolchain name
+
+BOOSTCHAIN = intel-linux
+
+# Group and permissions to set
+
+CHGRP =
+CHMOD = 

--- a/external/conf/tacc-knl-intel
+++ b/external/conf/tacc-knl-intel
@@ -35,11 +35,11 @@ CROSS =
 
 INTEL_CONDA = yes
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, use MKL
 
-BLAS = -L${TACC_INTEL_DIR}/mkl/lib/intel64 -lmkl_rt -fopenmp -lpthread -lmemkind -lm -ldl
+BLAS = -L${TACC_INTEL_DIR}/mkl/lib/intel64 -lmkl_rt -liomp5 -lpthread -lmemkind -limf -ldl
 LAPACK = 
 
 # Group and permissions to set

--- a/external/conf/tacc-knl-intel-cross
+++ b/external/conf/tacc-knl-intel-cross
@@ -35,11 +35,11 @@ CROSS = --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu
 
 INTEL_CONDA = yes
 MINICONDA = https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-PYVERSION = 3.5
+PYVERSION = 3.6
 
 # For BLAS/LAPACK, use MKL
 
-BLAS = -L${TACC_INTEL_DIR}/mkl/lib/intel64 -lmkl_rt -fopenmp -lpthread -lmemkind -lm -ldl
+BLAS = -L${TACC_INTEL_DIR}/mkl/lib/intel64 -lmkl_rt -liomp5 -lpthread -lmemkind -lm -ldl
 LAPACK = 
 
 # Group and permissions to set

--- a/external/rules/conda_root.sh
+++ b/external/rules/conda_root.sh
@@ -3,6 +3,6 @@ curl -SL @MINICONDA@ \
     && /bin/bash miniconda.sh -b -f -p @CONDA_PREFIX@ \
     && conda config --add channels intel \
     && conda config --remove channels intel \
-    && conda install --copy --yes python=3.5 \
+    && conda install --copy --yes python=3.6 \
     && rm miniconda.sh \
     && rm -rf @CONDA_PREFIX@/pkgs/*

--- a/m4/acx_mkl.m4
+++ b/m4/acx_mkl.m4
@@ -97,7 +97,7 @@ else
    # First, try user-specified location or linked-by-default (for example using
    # a compiler wrapper script)
 
-   MKL="$acx_mkl_ldflags -lmkl_rt -lmemkind -ldl"
+   MKL="$acx_mkl_ldflags -lmkl_rt -lmemkind -liomp5 -ldl"
    CPPFLAGS="$acx_mkl_save_CPPFLAGS $OPENMP_CFLAGS $PTHREAD_CFLAGS $MKL_CPPFLAGS"
    LIBS="$acx_mkl_save_LIBS $MKL $OPENMP_CFLAGS $PTHREAD_LIBS $MATH"
 
@@ -109,7 +109,7 @@ else
 
    if test $acx_mkl_ok = no; then
 
-      MKL="$acx_mkl_ldflags -lmkl_rt -ldl"
+      MKL="$acx_mkl_ldflags -lmkl_rt -liomp5 -ldl"
       CPPFLAGS="$acx_mkl_save_CPPFLAGS $OPENMP_CFLAGS $PTHREAD_CFLAGS $MKL_CPPFLAGS"
       LIBS="$acx_mkl_save_LIBS $MKL $OPENMP_CFLAGS $PTHREAD_LIBS $MATH"
 

--- a/m4/ax_compiler_vendor.m4
+++ b/m4/ax_compiler_vendor.m4
@@ -1,0 +1,87 @@
+# ===========================================================================
+#    https://www.gnu.org/software/autoconf-archive/ax_compiler_vendor.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_COMPILER_VENDOR
+#
+# DESCRIPTION
+#
+#   Determine the vendor of the C/C++ compiler, e.g., gnu, intel, ibm, sun,
+#   hp, borland, comeau, dec, cray, kai, lcc, metrowerks, sgi, microsoft,
+#   watcom, etc. The vendor is returned in the cache variable
+#   $ax_cv_c_compiler_vendor for C and $ax_cv_cxx_compiler_vendor for C++.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Steven G. Johnson <stevenj@alum.mit.edu>
+#   Copyright (c) 2008 Matteo Frigo
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 16
+
+AC_DEFUN([AX_COMPILER_VENDOR],
+[AC_CACHE_CHECK([for _AC_LANG compiler vendor], ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor,
+  dnl Please add if possible support to ax_compiler_version.m4
+  [# note: don't check for gcc first since some other compilers define __GNUC__
+  vendors="intel:     __ICC,__ECC,__INTEL_COMPILER
+           ibm:       __xlc__,__xlC__,__IBMC__,__IBMCPP__
+           pathscale: __PATHCC__,__PATHSCALE__
+           clang:     __clang__
+           cray:      _CRAYC
+           fujitsu:   __FUJITSU
+           gnu:       __GNUC__
+           sun:       __SUNPRO_C,__SUNPRO_CC
+           hp:        __HP_cc,__HP_aCC
+           dec:       __DECC,__DECCXX,__DECC_VER,__DECCXX_VER
+           borland:   __BORLANDC__,__CODEGEARC__,__TURBOC__
+           comeau:    __COMO__
+           kai:       __KCC
+           lcc:       __LCC__
+           sgi:       __sgi,sgi
+           microsoft: _MSC_VER
+           metrowerks: __MWERKS__
+           watcom:    __WATCOMC__
+           portland:  __PGI
+	   tcc:       __TINYC__
+           unknown:   UNKNOWN"
+  for ventest in $vendors; do
+    case $ventest in
+      *:) vendor=$ventest; continue ;;
+      *)  vencpp="defined("`echo $ventest | sed 's/,/) || defined(/g'`")" ;;
+    esac
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,[
+      #if !($vencpp)
+        thisisanerror;
+      #endif
+    ])], [break])
+  done
+  ax_cv_[]_AC_LANG_ABBREV[]_compiler_vendor=`echo $vendor | cut -d: -f1`
+ ])
+])

--- a/platforms/cori-gcc.sh
+++ b/platforms/cori-gcc.sh
@@ -19,4 +19,6 @@ export OPENMP_CFLAGS="-fopenmp"
 export OPENMP_CXXFLAGS="-fopenmp"
 
 ./configure ${OPTS} \
-    --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
+    --witout-mkl \
+    --with-blas="-lopenblas"
+

--- a/platforms/cori-intel-haswell.sh
+++ b/platforms/cori-intel-haswell.sh
@@ -13,8 +13,8 @@ export CC=cc
 export CXX=CC
 export MPICC=cc
 export MPICXX=CC
-export CFLAGS="-O3 -g -fPIC -xAVX -pthread"
-export CXXFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export CFLAGS="-O3 -g -fPIC -xcore-avx2 -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xcore-avx2 -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
 

--- a/platforms/cori-intel-haswell.sh
+++ b/platforms/cori-intel-haswell.sh
@@ -3,8 +3,8 @@
 # This script assumes that the "toast-deps" module has been loaded.
 # To install to my scratch directory, I might run this script with:
 #
-# $> ./platforms/cori-knl_intel_mkl.sh \
-#    --prefix=$SCRATCH/software/toast-knl
+# $> ./platforms/cori-haswell_intel_mkl.sh \
+#    --prefix=$SCRATCH/software/toast-haswell
 #
 
 OPTS="$@"
@@ -13,16 +13,12 @@ export CC=cc
 export CXX=CC
 export MPICC=cc
 export MPICXX=CC
-export CFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
-export CXXFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
+export CFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xAVX -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
-export LDFLAGS="-lpthread -liomp5"
-
-#-lmemkind
 
 ./configure ${OPTS} \
-    --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu \
     --with-math="-limf" \
     --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
 

--- a/platforms/cori-intel-knl.sh
+++ b/platforms/cori-intel-knl.sh
@@ -13,8 +13,8 @@ export CC=cc
 export CXX=CC
 export MPICC=cc
 export MPICXX=CC
-export CFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
-export CXXFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
+export CFLAGS="-O3 -g -fPIC -xmic-avx512 -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xmic-avx512 -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
 

--- a/platforms/cori-intel-knl.sh
+++ b/platforms/cori-intel-knl.sh
@@ -3,8 +3,8 @@
 # This script assumes that the "toast-deps" module has been loaded.
 # To install to my scratch directory, I might run this script with:
 #
-# $> ./platforms/cori-haswell_intel_mkl.sh \
-#    --prefix=$SCRATCH/software/toast-haswell
+# $> ./platforms/cori-knl_intel_mkl.sh \
+#    --prefix=$SCRATCH/software/toast-knl
 #
 
 OPTS="$@"
@@ -13,13 +13,13 @@ export CC=cc
 export CXX=CC
 export MPICC=cc
 export MPICXX=CC
-export CFLAGS="-O3 -g -fPIC -xAVX -pthread"
-export CXXFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export CFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
-export LDFLAGS="-lpthread -liomp5"
 
 ./configure ${OPTS} \
+    --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu \
     --with-math="-limf" \
     --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
 

--- a/platforms/edison-gcc.sh
+++ b/platforms/edison-gcc.sh
@@ -19,4 +19,5 @@ export OPENMP_CFLAGS="-fopenmp"
 export OPENMP_CXXFLAGS="-fopenmp"
 
 ./configure ${OPTS} \
-    --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
+    --without-mkl \
+    --with-blas="-lopenblas"

--- a/platforms/edison-intel.sh
+++ b/platforms/edison-intel.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script assumes that the "toast-deps" module has been loaded.
+# To install to my scratch directory, I might run this script with:
+#
+# $> ./platforms/cori-haswell_intel_mkl.sh \
+#    --prefix=$SCRATCH/software/toast-haswell
+#
+
+OPTS="$@"
+
+export CC=cc
+export CXX=CC
+export MPICC=cc
+export MPICXX=CC
+export CFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export OPENMP_CFLAGS="-qopenmp"
+export OPENMP_CXXFLAGS="-qopenmp"
+
+./configure ${OPTS} \
+    --with-math="-limf" \
+    --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
+

--- a/platforms/edison-intel.sh
+++ b/platforms/edison-intel.sh
@@ -13,8 +13,8 @@ export CC=cc
 export CXX=CC
 export MPICC=cc
 export MPICXX=CC
-export CFLAGS="-O3 -g -fPIC -xAVX -pthread"
-export CXXFLAGS="-O3 -g -fPIC -xAVX -pthread"
+export CFLAGS="-O3 -g -fPIC -xavx -pthread"
+export CXXFLAGS="-O3 -g -fPIC -xavx -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
 

--- a/platforms/linux-intel-dbg.sh
+++ b/platforms/linux-intel-dbg.sh
@@ -9,12 +9,11 @@ export CC=mpiicc
 export CXX=mpiicpc
 export MPICC=mpiicc
 export MPICXX=mpiicpc
-export CFLAGS="-O3 -g -fPIC -pthread"
-export CXXFLAGS="-O3 -g -fPIC -pthread"
+export CFLAGS="-O0 -g -fPIC -pthread"
+export CXXFLAGS="-O0 -g -fPIC -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
-export LDFLAGS="-lpthread -liomp5"
 
 ./configure ${OPTS} \
     --with-math="-limf" \
-    --with-mkl="${MKLROOT}/lib/intel64"
+    --with-mkl="${MKLROOT}/lib/intel64" \

--- a/platforms/linux-intel.sh
+++ b/platforms/linux-intel.sh
@@ -9,12 +9,11 @@ export CC=mpiicc
 export CXX=mpiicpc
 export MPICC=mpiicc
 export MPICXX=mpiicpc
-export CFLAGS="-O0 -g -fPIC -pthread"
-export CXXFLAGS="-O0 -g -fPIC -pthread"
+export CFLAGS="-O3 -g -fPIC -pthread"
+export CXXFLAGS="-O3 -g -fPIC -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
-export LDFLAGS="-lpthread -liomp5"
 
 ./configure ${OPTS} \
     --with-math="-limf" \
-    --with-mkl="${MKLROOT}/lib/intel64" \
+    --with-mkl="${MKLROOT}/lib/intel64"

--- a/platforms/nersc-intel.sh
+++ b/platforms/nersc-intel.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script assumes that the "toast-deps" module has been loaded.
+# To install to my scratch directory, I might run this script with:
+#
+# $> ./platforms/nersc-intel.sh \
+#    --prefix=$SCRATCH/software/toast-intel
+#
+# This compiles "universal" or "fat" binaries with multiple optimized
+# code paths.  It builds one with AVX optimizations (highest that
+# edison supports), and another for KNL.
+#
+
+OPTS="$@"
+
+export CC=cc
+export CXX=CC
+export MPICC=cc
+export MPICXX=CC
+export CFLAGS="-O3 -g -fPIC -axmic-avx512,avx -pthread"
+export CXXFLAGS="-O3 -g -fPIC -axmic-avx512,avx -pthread"
+export OPENMP_CFLAGS="-qopenmp"
+export OPENMP_CXXFLAGS="-qopenmp"
+
+./configure ${OPTS} \
+    --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu \
+    --with-math="-limf" \
+    --with-mkl="${INTEL_PATH}/linux/mkl/lib/intel64"
+

--- a/platforms/tacc-intel-knl.sh
+++ b/platforms/tacc-intel-knl.sh
@@ -10,7 +10,6 @@ export CFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
 export CXXFLAGS="-O3 -g -fPIC -xMIC-AVX512 -pthread"
 export OPENMP_CFLAGS="-qopenmp"
 export OPENMP_CXXFLAGS="-qopenmp"
-export LDFLAGS="-lpthread -liomp5"
 
 ./configure ${OPTS} \
     --build x86_64-pc-linux-gnu --host x86_64-unknown-linux-gnu \

--- a/src/libtoast/Makefile.am
+++ b/src/libtoast/Makefile.am
@@ -69,7 +69,7 @@ libtoast_la_LIBADD += $(top_builddir)/src/libtoast/math/libtoast_math.la
 
 if HAVE_AM_MPI
 else
-  libtoast_la_LIBADD += $(top_builddir)/src/libtoast/fakempi/libtoast_fakempi.la $(AM_LIBS)
+  libtoast_la_LIBADD += $(top_builddir)/src/libtoast/fakempi/libtoast_fakempi.la
 endif
 
 libtoast_la_LIBADD += $(AM_LIBS)

--- a/src/libtoast/math/toast/fft.hpp
+++ b/src/libtoast/math/toast/fft.hpp
@@ -71,8 +71,8 @@ namespace toast { namespace fft {
 
         private:
             r1d_plan_store ( ) { }
-            std::map < int, std::map < std::pair < int64_t, int64_t >, r1d_p > > fplans_;
-            std::map < int, std::map < std::pair < int64_t, int64_t >, r1d_p > > rplans_;
+            std::map < std::pair < int64_t, int64_t >, r1d_p > fplans_;
+            std::map < std::pair < int64_t, int64_t >, r1d_p > rplans_;
 
     };
 

--- a/src/libtoast/test/Makefile.am
+++ b/src/libtoast/test/Makefile.am
@@ -18,8 +18,8 @@ AM_CXXFLAGS =
 
 AM_LDFLAGS =
 
-AM_LIBS = \
-$(top_builddir)/src/libtoast/test/gtest/libtoast_gtest.la
+AM_LIBS =
+
 
 # Add check flags
 
@@ -47,4 +47,6 @@ toast_test_mpi_shmem.cpp \
 toast_test_polyfilter.cpp \
 toast_test_runner.cpp
 
-libtoast_test_la_LIBADD = $(AM_LIBS)
+libtoast_test_la_LIBADD = \
+$(top_builddir)/src/libtoast/test/gtest/libtoast_gtest.la
+

--- a/src/libtoast/test/toast_test.hpp
+++ b/src/libtoast/test/toast_test.hpp
@@ -121,7 +121,8 @@ class fftTest : public ::testing::Test {
         virtual void SetUp() { }
         virtual void TearDown() { }
 
-        void runbatch(int64_t nbatch);
+        void runbatch(int64_t nbatch, toast::fft::r1d_p forward, 
+            toast::fft::r1d_p reverse);
 
         static const int64_t length;
         static const int64_t n;

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -13,6 +13,8 @@ from .._version import __version__
 
 from .mpi import MPITestRunner
 
+from ..vis import set_backend
+
 from .ctoast import test_ctoast
 
 from . import cbuffer as testcbuffer
@@ -41,6 +43,8 @@ from . import binned as testbinned
 def test(name=None):
     # We run tests with COMM_WORLD
     comm = MPI.COMM_WORLD
+
+    set_backend()
 
     outdir = "toast_test_output"
 


### PR DESCRIPTION
As described in #110 , do not use MKL except with the Intel compilers.  This is due to the fact that Python / numpy scripts frequently load MKL prior to importing toast- which itself will try to dlopen MKL.  This means that MKL used by python (with the Intel thread layer) must be compatible witth the MKL used with toast.  This implies that toast must also use the Intel threading layer, which implies compilation with the Intel compilers.