### PR TITLE
Faster noise

### DIFF
--- a/examples/generate_slurm.sh
+++ b/examples/generate_slurm.sh
@@ -6,7 +6,7 @@ topdir=$(pwd -P)
 popd > /dev/null
 
 : ${TYPES:="satellite ground ground_simple"}
-: ${SIZES:="tiny small medium large"}
+: ${SIZES:="tiny small medium large representative"}
 : ${MACHINES:="cori-intel-knl cori-intel-haswell edison-intel"}
 
 for type in ${TYPES}; do

--- a/examples/ground.large
+++ b/examples/ground.large
@@ -7,3 +7,4 @@ tiny = no
 patch = 8x8deg,1,4,-26,-4,-34
 schedule_stop = "2016-12-18 00:00:00"
 cellsize = 30
+itermax = 1000

--- a/examples/ground.medium
+++ b/examples/ground.medium
@@ -7,3 +7,4 @@ tiny = no
 patch = 8x8deg,1,4,-26,-4,-34
 schedule_stop = "2016-06-21 00:00:00"
 cellsize = 30
+itermax = 1000

--- a/examples/ground.representative
+++ b/examples/ground.representative
@@ -1,9 +1,10 @@
 queue = debug
-nodes = 128
-nodes_per_group = 128
+nodes = 64
+nodes_per_group = 64
 time = 00:30:00
-detpix = 3571
+detpix = 7651
 tiny = no
 patch = 8x8deg,1,4,-26,-4,-34
-schedule_stop = "2016-06-01 08:00:00"
-cellsize = 5
+schedule_stop = "2016-06-02 00:00:00"
+cellsize = 10
+itermax = 10

--- a/examples/ground.representative
+++ b/examples/ground.representative
@@ -1,0 +1,9 @@
+queue = debug
+nodes = 128
+nodes_per_group = 128
+time = 00:30:00
+detpix = 3571
+tiny = no
+patch = 8x8deg,1,4,-26,-4,-34
+schedule_stop = "2016-06-01 08:00:00"
+cellsize = 5

--- a/examples/ground.small
+++ b/examples/ground.small
@@ -7,3 +7,4 @@ tiny = no
 patch = 8x8deg,1,4,-26,-4,-34
 schedule_stop = "2016-06-02 00:00:00"
 cellsize = 30
+itermax = 1000

--- a/examples/ground.tiny
+++ b/examples/ground.tiny
@@ -7,3 +7,4 @@ tiny = yes
 patch = 8x8deg,1,4,-26,-4,-34
 schedule_stop = "2016-06-01 08:00:00"
 cellsize = 30
+itermax = 1000

--- a/examples/ground_simple.representative
+++ b/examples/ground_simple.representative
@@ -1,0 +1,9 @@
+queue = debug
+nodes = 128
+nodes_per_group = 128
+time = 00:30:00
+detpix = 3571
+tiny = no
+patch = 8x8deg,1,4,-26,-4,-34
+schedule_stop = "2016-06-01 08:00:00"
+cellsize = 5

--- a/examples/ground_template
+++ b/examples/ground_template
@@ -87,6 +87,7 @@ com="${ex} @${parfile} \
 --atm_xstep @@cellsize@@ \
 --atm_ystep @@cellsize@@ \
 --atm_zstep @@cellsize@@ \
+--madam_iter_max @@itermax@@ \
 "
 
 #--- Hardware configuration (no need to change) ----

--- a/examples/satellite.representative
+++ b/examples/satellite.representative
@@ -1,0 +1,6 @@
+queue = debug
+nodes = 314
+time = 00:30:00
+detpix = 217
+nobs = 157
+groupnodes = 2

--- a/src/libtoast/capi/ctoast.cpp
+++ b/src/libtoast/capi/ctoast.cpp
@@ -723,6 +723,20 @@ void ctoast_filter_polyfilter (
     return;
 }
 
+void ctoast_sim_noise_sim_noise_timestream (
+    const uint64_t realization, const uint64_t telescope,
+    const uint64_t component, const uint64_t obsindx, const uint64_t detindx,
+    const double rate, const uint64_t firstsamp, const uint64_t samples,
+    const uint64_t oversample, const double *freq, const double *psd,
+    const uint64_t psdlen, double *noise ) {
+
+    toast::sim_noise::sim_noise_timestream(
+        realization, telescope, component, obsindx, detindx, rate, firstsamp,
+        samples, oversample, freq, psd, psdlen, noise);
+}
+
+
+
 void ctoast_sim_map_scan_map32 (
     long *submap, long subnpix, double *weights, size_t nmap, long *subpix,
     float *map, double *tod, size_t nsamp ) {

--- a/src/libtoast/capi/ctoast.h
+++ b/src/libtoast/capi/ctoast.h
@@ -269,6 +269,13 @@ void ctoast_sim_map_scan_map64 (
     long *submap, long subnpix, double *weights, size_t nmap, long *subpix,
     double *map, double *tod, size_t nsamp );
 
+void ctoast_sim_noise_sim_noise_timestream (
+    const uint64_t realization, const uint64_t telescope,
+    const uint64_t component, const uint64_t obsindx, const uint64_t detindx,
+    const double rate, const uint64_t firstsamp, const uint64_t samples,
+    const uint64_t oversample, const double *freq, const double *psd,
+    const uint64_t psdlen, double *noise );
+
 
 //--------------------------------------
 // FOD sub-library

--- a/src/libtoast/tod/toast/sim_noise.hpp
+++ b/src/libtoast/tod/toast/sim_noise.hpp
@@ -1,18 +1,25 @@
 /*
 Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-All rights reserved.  Use of this source code is governed by 
+All rights reserved.  Use of this source code is governed by
 a BSD-style license that can be found in the LICENSE file.
 */
 
 #ifndef TOAST_SIM_NOISE_HPP
 #define TOAST_SIM_NOISE_HPP
 
+#include <math.h>
+#include <sstream>
+
 
 namespace toast { namespace sim_noise {
 
-
+void sim_noise_timestream(
+    const uint64_t realization, const uint64_t telescope,
+    const uint64_t component, const uint64_t obsindx, const uint64_t detindx,
+    const double rate, const uint64_t firstsamp, const uint64_t samples,
+    const uint64_t oversample, const double *freq, const double *psd,
+    const uint64_t psdlen, double *noise);
 
 } }
 
 #endif
-

--- a/src/libtoast/tod/toast_sim_noise.cpp
+++ b/src/libtoast/tod/toast_sim_noise.cpp
@@ -1,11 +1,170 @@
 /*
 Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-All rights reserved.  Use of this source code is governed by 
+All rights reserved.  Use of this source code is governed by
 a BSD-style license that can be found in the LICENSE file.
 */
 
 #include <toast_tod_internal.hpp>
 
 
+void toast::sim_noise::sim_noise_timestream(
+    const uint64_t realization, const uint64_t telescope,
+    const uint64_t component, const uint64_t obsindx, const uint64_t detindx,
+    const double rate, const uint64_t firstsamp, const uint64_t samples,
+    const uint64_t oversample, const double *freq, const double *psd,
+    const uint64_t psdlen, double *noise) {
 
+    /*
+    Generate a noise timestream, given a starting RNG state.
 
+    Use the RNG parameters to generate unit-variance Gaussian samples
+    and then modify the Fourier domain amplitudes to match the desired
+    PSD.
+
+    The RNG (Threefry2x64 from Random123) takes a "key" and a "counter"
+    which each consist of two unsigned 64bit integers.  These four
+    numbers together uniquely identify a single sample.  We construct
+    those four numbers in the following way:
+
+    key1 = realization * 2^32 + telescope * 2^16 + component
+    key2 = obsindx * 2^32 + detindx
+    counter1 = currently unused (0)
+    counter2 = sample in stream
+
+    counter2 is incremented internally by the RNG function as it calls
+    the underlying Random123 library for each sample.
+
+    Args:
+        realization (int): the Monte Carlo realization.
+        telescope (int): a unique index assigned to a telescope.
+        component (int): a number representing the type of timestream
+            we are generating (detector noise, common mode noise,
+            atmosphere, etc).
+        obsindx (int): the global index of this observation.
+        detindx (int): the global index of this detector.
+        rate (float): the sample rate.
+        firstsamp (int): the start sample in the stream.
+        samples (int): the number of samples to generate.
+        oversample (int): the factor by which to expand the FFT length
+            beyond the number of samples.
+        freq (array): the frequency points of the PSD.
+        psd (array): the PSD values.
+
+    Returns (tuple):
+        the timestream array, the interpolated PSD frequencies, and
+            the interpolated PSD values.
+    */
+
+    uint64_t fftlen = 2;
+    while (fftlen <= (oversample * samples)) {
+        fftlen *= 2;
+    }
+    uint64_t npsd = fftlen/2 + 1;
+    double norm = rate * float(npsd - 1);
+
+    // Python implementation is missing "-1"
+    double increment = rate / (fftlen - 1);
+
+    for (uint64_t i=0; i<psdlen; ++i) {
+        if (psd[i] < 0) {
+            throw std::runtime_error("input PSD values should be >= zero");
+        }
+    }
+
+    if (freq[0] > increment) {
+        throw std::runtime_error(
+            "input PSD does not go to low enough frequency to "
+            "allow for interpolation");
+    }
+
+    double nyquist = rate / 2;
+    if (abs((freq[psdlen-1]-nyquist) / nyquist) > .01) {
+        std::ostringstream o;
+        o.precision(16);
+        o << "last frequency element does not match Nyquist "
+          << "frequency for given sample rate: "
+          << freq[psdlen-1] << " != " << nyquist
+          << std::endl;
+        throw std::runtime_error(o.str().c_str());
+    }
+
+    // Perform a logarithmic interpolation.  In order to avoid zero
+    // values, we shift the PSD by a fixed amount in frequency and
+    // amplitude.
+
+    double psdmin = 1e30;
+    for (uint64_t i=0; i<psdlen; ++i) {
+        if (psd[i] != 0) {
+            if (psd[i] < psdmin) psdmin = psd[i];
+        }
+    }
+
+    double psdshift = 0.01 * psdmin;
+    double freqshift = increment;
+
+    std::vector<double> logfreq(psdlen);
+    std::vector<double> logpsd(psdlen);
+    for (uint64_t i=0; i<psdlen; ++i) {
+        logfreq[i] = log10(freq[i] + freqshift);
+        logpsd[i] = log10(psd[i] + psdshift);
+    }
+
+    uint64_t ibin = 0;
+    std::vector<double> interp_psd(npsd);
+    for (uint64_t i=0; i<npsd; ++i) {
+        double loginterp_freq = log10(i*increment + freqshift);
+        while (ibin < psdlen-1 && logfreq[ibin+1] < loginterp_freq) ++ibin;
+        double r = (loginterp_freq-logfreq[ibin])
+            / (logfreq[ibin+1]-logfreq[ibin]);
+        double loginterp_psd = (1-r)*logpsd[ibin] + r*logfreq[ibin+1];
+        interp_psd[i] = pow(10, loginterp_psd) - psdshift;
+        //std::cerr<<"interp_psd[" << i << "] = " << interp_psd[i] << std::endl; // DEBUG
+    }
+
+    //scale = np.sqrt(interp_psd * norm)
+
+    // Zero out DC value
+
+    interp_psd[0] = 0;
+
+    // gaussian Re/Im randoms, packed into a complex valued array
+
+    uint64_t key1 = realization*4294967296 + telescope*65536 + component;
+    uint64_t key2 = obsindx*4294967296 + detindx;
+    uint64_t counter1 = 0;
+    uint64_t counter2 = firstsamp * oversample;
+    std::vector<double> rngdata(2*npsd);
+
+    rng::dist_normal(2*npsd, key1, key2, counter1, counter2, rngdata.data());
+
+    fft::r1d_p plan(fft::r1d::create(fftlen, 1, fft::plan_type::fast,
+                                     fft::direction::backward, 1));
+
+    for (uint64_t i=0; i<npsd; ++i) plan->fdata()[0][i] = rngdata[i];
+    for (uint64_t i=0; i<npsd; ++i) plan->fdata()[0][fftlen-1-i] = rngdata[npsd+i];
+
+    plan->fdata()[0][0] = 0;
+    for (uint64_t i=1; i<=fftlen/2; ++i) {
+        double psdval = interp_psd[i] * norm;
+        plan->fdata()[0][i] *= psdval;
+        plan->fdata()[0][fftlen-i] *= psdval;
+    }
+
+    plan->exec();
+
+    uint64_t offset = (fftlen - samples) / 2;
+
+    for (long i=0; i<samples; ++i) {
+        noise[i] = plan->tdata()[0][offset+i];
+    }
+
+    // subtract the DC level
+
+    double DC = 0;
+    for (long i=0; i<samples; ++i) DC += noise[i];
+    DC /= samples;
+    for (long i=0; i<samples; ++i) noise[i] -= DC;
+
+    return;
+
+}

--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -933,20 +933,13 @@ def filter_polyfilter(order, signals, flags, starts, stops):
 
 lib.ctoast_sim_noise_sim_noise_timestream.restype = None
 lib.ctoast_sim_noise_sim_noise_timestream.argtypes = [
-    ct.c_ulonglong, ct.c_ulonglong, 
-    ct.c_ulonglong, ct.c_ulonglong, ct.c_double,
-    ct.c_ulonglong, ct.c_ulonglong, ct.c_ulonglong,
-    ct.POINTER(ct.c_double), ct.POINTER(ct.c_double), ct.c_ulonglong,
-    ct.POINTER(ct.c_double)]
+    ct.c_ulonglong, ct.c_ulonglong, ct.c_ulonglong, ct.c_ulonglong,
+    ct.c_ulonglong, ct.c_double, ct.c_ulonglong, ct.c_ulonglong, ct.c_ulonglong,
+    npf64, npf64, ct.c_ulonglong, npf64]
 
 def sim_noise_sim_noise_timestream(
         realization, telescope, component, obsindx, detindx,
-        rate, firstsamp, samples, oversample, freq, psd)
-
-    if not freq.flags['C']:
-        raise RuntimeError('freq must be in C_CONTIGUOUS memory')
-    if not psd.flags['C']:
-        raise RuntimeError('psd must be in C_CONTIGUOUS memory')
+        rate, firstsamp, samples, oversample, freq, psd):
 
     if freq.size != psd.size:
         raise RuntimeError(
@@ -955,7 +948,7 @@ def sim_noise_sim_noise_timestream(
     noise = np.zeros(samples, dtype=np.float64)
 
     lib.ctoast_sim_noise_sim_noise_timestream(
-        realization, telescope,
+        realization, telescope, component,
         obsindx, detindx, rate,
         firstsamp, samples, oversample,
         freq, psd, psd.size, noise)

--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -931,6 +931,37 @@ def filter_polyfilter(order, signals, flags, starts, stops):
 
     return
 
+lib.ctoast_sim_noise_sim_noise_timestream.restype = None
+lib.ctoast_sim_noise_sim_noise_timestream.argtypes = [
+    ct.c_ulonglong, ct.c_ulonglong, 
+    ct.c_ulonglong, ct.c_ulonglong, ct.c_double,
+    ct.c_ulonglong, ct.c_ulonglong, ct.c_ulonglong,
+    ct.POINTER(ct.c_double), ct.POINTER(ct.c_double), ct.c_ulonglong,
+    ct.POINTER(ct.c_double)]
+
+def sim_noise_sim_noise_timestream(
+        realization, telescope, component, obsindx, detindx,
+        rate, firstsamp, samples, oversample, freq, psd)
+
+    if not freq.flags['C']:
+        raise RuntimeError('freq must be in C_CONTIGUOUS memory')
+    if not psd.flags['C']:
+        raise RuntimeError('psd must be in C_CONTIGUOUS memory')
+
+    if freq.size != psd.size:
+        raise RuntimeError(
+            'freq and psd must be same size')
+
+    noise = np.zeros(samples, dtype=np.float64)
+
+    lib.ctoast_sim_noise_sim_noise_timestream(
+        realization, telescope,
+        obsindx, detindx, rate,
+        firstsamp, samples, oversample,
+        freq, psd, psd.size, noise)
+
+    return noise
+
 lib.ctoast_pointing_healpix_matrix.restype = None
 lib.ctoast_pointing_healpix_matrix.argtypes = [ ct.POINTER(cHealpix), ct.c_int,
     ct.c_double, ct.c_double, ct.c_char_p, ct.c_ulong, npf64, npf64, npu8, npi64,

--- a/src/python/tests/psd_math.py
+++ b/src/python/tests/psd_math.py
@@ -194,7 +194,8 @@ class PSDTest(MPITestCase):
 
             df = nse.rate(det) / float(fftlen)
 
-            (temp, freqs[det], psds[det]) = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
+            #(temp, freqs[det], psds[det]) = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
+            temp = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
 
             if False:
                 psdfreq = freqs[det]

--- a/src/python/tod/sim_det_noise.py
+++ b/src/python/tod/sim_det_noise.py
@@ -12,7 +12,7 @@ import numpy as np
 from ..op import Operator
 
 #from .tod_math import sim_noise_timestream
-from ..ctoast import sim_noise_sim_noise_timestream
+from ..ctoast import sim_noise_sim_noise_timestream as sim_noise_timestream
 
 
 class OpSimNoise(Operator):
@@ -158,7 +158,7 @@ class OpSimNoise(Operator):
             #    self._oversample, nse.freq(key), nse.psd(key),
             #    self._altfft)[0]
 
-            nsedata = sim_noise_sim_noise_timestream(
+            nsedata = sim_noise_timestream(
                 self._realization, telescope, self._component, obsindx,
                 nse.index(key), rate, chunk_first+global_offset, chunk_samp,
                 self._oversample, nse.freq(key), nse.psd(key))

--- a/src/python/tod/sim_det_noise.py
+++ b/src/python/tod/sim_det_noise.py
@@ -11,7 +11,8 @@ import numpy as np
 
 from ..op import Operator
 
-from .tod_math import sim_noise_timestream
+#from .tod_math import sim_noise_timestream
+from ..ctoast import sim_noise_sim_noise_timestream
 
 
 class OpSimNoise(Operator):
@@ -151,11 +152,16 @@ class OpSimNoise(Operator):
                 continue
 
             # Simulate the noise matching this key
-            nsedata = sim_noise_timestream(
+            #nsedata = sim_noise_timestream(
+            #    self._realization, telescope, self._component, obsindx,
+            #    nse.index(key), rate, chunk_first+global_offset, chunk_samp,
+            #    self._oversample, nse.freq(key), nse.psd(key),
+            #    self._altfft)[0]
+
+            nsedata = sim_noise_sim_noise_timestream(
                 self._realization, telescope, self._component, obsindx,
                 nse.index(key), rate, chunk_first+global_offset, chunk_samp,
-                self._oversample, nse.freq(key), nse.psd(key),
-                self._altfft)[0]
+                self._oversample, nse.freq(key), nse.psd(key))
 
             # Add the noise to all detectors that have nonzero weights
             for det in tod.local_dets:

--- a/src/python/tod/sim_tod.py
+++ b/src/python/tod/sim_tod.py
@@ -753,8 +753,8 @@ class TODGround(TOD):
             "sun_angle_min": sun_angle_min
         }
         super().__init__(mpicomm, self._detlist, samples, detindx=detindx, 
-            detranks=detranks, detbreaks=detbreaks, sampsizes=sizes, 
-            sampbreaks=sampbreaks, meta=props)
+                         detranks=detranks, detbreaks=detbreaks,
+                         sampsizes=[samples], sampbreaks=sampbreaks, meta=props)
 
         if self._report_timing:
             mpicomm.Barrier()


### PR DESCRIPTION
This pull request implements a compiled method for simulating realizations of a given noise PSD: `sim_noise_timestream`. It calls RNG and FFT directly in `libtoast`. The simulation method is not yet threaded. If threading is needed, it will be best to put the threading in the interface and place multiple concurrent calls to `sim_noise_timestream`.

The pull request also fixes an error in simulated ground TOD class that was inadvertently splitting the TOD into subscan-sized chunks.