### PR TITLE
install libsharp from official repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ before_install:
     - conda install -c conda-forge numpy scipy matplotlib healpy pyephem pip cython
     - pip install mpi4py
     # Install libsharp C
-    - git clone https://github.com/zonca/libsharp --branch almxfl --single-branch --depth 1
+    - git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1
     - cd libsharp
     - autoreconf
     - ./configure --enable-mpi --enable-pic

--- a/external/rules/libsharp.sh
+++ b/external/rules/libsharp.sh
@@ -1,4 +1,4 @@
-git clone https://github.com/zonca/libsharp --branch almxfl --single-branch --depth 1 \
+git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1 \
     && cd libsharp \
     && patch -p1 < ../rules/patch_libsharp \
     && autoreconf \


### PR DESCRIPTION
Contributed back my changes to the `libsharp` official repo in https://github.com/Libsharp/libsharp/pull/15.
We can now install from there.