### PR TITLE
do not use absolute path for mpirun in shell

### DIFF
--- a/examples/generate_shell.sh
+++ b/examples/generate_shell.sh
@@ -29,7 +29,7 @@ SIZES="tiny"
 for i in mpirun mpiexec lamexec srun
 do
     if command -v ${i} &> /dev/null; then
-        MPI_RUN=$(which ${i})
+        MPI_RUN=${i}
         break
     fi
 done


### PR DESCRIPTION
On Ubuntu with openmpi and conda, this breaks the conda environment

if I run with `/usr/bin/mpirun` the conda env is not detected
instead if I run with `mpirun`, it works fine.

Do you think this could cause other problems?