### PR TITLE
Add split() method to Data class.

### DIFF
--- a/src/python/dist.py
+++ b/src/python/dist.py
@@ -328,7 +328,9 @@ def distribute_samples(mpicomm, detectors, samples, detranks=1, detbreaks=None, 
 
     """
     if mpicomm.size % detranks != 0:
-        raise RuntimeError("The number of detranks ({}) does not divide evenly into the communicator size ({})".format(detranks, mpicomm.size))
+        raise RuntimeError(
+            "The number of detranks ({}) does not divide evenly "
+            "into the communicator size ({})".format(detranks, mpicomm.size))
 
     # Compute the other dimension of the process grid.
 
@@ -562,6 +564,10 @@ class Data(object):
         all_values = self._comm.comm_world.allgather(values)
         for vals in all_values:
             values = values.union(vals)
+
+        # Order the values alphabetically.
+
+        values = sorted(list(values))
 
         # Split the data
 


### PR DESCRIPTION
This pull request adds a method to the Data class that allows splitting the observations into disjoint data objects based on keywords present in the observation dictionaries.

It is an error to request splitting based on a keyword that is not specified in all of the observations.

The split is based on a superset of key values across the world communicator. Every process will return an equal number of split data objects (even if some are empty) to allow iterating over the data objects in lock-step.