### PR TITLE
Python timers to replace Wtime() usage

### DIFF
--- a/cmake/Modules/GenerateExamples.cmake
+++ b/cmake/Modules/GenerateExamples.cmake
@@ -40,17 +40,18 @@ endfunction(machine_defined)
 #------------------------------------------------------------------------------#
 set(PROBLEM_TYPES ground ground_simple ground_multisite satellite)
 set(PROBLEM_SIZES tiny small medium large representative)
-set(FREQ_tiny           "Nightly")
-set(FREQ_small          "Nightly")
-set(FREQ_medium         "Weekly")
-set(FREQ_representative "Weekly")
-set(FREQ_large          "Monthly")
+set(FREQ_tiny               "Nightly")
+set(FREQ_small              "Nightly")
+set(FREQ_medium             "Weekly")
+set(FREQ_representative     "Weekly")
+set(FREQ_large              "Monthly")
+set(PROJECT_EXAMPLES_DIR    ${CMAKE_BINARY_DIR}/examples)
 
 #------------------------------------------------------------------------------#
 
 message(STATUS "Cleaning up examples directory...")
-execute_process(COMMAND ./cleanup.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+execute_process(COMMAND ${PROJECT_EXAMPLES_DIR}/cleanup.sh
+    WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
     OUTPUT_FILE cleanup.log
     ERROR_FILE cleanup.log
     RESULT_VARIABLE CLEAN_RET)
@@ -59,8 +60,8 @@ check_return(CLEAN_RET)
 #------------------------------------------------------------------------------#
 
 message(STATUS "Fetching data for examples...")
-execute_process(COMMAND ./fetch_data.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+execute_process(COMMAND ${PROJECT_EXAMPLES_DIR}/fetch_data.sh
+    WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
     OUTPUT_FILE fetch_data.log
     ERROR_FILE fetch_data.log
     RESULT_VARIABLE FETCH_RET)
@@ -69,13 +70,13 @@ check_return(FETCH_RET)
 #------------------------------------------------------------------------------#
 
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/ctest-wrapper.sh.in
-    ${CMAKE_BINARY_DIR}/examples/ctest-wrapper.sh @ONLY)
+    ${PROJECT_EXAMPLES_DIR}/ctest-wrapper.sh @ONLY)
 
 #------------------------------------------------------------------------------#
 
 message(STATUS "Generating shell examples...")
-execute_process(COMMAND ./generate_shell.sh
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+execute_process(COMMAND ${PROJECT_EXAMPLES_DIR}/generate_shell.sh
+    WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
     OUTPUT_FILE generate_shell.log
     ERROR_FILE generate_shell.log
     RESULT_VARIABLE GENERATE_SHELL_RET)
@@ -87,16 +88,11 @@ check_return(GENERATE_SHELL_RET)
 foreach(_TYPE ${PROBLEM_TYPES})
     set(_file_name tiny_${_TYPE}_shell)
     set(_test_name pyc_${_file_name}_example)
-    # set the job name
-    if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-        set(SLURM_JOB_NAME --job-name=${_test_name})
-    endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
     # add the test
     add_test(NAME ${_test_name}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
-        COMMAND ${SLURM_COMMAND} ${SLURM_JOB_NAME}
-            ${CMAKE_BINARY_DIR}/examples/ctest-wrapper.sh
-            ${CMAKE_BINARY_DIR}/examples/${_file_name}.sh)
+        WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
+        COMMAND ${PROJECT_EXAMPLES_DIR}/ctest-wrapper.sh
+            ${PROJECT_EXAMPLES_DIR}/${_file_name}.sh)
     # set the properties
     set_tests_properties(${_test_name} PROPERTIES 
         LABELS "Examples;shell;tiny;${_TYPE};EXAMPLE_1_NODE" TIMEOUT 7200)
@@ -120,25 +116,26 @@ set(ENV{MACHINES} "${MACHINE}")
 
 set(PATH_INFO_FILE ctest-path-info.sh)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/${PATH_INFO_FILE}.in
-    ${CMAKE_BINARY_DIR}/examples/${PATH_INFO_FILE} @ONLY)
+    ${PROJECT_EXAMPLES_DIR}/${PATH_INFO_FILE} @ONLY)
 
-FILE(WRITE "${CMAKE_BINARY_DIR}/examples/read.cmake"
+FILE(WRITE "${PROJECT_EXAMPLES_DIR}/read.cmake"
 "
-FILE(READ \"${CMAKE_BINARY_DIR}/examples/${PATH_INFO_FILE}\" _INIT)
+FILE(READ \"${PROJECT_EXAMPLES_DIR}/${PATH_INFO_FILE}\" _INIT)
 set(EXTRA_INIT \"\${_INIT}\" CACHE STRING \"Extra initialization\" FORCE)
 
 ")
 
 set(SRUN_WRAPPER srun-wrapper.sh)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/${SRUN_WRAPPER}
-    ${CMAKE_BINARY_DIR}/examples/${SRUN_WRAPPER} @ONLY)
+    ${PROJECT_EXAMPLES_DIR}/${SRUN_WRAPPER} @ONLY)
 
 #------------------------------------------------------------------------------#
 
 message(STATUS "Generating SLURM examples for ${MACHINE}...")
-execute_process(COMMAND ./generate_slurm.sh -DACCOUNT=${ACCOUNT} -DTIME=${TIME} 
-        -DQUEUE=${QUEUE} -DREADFILE=${CMAKE_BINARY_DIR}/examples/read.cmake
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
+execute_process(COMMAND ${PROJECT_EXAMPLES_DIR}/generate_slurm.sh
+        -DACCOUNT=${ACCOUNT} -DTIME=${TIME} -DQUEUE=${QUEUE}
+        -DREADFILE=${PROJECT_EXAMPLES_DIR}/read.cmake
+    WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
     OUTPUT_FILE generate_slurm.log
     ERROR_FILE generate_slurm.log
     RESULT_VARIABLE GENERATE_SLURM_RET)
@@ -151,17 +148,13 @@ check_return(GENERATE_SLURM_RET)
 foreach(_TYPE ${PROBLEM_TYPES})
     foreach(_SIZE ${PROBLEM_SIZES})
         set(_test_name ${_TYPE}_${_SIZE}_${MACHINE})
-        # set the job name
-        if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-            set(SLURM_JOB_NAME --job-name=${_test_name})
-        endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
         # add the test
         add_test(NAME ${_test_name}
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/examples
-            COMMAND ${CMAKE_BINARY_DIR}/examples/${SRUN_WRAPPER}
-                ${CMAKE_BINARY_DIR}/examples/${_SIZE}_${_TYPE}_${MACHINE}.slurm)
+            WORKING_DIRECTORY ${PROJECT_EXAMPLES_DIR}
+            COMMAND ${PROJECT_EXAMPLES_DIR}/${SRUN_WRAPPER}
+                ${PROJECT_EXAMPLES_DIR}/${_SIZE}_${_TYPE}_${MACHINE}.slurm)
         get_parameter(_NODES
-            "${CMAKE_BINARY_DIR}/examples/templates/params/${_TYPE}.${_SIZE}" NODES)
+            "${PROJECT_EXAMPLES_DIR}/templates/params/${_TYPE}.${_SIZE}" NODES)
         string(REGEX MATCHALL "([0-9]+)" _NODES "${_NODES}")    
         set(_FREQ "${FREQ_${_SIZE}}")
         string(TOLOWER "${_FREQ}" _LFREQ)
@@ -208,6 +201,6 @@ foreach(_N ${NODES_LIST})
         ${CMAKE_BINARY_DIR}/${FILENAME} @ONLY)
     set(QUEUE "${QUEUE_ORIG}")
 endforeach(_N ${NODES_LIST})
-file(WRITE ${CMAKE_BINARY_DIR}/examples/nodes.cmake.out "${_STR}")
+file(WRITE ${PROJECT_EXAMPLES_DIR}/nodes.cmake.out "${_STR}")
 
 #------------------------------------------------------------------------------#

--- a/cmake/Modules/Testing.cmake
+++ b/cmake/Modules/Testing.cmake
@@ -207,19 +207,13 @@ if(NOT DASHBOARD_MODE AND BUILD_TESTING)
 
 endif(NOT DASHBOARD_MODE AND BUILD_TESTING)
 
-
 # ------------------------------------------------------------------------ #
 # -- Configure CTest tests
 # ------------------------------------------------------------------------ #
-find_program(SLURM_SALLOC_COMMAND salloc)
 set(SLURM_COMMAND )
-set(SLURM_COMMAND_RUN )
-set(SLURM_JOB_NAME )
-if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-    convert_time(_TIME ${TIME})
-    set(SLURM_COMMAND ${SLURM_SALLOC_COMMAND} -N 1 -C ${_MACHINE} -A ${ACCOUNT} -p ${QUEUE} -t ${_TIME})
-    set(SLURM_COMMAND_RUN ${SLURM_SRUN_COMMAND})
-endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
+if(USE_SLURM)
+    set(SLURM_COMMAND ${SLURM_SRUN_COMMAND} -n 1)
+endif(USE_SLURM)
 
 # ------------------------------------------------------------------------ #
 # get the python tests
@@ -232,17 +226,12 @@ foreach(_FILE ${_PYTHON_TEST_FILES})
     list(APPEND PYTHON_TEST_FILES "${_FILE_NE}")
 endforeach(_FILE ${_PYTHON_TEST_FILES})
 
-if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-    set(SLURM_JOB_NAME --job-name=cxx_toast_test)
-endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
-
 # ------------------------------------------------------------------------ #
 # add CXX unit test
 add_test(NAME cxx_toast_test
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    COMMAND ${SLURM_COMMAND} ${SLURM_JOB_NAME}
-        ${CMAKE_BINARY_DIR}/ctest-wrapper.sh
-        ${SLURM_COMMAND_RUN} ${CMAKE_BINARY_DIR}/toast_test)
+    COMMAND ${CMAKE_BINARY_DIR}/ctest-wrapper.sh
+        ${SLURM_COMMAND} ${CMAKE_BINARY_DIR}/toast_test)
 # set the properties
 set_tests_properties(cxx_toast_test PROPERTIES
     LABELS "UnitTest;CXX" TIMEOUT 7200)
@@ -254,15 +243,10 @@ foreach(_test_ext ${PYTHON_TEST_FILES})
     set(_test_name pyc_toast_test_${_test_ext})
     configure_file(${CMAKE_SOURCE_DIR}/cmake/Templates/pytestscript.sh.in
         ${CMAKE_BINARY_DIR}/scripts/${_test_name}.sh @ONLY)
-    # set the job name
-    if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-        set(SLURM_JOB_NAME --job-name=${_test_name})
-    endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
     # add the test
     add_test(NAME ${_test_name}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND ${SLURM_COMMAND} ${SLURM_JOB_NAME}
-            ${SLURM_COMMAND_RUN} ${CMAKE_BINARY_DIR}/scripts/${_test_name}.sh)
+        COMMAND ${SLURM_COMMAND} ${CMAKE_BINARY_DIR}/scripts/${_test_name}.sh)
     # set the properties
     set_tests_properties(${_test_name} PROPERTIES
         LABELS "UnitTest;Python" TIMEOUT 7200)
@@ -271,13 +255,10 @@ endforeach(_test_ext ${PYTHON_TEST_FILES})
 # ------------------------------------------------------------------------ #
 # coverage
 if(USE_COVERAGE)
-    if(USE_SLURM AND SLURM_SALLOC_COMMAND)
-        set(SLURM_JOB_NAME --job-name=pyc_coverage)
-    endif(USE_SLURM AND SLURM_SALLOC_COMMAND)
+    # add the test
     add_test(NAME pyc_coverage
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMAND ${SLURM_COMMAND} ${SLURM_JOB_NAME}
-            ${CMAKE_BINARY_DIR}/ctest-wrapper.sh
+        COMMAND ${SLURM_COMMAND} ${CMAKE_BINARY_DIR}/ctest-wrapper.sh
             ${PYTHON_EXECUTABLE}
             ${CMAKE_BINARY_DIR}/pyc_toast_test_coverage.py)
     # set the properties

--- a/cmake/Templates/CDashTest.cmake.in
+++ b/cmake/Templates/CDashTest.cmake.in
@@ -8,7 +8,10 @@ endif(NOT "${DASHBOARD_LABEL}" STREQUAL "")
 include("${CMAKE_CURRENT_LIST_DIR}/Init.cmake")
 
 setup(Test)
-ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}" RETURN_VALUE ret)
+ctest_test(BUILD "${CTEST_BINARY_DIRECTORY}"
+    APPEND
+    SCHEDULE_RANDOM OFF
+    RETURN_VALUE ret)
 submit(Test)
 
 message(" -- Finished ${MODEL} Testing - ${CTEST_BUILD_NAME} --")

--- a/cmake/Templates/srun-wrapper.sh
+++ b/cmake/Templates/srun-wrapper.sh
@@ -44,23 +44,8 @@ do
     else
         chmod a+x ${i}
     fi
-    
-    for j in $(grep '^#SBATCH ' ${i} | sed 's/#SBATCH//g' | sed 's/  / /g')
-    do
-        if [ "${INCLUDE_OUTPUT}" -gt 0 -a ! -z "$(echo $j | grep 'output=')" ]
-        then
-            continue
-        fi
-        if [ ! -z "$(echo ${j} | grep '\--time=')" ]; then
-            TIME=$(convert_time ${j})
-            j="-t ${TIME}"
-        fi
-        SRUN_ARGS="${SRUN_ARGS} ${j}"
-    done
-
-    SRUN_ARGS="$(echo ${SRUN_ARGS} | sed 's/^ //g')"
 done
-
+#------------------------------------------------------------------------------#
 # set environment paths
 export LOG_OUT=/dev/stdout
 export PATH="${PROJECT_BIN_PATH}:@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_BINDIR@:@PATH@"
@@ -73,6 +58,6 @@ else
     export LD_LIBRARY_PATH="${PROJECT_LIB_PATH}:@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@:@LD_LIBRARY_PATH@"
 fi
 
-echo -e "\nRunning \"${SLURM_SALLOC_COMMAND} ${SRUN_ARGS} ${ARGS}\"...\n"
+echo -e "\nRunning \"${ARGS}\"...\n"
 
-${SLURM_SALLOC_COMMAND} ${SRUN_ARGS} ${ARGS}
+eval ${ARGS}

--- a/examples/templates/ground.in
+++ b/examples/templates/ground.in
@@ -126,6 +126,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/ground_multisite.in
+++ b/examples/templates/ground_multisite.in
@@ -144,6 +144,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/ground_multisite_shell.in
+++ b/examples/templates/ground_multisite_shell.in
@@ -104,6 +104,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/ground_shell.in
+++ b/examples/templates/ground_shell.in
@@ -85,6 +85,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/ground_simple.in
+++ b/examples/templates/ground_simple.in
@@ -121,6 +121,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/ground_simple_shell.in
+++ b/examples/templates/ground_simple_shell.in
@@ -81,6 +81,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/satellite.in
+++ b/examples/templates/satellite.in
@@ -110,6 +110,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/satellite_shell.in
+++ b/examples/templates/satellite_shell.in
@@ -80,6 +80,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/vtune_ground.in
+++ b/examples/templates/vtune_ground.in
@@ -125,6 +125,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/vtune_ground_shell.in
+++ b/examples/templates/vtune_ground_shell.in
@@ -83,6 +83,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/vtune_ground_simple.in
+++ b/examples/templates/vtune_ground_simple.in
@@ -120,6 +120,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/vtune_ground_simple_shell.in
+++ b/examples/templates/vtune_ground_simple_shell.in
@@ -79,6 +79,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/examples/templates/vtune_satellite.in
+++ b/examples/templates/vtune_satellite.in
@@ -113,6 +113,8 @@ export OMP_PLACES=threads
 export OMP_PROC_BIND=spread
 export TOAST_NODE_COUNT=${nodes}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 # Set TMPDIR to be on the ramdisk
 export TMPDIR=/dev/shm

--- a/examples/templates/vtune_satellite_shell.in
+++ b/examples/templates/vtune_satellite_shell.in
@@ -80,6 +80,8 @@ fi
 
 export OMP_NUM_THREADS=${threads}
 export TOAST_NUM_THREADS=${OMP_NUM_THREADS}
+echo "OpenMP # threads: ${OMP_NUM_THREADS}"
+echo "TOAST # threads: ${TOAST_NUM_THREADS}"
 
 run="@MPI_RUN@ -n ${procs}"
 

--- a/external/tools/install.in
+++ b/external/tools/install.in
@@ -24,6 +24,7 @@ fi
 popd > /dev/null
 
 export TOAST_AUX_ROOT=@AUX_PREFIX@
+export CMAKE_PREFIX_PATH=@AUX_PREFIX@:${CMAKE_PREFIX_PATH}
 export PATH=@AUX_PREFIX@/bin:@CONDA_PREFIX@/bin:${PATH}
 export CPATH=@AUX_PREFIX@/include:${CPATH}
 export LIBRARY_PATH=@AUX_PREFIX@/lib:${LIBRARY_PATH}

--- a/external/tools/modulefile.in
+++ b/external/tools/modulefile.in
@@ -39,6 +39,7 @@ setenv PYTHONPATH "@CONDA_PREFIX@/lib/python@PYVERSION@/site-packages"
 
 # This is the location of the extra compiled software
 setenv TOAST_AUX_ROOT "@AUX_PREFIX@"
+prepend-path CMAKE_PREFIX_PATH "@AUX_PREFIX@"
 prepend-path PATH "@AUX_PREFIX@/bin"
 prepend-path CPATH "@AUX_PREFIX@/include"
 prepend-path LD_LIBRARY_PATH "@AUX_PREFIX@/lib"

--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -1338,7 +1338,8 @@ def main():
         print('Running with {} processes at {}'.format(
             comm.comm_world.size, str(datetime.now())), flush=True)
 
-    global_start = MPI.Wtime()
+    global_timer = timing.simple_timer("Total time")
+    global_timer.start()
 
     args, comm = parse_arguments(comm)
 
@@ -1461,10 +1462,9 @@ def main():
     counter.exec(data)
 
     comm.comm_world.barrier()
-    stop = MPI.Wtime()
-    elapsed = stop - global_start
+    global_timer.stop()
     if comm.comm_world.rank == 0:
-        print('Total Time:  {:.2f} seconds'.format(elapsed), flush=True)
+        global_timer.report()
 
 
 if __name__ == '__main__':

--- a/pipelines/toast_ground_sim_simple.py
+++ b/pipelines/toast_ground_sim_simple.py
@@ -1108,7 +1108,8 @@ def main():
         print('Running with {} processes at {}'.format(
             comm.comm_world.size, str(datetime.now())), flush=True)
 
-    global_start = MPI.Wtime()
+    global_timer = timing.simple_timer('Total time')
+    global_timer.start()
 
     args, comm = parse_arguments(comm)
 
@@ -1188,10 +1189,9 @@ def main():
                 signalname_madam, flag_name, common_flag_name)
 
     comm.comm_world.barrier()
-    stop = MPI.Wtime()
-    elapsed = stop - global_start
+    global_timer.stop()
     if comm.comm_world.rank == 0:
-        print('Total Time:  {:.2f} seconds'.format(elapsed), flush=True)
+        global_timer.report()
 
 if __name__ == '__main__':
     try:

--- a/src/libtoast/capi/ctoast.cpp
+++ b/src/libtoast/capi/ctoast.cpp
@@ -57,6 +57,31 @@ void ctoast_timers_toggle(int32_t val)
 }
 
 //----------------------------------------------------------------------------//
+ctoast_timer* ctoast_get_simple_timer(char* ckey, char* _cfmt)
+{
+#if defined(DISABLE_TIMERS)
+    return nullptr;
+#endif
+    std::string cfmt = const_cast<const char*>(_cfmt);
+    std::string fmt = (cfmt.empty())
+                      ? toast::util::timer::default_format
+                      : cfmt;
+    toast_timer_t* _t = new toast_timer_t(ckey, "", fmt);
+    return reinterpret_cast<ctoast_timer*>(_t);
+}
+
+//----------------------------------------------------------------------------//
+
+void ctoast_del_simple_timer(ctoast_timer* _ct)
+{
+#if defined(DISABLE_TIMERS)
+    return;
+#endif
+    toast_timer_t* _t = reinterpret_cast<toast_timer_t*>(_ct);
+    delete _t;
+}
+
+//----------------------------------------------------------------------------//
 
 ctoast_timer* ctoast_get_timer(char* ckey)
 {

--- a/src/libtoast/capi/ctoast.h
+++ b/src/libtoast/capi/ctoast.h
@@ -35,6 +35,9 @@ typedef struct ctoast_timer_ ctoast_timer;
 struct ctoast_timing_manager_;
 typedef struct ctoast_timing_manger_ ctoast_timing_manager;
 
+ctoast_timer* ctoast_get_simple_timer(char* ckey, char* cfmt);
+void ctoast_del_simple_timer(ctoast_timer*);
+
 int ctoast_timers_enabled();
 void ctoast_timers_toggle(int32_t val);
 ctoast_timer* ctoast_get_timer(char* ckey);

--- a/src/libtoast/map/toast_cov.cpp
+++ b/src/libtoast/map/toast_cov.cpp
@@ -78,7 +78,6 @@ void toast::cov::accumulate_diagonal ( int64_t nsub, int64_t subsize, int64_t nn
     int64_t const * indx_submap, int64_t const * indx_pix, double const * weights, 
     double scale, double const * signal, double * zdata, int64_t * hits, double * invnpp ) {
 
-    TOAST_AUTO_TIMER();
 
     #pragma omp parallel default(shared)
     {
@@ -156,7 +155,6 @@ void toast::cov::accumulate_diagonal ( int64_t nsub, int64_t subsize, int64_t nn
 void toast::cov::accumulate_diagonal_hits ( int64_t nsub, int64_t subsize, int64_t nnz, int64_t nsamp, 
     int64_t const * indx_submap, int64_t const * indx_pix, int64_t * hits ) {
 
-    TOAST_AUTO_TIMER();
 
     #pragma omp parallel default(shared)
     {
@@ -240,7 +238,6 @@ void toast::cov::accumulate_diagonal_invnpp ( int64_t nsub, int64_t subsize, int
     int64_t const * indx_submap, int64_t const * indx_pix, double const * weights, 
     double scale, int64_t * hits, double * invnpp ) {
 
-    TOAST_AUTO_TIMER();
 
     #pragma omp parallel default(shared)
     {
@@ -328,7 +325,6 @@ void toast::cov::accumulate_zmap ( int64_t nsub, int64_t subsize, int64_t nnz, i
     int64_t const * indx_submap, int64_t const * indx_pix, double const * weights, 
     double scale, double const * signal, double * zdata ) {
 
-    TOAST_AUTO_TIMER();
 
     #pragma omp parallel default(shared)
     {
@@ -363,7 +359,6 @@ void toast::cov::accumulate_zmap ( int64_t nsub, int64_t subsize, int64_t nnz, i
 void toast::cov::eigendecompose_diagonal ( int64_t nsub, int64_t subsize, int64_t nnz,
     double * data, double * cond, double threshold, int32_t do_invert, int32_t do_rcond ) {
 
-    TOAST_AUTO_TIMER();
 
     if ( ( do_invert == 0 ) && ( do_rcond == 0 ) ) {
         return;
@@ -550,7 +545,6 @@ void toast::cov::eigendecompose_diagonal ( int64_t nsub, int64_t subsize, int64_
 void toast::cov::multiply_diagonal ( int64_t nsub, int64_t subsize, int64_t nnz,
     double * data1, double const * data2 ) {
 
-    TOAST_AUTO_TIMER();
 
     int64_t i, j, k;
     int64_t block = (int64_t)(nnz * (nnz+1) / 2);
@@ -640,7 +634,6 @@ void toast::cov::multiply_diagonal ( int64_t nsub, int64_t subsize, int64_t nnz,
 void toast::cov::apply_diagonal ( int64_t nsub, int64_t subsize, int64_t nnz,
     double const * mat, double * vec ) {
 
-    TOAST_AUTO_TIMER();
 
     int64_t i, j, k;
     int64_t block = (int64_t)(nnz * (nnz+1) / 2);

--- a/src/libtoast/math/toast_fft.cpp
+++ b/src/libtoast/math/toast_fft.cpp
@@ -41,7 +41,6 @@ class r1d_fftw : public toast::fft::r1d {
             toast::fft::direction dir, double scale ) : 
             toast::fft::r1d ( length, n, type, dir, scale ) {
 
-            TOAST_AUTO_TIMER();
 
             int threads = 1;
 
@@ -114,7 +113,6 @@ class r1d_fftw : public toast::fft::r1d {
 
         void exec ( ) {
 
-            TOAST_AUTO_TIMER("@r1d_fftw");
 
             fftw_execute ( plan_ );
 

--- a/src/libtoast/math/toast_rng.cpp
+++ b/src/libtoast/math/toast_rng.cpp
@@ -45,7 +45,6 @@ void toast::rng::dist_uint64 ( size_t n,
                                uint64_t key1, uint64_t key2,
                                uint64_t counter1, uint64_t counter2,
                                uint64_t* data, size_t beg) {    
-    TOAST_AUTO_TIMER();
 
     RNG rng;
     RNG::ukey_type uk = {{ key1, key2 }};
@@ -115,7 +114,6 @@ void toast::rng::dist_uniform_01 ( size_t n,
         return;
 #endif
   */
-    TOAST_AUTO_TIMER();
 
     RNG rng;
     RNG::ukey_type uk = {{ key1, key2 }};
@@ -138,7 +136,6 @@ void toast::rng::dist_uniform_11 ( size_t n,
                                    uint64_t key1, uint64_t key2,
                                    uint64_t counter1, uint64_t counter2,
                                    double * data, size_t beg ) {
-    TOAST_AUTO_TIMER();
 
     RNG rng;
     RNG::ukey_type uk = {{ key1, key2 }};
@@ -161,7 +158,6 @@ void toast::rng::dist_normal ( size_t n,
                                uint64_t key1, uint64_t key2,
                                uint64_t counter1, uint64_t counter2,
                                double * data, size_t beg ) {
-    TOAST_AUTO_TIMER();
 
     // first compute uniform randoms on [0.0, 1.0)
 
@@ -226,7 +222,6 @@ void toast::rng::mt::dist_uint64 ( size_t blocks,      size_t n,
                                    uint64_t* counter1, uint64_t* counter2,
                                    uint64_t* data )
 {
-    TOAST_AUTO_TIMER();
     // call dist_uint64 in parallel
     dist_mt(toast::rng::dist_uint64,
             blocks, n, key1, key2, counter1, counter2, data);
@@ -240,7 +235,6 @@ void toast::rng::mt::dist_uniform_01 ( size_t blocks,      size_t n,
                                        uint64_t* counter1, uint64_t* counter2,
                                        double* data )
 {
-    TOAST_AUTO_TIMER();
     // call dist_uniform_01 in parallel
     dist_mt(toast::rng::dist_uniform_01,
             blocks, n, key1, key2, counter1, counter2, data);
@@ -254,7 +248,6 @@ void toast::rng::mt::dist_uniform_11 ( size_t blocks,      size_t n,
                                        uint64_t* counter1, uint64_t* counter2,
                                        double* data )
 {
-    TOAST_AUTO_TIMER();
     // call dist_uniform_11 in parallel
     dist_mt(toast::rng::dist_uniform_11,
             blocks, n, key1, key2, counter1, counter2, data);
@@ -267,7 +260,6 @@ void toast::rng::mt::dist_normal ( size_t blocks,      size_t n,
                                    uint64_t* counter1, uint64_t* counter2,
                                    double* data )
 {
-    TOAST_AUTO_TIMER();
     // call dist_normal in parallel
     dist_mt(toast::rng::dist_normal,
             blocks, n, key1, key2, counter1, counter2, data);

--- a/src/libtoast/toast.hpp
+++ b/src/libtoast/toast.hpp
@@ -61,7 +61,7 @@ namespace toast
         static thread_local uint32_t nthread = 0;
         if(nthread == 0)
             nthread = util::get_env<uint32_t>("TOAST_NUM_THREADS",
-                                              std::thread::hardware_concurrency());
+                                        std::thread::hardware_concurrency());
         return nthread;
     }
 

--- a/src/libtoast/util/toast/base_timer.hpp
+++ b/src/libtoast/util/toast/base_timer.hpp
@@ -122,7 +122,9 @@ public:
 
     template <int N> uint64_t get_sum() const { return std::get<N>(m_sum); }
     template <int N> uint64_t get_sqr() const { return std::get<N>(m_sqr); }
+    uint64_t size() const { return m_lap; }
 
+protected:
     template <int N> uint64_t compute(const op_type& data)
     {
         auto _ts = get_start<N>(data);
@@ -145,8 +147,6 @@ public:
         std::get<1>(m_sum) += std::pow(std::get<1>(rhs), 2);
         std::get<2>(m_sum) += std::pow(std::get<2>(rhs), 2);
     }
-
-    uint64_t size() const { return m_lap; }
 
 protected:
     uint_type m_lap;
@@ -248,10 +248,6 @@ private:
     static thread_local data_map_t* f_data_map;
     static mutex_map_t              w_mutex_map;
 
-protected:
-    //template <int N> uint64_t get_min() const { return m_accum.get_min<N>(); }
-    //template <int N> uint64_t get_max() const { return m_accum.get_max<N>(); }
-
 public:
     template <typename Archive> void
     serialize(Archive& ar, const unsigned int /*version*/)
@@ -260,18 +256,12 @@ public:
            // user clock elapsed
            cereal::make_nvp("user_elapsed",     m_accum.get_sum<0>()),
            //cereal::make_nvp("user_elapsed_sqr", m_accum.get_sqr<0>()),
-           //cereal::make_nvp("user_elapsed_min", m_accum.get_min<0>()),
-           //cereal::make_nvp("user_elapsed_max", m_accum.get_max<0>()),
            // system clock elapsed
            cereal::make_nvp("system_elapsed",      m_accum.get_sum<1>()),
            //cereal::make_nvp("system_elapsed_sqr",  m_accum.get_sqr<1>()),
-           //cereal::make_nvp("system_elapsed_min",  m_accum.get_min<1>()),
-           //cereal::make_nvp("system_elapsed_max",  m_accum.get_max<1>()),
            // wall clock elapsed
            cereal::make_nvp("wall_elapsed",     m_accum.get_sum<2>()),
            //cereal::make_nvp("wall_elapsed_sqr", m_accum.get_sqr<2>()),
-           //cereal::make_nvp("wall_elapsed_min", m_accum.get_min<2>()),
-           //cereal::make_nvp("wall_elapsed_max", m_accum.get_max<2>()),
            // cpu elapsed
            cereal::make_nvp("cpu_elapsed",
                             m_accum.get_sum<0>() + m_accum.get_sum<1>()),

--- a/src/libtoast/util/toast/timer.hpp
+++ b/src/libtoast/util/toast/timer.hpp
@@ -51,31 +51,37 @@ class timer : public details::base_timer
 public:
     typedef base_timer                      base_type;
     typedef timer                           this_type;
-    typedef std::string                     str_t;
+    typedef std::string                     string_t;
 
 public:
-    timer(uint16_t prec = 3,
-          std::string begin = "[ ",
-          std::string close = " ]");
-    timer(std::string, std::string close = "");
+    timer(const string_t& _begin = "[ ",
+          const string_t& _close = " ]",
+          bool _use_static_width = true,
+          uint16_t prec = default_precision);
+    timer(const string_t& _begin,
+          const string_t& _close,
+          const string_t& _fmt,
+          bool _use_static_width = false,
+          uint16_t prec = default_precision);
     virtual ~timer();
 
 public:
-    static std::string default_format;
+    static string_t default_format;
     static uint16_t default_precision;
     static void propose_output_width(uint64_t);
 
 public:
     timer& stop_and_return() { this->stop(); return *this; }
-    str_t begin() const { return m_begin; }
-    str_t close() const { return m_close; }
+    string_t begin() const { return m_begin; }
+    string_t close() const { return m_close; }
 
 protected:
     virtual void compose() final;
 
 protected:
-    str_t m_begin;
-    str_t m_close;
+    bool     m_use_static_width;
+    string_t m_begin;
+    string_t m_close;
 
 private:
     static thread_local uint64_t f_output_width;

--- a/src/libtoast/util/toast/timing_manager.hpp
+++ b/src/libtoast/util/toast/timing_manager.hpp
@@ -144,7 +144,7 @@ public:
     typedef uomap<uint64_t, toast_timer_t>  timer_map_t;
     typedef toast_timer_t::ostream_t        ostream_t;
     typedef toast_timer_t::ofstream_t       ofstream_t;
-    typedef toast::clock_type               clock_type;
+    typedef toast::timer_field              timer_field;
     typedef std::tuple<MPI_Comm, int32_t>   comm_group_t;
 
 public:

--- a/src/libtoast/util/toast_timing_manager.cpp
+++ b/src/libtoast/util/toast_timing_manager.cpp
@@ -299,12 +299,17 @@ toast::util::timer& toast::util::timing_manager::timer(const string_t& key,
 
     // indent
     for(int64_t i = 0; i < ncount; ++i)
-        ss << "| ";
+    {
+        if(i+1 == ncount || i == 0)
+            ss << "|_";
+        else
+            ss << "|_";
+    }
 
     ss << std::left << key;
     toast::util::timer::propose_output_width(ss.str().length());
 
-    m_timer_map[ref] = toast_timer_t(3, ss.str(), string_t(""));
+    m_timer_map[ref] = toast_timer_t(ss.str(), string_t(""), true, 3);
 
     std::stringstream tag_ss;
     tag_ss << tag << "_" << std::left << key;
@@ -318,6 +323,14 @@ toast::util::timer& toast::util::timing_manager::timer(const string_t& key,
 
 void toast::util::timing_manager::report() const
 {
+    if(mpi_rank() == 0)
+    {
+        std::stringstream _info;
+        _info << "[" << mpi_rank() << "] Reporting timing output..."
+              << std::endl;
+        std::cout << _info.str();
+    }
+
     for(int32_t i = 0; i < mpi_size(); ++i)
     {
         // blocking

--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -86,6 +86,19 @@ lib.ctoast_timers_toggle.argtypes = [ ct.c_int ]
 def timers_toggle(on_or_off):
     lib.ctoast_timers_toggle(on_or_off)
 
+lib.ctoast_get_simple_timer.restype = ct.POINTER(cTimer)
+lib.ctoast_get_simple_timer.argtypes = [ p_c_char, p_c_char ]
+
+def get_simple_timer(prefix, fmt = ""):
+    return lib.ctoast_get_simple_timer(convert_to_p_c_char(prefix),
+                                       convert_to_p_c_char(fmt));
+
+lib.ctoast_del_simple_timer.restype = None
+lib.ctoast_del_simple_timer.argtypes = [ ct.POINTER(cTimer) ]
+
+def delete_simple_timer(_ct):
+    lib.ctoast_del_simple_timer(_ct)
+
 lib.ctoast_get_timer.restype = ct.POINTER(cTimer)
 lib.ctoast_get_timer.argtypes = [ p_c_char ]
 

--- a/src/python/timing.py
+++ b/src/python/timing.py
@@ -78,6 +78,48 @@ def ensure_directory_exists(file_path):
 
 
 #------------------------------------------------------------------------------#
+class simple_timer(object):
+    """Class that provides simple interface to C++ toast::util::timer"""
+
+    def __init__(self, key=None, obj=None):
+        if obj is not None:
+            self._ctimer = obj
+        else:
+            self._ctimer = ctoast.get_simple_timer(key)
+
+    def __del__(self):
+        if self._ctimer is not None:
+            ctoast.delete_simple_timer(self._ctimer)
+
+    def start(self):
+        if self._ctimer is not None:
+            ctoast.timer_start(self._ctimer)
+
+    def stop(self):
+        if self._ctimer is not None:
+            ctoast.timer_stop(self._ctimer)
+
+    def report(self):
+        if self._ctimer is not None:
+            ctoast.timer_report(self._ctimer)
+
+    def real_elapsed(self):
+        if self._ctimer is not None:
+            return ctoast.timer_real_elapsed(self._ctimer)
+        return 0.0
+
+    def system_elapsed(self):
+        if self._ctimer is not None:
+            return ctoast.timer_system_elapsed(self._ctimer)
+        return 0.0
+
+    def user_elapsed(self):
+        if self._ctimer is not None:
+            return ctoast.timer_user_elapsed(self._ctimer)
+        return 0.0
+
+
+#------------------------------------------------------------------------------#
 class timer(object):
     """Class that provides interface to C++ toast::util::timer"""
 


### PR DESCRIPTION
- Added timing.simple_timer class to python. These timers are not added to timing_manager
- Stripped TOAST_AUTO_TIMER() from most C++ classes
- Improved format of timers to handle RSS
- Reduced memory overhead of base_timer