### PR TITLE
Faster initialization

### DIFF
--- a/pipelines/toast_ground_schedule.py
+++ b/pipelines/toast_ground_schedule.py
@@ -53,6 +53,8 @@ def prioritize(visible, hits):
 
 def corner_coordinates(observer, corners):
     """ Return the corner coordinates in horizontal frame.
+
+    PyEphem measures the azimuth East (clockwise) from North.
     """
     azs = []
     els = []

--- a/src/libtoast/atm/toast_atm.cpp
+++ b/src/libtoast/atm/toast_atm.cpp
@@ -787,7 +787,7 @@ int toast::tatm::sim::observe( double *t, double *az, double *el, double *tod,
             zz = r * sin_el;
             double rproj = r * cos_el;
             double xx = rproj * cos_az;
-            double yy = -rproj * sin_az;
+            double yy = rproj * sin_az;
 
             // Rotate to scan frame
 

--- a/src/python/tod/sim_det_atm.py
+++ b/src/python/tod/sim_det_atm.py
@@ -465,7 +465,8 @@ class OpSimAtmosphere(Operator):
                     # angles for the simulation.
 
                     theta, phi, pa = qa.to_angles(azelquat)
-                    az = phi
+                    # Azimuth is measured in the opposite direction than longitude
+                    az = 2*np.pi - phi
                     el = np.pi/2 - theta
 
                     if np.ptp(az) < np.pi:

--- a/src/python/tod/sim_tod.py
+++ b/src/python/tod/sim_tod.py
@@ -1008,20 +1008,20 @@ class TODGround(TOD):
         # Strictly speaking, two coordinate axes would suffice but the
         # math is cleaner with three axes.
         try:
-            xra, xdec = self._observer.radec_of(      0,       0, fixed=False)
-            yra, ydec = self._observer.radec_of(np.pi/2,       0, fixed=False)
-            zra, zdec = self._observer.radec_of(np.pi/2, np.pi/2, fixed=False)
+            xra, xdec = self._observer.radec_of(   np.pi,       0, fixed=False)
+            yra, ydec = self._observer.radec_of( np.pi/2,       0, fixed=False)
+            zra, zdec = self._observer.radec_of(       0, np.pi/2, fixed=False)
         except:
             # Modified pyephem not available.
             # We will have sub arc minute errors.
-            xra, xdec = self._observer.radec_of(      0,       0)
-            yra, ydec = self._observer.radec_of(np.pi/2,       0)
-            zra, zdec = self._observer.radec_of(np.pi/2, np.pi/2)
+            xra, xdec = self._observer.radec_of(   np.pi,       0)
+            yra, ydec = self._observer.radec_of( np.pi/2,       0)
+            zra, zdec = self._observer.radec_of(       0, np.pi/2)
         self._observer.pressure = pressure
-        # RA  = -phi
+        # RA  = phi
         # Dec = pi/2 - theta
         xvec, yvec, zvec = ang2vec(np.pi/2-np.array([xdec, ydec, zdec]),
-                                   -np.array([xra, yra, zra]))
+                                   np.array([xra, yra, zra]))
         # Solve for the quaternions from the transformed axes.
         X = (xvec[1] + yvec[0]) / 4
         Y = (xvec[2] + zvec[0]) / 4
@@ -1032,7 +1032,6 @@ class TODGround(TOD):
         a = (xvec[1]/2 - b*c) / d
         # qarray has the scalar part as the last index
         quat = np.array([b, c, d, a])
-
         return quat
 
     def free_azel_quats(self):


### PR DESCRIPTION
- Speed up the ground TOD initialization by explicitly measuring the time-dependent coordinate transformation quaternions between horizontal and equatorial frames.
- Fix error in interpreting the azimuth angle. It is measured in the opposite direction than usual longitude.