### PR TITLE
Improve the built-in focalplane simulation helper functions

### DIFF
--- a/external/static/install_ubuntu_17.10.sh
+++ b/external/static/install_ubuntu_17.10.sh
@@ -1,0 +1,259 @@
+#!/bin/bash
+
+# WARNING:  If you upgrade versions of python3 (i.e. 3.6 --> 3.7) you will
+# need to rerun this install.
+
+# NOTE:  This script expects to be located in the toast/external/static
+# directory, so that it can find patch files at the relative location.  You
+# can run the script in some other working directory, but leave this file
+# in place.  For example:
+#
+# $>  cd workdir
+# $>  /path/to/toast/external/static/install_ubuntu_16.04.sh | tee log
+#
+
+# ---------------------- Install options ------------------------
+
+# Set this to the install prefix for compiled dependencies.  If only the root
+# user can write to this directory, then you will have to run this script with
+# "sudo".
+PREFIX=/home/kisner/software/toastdeps
+
+# Set this to the unix group that should own the final installed software.
+# If empty, it will not be changed.
+CHGRP=""
+
+# Set this to the permissions string that should be used on the final installed
+# software.  If empty, it will not be changed.  This default ensures that no
+# one can change the installed files without first restoring write permission.
+CHMOD=""
+
+
+# ------------- Install dependencies provided by the OS. ---------------
+#
+# Use APT to get everything we can.  Alternatively, you could provide the
+# python packages here by installing Anaconda.
+#
+
+sudo apt-get update
+
+sudo apt-get install -y curl procps build-essential gfortran git subversion \
+    autoconf automake libtool m4 cmake locales libgl1-mesa-glx xvfb \
+    libfftw3-dev \
+    libopenblas-dev \
+    libcfitsio-dev \
+    libhdf5-dev \
+    mpich \
+    libmpich-dev \
+    python3 \
+    libpython3-dev \
+    python3-pip \
+    python3-nose \
+    python3-numpy \
+    python3-scipy \
+    python3-matplotlib \
+    python3-yaml \
+    python3-h5py \
+    cython3
+
+# ------------------- Set up install prefix ------------------------
+#
+# Much of this stuff is not strictly necessary- it is just making the
+# software nicer to load into user shell environments.
+#
+
+# Create the prefix directories
+
+mkdir -p "${PREFIX}/lib"
+mkdir -p "${PREFIX}/bin"
+mkdir -p "${PREFIX}/include"
+mkdir -p "${PREFIX}/etc"
+pushd "${PREFIX}"
+if [ ! -e lib64 ]; then
+    ln -s lib lib64
+fi
+popd > /dev/null
+
+# In the ${PREFIX}/etc directory above, create a small shell file which will
+# load all this software into a user's environment.
+
+ENV_FILE="${PREFIX}/etc/toast_env.sh"
+
+# What is the name of our python site-packages directory?
+PYSITE=$(python3 --version 2>&1 | awk '{print $2}' | sed -e "s#\(.*\)\.\(.*\)\..*#\1.\2#")
+mkdir -p "${PREFIX}/lib/python${PYSITE}/site-packages"
+
+echo "# Load TOAST dependencies into the environment" > "${ENV_FILE}"
+
+echo "export PATH=\"${PREFIX}/bin:${PATH}\"" >> "${ENV_FILE}"
+echo "export CPATH=\"${PREFIX}/include:${CPATH}\"" >> "${ENV_FILE}"
+echo "export LIBRARY_PATH=\"${PREFIX}/lib:${LIBRARY_PATH}\"" >> "${ENV_FILE}"
+echo "export LD_LIBRARY_PATH=\"${PREFIX}/lib:${LD_LIBRARY_PATH}\"" >> "${ENV_FILE}"
+echo "export PYTHONPATH=\"${PREFIX}/lib/python${PYSITE}/site-packages:${PYTHONPATH}\"" >> "${ENV_FILE}"
+echo "" >> "${ENV_FILE}"
+
+# Load this shell snippet now, to put the prefix into our search paths
+
+. "${ENV_FILE}"
+
+
+# -------------- Install other required software  --------------------
+#
+# These are required packages where we would really like to have the
+# latest stable versions (i.e. not from the OS package manager).
+#
+
+# Use pip where possible to install packages into our separate prefix.
+# Note that this will pull in other updated dependencies, but we are
+# putting this into our own prefix (not /usr), so it is fine.  One could
+# also use a virtualenv or install these via anaconda if you were using
+# anaconda already to provide python3.
+
+pip3 install --system --target="${PREFIX}/lib/python${PYSITE}/site-packages" ephem
+
+# Install Healpix
+
+ curl -SL https://github.com/tskisner/healpix-autotools/releases/download/v3.31.4/healpix-autotools-3.31.4.tar.bz2 \
+    | tar -xjf - \
+    && cd healpix-autotools-3.31.4 \
+    && CC="gcc" CXX="g++" FC="gfortran" \
+    CFLAGS="-O3 -fPIC -pthread -std=gnu99" CXXFLAGS="-O3 -fPIC -pthread -std=c++98" FCFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" --prefix="${PREFIX}" \
+    && make && make install \
+    && cd .. \
+    && rm -rf healpix*
+
+# Install Latest mpi4py.  We want to build this ourselves so that it uses the
+# MPI version we have installed (MPICH or OpenMPI).  We also need a version
+# >= 2.0 so that we can pass the communicator between python and C++.
+
+ curl -SL https://pypi.python.org/packages/31/27/1288918ac230cc9abc0da17d84d66f3db477757d90b3d6b070d709391a15/mpi4py-3.0.0.tar.gz#md5=bfe19f20cef5e92f6e49e50fb627ee70 \
+    | tar xzf - \
+    && cd mpi4py-3.0.0 \
+    && python3 setup.py install --prefix="${PREFIX}" \
+    && cd .. \
+    && rm -rf mpi4py*
+
+
+#--------------------- Optional dependecies ---------------------
+#
+# Although not strictly required, these packages enable important
+# features, such as destriping map-making, 4Pi beam convolution,
+# atmosphere simulation and bandpass integration.
+#
+
+# Where is this script located, so we can find any patch files?
+
+pushd $(dirname $0) > /dev/null
+SDIR=$(pwd)
+popd > /dev/null
+
+# Install latest libmadam
+
+ curl -SL https://github.com/hpc4cmb/libmadam/releases/download/0.2.7/libmadam-0.2.7.tar.bz2 \
+    | tar -xjf - \
+    && cd libmadam-0.2.7 \
+    && FC="mpifort" MPIFC="mpifort" FCFLAGS="-O3 -fPIC -pthread" \
+    CC="mpicc" MPICC="mpicc" CFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" \
+    --with-blas="-lopenblas" --with-lapack="" \
+    --with-fftw="/usr" --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf libmadam*
+
+# Install conviqt
+
+ curl -SL https://www.dropbox.com/s/4tzjn9bgq7enkf9/libconviqt-1.0.2.tar.bz2?dl=0 \
+    | tar -xjf - \
+    && cd libconviqt-1.0.2 \
+    && CC="mpicc" CXX="mpicxx" MPICC="mpicc" MPICXX="mpicxx" \
+    CFLAGS="-O3 -fPIC -pthread -std=gnu99" CXXFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf libconviqt*
+
+# Install elemental
+
+ curl -SL https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz \
+    | tar -xzf - \
+    && cd Elemental-0.87.7 \
+    && mkdir build && cd build \
+    && cmake \
+    -D CMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -D INSTALL_PYTHON_PACKAGE=OFF \
+    -D CMAKE_CXX_COMPILER="mpicxx" \
+    -D CMAKE_C_COMPILER="mpicc" \
+    -D CMAKE_Fortran_COMPILER="mpifort" \
+    -D MPI_CXX_COMPILER="mpicxx" \
+    -D MPI_C_COMPILER="mpicc" \
+    -D MPI_Fortran_COMPILER="mpifort" \
+    -D METIS_GKREGEX=ON \
+    -D EL_DISABLE_PARMETIS=TRUE \
+    -D MATH_LIBS="$(echo ' -lopenblas' | sed -e 's#^ ##g')" \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_CXX_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_C_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_Fortran_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_SHARED_LINKER_FLAGS="-fopenmp" \
+    .. \
+    && make -j 4 && make install \
+    && cd ../.. \
+    && rm -rf Elemental*
+
+# Install libsharp
+
+ git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1 \
+    && cd libsharp \
+    && patch -p1 < "${SDIR}/../rules/patch_libsharp" \
+    && autoreconf \
+    && CC="mpicc" CFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --enable-mpi --enable-pic --prefix="${PREFIX}" \
+    && make \
+    && cp -a auto/* "${PREFIX}" \
+    && cd python \
+    && LIBSHARP="${PREFIX}" CC="mpicc -g" LDSHARED="mpicc -g -shared" \
+    python3 setup.py install --prefix="${PREFIX}" \
+    && cd ../.. \
+    && rm -rf libsharp*
+
+# Install PySM
+
+ git clone https://github.com/zonca/PySM_public.git --branch megarun_2017 --single-branch --depth 1 \
+    && cd PySM_public \
+    && python3 setup.py install --prefix="${PREFIX}" \
+    && cd .. \
+    && rm -rf PySM*
+
+# Install aatm
+
+ curl -SL https://launchpad.net/aatm/trunk/0.5/+download/aatm-0.5.tar.gz \
+    | tar xzf - \
+    && cd aatm-0.5 \
+    && chmod -R u+w . \
+    && patch -p1 < "${SDIR}/../rules/patch_aatm" \
+    && autoreconf \
+    && CC="gcc" CFLAGS="-O3 -fPIC -pthread" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    ./configure  \
+    --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf aatm*
+
+# Make sure that any python modules installed to our prefix are built into pyc
+# files- so that we can make those directories read-only
+
+python3 -m compileall -f "${PREFIX}/lib/python${PYSITE}/site-packages"
+
+# Set permissions
+
+if [ "x${CHGRP}" != "x" ]; then
+    chgrp -R ${CHGRP} "${PREFIX}"
+fi
+
+if [ "x${CHMOD}" != "x" ]; then
+    chmod -R ${CHMOD} "${PREFIX}"
+fi

--- a/src/python/tests/Makefile.am
+++ b/src/python/tests/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = 
+SUBDIRS =
 
 # Initialize compile and linking flags
 
@@ -47,10 +47,10 @@ rng.py \
 fft.py \
 runner.py \
 tod.py \
+sim_focalplane.py \
 tidas.py \
 timing.py
 
 
 clean-local :
 	@rm -f *.pyc
-

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -40,6 +40,7 @@ from . import ops_madam as testopsmadam
 from . import map_satellite as testmapsatellite
 from . import map_ground as testmapground
 from . import binned as testbinned
+from . import sim_focalplane as testsimfocalplane
 
 from ..tod import tidas_available
 if tidas_available:
@@ -87,6 +88,7 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testqarray) )
         suite.addTest( loader.loadTestsFromModule(testtod) )
         suite.addTest( loader.loadTestsFromModule(testpsdmath) )
+        suite.addTest( loader.loadTestsFromModule(testsimfocalplane) )
         suite.addTest( loader.loadTestsFromModule(testintervals) )
         suite.addTest( loader.loadTestsFromModule(testopspmat) )
         suite.addTest( loader.loadTestsFromModule(testcov) )

--- a/src/python/tests/sim_focalplane.py
+++ b/src/python/tests/sim_focalplane.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+import numpy.testing as nt
+
+from ..mpi import MPI
+from .mpi import MPITestCase
+
+from ..tod import sim_focalplane as sfp
+
+
+def generate_hex(npix, width, poltype, fwhm):
+    if poltype == "qu":
+        pol_a = sfp.hex_pol_angles_qu(npix)
+        pol_b = sfp.hex_pol_angles_qu(npix, offset=90.0)
+    elif poltype == "radial":
+        pol_a = sfp.hex_pol_angles_radial(npix)
+        pol_b = sfp.hex_pol_angles_radial(npix, offset=90.0)
+    dets_a = sfp.hex_layout(npix, width, "", "A", pol_a)
+    dets_b = sfp.hex_layout(npix, width, "", "B", pol_b)
+
+    dets = dict()
+    dets.update(dets_a)
+    dets.update(dets_b)
+
+    # Pol color different for A/B detectors
+    detpolcolor = dict()
+    detpolcolor.update({ x : "red" for x in dets_a.keys() })
+    detpolcolor.update({ x : "blue" for x in dets_b.keys() })
+
+    # set the label to just the detector name
+    detlabels = { x : x for x in dets.keys() }
+
+    # fwhm and face color the same
+    detfwhm = { x : fwhm for x in dets.keys() }
+
+    # cycle through some colors just for fun
+    pclr = [
+        (1.0, 0.0, 0.0, 0.1),
+        (1.0, 0.5, 0.0, 0.1),
+        (0.25, 0.5, 1.0, 0.1),
+        (0.0, 0.75, 0.0, 0.1)
+    ]
+    detcolor = { y : pclr[(x // 2) % 4] for x, y in \
+        enumerate(sorted(dets.keys())) }
+
+    # split out quaternions for plotting
+    detquats = { x : dets[x]["quat"] for x in dets.keys() }
+
+    return dets, detquats, detfwhm, detcolor, detpolcolor, detlabels
+
+
+def generate_rhombus(npix, width, fwhm, prefix, center):
+    pol_a = sfp.rhomb_pol_angles_qu(npix)
+    pol_b = sfp.rhomb_pol_angles_qu(npix, offset=90.0)
+    dets_a = sfp.rhombus_layout(npix, width, prefix, "A", pol_a, center=center)
+    dets_b = sfp.rhombus_layout(npix, width, prefix, "B", pol_b, center=center)
+
+    dets = dict()
+    dets.update(dets_a)
+    dets.update(dets_b)
+
+    # Pol color different for A/B detectors
+    detpolcolor = dict()
+    detpolcolor.update({ x : "red" for x in dets_a.keys() })
+    detpolcolor.update({ x : "blue" for x in dets_b.keys() })
+
+    # set the label to just the detector name
+    detlabels = { x : x for x in dets.keys() }
+
+    # fwhm and face color the same
+    detfwhm = { x : fwhm for x in dets.keys() }
+
+    # cycle through some colors just for fun
+    pclr = [
+        (1.0, 0.0, 0.0, 0.1),
+        (1.0, 0.5, 0.0, 0.1),
+        (0.25, 0.5, 1.0, 0.1),
+        (0.0, 0.75, 0.0, 0.1)
+    ]
+    detcolor = { y : pclr[(x // 2) % 4] for x, y in \
+        enumerate(sorted(dets.keys())) }
+
+    # split out quaternions for plotting
+    detquats = { x : dets[x]["quat"] for x in dets.keys() }
+
+    return dets, detquats, detfwhm, detcolor, detpolcolor, detlabels
+
+
+class SimFocalplaneTest(MPITestCase):
+
+    def setUp(self):
+        self.outdir = "toast_test_output"
+        if self.comm.rank == 0:
+            if not os.path.isdir(self.outdir):
+                os.mkdir(self.outdir)
+
+
+    def test_cart_quat(self):
+        xincr = np.linspace(-5.0, 5.0, num=10, endpoint=True)
+        yincr = np.linspace(-5.0, 5.0, num=10, endpoint=True)
+        offsets = list()
+        for x in xincr:
+            for y in yincr:
+                ang = 3.6 * (x - xincr[0]) * (y - yincr[0])
+                offsets.append([x, y, ang])
+        quats = sfp.cartesian_to_quat(offsets)
+        detquats = { "{}".format(x) : y for x, y in enumerate(quats) }
+        fwhm = { x : 30.0 for x in detquats.keys() }
+        outfile = os.path.join(self.outdir, "out_test_cart2quat.png")
+        sfp.plot_focalplane(detquats, 12.0, 12.0, outfile, fwhm=fwhm)
+        return
+
+
+    def test_hex_nring(self):
+        result = {
+            1 : 1,
+            7 : 2,
+            19 : 3,
+            37 : 4,
+            61 : 5,
+            91 : 6,
+            127 : 7,
+            169 : 8,
+            217 : 9,
+            271 : 10,
+            331 : 11,
+            397 : 12
+        }
+        for npix, check in result.items():
+            test = sfp.hex_nring(npix)
+            nt.assert_equal(test, check)
+        return
+
+
+    def test_vis_hex_small(self):
+        dets, detquats, detfwhm, detcolor, detpolcolor, detlabels = \
+            generate_hex(7, 5.0, "qu", 15.0)
+        outfile = os.path.join(self.outdir, "out_test_vis_hex_small.png")
+        sfp.plot_focalplane(detquats, 6.0, 6.0, outfile,
+        	fwhm=detfwhm, facecolor=detcolor, polcolor=detpolcolor,
+            labels=detlabels)
+        return
+
+
+    def test_vis_hex_small_rad(self):
+        dets, detquats, detfwhm, detcolor, detpolcolor, detlabels = \
+            generate_hex(7, 5.0, "radial", 15.0)
+        outfile = os.path.join(self.outdir, "out_test_vis_hex_small_rad.png")
+        sfp.plot_focalplane(detquats, 6.0, 6.0, outfile,
+        	fwhm=detfwhm, facecolor=detcolor, polcolor=detpolcolor,
+            labels=detlabels)
+        return
+
+
+    def test_vis_hex_medium(self):
+        dets, detquats, detfwhm, detcolor, detpolcolor, detlabels = \
+            generate_hex(91, 5.0, "qu", 10.0)
+        outfile = os.path.join(self.outdir, "out_test_vis_hex_medium.png")
+        sfp.plot_focalplane(detquats, 6.0, 6.0, outfile,
+        	fwhm=detfwhm, facecolor=detcolor, polcolor=detpolcolor,
+            labels=detlabels)
+        return
+
+
+    def test_vis_hex_large(self):
+        dets, detquats, detfwhm, detcolor, detpolcolor, detlabels = \
+            generate_hex(217, 5.0, "qu", 5.0)
+        outfile = os.path.join(self.outdir, "out_test_vis_hex_large.png")
+        sfp.plot_focalplane(detquats, 6.0, 6.0, outfile,
+        	fwhm=detfwhm, facecolor=detcolor, polcolor=detpolcolor,
+            labels=detlabels)
+        return
+
+
+    def test_vis_rhombus(self):
+        sixty = np.pi/3.0
+        thirty = np.pi/6.0
+        rtthree = np.sqrt(3.0)
+
+        rdim = 8
+        rpix = rdim**2
+
+        hexwidth = 5.0
+        rwidth = hexwidth / rtthree
+
+        # angular separation of rhombi
+        margin = 0.60 * hexwidth
+
+        centers = [
+            np.array([0.5*margin, 0.0, 0.0]),
+            np.array([-0.5*np.cos(sixty)*margin, 0.5*np.sin(sixty)*margin,
+                120.0]),
+            np.array([-0.5*np.cos(sixty)*margin, -0.5*np.sin(sixty)*margin,
+                240.0])
+        ]
+
+        cquats = sfp.cartesian_to_quat(centers)
+
+        dets = dict()
+        detquats = dict()
+        detfwhm = dict()
+        detcolor = dict()
+        detpolcolor = dict()
+        detlabels = dict()
+        for w, c in enumerate(cquats):
+            wdets, wdetquats, wdetfwhm, wdetcolor, wdetpolcolor, wdetlabels = \
+                generate_rhombus(rpix, rwidth, 7.0, "{}".format(w), c)
+            dets.update(wdets)
+            detquats.update(wdetquats)
+            detfwhm.update(wdetfwhm)
+            detcolor.update(wdetcolor)
+            detpolcolor.update(wdetpolcolor)
+            detlabels.update(wdetlabels)
+
+        outfile = os.path.join(self.outdir, "out_test_vis_rhombus.png")
+        sfp.plot_focalplane(detquats, 1.2*hexwidth, 1.2*hexwidth, outfile,
+        	fwhm=detfwhm, facecolor=detcolor, polcolor=detpolcolor,
+            labels=detlabels)
+        return

--- a/src/python/tod/sim_focalplane.py
+++ b/src/python/tod/sim_focalplane.py
@@ -1,12 +1,41 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 
 import numpy as np
 
 from .. import qarray as qa
-from .. import timing as timing
+
+
+def cartesian_to_quat(offsets):
+    """Convert cartesian angle offsets and rotation into quaternions.
+
+    Focalplane geometries are often described in terms of wafer locations or
+    separations given in simple X/Y angle offsets from a center point.
+    this helper function converts such parameters into a quaternion describing
+    the rotation.
+
+    Args:
+        offsets (list of arrays):  each item of the list has 3 elements for
+            the X / Y angle offsets in degrees and the rotation in degrees
+            about the Z axis.
+
+    Returns:
+        list: list of quaternions for each item in the input list.
+
+    """
+    centers = list()
+    zaxis = np.array([0,0,1], dtype=np.float64)
+    for off in offsets:
+        angrot = qa.rotation(zaxis, off[2]*np.pi/180.0)
+        wx = off[0]*np.pi/180.0
+        wy = off[1]*np.pi/180.0
+        wz = np.sqrt(1.0 - (wx*wx + wy*wy))
+        wdir = np.array([wx, wy, wz])
+        posrot = qa.from_vectors(zaxis, wdir)
+        centers.append(qa.mult(posrot, angrot))
+    return centers
 
 
 def hex_nring(npix):
@@ -26,12 +55,11 @@ def hex_nring(npix):
 
 def hex_row_col(npix, pix):
     """
-    For a hexagonal layout, indexed in a "spiral" scheme (see hex_layout), 
+    For a hexagonal layout, indexed in a "spiral" scheme (see hex_layout),
     this function returnes the "row" and "column" of a pixel.
     The row is zero along the main vertex-vertex axis, and is positive
     or negative above / below this line of pixels.
     """
-    autotimer = timing.auto_timer()
     if pix >= npix:
         raise ValueError("pixel value out of range")
     test = npix - 1
@@ -62,10 +90,10 @@ def hex_row_col(npix, pix):
             col = coloff
         elif sector == 3:
             row = -steps
-            col = coloff 
+            col = coloff
         elif sector == 4:
             row = -ring
-            col = coloff + steps 
+            col = coloff + steps
         elif sector == 5:
             row = -ring + steps
             col = coloff + ring + steps
@@ -87,7 +115,6 @@ def hex_pol_angles_qu(npix, offset=0.0):
         The detector polarization angles.
 
     """
-    autotimer = timing.auto_timer()
     pol = np.zeros(npix, dtype=np.float64)
     for pix in range(npix):
         # get the row / col of the pixel
@@ -115,7 +142,6 @@ def hex_pol_angles_radial(npix, offset=0.0):
         The detector polarization angles.
 
     """
-    autotimer = timing.auto_timer()
     sixty = np.pi/3.0
     thirty = np.pi/6.0
     pol = np.zeros(npix, dtype=np.float64)
@@ -136,15 +162,15 @@ def hex_pol_angles_radial(npix, offset=0.0):
     return pol
 
 
-def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
+def hex_layout(npix, angwidth, prefix, suffix, pol,
     center=np.array([0,0,0,1], dtype=np.float64)):
     """
     Return detectors in a hexagon layout.
 
-    This maps the physical positions of pixels into angular positions 
-    from the hexagon center.  The X axis in the hexagon frame is along 
-    the vertex-to-opposite-vertex direction.  The Y axis is along 
-    flat-to-opposite-flat direction.  The origin is at the center of 
+    This maps the physical positions of pixels into angular positions
+    from the hexagon center.  The X axis in the hexagon frame is along
+    the vertex-to-opposite-vertex direction.  The Y axis is along
+    flat-to-opposite-flat direction.  The origin is at the center of
     the wafer.  For example::
 
         Y ^             O O O
@@ -154,23 +180,20 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
                         O O O
 
     Each pixel is numbered 1..npix and each detector is named by the
-    prefix, the pixel number, and the suffix.  The first pixel is at 
+    prefix, the pixel number, and the suffix.  The first pixel is at
     the center, and then the pixels are numbered moving outward in rings.
 
-    The extent of the hexagon is directly specified by the width and
-    angwidth parameters (the plate scale).  These, along with the npix 
-    parameter, constrain the packing locations of the pixel centers.
+    The extent of the hexagon is directly specified by the angwidth
+    parameter.  These, along with the npix parameter, constrain the packing
+    locations of the pixel centers.
 
     Args:
         npix (int): number of pixels packed onto wafer.
-        width (float): physical width (in mm) between flat sides.
         angwidth (float): the angle (in degrees) subtended by the width.
-        fwhm (float): the detector beam FWHM, useful for later 
-            visualization.
         prefix (str): the detector name prefix.
         suffix (str): the detector name suffix.
-        pol (ndarray): 1D array of detector polarization angles.  The 
-            rotation is applied to the hexagon center prior to rotation 
+        pol (ndarray): 1D array of detector polarization angles.  The
+            rotation is applied to the hexagon center prior to rotation
             to the pixel location.
         center (ndarray): quaternion offset of the center of the layout.
 
@@ -179,7 +202,6 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
             dictionary of detector properties.
 
     """
-    autotimer = timing.auto_timer()
     zaxis = np.array([0,0,1], dtype=np.float64)
     nullquat = np.array([0,0,0,1], dtype=np.float64)
     sixty = np.pi/3.0
@@ -188,8 +210,7 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
     angwidth = angwidth * np.pi / 180.0
 
     # compute the diameter (vertex to vertex width)
-    diameter = width / np.cos(thirty)
-    angdiameter = diameter * angwidth / width
+    angdiameter = angwidth / np.cos(thirty)
 
     # find the angular packing size of one detector
     test = npix - 1
@@ -244,7 +265,7 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
             #        O   O (step 1)
             #       X O O O (step 0)
             #
-            # For a given ring, "R" (center is R=0), there are R steps along 
+            # For a given ring, "R" (center is R=0), there are R steps along
             # the sector edge.  The line from the origin to the opposite edge
             # that bisects this triangle has length R*sqrt(3)/2.  For each
             # equally-spaced step, we use the right triangle formed with this
@@ -265,7 +286,7 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
             pixang = sectors * sixty + thirty + relang
 
             pixdist = 0.5 * pixdiam * float(ring) * np.sqrt(3) / np.cos(relang)
-            
+
             pixx = np.sin(pixdist) * np.cos(pixang)
             pixy = np.sin(pixdist) * np.sin(pixang)
             pixz = np.cos(pixdist)
@@ -277,7 +298,6 @@ def hex_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
 
         dprops = {}
         dprops["quat"] = qa.mult(center, qa.mult(pixrot, polrot))
-        dprops["fwhm"] = fwhm
 
         dets[dname] = dprops
 
@@ -298,10 +318,9 @@ def rhomb_dim(npix):
 def rhomb_row_col(npix, pix):
     """
     For a rhombus layout, indexed from top to bottom (see rhombus_layout),
-    this function returnes the "row" and "column" of a pixel.  The column 
+    this function returnes the "row" and "column" of a pixel.  The column
     starts at zero on the left hand side of a row.
     """
-    autotimer = timing.auto_timer()
     if pix >= npix:
         raise ValueError("pixel value out of range")
     dim = rhomb_dim(npix)
@@ -333,12 +352,11 @@ def rhomb_pol_angles_qu(npix, offset=0.0):
         The detector polarization angles.
 
     """
-    autotimer = timing.auto_timer()
     pol = np.zeros(npix, dtype=np.float64)
     for pix in range(npix):
         # get the row / col of the pixel
         row, col = rhomb_row_col(npix, pix)
-        if np.mod(row, 2) == 0:
+        if np.mod(col, 2) == 0:
             pol[pix] = 45.0 + offset
         else:
             pol[pix] = 0.0 + offset
@@ -346,19 +364,19 @@ def rhomb_pol_angles_qu(npix, offset=0.0):
 
 
 
-def rhombus_layout(npix, width, angwidth, fwhm, prefix, suffix, pol, 
+def rhombus_layout(npix, angwidth, prefix, suffix, polang,
     center=np.array([0,0,0,1], dtype=np.float64)):
     """
     Return detectors in a rhombus layout.
 
     This particular rhombus geometry is essentially a third of a
-    hexagon.  In other words the aspect ratio of the rhombus is 
-    constrained to have the long dimension be sqrt(3) times the short 
+    hexagon.  In other words the aspect ratio of the rhombus is
+    constrained to have the long dimension be sqrt(3) times the short
     dimension.
 
-    This function maps the physical positions of pixels into angular 
-    positions from the rhombus center.  The X axis is along the short 
-    direction.  The Y axis is along longer direction.  The origin is 
+    This function maps the physical positions of pixels into angular
+    positions from the rhombus center.  The X axis is along the short
+    direction.  The Y axis is along longer direction.  The origin is
     at the center of the rhombus.  For example::
 
                           O
@@ -370,24 +388,22 @@ def rhombus_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
                           O
 
     Each pixel is numbered 1..npix and each detector is named by the
-    prefix, the pixel number, and the suffix.  The first pixel is at the 
-    "top", and then the pixels are numbered moving downward and left to 
+    prefix, the pixel number, and the suffix.  The first pixel is at the
+    "top", and then the pixels are numbered moving downward and left to
     right.
 
-    The extent of the rhombus is directly specified by the width and
-    angwidth parameters (the plate scale).  These, along with the npix 
-    parameter, constrain the packing locations of the pixel centers.
+    The extent of the rhombus is directly specified by the angwidth parameter.
+    This, along with the npix parameter, constrain the packing locations of
+    the pixel centers.
 
     Args:
         npix (int): number of pixels packed onto wafer.
-        width (float): physical width (in mm) along the "short" dimension.
-        angwidth (float): the angle (in degrees) subtended by the width.
-        fwhm (float): the detector beam FWHM, useful for later 
-            visualization.
+        angwidth (float): the angle (in degrees) subtended by the short
+            dimension.
         prefix (str): the detector name prefix.
         suffix (str): the detector name suffix.
-        pol (ndarray): 1D array of detector polarization angles.  The 
-            rotation is applied to the hexagon center prior to rotation 
+        polang (ndarray): 1D array of detector polarization angles.  The
+            rotation is applied to the hexagon center prior to rotation
             to the pixel location.
         center (ndarray): quaternion offset of the center of the layout.
 
@@ -396,7 +412,6 @@ def rhombus_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
             dictionary of detector properties.
 
     """
-    autotimer = timing.auto_timer()
     zaxis = np.array([0,0,1], dtype=np.float64)
     nullquat = np.array([0,0,0,1], dtype=np.float64)
     rtthree = np.sqrt(3.0)
@@ -405,14 +420,13 @@ def rhombus_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
     dim = rhomb_dim(npix)
 
     # compute the height
-    height = width * rtthree
-    angheight = height * angwidth / width
+    angheight = rtthree * angwidth
 
     # find the angular packing size of one detector
     pixdiam = angwidth / dim
 
     # convert pol vector to radians
-    pol *= np.pi / 180.0
+    pol = polang * np.pi / 180.0
 
     # number of digits for pixel indexing
 
@@ -450,29 +464,42 @@ def rhombus_layout(npix, width, angwidth, fwhm, prefix, suffix, pol,
 
         dprops = {}
         dprops["quat"] = qa.mult(center, qa.mult(pixrot, polrot))
-        dprops["fwhm"] = fwhm
 
         dets[dname] = dprops
 
     return dets
 
 
-def plot_focalplane(dets, width, height, outfile):
+def plot_focalplane(dets, width, height, outfile, fwhm=None, facecolor=None,
+    polcolor=None, labels=None):
     """
     Visualize a dictionary of detectors.
 
     This makes a simple plot of the detector positions on the projected
     focalplane.
 
-    To avoid python overhead in large MPI jobs, we place the matplotlib 
-    import inside this function, so that it is only imported when the 
+    To avoid python overhead in large MPI jobs, we place the matplotlib
+    import inside this function, so that it is only imported when the
     function is actually called.
 
+    If the detector dictionary contains a key "fwhm", that will be assumed
+    to be in arcminutes.  Otherwise a nominal value is used.
+
+    If the detector dictionary contains a key "viscolor", then that color
+    will be used.
+
     Args:
-        dets (dict): dictionary of detectors.
+        dets (dict): dictionary of detector quaternions.
         width (float): width of plot in degrees.
         height (float): height of plot in degrees.
         outfile (str): output PNG path.
+        fwhm (dict): dictionary of detector beam FWHM in arcminutes, used
+            to draw the circles to scale.
+        facecolor (dict): dictionary of color values for the face of each
+            detector circle.
+        polcolor (dict): dictionary of color values for the polarization
+            arrows.
+        labels (dict): plot this text in the center of each pixel.
 
     """
     import matplotlib
@@ -480,7 +507,15 @@ def plot_focalplane(dets, width, height, outfile):
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
-    fig = plt.figure( figsize=(12,12), dpi=150 )
+    xfigsize = int(5 * width)
+    yfigsize = int(5 * height)
+    figdpi = 75
+
+    # Compute the font size to use for detector labels
+    fontpix = 0.2 * figdpi
+    fontpt = int(0.75 * fontpix)
+
+    fig = plt.figure(figsize=(xfigsize, yfigsize), dpi=figdpi)
     ax = fig.add_subplot(1, 1, 1)
 
     half_width = 0.5 * width
@@ -494,35 +529,55 @@ def plot_focalplane(dets, width, height, outfile):
     yaxis = np.array([0.0, 1.0, 0.0], dtype=np.float64)
     zaxis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
 
-    for d in dets:
+    for d, quat in dets.items():
 
         # radius in degrees
-        detradius = 0.5 * dets[d]["fwhm"]
+        detradius = 0.5 * 5.0 / 60.0
+        if fwhm is not None:
+            detradius = 0.5 * fwhm[d] / 60.0
 
         # rotation from boresight
-        dir = qa.rotate(dets[d]["quat"], zaxis).flatten()
-        ang = np.arctan2(dir[1], dir[0])
+        rdir = qa.rotate(quat, zaxis).flatten()
+        ang = np.arctan2(rdir[1], rdir[0])
 
-        orient = qa.rotate(dets[d]["quat"], xaxis).flatten()
+        orient = qa.rotate(quat, xaxis).flatten()
         polang = np.arctan2(orient[1], orient[0])
 
-        mag = np.arccos(dir[2]) * 180.0 / np.pi
+        mag = np.arccos(rdir[2]) * 180.0 / np.pi
         xpos = mag * np.cos(ang)
         ypos = mag * np.sin(ang)
 
-        circ = plt.Circle((xpos, ypos), radius=detradius, fc="none", ec="k")
+        detface = "none"
+        if facecolor is not None:
+            detface = facecolor[d]
+
+        circ = plt.Circle((xpos, ypos), radius=detradius, fc=detface, ec="k")
         ax.add_artist(circ)
 
-        ascale = 2.5
+        ascale = 2.0
 
         xtail = xpos - ascale * detradius * np.cos(polang)
         ytail = ypos - ascale * detradius * np.sin(polang)
         dx = ascale * 2.0 * detradius * np.cos(polang)
-        dy = ascale * 2.0 * detradius * np.sin(polang)    
+        dy = ascale * 2.0 * detradius * np.sin(polang)
 
-        detcolor = "red"
-        ax.arrow(xtail, ytail, dx, dy, width=0.1*detradius, head_width=0.5*detradius, head_length=0.5*detradius, fc=detcolor, ec=detcolor, length_includes_head=True)
+        detcolor = "black"
+        if polcolor is not None:
+            detcolor = polcolor[d]
+
+        ax.arrow(xtail, ytail, dx, dy, width=0.1*detradius,
+            head_width=0.5*detradius, head_length=0.5*detradius, fc=detcolor,
+            ec=detcolor, length_includes_head=True)
+
+        if labels is not None:
+            xsgn = 1.0
+            if dx < 0.0:
+                xsgn = -1.0
+            labeloff = 0.05 * xsgn * fontpix * len(labels[d]) / figdpi
+            ax.text((xtail+1.1*dx+labeloff), (ytail+1.1*dy), labels[d],
+                color='k', fontsize=fontpt, horizontalalignment='center',
+                verticalalignment='center',
+                bbox=dict(fc='w', ec='none', pad=1, alpha=1.0))
 
     plt.savefig(outfile)
     return
-


### PR DESCRIPTION
This ports some code from experiment-specific repos and generalizes it.  Both hexagons and rhombi are supported.  Also adds some visualization tests.  Examples attached from the unit test output.  Colors can all be customized.  This also adds an extraneous file for installing dependencies on a newer ubuntu system.

![out_test_vis_rhombus](https://user-images.githubusercontent.com/84221/35662918-b1a7dae8-06cf-11e8-9839-41d558254c67.png)
![out_test_vis_hex_medium](https://user-images.githubusercontent.com/84221/35662919-b1bfd4e0-06cf-11e8-9ed2-10132f96cabe.png)
![out_test_vis_hex_large](https://user-images.githubusercontent.com/84221/35662920-b1d9ea24-06cf-11e8-855a-c1ce4751d6a6.png)



