### PR TITLE
[WIP] fix wrong num samples in interval

### DIFF
--- a/src/python/tod/sim_interval.py
+++ b/src/python/tod/sim_interval.py
@@ -40,8 +40,8 @@ def regular_intervals(n, start, first, rate, duration, gap):
 
     # Compute the whole number of samples that fit within the
     # requested time span (rounded to nearest sample).
-    totsamples = int(0.5 + (duration + gap) * rate) + 1
-    dursamples = int(0.5 + duration * rate) + 1
+    totsamples = int(0.5 + (duration + gap) * rate)
+    dursamples = int(0.5 + duration * rate)
     gapsamples = totsamples - dursamples
 
     # Compute the actual time span for this number of samples

--- a/src/python/tod/sim_interval.py
+++ b/src/python/tod/sim_interval.py
@@ -42,19 +42,16 @@ def regular_intervals(n, start, first, rate, duration, gap):
     # requested time span (rounded to nearest sample).
     totsamples = int(0.5 + (duration + gap) * rate)
     dursamples = int(0.5 + duration * rate)
-    gapsamples = totsamples - dursamples
-
-    # Compute the actual time span for this number of samples
-    tottime = (totsamples - 1) * invrate
-    durtime = (dursamples - 1) * invrate
-    gaptime = tottime - durtime
 
     intervals = []
 
     for i in range(n):
         ifirst = first + i * totsamples
         ilast = ifirst + dursamples - 1
-        istart = start + i * tottime
+        # The time span between interval starts (the first sample of one interval
+        # to the first sample of the next) includes the one extra sample time.
+        istart = start + i * (totsamples * invrate)
+        # The stop time is the timestamp of the last valid sample (thus the -1).
         istop = istart + (dursamples - 1) * invrate
         intervals.append(Interval(start=istart, stop=istop, first=ifirst, last=ilast))
 


### PR DESCRIPTION
@tskisner I think I found the issue causing #223, this fix is not complete, but wanted to ask for feedback.

Num of samples per interval was computed as:
    
```
duration = 3600
rate = 1
int(0.5 + duration * rate) + 1
```

But this gave 3601 samples in 1 hour at 1 Hz, so I think I should remove the `+1`.

However I am concerned about the following part of the code:

```
# Compute the actual time span for this number of samples                                                 
tottime = (totsamples - 1) * invrate
```

I would say that `tottime` is just `totsamples * invrate`, are you making any different assumption here? 