### PR TITLE
Bugfix in MPI import

### DIFF
--- a/src/python/__init__.py
+++ b/src/python/__init__.py
@@ -23,7 +23,7 @@ if 'mpi4py' in sys.modules:
 #   from toast.mpi import MPI
 # as the first line
 if not 'toast.mpi' in sys.modules:
-    from . import MPI
+    from .mpi import MPI
 
 from .tests import test
 


### PR DESCRIPTION
MPI is defined in the `mpi.py` module so relative import should be from `.mpi` instead of `.`