### PR TITLE
Fix simulation of regular intervals

### DIFF
--- a/src/python/tests/intervals.py
+++ b/src/python/tests/intervals.py
@@ -38,7 +38,7 @@ class IntervalTest(MPITestCase):
         intrvls = regular_intervals(self.nint, self.start, self.first,
                                     self.rate, self.duration, self.gap)
 
-        goodsamp = self.nint * ( int(0.5 + self.duration * self.rate) + 1 )
+        goodsamp = self.nint * ( int(self.duration * self.rate) + 1 )
 
         check = 0
 

--- a/src/python/tod/sim_interval.py
+++ b/src/python/tod/sim_interval.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 
@@ -11,18 +11,33 @@ from .. import timing as timing
 from .interval import Interval
 
 
-
 def regular_intervals(n, start, first, rate, duration, gap):
     """
-    Function to generate regular intervals.
+    Function to generate simulated regular intervals.
 
     This creates a list of intervals, given a start time/sample and time
-    span for the interval and the gap in time between intervals.  The 
-    length of the interval and the gap are rounded to the nearest sample
-    and all intervals in the list are created using those lengths.
+    span for the interval and the gap in time between intervals.  The
+    length of the interval and the total interval + gap are rounded down to the
+    nearest sample and all intervals in the list are created using those
+    lengths.
 
-    Optionally, the full data span can be subdivided into some number
-    of contiguous subchunks.
+    If the time span is an exact multiple of the sampling, then the
+    final sample is excluded.  The reason we always round down to the whole
+    number of samples that fits inside the time range is so that the requested
+    time span boundary (one hour, one day, etc) will fall in between the last
+    sample of one interval and the first sample of the next.
+
+    Example:  you want to simulate science observations of length 22 hours and
+    then have 4 hours of down time (e.g. a cooler cycle).  Specifying a
+    duration of 22*3600 and a gap of 4*3600 will result in a total time for the
+    science + gap of a fraction of a sample less than 26 hours.  So the
+    requested 26 hour mark will fall between the last sample of one regular
+    interval and the first sample of the next.  Note that this fraction of
+    a sample will accumulate if you have many, many intervals.
+
+    This function is intended only for simulations- in the case of real data,
+    the timestamp of every sample is known and boundaries between changes in
+    the experimental configuration are already specified.
 
     Args:
         n (int): the number of intervals.
@@ -39,26 +54,38 @@ def regular_intervals(n, start, first, rate, duration, gap):
     invrate = 1.0 / rate
 
     # Compute the whole number of samples that fit within the
-    # requested time span (rounded to nearest sample).
-    totsamples = int(0.5 + (duration + gap) * rate) + 1
-    dursamples = int(0.5 + duration * rate) + 1
-    gapsamples = totsamples - dursamples
+    # requested time span (rounded down to a whole number).  Check for the
+    # case of the time span being an exact number of samples- in which case
+    # the final sample is excluded.
 
-    # Compute the actual time span for this number of samples
-    tottime = (totsamples - 1) * invrate
-    durtime = (dursamples - 1) * invrate
-    gaptime = tottime - durtime
+    lower = int((duration + gap) * rate)
+    totsamples = None
+    if np.absolute(lower * invrate - (duration + gap)) > 1.0e-12:
+        totsamples = lower + 1
+    else:
+        totsamples = lower
+
+    lower = int(duration * rate)
+    dursamples = None
+    if np.absolute(lower * invrate - duration) > 1.0e-12:
+        dursamples = lower + 1
+    else:
+        dursamples = lower
+
+    gapsamples = totsamples - dursamples
 
     intervals = []
 
     for i in range(n):
         ifirst = first + i * totsamples
         ilast = ifirst + dursamples - 1
-        istart = start + i * tottime
-        istop = istart + (dursamples - 1) * invrate
-        intervals.append(Interval(start=istart, stop=istop, first=ifirst, last=ilast))
+        # The time span between interval starts (the first sample of one
+        # interval to the first sample of the next) includes the one extra
+        # sample time.
+        istart = start + i * (totsamples * invrate)
+        # The stop time is the timestamp of the last valid sample (thus the -1).
+        istop = istart + ((dursamples - 1) * invrate)
+        intervals.append(Interval(start=istart, stop=istop, first=ifirst,
+            last=ilast))
 
     return intervals
-
-
-


### PR DESCRIPTION
We always round down to the whole number of samples that fit within the requested time span.  Add more documentation about the intention of this function and how number of samples is calculated.

Based on some small tests, I believe this function behaves as I expect (and I have tried to clarify that expected behavior).

Essentially, the requested time spans for the "good" data and the total of the "good" + "gap" are treated as a goal, and then the whole number of samples that fits within that goal is used.  So if you ask for a total time (good + gap) of 6 hours, then each good+gap number of samples will be slightly less that this, so the "6 hours" will occur between the last sample of the previous interval and first sample of the next.

This was the intended behavior of this function- to make it easy to simulate some repeating intervals given timespans which were not a whole number of samples.  In addition, this should fix the repeating timestamp problem, which was a bug.  Closes #223 