### PR TITLE
Fix unit test segfault

### DIFF
--- a/src/libtoast/test/toast_test.hpp
+++ b/src/libtoast/test/toast_test.hpp
@@ -19,22 +19,22 @@ namespace toast { namespace test {
     int runner ( int argc, char *argv[] );
 }}
 
-class timingTest : public ::testing::Test
+class TOASTtimingTest : public ::testing::Test
 {
 public:
-    timingTest () { }
-    ~timingTest () { }
+    TOASTtimingTest () { }
+    ~TOASTtimingTest () { }
     virtual void SetUp() { }
     virtual void TearDown() { }
 };
 
 
-class qarrayTest : public ::testing::Test {
+class TOASTqarrayTest : public ::testing::Test {
 
     public :
 
-        qarrayTest () { }
-        ~qarrayTest () { }
+        TOASTqarrayTest () { }
+        ~TOASTqarrayTest () { }
         virtual void SetUp();
         virtual void TearDown() { }
 
@@ -53,12 +53,12 @@ class qarrayTest : public ::testing::Test {
 };
 
 
-class rngTest : public ::testing::Test {
+class TOASTrngTest : public ::testing::Test {
 
     public :
 
-        rngTest () { }
-        ~rngTest () { }
+        TOASTrngTest () { }
+        ~TOASTrngTest () { }
         virtual void SetUp();
         virtual void TearDown() { }
 
@@ -81,12 +81,12 @@ class rngTest : public ::testing::Test {
 };
 
 
-class sfTest : public ::testing::Test {
+class TOASTsfTest : public ::testing::Test {
 
     public :
 
-        sfTest () { }
-        ~sfTest () { }
+        TOASTsfTest () { }
+        ~TOASTsfTest () { }
         virtual void SetUp();
         virtual void TearDown();
 
@@ -109,24 +109,24 @@ class sfTest : public ::testing::Test {
 };
 
 
-class healpixTest : public ::testing::Test {
+class TOASThealpixTest : public ::testing::Test {
 
     public :
 
-        healpixTest () { }
-        ~healpixTest () { }
+        TOASThealpixTest () { }
+        ~TOASThealpixTest () { }
         virtual void SetUp() { }
         virtual void TearDown() { }
 
 };
 
 
-class fftTest : public ::testing::Test {
+class TOASTfftTest : public ::testing::Test {
 
     public :
 
-        fftTest () { }
-        ~fftTest () { }
+        TOASTfftTest () { }
+        ~TOASTfftTest () { }
         virtual void SetUp() { }
         virtual void TearDown() { }
 
@@ -139,12 +139,12 @@ class fftTest : public ::testing::Test {
 };
 
 
-class covTest : public ::testing::Test {
+class TOASTcovTest : public ::testing::Test {
 
     public :
 
-        covTest () { }
-        ~covTest () { }
+        TOASTcovTest () { }
+        ~TOASTcovTest () { }
         virtual void SetUp() { }
         virtual void TearDown() { }
 
@@ -157,12 +157,12 @@ class covTest : public ::testing::Test {
 };
 
 
-class mpiShmemTest : public ::testing::Test {
+class TOASTmpiShmemTest : public ::testing::Test {
 
     public :
 
-        mpiShmemTest () { }
-        ~mpiShmemTest () { }
+        TOASTmpiShmemTest () { }
+        ~TOASTmpiShmemTest () { }
         virtual void SetUp() { }
         virtual void TearDown() { }
 
@@ -171,12 +171,12 @@ class mpiShmemTest : public ::testing::Test {
 };
 
 
-class polyfilterTest : public ::testing::Test {
+class TOASTpolyfilterTest : public ::testing::Test {
 
 public :
 
-    polyfilterTest () { }
-    ~polyfilterTest () { }
+    TOASTpolyfilterTest () { }
+    ~TOASTpolyfilterTest () { }
     virtual void SetUp() { }
     virtual void TearDown() { }
 

--- a/src/libtoast/test/toast_test_cov.cpp
+++ b/src/libtoast/test/toast_test_cov.cpp
@@ -14,14 +14,14 @@ using namespace std;
 using namespace toast;
 
 
-const int64_t covTest::nsm = 2;
-const int64_t covTest::npix = 3;
-const int64_t covTest::nnz = 4;
-const int64_t covTest::nsamp = 100;
-const int64_t covTest::scale = 2.0;
+const int64_t TOASTcovTest::nsm = 2;
+const int64_t TOASTcovTest::npix = 3;
+const int64_t TOASTcovTest::nnz = 4;
+const int64_t TOASTcovTest::nsamp = 100;
+const int64_t TOASTcovTest::scale = 2.0;
 
 
-TEST_F( covTest, accumulate ) {
+TEST_F( TOASTcovTest, accumulate ) {
 
     int64_t block = (int64_t)(nnz * (nnz+1) / 2);
 
@@ -99,7 +99,7 @@ TEST_F( covTest, accumulate ) {
 }
 
 
-TEST_F( covTest, eigendecompose ) {
+TEST_F( TOASTcovTest, eigendecompose ) {
 
     int64_t block = (int64_t)(nnz * (nnz+1) / 2);
 
@@ -141,7 +141,7 @@ TEST_F( covTest, eigendecompose ) {
 }
 
 
-TEST_F( covTest, matrixmultiply ) {
+TEST_F( TOASTcovTest, matrixmultiply ) {
 
     int64_t block = (int64_t)(nnz * (nnz+1) / 2);
 

--- a/src/libtoast/test/toast_test_fft.cpp
+++ b/src/libtoast/test/toast_test_fft.cpp
@@ -14,12 +14,12 @@ using namespace std;
 using namespace toast;
 
 
-const int64_t fftTest::length = 32;
-const int64_t fftTest::n = 3;
+const int64_t TOASTfftTest::length = 32;
+const int64_t TOASTfftTest::n = 3;
 
 
 
-void fftTest::runbatch(int64_t nbatch, fft::r1d_p forward, 
+void TOASTfftTest::runbatch(int64_t nbatch, fft::r1d_p forward, 
     fft::r1d_p reverse) {
     bool debug = false;
 
@@ -106,7 +106,7 @@ void fftTest::runbatch(int64_t nbatch, fft::r1d_p forward,
 }
 
 
-TEST_F( fftTest, roundtrip_single ) {
+TEST_F( TOASTfftTest, roundtrip_single ) {
     // create FFT plans
     fft::r1d_p fplan ( fft::r1d::create ( length, 1, fft::plan_type::fast, 
         fft::direction::forward, 1.0 ) );
@@ -116,7 +116,7 @@ TEST_F( fftTest, roundtrip_single ) {
     runbatch(1, fplan, rplan);
 }
 
-TEST_F( fftTest, roundtrip_multi ) {
+TEST_F( TOASTfftTest, roundtrip_multi ) {
     // create FFT plans
     fft::r1d_p fplan ( fft::r1d::create ( length, n, fft::plan_type::fast, 
         fft::direction::forward, 1.0 ) );
@@ -126,7 +126,7 @@ TEST_F( fftTest, roundtrip_multi ) {
     runbatch(n, fplan, rplan);
 }
 
-TEST_F( fftTest, plancache_single ) {
+TEST_F( TOASTfftTest, plancache_single ) {
     // use the plan store.  test both reuse of plans and
     // creation after a clear().
     fft::r1d_plan_store & store = fft::r1d_plan_store::get();
@@ -148,7 +148,7 @@ TEST_F( fftTest, plancache_single ) {
 }
 
 
-TEST_F( fftTest, plancache_multi ) {
+TEST_F( TOASTfftTest, plancache_multi ) {
     // use the plan store.  test both reuse of plans and
     // creation after a clear().
     fft::r1d_plan_store & store = fft::r1d_plan_store::get();

--- a/src/libtoast/test/toast_test_healpix.cpp
+++ b/src/libtoast/test/toast_test_healpix.cpp
@@ -14,7 +14,7 @@ using namespace std;
 using namespace toast;
 
 
-TEST_F( healpixTest, pixelops ) {
+TEST_F( TOASThealpixTest, pixelops ) {
 
     // These numbers were generated with the included script.
 

--- a/src/libtoast/test/toast_test_mpi_shmem.cpp
+++ b/src/libtoast/test/toast_test_mpi_shmem.cpp
@@ -14,10 +14,10 @@ using namespace std;
 using namespace toast;
 
 
-const size_t mpiShmemTest::n = 100;
+const size_t TOASTmpiShmemTest::n = 100;
 
 
-TEST_F( mpiShmemTest, instantiate ) {
+TEST_F( TOASTmpiShmemTest, instantiate ) {
 
     toast::mpi_shmem::mpi_shmem<double> shmem;
     shmem.allocate( n );
@@ -32,7 +32,7 @@ TEST_F( mpiShmemTest, instantiate ) {
 
 }
 
-TEST_F( mpiShmemTest, access ) {
+TEST_F( TOASTmpiShmemTest, access ) {
 
     toast::mpi_shmem::mpi_shmem<double> shmem( n );
 

--- a/src/libtoast/test/toast_test_polyfilter.cpp
+++ b/src/libtoast/test/toast_test_polyfilter.cpp
@@ -14,11 +14,11 @@ using namespace std;
 using namespace toast;
 
 
-const size_t polyfilterTest::order = 3;
-const size_t polyfilterTest::n = 1000;
+const size_t TOASTpolyfilterTest::order = 3;
+const size_t TOASTpolyfilterTest::n = 1000;
 
 
-TEST_F( polyfilterTest, filter ) {
+TEST_F( TOASTpolyfilterTest, filter ) {
 
     vector<double> signal1(n);
     vector<double> signal2(n);
@@ -76,7 +76,7 @@ TEST_F( polyfilterTest, filter ) {
 }
 
 
-TEST_F( polyfilterTest, filter_with_flags ) {
+TEST_F( TOASTpolyfilterTest, filter_with_flags ) {
 
     vector<double> signal1(n);
     vector<double> signal2(n);

--- a/src/libtoast/test/toast_test_qarray.cpp
+++ b/src/libtoast/test/toast_test_qarray.cpp
@@ -16,25 +16,25 @@ using namespace std;
 using namespace toast;
 
 
-const double qarrayTest::q1[] = { 0.50487417,  0.61426059,  0.60118994,  0.07972857 };
-const double qarrayTest::q1inv[] = { -0.50487417,  -0.61426059,  -0.60118994,  0.07972857 };
-const double qarrayTest::q2[] = { 0.43561544,  0.33647027,  0.40417115,  0.73052901 };
-const double qarrayTest::qtonormalize[] = { 1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 5.0 };
-const double qarrayTest::qnormalized[] = { 0.18257419, 0.36514837, 0.54772256, 0.73029674, 0.27216553, 0.40824829, 0.54433105, 0.68041382 };
-const double qarrayTest::vec[] = { 0.57734543, 0.30271255, 0.75831218 };
-const double qarrayTest::vec2[] = { 0.57734543, 8.30271255, 5.75831218, 1.57734543, 3.30271255, 0.75831218 };
-const double qarrayTest::qeasy[] = { 0.3, 0.3, 0.1, 0.9, 0.3, 0.3, 0.1, 0.9 };
-const double qarrayTest::mult_result[] = { 0.44954009, 0.53339352, 0.37370443, -0.61135101 };
-const double qarrayTest::rot_by_q1[] = { 0.4176698, 0.84203849, 0.34135482 };
-const double qarrayTest::rot_by_q2[] = { 0.8077876, 0.3227185, 0.49328689 };
+const double TOASTqarrayTest::q1[] = { 0.50487417,  0.61426059,  0.60118994,  0.07972857 };
+const double TOASTqarrayTest::q1inv[] = { -0.50487417,  -0.61426059,  -0.60118994,  0.07972857 };
+const double TOASTqarrayTest::q2[] = { 0.43561544,  0.33647027,  0.40417115,  0.73052901 };
+const double TOASTqarrayTest::qtonormalize[] = { 1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 5.0 };
+const double TOASTqarrayTest::qnormalized[] = { 0.18257419, 0.36514837, 0.54772256, 0.73029674, 0.27216553, 0.40824829, 0.54433105, 0.68041382 };
+const double TOASTqarrayTest::vec[] = { 0.57734543, 0.30271255, 0.75831218 };
+const double TOASTqarrayTest::vec2[] = { 0.57734543, 8.30271255, 5.75831218, 1.57734543, 3.30271255, 0.75831218 };
+const double TOASTqarrayTest::qeasy[] = { 0.3, 0.3, 0.1, 0.9, 0.3, 0.3, 0.1, 0.9 };
+const double TOASTqarrayTest::mult_result[] = { 0.44954009, 0.53339352, 0.37370443, -0.61135101 };
+const double TOASTqarrayTest::rot_by_q1[] = { 0.4176698, 0.84203849, 0.34135482 };
+const double TOASTqarrayTest::rot_by_q2[] = { 0.8077876, 0.3227185, 0.49328689 };
 
 
-void qarrayTest::SetUp () {
+void TOASTqarrayTest::SetUp () {
     return;
 }
 
 
-TEST_F( qarrayTest, arraylist_dot1 ) {
+TEST_F( TOASTqarrayTest, arraylist_dot1 ) {
     double check;
     double result;
     double pone[3];
@@ -51,7 +51,7 @@ TEST_F( qarrayTest, arraylist_dot1 ) {
 }
 
 
-TEST_F( qarrayTest, arraylist_dot2 ) {
+TEST_F( TOASTqarrayTest, arraylist_dot2 ) {
     double check[2];
     double result[2];
     double pone[6];
@@ -72,7 +72,7 @@ TEST_F( qarrayTest, arraylist_dot2 ) {
 }
 
 
-TEST_F( qarrayTest, inv ) {
+TEST_F( TOASTqarrayTest, inv ) {
     double result[4];
 
     for ( size_t i = 0; i < 4; ++i ) {
@@ -87,7 +87,7 @@ TEST_F( qarrayTest, inv ) {
 }
 
 
-TEST_F( qarrayTest, norm ) {
+TEST_F( TOASTqarrayTest, norm ) {
     double result[4];
 
     qarray::normalize ( 1, 4, 4, qtonormalize, result );
@@ -98,7 +98,7 @@ TEST_F( qarrayTest, norm ) {
 }
 
 
-TEST_F( qarrayTest, mult ) {
+TEST_F( TOASTqarrayTest, mult ) {
     double result[4];
 
     qarray::mult ( 1, q1, 1, q2, result );
@@ -109,7 +109,7 @@ TEST_F( qarrayTest, mult ) {
 }
 
 
-TEST_F( qarrayTest, multarray ) {
+TEST_F( TOASTqarrayTest, multarray ) {
     size_t n = 3;
     double in1[4*n];
     double in2[4*n];
@@ -146,7 +146,7 @@ TEST_F( qarrayTest, multarray ) {
 }
 
 
-TEST_F( qarrayTest, rot1 ) {
+TEST_F( TOASTqarrayTest, rot1 ) {
     double result[3];
 
     qarray::rotate ( 1, q1, 1, vec, result );
@@ -157,7 +157,7 @@ TEST_F( qarrayTest, rot1 ) {
 }
 
 
-TEST_F( qarrayTest, rotarray ) {
+TEST_F( TOASTqarrayTest, rotarray ) {
     size_t n = 2;
     double qin[4*n];
     double vin[3*n];
@@ -183,7 +183,7 @@ TEST_F( qarrayTest, rotarray ) {
 }
 
 
-TEST_F( qarrayTest, slerp ) {
+TEST_F( TOASTqarrayTest, slerp ) {
     size_t n = 2;
     size_t ninterp = 4;
 
@@ -215,7 +215,7 @@ TEST_F( qarrayTest, slerp ) {
 }
 
 
-TEST_F( qarrayTest, rotation ) {
+TEST_F( TOASTqarrayTest, rotation ) {
     double result[4];
     double axis[3] = { 0.0, 0.0, 1.0 };
     double ang = PI * 30.0 / 180.0;
@@ -229,7 +229,7 @@ TEST_F( qarrayTest, rotation ) {
 }
 
 
-TEST_F( qarrayTest, toaxisangle ) {
+TEST_F( TOASTqarrayTest, toaxisangle ) {
     double in[4] = { 0.0, 0.0, ::sin(15.0 * PI / 180.0), ::cos(15.0 * PI / 180.0) };
     double axis[3];
     double ang;
@@ -245,7 +245,7 @@ TEST_F( qarrayTest, toaxisangle ) {
 }
 
 
-TEST_F( qarrayTest, exp ) {
+TEST_F( TOASTqarrayTest, exp ) {
     double result[8];
     double check[8] = { 0.71473568, 0.71473568, 0.23824523, 2.22961712, 0.71473568, 0.71473568, 0.23824523, 2.22961712 };
 
@@ -257,7 +257,7 @@ TEST_F( qarrayTest, exp ) {
 }
 
 
-TEST_F( qarrayTest, ln ) {
+TEST_F( TOASTqarrayTest, ln ) {
     double result[8];
     double check[8] = { 0.31041794, 0.31041794, 0.10347265, 0.0, 0.31041794, 0.31041794, 0.10347265, 0.0 };
 
@@ -269,7 +269,7 @@ TEST_F( qarrayTest, ln ) {
 }
 
 
-TEST_F( qarrayTest, pow ) {
+TEST_F( TOASTqarrayTest, pow ) {
     double p[2];
     double result[8];
     double check1[8] = { 0.672, 0.672, 0.224, 0.216, 0.672, 0.672, 0.224, 0.216 };
@@ -293,7 +293,7 @@ TEST_F( qarrayTest, pow ) {
 }
 
 
-TEST_F( qarrayTest, torotmat ) {
+TEST_F( TOASTqarrayTest, torotmat ) {
     double result[9];
     double check[9] = { 8.00000000e-01, -2.77555756e-17, 6.00000000e-01, 3.60000000e-01, 8.00000000e-01, -4.80000000e-01, -4.80000000e-01, 6.00000000e-01, 6.40000000e-01 };
 
@@ -307,7 +307,7 @@ TEST_F( qarrayTest, torotmat ) {
 }
 
 
-TEST_F( qarrayTest, fromrotmat ) {
+TEST_F( TOASTqarrayTest, fromrotmat ) {
     double result[9];
     double qresult[4];
 
@@ -320,7 +320,7 @@ TEST_F( qarrayTest, fromrotmat ) {
 }
 
 
-TEST_F( qarrayTest, fromvectors ) {
+TEST_F( TOASTqarrayTest, fromvectors ) {
     double result[4];
     double check[4] = { 0.0, 0.0, ::sin(15.0 * PI / 180.0), ::cos(15.0 * PI / 180.0) };
     double ang = 30.0 * PI / 180.0;
@@ -335,7 +335,7 @@ TEST_F( qarrayTest, fromvectors ) {
 }
 
 
-TEST_F( qarrayTest, thetaphipa ) {
+TEST_F( TOASTqarrayTest, thetaphipa ) {
     size_t n_theta = 5;
     size_t n_phi = 5;
     size_t n = n_theta * n_phi;

--- a/src/libtoast/test/toast_test_rng.cpp
+++ b/src/libtoast/test/toast_test_rng.cpp
@@ -14,27 +14,27 @@ using namespace std;
 using namespace toast;
 
 
-const int64_t rngTest::size = 11;
-const uint64_t rngTest::counter[] = { 1357111317, 888118218888 };
-const uint64_t rngTest::key[] = { 3405692589, 3131965165 };
-const uint64_t rngTest::counter00[] = { 0, 0 };
-const uint64_t rngTest::key00[] = { 0, 0 };
+const int64_t TOASTrngTest::size = 11;
+const uint64_t TOASTrngTest::counter[] = { 1357111317, 888118218888 };
+const uint64_t TOASTrngTest::key[] = { 3405692589, 3131965165 };
+const uint64_t TOASTrngTest::counter00[] = { 0, 0 };
+const uint64_t TOASTrngTest::key00[] = { 0, 0 };
 
 //const double rngTest::array_gaussian[] = { -0.602799, 2.141513, -0.433604, 0.493275, -0.037459, -0.926340, -0.536562, -0.064849, -0.662582, -1.024292, -0.170119 };
 
-const double rngTest::array_m11[] = { -0.951008, 0.112014, -0.391117, 0.858437, -0.232332, -0.929797, 0.513278, -0.722889, -0.439833, 0.814677, 0.466897 };
-const double rngTest::array_01[] = { 0.524496, 0.056007, 0.804442, 0.429218, 0.883834, 0.535102, 0.256639, 0.638556, 0.780084, 0.407338, 0.233448 };
-const uint64_t rngTest::array_uint64[] = { 9675248043493244317ul, 1033143684219887964ul, 14839328367301273822ul, 7917682351778602270ul, 16303863741333868668ul, 9870884412429777903ul, 4734154306332135586ul, 11779270208507399991ul, 14390002533568630569ul, 7514066637753215609ul, 4306362335420736255ul };
+const double TOASTrngTest::array_m11[] = { -0.951008, 0.112014, -0.391117, 0.858437, -0.232332, -0.929797, 0.513278, -0.722889, -0.439833, 0.814677, 0.466897 };
+const double TOASTrngTest::array_01[] = { 0.524496, 0.056007, 0.804442, 0.429218, 0.883834, 0.535102, 0.256639, 0.638556, 0.780084, 0.407338, 0.233448 };
+const uint64_t TOASTrngTest::array_uint64[] = { 9675248043493244317ul, 1033143684219887964ul, 14839328367301273822ul, 7917682351778602270ul, 16303863741333868668ul, 9870884412429777903ul, 4734154306332135586ul, 11779270208507399991ul, 14390002533568630569ul, 7514066637753215609ul, 4306362335420736255ul };
 
 //const double rngTest::array00_gaussian[] = { -0.680004, -0.633214, -1.523790, -1.847484, -0.427139, 0.991348, 0.601200, 0.481707, -0.085967, 0.110980, -1.220734 };
 
-const double rngTest::array00_m11[] = { -0.478794, -0.704256, 0.533997, 0.004571, 0.392376, -0.785938, -0.373569, 0.866371, 0.325575, -0.266422, 0.937621 };
-const double rngTest::array00_01[] = { 0.760603, 0.647872, 0.266998, 0.002285, 0.196188, 0.607031, 0.813215, 0.433185, 0.162788, 0.866789, 0.468810 };
-const uint64_t rngTest::array00_uint64[] = { 14030652003081164901ul, 11951131804325250240ul, 4925249918008276254ul, 42156276261651215ul, 3619028682724454876ul, 11197741606642300638ul, 15001177968947004470ul, 7990859118804543502ul, 3002902877118036975ul, 15989435820833075781ul, 8648023362736035120ul };
+const double TOASTrngTest::array00_m11[] = { -0.478794, -0.704256, 0.533997, 0.004571, 0.392376, -0.785938, -0.373569, 0.866371, 0.325575, -0.266422, 0.937621 };
+const double TOASTrngTest::array00_01[] = { 0.760603, 0.647872, 0.266998, 0.002285, 0.196188, 0.607031, 0.813215, 0.433185, 0.162788, 0.866789, 0.468810 };
+const uint64_t TOASTrngTest::array00_uint64[] = { 14030652003081164901ul, 11951131804325250240ul, 4925249918008276254ul, 42156276261651215ul, 3619028682724454876ul, 11197741606642300638ul, 15001177968947004470ul, 7990859118804543502ul, 3002902877118036975ul, 15989435820833075781ul, 8648023362736035120ul };
 
 const size_t num_threads = 4;
 
-void rngTest::SetUp () {
+void TOASTrngTest::SetUp () {
     return;
 }
 
@@ -67,7 +67,7 @@ void deconstruct(uint64_t** data)
 
 //============================================================================//
 
-TEST_F( rngTest, reprod ) {
+TEST_F( TOASTrngTest, reprod ) {
     double result1[size];
     double result2[size];
 
@@ -81,7 +81,7 @@ TEST_F( rngTest, reprod ) {
 
 //============================================================================//
 
-TEST_F( rngTest, reprod_mt ) {
+TEST_F( TOASTrngTest, reprod_mt ) {
     const size_t nthread = num_threads;
 
     toast::mem::simd_array<double> result1(nthread*size);
@@ -107,7 +107,7 @@ TEST_F( rngTest, reprod_mt ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uniform11 ) {
+TEST_F( TOASTrngTest, uniform11 ) {
     double result[size];
 
     rng::dist_uniform_11 ( size, key[0], key[1], counter[0], counter[1], result );
@@ -125,7 +125,7 @@ TEST_F( rngTest, uniform11 ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uniform11_mt ) {
+TEST_F( TOASTrngTest, uniform11_mt ) {
     const size_t nthread = num_threads;
     toast::mem::simd_array<double> result(nthread*size);
 
@@ -158,7 +158,7 @@ TEST_F( rngTest, uniform11_mt ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uniform01 ) {
+TEST_F( TOASTrngTest, uniform01 ) {
     double result[size];
 
     rng::dist_uniform_01 ( size, key[0], key[1], counter[0], counter[1], result );
@@ -176,7 +176,7 @@ TEST_F( rngTest, uniform01 ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uniform10_mt ) {
+TEST_F( TOASTrngTest, uniform10_mt ) {
     const size_t nthread = num_threads;
     toast::mem::simd_array<double> result(nthread*size);
 
@@ -209,7 +209,7 @@ TEST_F( rngTest, uniform10_mt ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uint64 ) {
+TEST_F( TOASTrngTest, uint64 ) {
     uint64_t result[size];
 
     rng::dist_uint64 ( size, key[0], key[1], counter[0], counter[1], result );
@@ -227,7 +227,7 @@ TEST_F( rngTest, uint64 ) {
 
 //============================================================================//
 
-TEST_F( rngTest, uint64_mt ) {
+TEST_F( TOASTrngTest, uint64_mt ) {
     const size_t nthread = num_threads;
     toast::mem::simd_array<uint64_t> result(nthread*size);
 

--- a/src/libtoast/test/toast_test_runner.cpp
+++ b/src/libtoast/test/toast_test_runner.cpp
@@ -10,6 +10,7 @@ a BSD-style license that can be found in the LICENSE file.
 
 int toast::test::runner ( int argc, char *argv[] ) {
 
+    ::testing::GTEST_FLAG(filter) = std::string("TOAST*");
     ::testing::InitGoogleTest ( &argc, argv );
 
     toast::init ( argc, argv );

--- a/src/libtoast/test/toast_test_sf.cpp
+++ b/src/libtoast/test/toast_test_sf.cpp
@@ -14,10 +14,10 @@ using namespace std;
 using namespace toast;
 
 
-const int sfTest::size = 1000;
+const int TOASTsfTest::size = 1000;
 
 
-void sfTest::SetUp () {
+void TOASTsfTest::SetUp () {
 
     angin = toast::mem::simd_array<double>(size);
     sinout = toast::mem::simd_array<double>(size);
@@ -57,13 +57,13 @@ void sfTest::SetUp () {
 }
 
 
-void sfTest::TearDown () {
+void TOASTsfTest::TearDown () {
 
     return;
 }
 
 
-TEST_F( sfTest, trig ) {
+TEST_F( TOASTsfTest, trig ) {
     double comp1[size];
     double comp2[size];
 
@@ -90,7 +90,7 @@ TEST_F( sfTest, trig ) {
 }
 
 
-TEST_F( sfTest, fasttrig ) {
+TEST_F( TOASTsfTest, fasttrig ) {
     double comp1[size];
     double comp2[size];
 
@@ -117,7 +117,7 @@ TEST_F( sfTest, fasttrig ) {
 }
 
 
-TEST_F( sfTest, sqrtlog ) {
+TEST_F( TOASTsfTest, sqrtlog ) {
     double comp[size];
 
     sf::sqrt ( size, sqin, comp );
@@ -142,7 +142,7 @@ TEST_F( sfTest, sqrtlog ) {
 }
 
 
-TEST_F( sfTest, fast_sqrtlog ) {
+TEST_F( TOASTsfTest, fast_sqrtlog ) {
     double comp[size];
 
     sf::fast_sqrt ( size, sqin, comp );
@@ -167,7 +167,7 @@ TEST_F( sfTest, fast_sqrtlog ) {
 }
 
 
-TEST_F( sfTest, fast_erfinv ) {
+TEST_F( TOASTsfTest, fast_erfinv ) {
     double in[10] = {
         -9.990000e-01,
         -7.770000e-01,

--- a/src/libtoast/test/toast_test_timing.cpp
+++ b/src/libtoast/test/toast_test_timing.cpp
@@ -83,7 +83,7 @@ void time_fibonacci_lv(int32_t n)
 
 //============================================================================//
 
-TEST_F( timingTest, manager )
+TEST_F( TOASTtimingTest, manager )
 {
     timing_manager_t* tman = timing_manager_t::instance();
     tman->clear();

--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -1202,10 +1202,10 @@ lib.ctoast_test_runner.restype = ct.c_int
 lib.ctoast_test_runner.argtypes = [ ct.c_int, pp_c_char ]
 
 def ctest_runner ():
-    argc = len(sys.argv)
-    argv = (p_c_char * (argc + 1))()
+    cargc = len(sys.argv)
+    cargv = (p_c_char * cargc)()
     for i, arg in enumerate(sys.argv):
         enc_arg = arg.encode('utf-8')
-        argv[i] = ct.create_string_buffer(enc_arg)
-    ret = lib.ctoast_test_runner(argc, argv)
+        cargv[i] = ct.create_string_buffer(enc_arg)
+    ret = lib.ctoast_test_runner(cargc, cargv)
     return ret

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -80,7 +80,7 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testpsdmath) )
         suite.addTest( loader.loadTestsFromModule(testintervals) )
         suite.addTest( loader.loadTestsFromModule(testopspmat) )
-        suite.addTest( loader.loadTestsFromModule(testtidas) )
+        #suite.addTest( loader.loadTestsFromModule(testtidas) )
         suite.addTest( loader.loadTestsFromModule(testcov) )
         suite.addTest( loader.loadTestsFromModule(testopsdipole) )
         suite.addTest( loader.loadTestsFromModule(testopssimnoise) )

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -39,7 +39,10 @@ from . import ops_madam as testopsmadam
 from . import map_satellite as testmapsatellite
 from . import map_ground as testmapground
 from . import binned as testbinned
-from . import tidas as testtidas
+
+from ..tod import tidas_available
+if tidas_available:
+    from . import tidas as testtidas
 
 
 def test(name=None):
@@ -80,7 +83,6 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testpsdmath) )
         suite.addTest( loader.loadTestsFromModule(testintervals) )
         suite.addTest( loader.loadTestsFromModule(testopspmat) )
-        #suite.addTest( loader.loadTestsFromModule(testtidas) )
         suite.addTest( loader.loadTestsFromModule(testcov) )
         suite.addTest( loader.loadTestsFromModule(testopsdipole) )
         suite.addTest( loader.loadTestsFromModule(testopssimnoise) )
@@ -92,9 +94,15 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testmapsatellite) )
         suite.addTest( loader.loadTestsFromModule(testmapground) )
         suite.addTest( loader.loadTestsFromModule(testbinned) )
+        if tidas_available:
+            suite.addTest( loader.loadTestsFromModule(testtidas) )
     elif name != "ctoast":
-        modname = "toast.tests.{}".format(name)
-        suite.addTest( loader.loadTestsFromModule(sys.modules[modname]) )
+        if (name == "tidas") and (not tidas_available):
+            print("Cannot run TIDAS tests- package not available")
+            return
+        else:
+            modname = "toast.tests.{}".format(name)
+            suite.addTest( loader.loadTestsFromModule(sys.modules[modname]) )
 
     with warnings.catch_warnings(record=True) as w:
         # Cause all toast warnings to be shown.

--- a/src/python/tests/tidas.py
+++ b/src/python/tests/tidas.py
@@ -19,12 +19,11 @@ from ..dist import *
 
 from .. import qarray as qa
 
-from ..tod import tidas_available
 from ..tod import Interval
 
-if tidas_available:
-    from tidas.mpi_volume import MPIVolume
-    from ..tod import tidas as tt
+# This file will only be imported if TIDAS is already available
+from tidas.mpi_volume import MPIVolume
+from ..tod import tidas as tt
 
 
 class TidasTest(MPITestCase):
@@ -71,10 +70,6 @@ class TidasTest(MPITestCase):
         self.detquats = {}
         for d in self.dets:
             self.detquats[d] = np.array([0,0,0,1], dtype=np.float64)
-
-        # Skip the rest of the setup if we don't have tidas.
-        if not tidas_available:
-            return
 
         # Group schema
         self.schm = tt.create_tidas_schema(self.dets, "float64", "volts")
@@ -367,7 +362,6 @@ class TidasTest(MPITestCase):
         return
 
 
-    @unittest.skipIf(not tidas_available, "TIDAS not found")
     def test_io(self):
         start = MPI.Wtime()
 
@@ -379,7 +373,6 @@ class TidasTest(MPITestCase):
         #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
 
 
-    @unittest.skipIf(not tidas_available, "TIDAS not found")
     def test_export(self):
         start = MPI.Wtime()
 

--- a/src/python/tod/tidas.py
+++ b/src/python/tod/tidas.py
@@ -18,12 +18,13 @@ from ..op import Operator
 from .tod import TOD
 from .interval import Interval
 
-available = True
-try:
-    import tidas as tds
-    from tidas.mpi_volume import MPIVolume
-except:
-    available = False
+available = False
+# available = True
+# try:
+#     import tidas as tds
+#     from tidas.mpi_volume import MPIVolume
+# except:
+#     available = False
 
 
 # Module-level constants


### PR DESCRIPTION
This renames the gtest unit tests so that we can select only the ones in the toast package.  It also disables tidas import until upstream problems are fixed.