### PR TITLE
Fix the failing PySM unit tests by making the output units an argument.

### DIFF
--- a/src/python/map/pysm.py
+++ b/src/python/map/pysm.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2017-2018 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+
 available = False
 try:
     import pysm
@@ -20,9 +25,11 @@ class PySMSky(object):
             containing the pointing weights to use.
         out (str): accumulate data to the cache with name <out>_<detector>.
             If the named cache objects do not exist, then they are created.
+        units (str): Output units.
     """
     def __init__(self, comm=None, pixels='pixels',
-                 out='pysm', nside=None, pysm_sky_config=None, init_sky=True, local_pixels=None):
+                 out='pysm', nside=None, pysm_sky_config=None, init_sky=True,
+                 local_pixels=None, units='K_CMB'):
         # We call the parent class constructor, which currently does nothing
         super().__init__()
         self._nside = nside
@@ -30,6 +37,7 @@ class PySMSky(object):
         self._out = out
         self._local_pixels = local_pixels
         self._comm = comm
+        self._units = units
 
         self.pysm_sky_config = pysm_sky_config
         self.sky = self.init_sky(self.pysm_sky_config) if init_sky else None
@@ -41,7 +49,8 @@ class PySMSky(object):
         initialized_sky_config = {}
         for name, model_id in pysm_sky_config.items():
             initialized_sky_config[name] = \
-                pysm.nominal.models(model_id, self._nside, self._local_pixels, mpi_comm=self._comm)
+                pysm.nominal.models(model_id, self._nside, self._local_pixels,
+                                    mpi_comm=self._comm)
         return pysm.Sky(initialized_sky_config, mpi_comm=self._comm)
 
     def exec(self, local_map, out, bandpasses=None):
@@ -60,7 +69,7 @@ class PySMSky(object):
             'channels': None,
             'channel_names': list(bandpasses.keys()),
             'add_noise': False,
-            'output_units': 'K_CMB',
+            'output_units': self._units,
             'use_smoothing': False,
             'pixel_indices': self._local_pixels
         }


### PR DESCRIPTION
PySM unit tests were failing because the they expected uK_RJ, not K_CMB. This pull request introduces an extra argument to the PySM operator to specify output units.

Debugging prints from PySM are now optional.

Same basic formatting to the PySM files was applied to conform to PEP-8.