### PR TITLE
Toast planck edits

### DIFF
--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -1118,10 +1118,9 @@ def sim_noise_sim_noise_timestream(
     noise = np.zeros(samples, dtype=np.float64)
 
     lib.ctoast_sim_noise_sim_noise_timestream(
-        realization, telescope, component,
-        obsindx, detindx, rate,
-        firstsamp, samples, oversample,
-        freq, psd, psd.size, noise)
+        realization, telescope, component, obsindx, detindx, rate, firstsamp,
+        samples, oversample, freq.astype(np.float64), psd.astype(np.float64),
+        psd.size, noise)
 
     return noise
 

--- a/src/python/tod/tod.py
+++ b/src/python/tod/tod.py
@@ -191,7 +191,7 @@ class TOD(object):
         """
         return self._dist_sizes[self._rank_samp]
 
-    def local_times(self, name=None):
+    def local_times(self, name=None, **kwargs):
         """ Timestamps covering locally stored data.
 
         Args:
@@ -199,20 +199,20 @@ class TOD(object):
         Returns:
             A cache reference to a timestamp vector.  If 'name' is None
             a default name 'timestamps' is used and the vector may be
-            constructed and cached using the 'read_timess' method.
+            constructed and cached using the 'read_times' method.
             If 'name' is given, then the times must already be cached.
 
         """
         if name is None:
             cachename = 'timestamps'
             if not self.cache.exists(cachename):
-                times = self.read_times()
+                times = self.read_times(**kwargs)
                 self.cache.put(cachename, times)
         else:
             cachename = name
         return self.cache.reference(cachename)
 
-    def local_signal(self, det, name=None):
+    def local_signal(self, det, name=None, **kwargs):
         """ Locally stored signal.
 
         Args:
@@ -228,13 +228,13 @@ class TOD(object):
         if name is None:
             cachename = 'signal_{}'.format(det)
             if not self.cache.exists(cachename):
-                signal = self.read(detector=det)
+                signal = self.read(detector=det, **kwargs)
                 self.cache.put(cachename, signal)
         else:
             cachename = '{}_{}'.format(name, det)
         return self.cache.reference(cachename)
 
-    def local_pointing(self, det, name=None):
+    def local_pointing(self, det, name=None, **kwargs):
         """ Locally stored pointing.
 
         Args:
@@ -250,13 +250,13 @@ class TOD(object):
         if name is None:
             cachename = 'quat_{}'.format(det)
             if not self.cache.exists(cachename):
-                quats = self.read_pntg(detector=det)
+                quats = self.read_pntg(detector=det, **kwargs)
                 self.cache.put(cachename, quats)
         else:
             cachename = '{}_{}'.format(name, det)
         return self.cache.reference(cachename)
 
-    def local_position(self, name=None):
+    def local_position(self, name=None, **kwargs):
         """ Locally stored position.
 
         Args:
@@ -271,13 +271,13 @@ class TOD(object):
         if name is None:
             cachename = 'position'
             if not self.cache.exists(cachename):
-                pos = self.read_position()
+                pos = self.read_position(**kwargs)
                 self.cache.put(cachename, pos)
         else:
             cachename = name
         return self.cache.reference(cachename)
 
-    def local_velocity(self, name=None):
+    def local_velocity(self, name=None, **kwargs):
         """ Locally stored velocity.
 
         Args:
@@ -292,13 +292,13 @@ class TOD(object):
         if name is None:
             cachename = 'velocity'
             if not self.cache.exists(cachename):
-                vel = self.read_velocity()
+                vel = self.read_velocity(**kwargs)
                 self.cache.put(cachename, vel)
         else:
             cachename = name
         return self.cache.reference(cachename)
 
-    def local_flags(self, det, name=None):
+    def local_flags(self, det, name=None, **kwargs):
         """ Locally stored flags.
 
         Args:
@@ -314,13 +314,13 @@ class TOD(object):
         if name is None:
             cachename = 'flags_{}'.format(det)
             if not self.cache.exists(cachename):
-                flags = self.read_flags(detector=det)
+                flags = self.read_flags(detector=det, **kwargs)
                 self.cache.put(cachename, flags)
         else:
             cachename = '{}_{}'.format(name, det)
         return self.cache.reference(cachename)
 
-    def local_common_flags(self, name=None):
+    def local_common_flags(self, name=None, **kwargs):
         """ Locally stored common flags.
 
         Args:
@@ -335,7 +335,7 @@ class TOD(object):
         if name is None:
             cachename = 'common_flags'
             if not self.cache.exists(cachename):
-                common_flags = self.read_common_flags()
+                common_flags = self.read_common_flags(**kwargs)
                 self.cache.put(cachename, common_flags)
         else:
             cachename = name

--- a/src/python/tod/tod.py
+++ b/src/python/tod/tod.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2018 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -14,6 +14,15 @@ from .. import timing as timing
 from .interval import Interval
 
 class TOD(object):
+
+    TIMESTAMP_NAME = 'timestamps'
+    COMMON_FLAG_NAME = 'common_flags'
+    VELOCITY_NAME = 'velocity'
+    POSITION_NAME = 'position'
+    SIGNAL_NAME = 'signal'
+    FLAG_NAME = 'flags'
+    POINTING_NAME = 'quat'
+
     """
     Base class for an object that provides detector pointing and
     timestreams for a single observation.
@@ -204,7 +213,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'timestamps'
+            cachename = self.TIMESTAMP_NAME
             if not self.cache.exists(cachename):
                 times = self.read_times(**kwargs)
                 self.cache.put(cachename, times)
@@ -226,7 +235,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'signal_{}'.format(det)
+            cachename = '{}_{}'.format(self.SIGNAL_NAME, det)
             if not self.cache.exists(cachename):
                 signal = self.read(detector=det, **kwargs)
                 self.cache.put(cachename, signal)
@@ -248,7 +257,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'quat_{}'.format(det)
+            cachename = '{}_{}'.format(self.POINTING_NAME, det)
             if not self.cache.exists(cachename):
                 quats = self.read_pntg(detector=det, **kwargs)
                 self.cache.put(cachename, quats)
@@ -263,13 +272,13 @@ class TOD(object):
             name (str):  Optional cache key to use.
         Returns:
             A cache reference to a position array.  If 'name' is None
-            a default name 'positino' is used and the array may be
+            a default name 'position' is used and the array may be
             constructed and cached using the 'read_position' method.
             If 'name' is given, then the position must already be cached.
 
         """
         if name is None:
-            cachename = 'position'
+            cachename = self.POSITION_NAME
             if not self.cache.exists(cachename):
                 pos = self.read_position(**kwargs)
                 self.cache.put(cachename, pos)
@@ -290,7 +299,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'velocity'
+            cachename = self.VELOCITY_NAME
             if not self.cache.exists(cachename):
                 vel = self.read_velocity(**kwargs)
                 self.cache.put(cachename, vel)
@@ -312,7 +321,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'flags_{}'.format(det)
+            cachename = '{}_{}'.format(self.FLAG_NAME, det)
             if not self.cache.exists(cachename):
                 flags = self.read_flags(detector=det, **kwargs)
                 self.cache.put(cachename, flags)
@@ -333,7 +342,7 @@ class TOD(object):
 
         """
         if name is None:
-            cachename = 'common_flags'
+            cachename = self.COMMON_FLAG_NAME
             if not self.cache.exists(cachename):
                 common_flags = self.read_common_flags(**kwargs)
                 self.cache.put(cachename, common_flags)


### PR DESCRIPTION
Toast Planck requires the ability to pass keyword arguments through the `tod` class. This pull request adds the missing `**kwargs` arguments to the new `local` methods. It also encodes default cache names for the usual TOD vectors into the `tod` object.