### PR TITLE
Tidas locking

### DIFF
--- a/pipelines/toast_cov_invert.py
+++ b/pipelines/toast_cov_invert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by 

--- a/pipelines/toast_cov_rcond.py
+++ b/pipelines/toast_cov_rcond.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by 

--- a/pipelines/toast_fake_focalplane.py
+++ b/pipelines/toast_fake_focalplane.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by

--- a/pipelines/toast_ground_schedule.py
+++ b/pipelines/toast_ground_schedule.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by

--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by

--- a/pipelines/toast_ground_sim_simple.py
+++ b/pipelines/toast_ground_sim_simple.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by 

--- a/src/python/mpi.py.in
+++ b/src/python/mpi.py.in
@@ -4,6 +4,9 @@
 
 import sys
 import ctypes as ct
+import itertools
+
+import numpy as np
 
 # open ctoast library
 
@@ -66,8 +69,13 @@ except Exception as e:
         ''.format(e))
 
 
-import itertools
-import numpy as np
+#
+# These general purpose MPI tools taken from:
+#
+#     https://github.com/tskisner/mpi_shmem
+#
+# Revision = 1479ed76de927b61b896398335569a0c70db7916
+#
 
 class MPILock(object):
     """
@@ -115,13 +123,15 @@ class MPILock(object):
             self._waiting = np.zeros((self._procs,), dtype=np.uint8)
 
         if self._comm is not None:
+            from mpi4py import MPI
             # Root allocates the buffer
             status = 0
             try:
                 self._win = MPI.Win.Create(self._waiting, comm=self._comm)
             except:
                 if self._debug:
-                    print("rank {} win create raised exception".format(self._rank),flush=True)
+                    print("rank {} win create raised exception".format(self._rank), 
+                        flush=True)
                 status = 1
             self._checkabort(self._comm, status, 
                 "shared memory allocation")
@@ -158,6 +168,7 @@ class MPILock(object):
 
 
     def _checkabort(self, comm, status, msg):
+        from mpi4py import MPI
         failed = comm.allreduce(status, op=MPI.SUM)
         if failed > 0:
             if comm.rank == self._root:
@@ -178,53 +189,55 @@ class MPILock(object):
         if self._have_lock:
             return
 
-        waiting = np.zeros((self._procs,), dtype=np.uint8)
-        lock = np.zeros((1,), dtype=np.uint8)
-        lock[0] = 1
-        
-        # lock the window
-        if self._debug:
-            print("lock:  rank {}, instance {} locking shared window".format(
-                self._rank, self._tag), flush=True)
-        self._win.Lock(self._root, MPI.LOCK_EXCLUSIVE)
+        if self._comm is not None:
+            from mpi4py import MPI
+            waiting = np.zeros((self._procs,), dtype=np.uint8)
+            lock = np.zeros((1,), dtype=np.uint8)
+            lock[0] = 1
+            
+            # lock the window
+            if self._debug:
+                print("lock:  rank {}, instance {} locking shared window".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Lock(self._root, MPI.LOCK_EXCLUSIVE)
 
-        # add ourselves to the list of waiting ranks
-        if self._debug:
-            print("lock:  rank {}, instance {} putting rank".format(
-                self._rank, self._tag), flush=True)
-        self._win.Put([lock, 1, MPI.UNSIGNED_CHAR], self._root, target=self._rank)
-        
-        # get the full list of current processes waiting or running
-        if self._debug:
-            print("lock:  rank {}, instance {} getting waitlist".format(
-                self._rank, self._tag), flush=True)
-        self._win.Get([waiting, self._procs, MPI.UNSIGNED_CHAR], self._root)
-        if self._debug:
-            print("lock:  rank {}, instance {} list = {}".format(self._rank,
-                self._tag, waiting), flush=True)
+            # add ourselves to the list of waiting ranks
+            if self._debug:
+                print("lock:  rank {}, instance {} putting rank".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Put([lock, 1, MPI.UNSIGNED_CHAR], self._root, target=self._rank)
+            
+            # get the full list of current processes waiting or running
+            if self._debug:
+                print("lock:  rank {}, instance {} getting waitlist".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Get([waiting, self._procs, MPI.UNSIGNED_CHAR], self._root)
+            if self._debug:
+                print("lock:  rank {}, instance {} list = {}".format(self._rank,
+                    self._tag, waiting), flush=True)
 
-        self._win.Flush(self._root)
-        
-        # unlock the window
-        if self._debug:
-            print("lock:  rank {}, instance {} unlocking shared window".format(
-                self._rank, self._tag), flush=True)
-        self._win.Unlock(self._root)
+            self._win.Flush(self._root)
+            
+            # unlock the window
+            if self._debug:
+                print("lock:  rank {}, instance {} unlocking shared window".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Unlock(self._root)
 
-        # Go through the list of waiting processes.  If any one is
-        # active or waiting, then wait for a signal that we can have 
-        # the lock.
-        for p in range(self._procs):
-            if (waiting[p] == 1) and (p != self._rank):
-                # we have to wait...
-                if self._debug:
-                    print("lock:  rank {} waiting for the lock".format(self._rank),
-                     flush=True)
-                self._comm.Recv(lock, source=MPI.ANY_SOURCE, tag=self._tag)
-                if self._debug:
-                    print("lock:  rank {} got the lock".format(self._rank),
-                     flush=True)
-                break
+            # Go through the list of waiting processes.  If any one is
+            # active or waiting, then wait for a signal that we can have 
+            # the lock.
+            for p in range(self._procs):
+                if (waiting[p] == 1) and (p != self._rank):
+                    # we have to wait...
+                    if self._debug:
+                        print("lock:  rank {} waiting for the lock".format(self._rank),
+                         flush=True)
+                    self._comm.Recv(lock, source=MPI.ANY_SOURCE, tag=self._tag)
+                    if self._debug:
+                        print("lock:  rank {} got the lock".format(self._rank),
+                         flush=True)
+                    break
 
         # We have the lock now!
         self._have_lock = True
@@ -239,51 +252,57 @@ class MPILock(object):
         if not self._have_lock:
             return
 
-        waiting = np.zeros((self._procs,), dtype=np.uint8)
-        lock = np.zeros((1,), dtype=np.uint8)
-        
-        # lock the window
-        if self._debug:
-            print("unlock:  rank {}, instance {} locking shared window".format(
-                self._rank, self._tag), flush=True)
-        self._win.Lock(self._root, MPI.LOCK_EXCLUSIVE)
+        if self._comm is not None:
+            from mpi4py import MPI
+            waiting = np.zeros((self._procs,), dtype=np.uint8)
+            lock = np.zeros((1,), dtype=np.uint8)
+            
+            # lock the window
+            if self._debug:
+                print("unlock:  rank {}, instance {} locking shared window"\
+                    .format(self._rank, self._tag), flush=True)
+            self._win.Lock(self._root, MPI.LOCK_EXCLUSIVE)
 
-        # remove ourselves to the list of waiting ranks
-        if self._debug:
-            print("unlock:  rank {}, instance {} putting rank".format(
-                self._rank, self._tag), flush=True)
-        self._win.Put([lock, 1, MPI.UNSIGNED_CHAR], self._root, target=self._rank)
-        
-        # get the full list of current processes waiting or running
-        if self._debug:
-            print("unlock:  rank {}, instance {} getting waitlist".format(
-                self._rank, self._tag), flush=True)
-        self._win.Get([waiting, self._procs, MPI.UNSIGNED_CHAR], self._root)
-        if self._debug:
-            print("unlock:  rank {}, instance {} list = {}".format(self._rank,
-                self._tag, waiting), flush=True)
+            # remove ourselves to the list of waiting ranks
+            if self._debug:
+                print("unlock:  rank {}, instance {} putting rank".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Put([lock, 1, MPI.UNSIGNED_CHAR], self._root, 
+                target=self._rank)
+            
+            # get the full list of current processes waiting or running
+            if self._debug:
+                print("unlock:  rank {}, instance {} getting waitlist".format(
+                    self._rank, self._tag), flush=True)
+            self._win.Get([waiting, self._procs, MPI.UNSIGNED_CHAR], 
+                self._root)
+            if self._debug:
+                print("unlock:  rank {}, instance {} list = {}"\
+                    .format(self._rank, self._tag, waiting), flush=True)
 
-        self._win.Flush(self._root)
-        
-        # unlock the window
-        if self._debug:
-            print("unlock:  rank {}, instance {} unlocking shared window".format(
-                self._rank, self._tag), flush=True)
-        self._win.Unlock(self._root)
+            self._win.Flush(self._root)
+            
+            # unlock the window
+            if self._debug:
+                print("unlock:  rank {}, instance {} unlocking shared window"\
+                    .format(self._rank, self._tag), flush=True)
+            self._win.Unlock(self._root)
 
-        # Go through the list of waiting processes.  Pass the lock
-        # to the next process.
-        next = self._rank + 1
-        for p in range(self._procs):
-            nextrank = next % self._procs
-            if waiting[nextrank] == 1:
-                if self._debug:
-                    print("unlock:  rank {} passing lock to {}".format(self._rank,
-                        nextrank), flush=True)
-                self._comm.Send(lock, nextrank, tag=self._tag)
-                self._have_lock = False
-                break
-            next += 1
+            # Go through the list of waiting processes.  Pass the lock
+            # to the next process.
+            next = self._rank + 1
+            for p in range(self._procs):
+                nextrank = next % self._procs
+                if waiting[nextrank] == 1:
+                    if self._debug:
+                        print("unlock:  rank {} passing lock to {}"\
+                            .format(self._rank, nextrank), flush=True)
+                    self._comm.Send(lock, nextrank, tag=self._tag)
+                    self._have_lock = False
+                    break
+                next += 1
+        else:
+            self._have_lock = False
         
         return
 
@@ -343,6 +362,7 @@ class MPIShared(object):
         self._nodes = 1
         self._mynode = 0
         if self._comm is not None:
+            import mpi4py.MPI as MPI
             self._nodecomm = self._comm.Split_type(MPI.COMM_TYPE_SHARED, 0)
             self._noderank = self._nodecomm.rank
             self._nodeprocs = self._nodecomm.size
@@ -392,12 +412,16 @@ class MPIShared(object):
 
         self._mpitype = None
         self._win = None
+
         self._buffer = None
         self._dbuf = None
         self._flat = None
         self._data = None
 
-        if self._comm is not None:
+        if self._comm is None:
+            dsize = self._dtype.itemsize
+        else:
+            import mpi4py.MPI as MPI
             # We are actually using MPI, so we need to ensure that
             # our specified numpy dtype has a corresponding MPI datatype.
             status = 0
@@ -411,10 +435,17 @@ class MPIShared(object):
             self._checkabort(self._comm, status, 
                 "numpy to MPI type conversion")
 
-            # Number of bytes in our buffer
             dsize = self._mpitype.Get_size()
-            nbytes = self._nlocal * dsize
 
+        # Number of bytes in our buffer 
+        nbytes = self._nlocal * dsize
+
+        self._buffer = None
+        if self._comm is None:
+            self._buffer = np.ndarray(shape=(nbytes,), dtype=np.dtype("B"),
+                order="C")
+        else:
+            import mpi4py.MPI as MPI
             # Every process allocates a piece of the buffer.  The per-
             # process pieces are guaranteed to be contiguous.
             status = 0
@@ -435,23 +466,20 @@ class MPIShared(object):
                 status = 1
             self._checkabort(self._nodecomm, status, "shared memory query")
 
-            # Create a numpy array which acts as a "view" of the buffer.
-            self._dbuf = np.array(self._buffer, dtype="B", copy=False)
-            self._flat = self._dbuf.view(self._dtype)
-            self._data = self._flat.reshape(self._shape)
+        # Create a numpy array which acts as a "view" of the buffer.
+        self._dbuf = np.array(self._buffer, dtype=np.dtype("B"), copy=False)
+        self._flat = self._dbuf.view(self._dtype)
+        self._data = self._flat.reshape(self._shape)
 
-            # Initialize to zero.  Any of the processes could do this to the
-            # whole buffer, but it is safe and easy for each process to just
-            # initialize its local piece.
+        # Initialize to zero.  Any of the processes could do this to the
+        # whole buffer, but it is safe and easy for each process to just
+        # initialize its local piece.
 
-            # FIXME: change this back once every process is allocating a 
-            # piece of the buffer.            
-            # self._flat[self._localoffset:self._localoffset + self._nlocal] = 0
-            if self._noderank == 0:
-                self._flat[:] = 0
-
-        else:
-            self._data = np.zeros(_n, dtype=_dtype).reshape(_shape)
+        # FIXME: change this back once every process is allocating a 
+        # piece of the buffer.            
+        # self._flat[self._localoffset:self._localoffset + self._nlocal] = 0
+        if self._noderank == 0:
+            self._flat[:] = 0
 
 
     def __del__(self):
@@ -522,6 +550,7 @@ class MPIShared(object):
 
 
     def _checkabort(self, comm, status, msg):
+        import mpi4py.MPI as MPI
         failed = comm.allreduce(status, op=MPI.SUM)
         if failed > 0:
             if comm.rank == 0:
@@ -564,27 +593,32 @@ class MPIShared(object):
 
         if self._rank == fromrank:
             if len(data.shape) != len(self._shape):
-                msg = "data has incompatible number of dimensions"
+                if len(data.shape) != len(self._shape):
+                    msg = "input data dimensions {} incompatible with "\
+                        "buffer ({})".format(len(data.shape), len(self._shape))
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
             if len(offset) != len(self._shape):
-                msg = "offset tuple has incompatible number of dimensions"
+                msg = "input offset dimensions {} incompatible with "\
+                    "buffer ({})".format(len(offset), len(self._shape))
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
             if data.dtype != self._dtype:
-                msg = "input data has different type than shared array"
+                msg = "input data type ({}, {}) incompatible with "\
+                    "buffer ({}, {})".format(data.dtype.str, data.dtype.num,
+                    self._dtype.str, self._dtype.num)
                 if self._comm is not None:
                     print(msg)
                     sys.stdout.flush()
-                    #self._comm.Abort()
+                    self._comm.Abort()
                 else:
                     raise RuntimeError(msg)
 
@@ -593,6 +627,7 @@ class MPIShared(object):
         # process on each of the nodes.
 
         if self._comm is not None:
+            import mpi4py.MPI as MPI
             target_noderank = self._comm.bcast(self._noderank, root=fromrank)
             fromnode = self._comm.bcast(self._mynode, root=fromrank)
 


### PR DESCRIPTION
Change the way that processes in a group write to a single observation.  Instead of relying on a mutex lock, take turns in rank order.  Small tweaks to installed pipeline script to explicitly call python3 rather than "python".