### PR TITLE
PySM precomputed cmb

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -205,7 +205,7 @@ def main():
                         'simulation, e.g. s3,d6,f1,a2"')
     parser.add_argument('--input_pysm_precomputed_cmb', required=False,
                         help='Precomputed CMB map for PySM '
-                        'input_pysm_model should NOT include a CMB model"')
+                        'it overrides any model defined in input_pysm_model"')
     parser.add_argument('--apply_beam', required=False, action='store_true',
                         help='Apply beam convolution to input map with gaussian '
                         'beam parameters defined in focalplane')

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -94,6 +94,7 @@ def simulate_sky_signal(args, comm, data, mem_counter, focalplanes, subnpix, loc
     op_sim_pysm = ttm.OpSimPySM(comm=comm.comm_rank,
                                out=signalname,
                                pysm_model=args.input_pysm_model,
+                               pysm_precomputed_cmb=args.input_pysm_precomputed_cmb,
                                focalplanes=focalplanes,
                                nside=args.nside,
                                subnpix=subnpix, localsm=localsm,
@@ -202,6 +203,9 @@ def main():
     parser.add_argument('--input_pysm_model', required=False,
                         help='Comma separated models for on-the-fly PySM '
                         'simulation, e.g. s3,d6,f1,a2"')
+    parser.add_argument('--input_pysm_precomputed_cmb', required=False,
+                        help='Precomputed CMB map for PySM '
+                        'input_pysm_model should NOT include a CMB model"')
     parser.add_argument('--apply_beam', required=False, action='store_true',
                         help='Apply beam convolution to input map with gaussian '
                         'beam parameters defined in focalplane')

--- a/src/python/todmap/pysm_operator.py
+++ b/src/python/todmap/pysm_operator.py
@@ -69,7 +69,8 @@ class OpSimPySM(Operator):
     """
 
     def __init__(self, comm=None,
-                 out='signal', pysm_model='', focalplanes=None, nside=None,
+                 out='signal', pysm_model='', pysm_precomputed_cmb=None,
+                 focalplanes=None, nside=None,
                  subnpix=None, localsm=None, apply_beam=False, nest=True,
                  units='K_CMB', debug=False):
         autotimer = timing.auto_timer(type(self).__name__)
@@ -79,6 +80,7 @@ class OpSimPySM(Operator):
         self._nest = nest
         self.comm = comm
         self._debug = debug
+        self.pysm_precomputed_cmb = pysm_precomputed_cmb
         self.dist_rings = DistRings(comm,
                                     nside=nside,
                                     nnz=3)
@@ -99,6 +101,7 @@ class OpSimPySM(Operator):
         self.pysm_sky = PySMSky(comm=self.comm,
                                 local_pixels=self.dist_rings.local_pixels,
                                 nside=nside, pysm_sky_config=pysm_sky_config,
+                                pysm_precomputed_cmb=self.pysm_precomputed_cmb,
                                 units=units)
 
         self.nside = nside


### PR DESCRIPTION
PySM supports reading a precomputed CMB map using the `c2` CMB model.
However, you cannot specify which map to read, it always reads `lensed_cmb.fits` from the templates folder.
Until now we have been installing PySM from my branch so I just overwrote that file.
However PySM has merged all my changes so I'd like to stop using my branch.

Therefore I have implemented support in TOAST for accepting a input path for the precomputed CMB and create a PySM model with that.