### PR TITLE
Always unload altd

### DIFF
--- a/external/tools/modulefile.in
+++ b/external/tools/modulefile.in
@@ -16,9 +16,14 @@ proc ModulesHelp { } {
   puts stderr ""
 }
 
-conflict toastdeps
+conflict toast-deps
 
 @modload@
+
+# altd is evil and causes random job hangs
+if [ is-loaded altd ] {
+  module unload altd
+}
 
 # This is set by OS python and gives us problems.
 unsetenv PYTHONSTARTUP


### PR DESCRIPTION
The Cray altd module causes some jobs to never start.  Always unload it when loading toast-deps.  Small usability updates to the satellite example pipeline.  Closes #153 