### PR TITLE
Multiple cleanups to satellite boresight pointing

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -360,6 +360,7 @@ def main():
             comm.comm_group,
             detquats,
             obsrange[ob].samples,
+            firstsamp=obsrange[ob].first,
             firsttime=obsrange[ob].start,
             rate=args.samplerate,
             spinperiod=args.spinperiod,
@@ -401,8 +402,8 @@ def main():
         # Constantly slewing precession axis
         degday = 360.0 / 365.25
         precquat = tt.slew_precession_axis(nsim=tod.local_samples[1],
-            firstsamp=obsoffset, samplerate=args.samplerate,
-            degday=degday)
+            firstsamp=(obsoffset + tod.local_samples[0]),
+            samplerate=args.samplerate, degday=degday)
 
         tod.set_prec_axis(qprec=precquat)
 

--- a/src/libtoast/capi/ctoast.cpp
+++ b/src/libtoast/capi/ctoast.cpp
@@ -597,10 +597,10 @@ void ctoast_qarray_from_rotmat ( const double * rotmat, double * q ) {
     return;
 }
 
-void ctoast_qarray_from_vectors ( double const * vec1, double const * vec2,
-                                  double * q ) {
+void ctoast_qarray_from_vectors ( size_t n, double const * vec1,
+    double const * vec2, double * q ) {
     TOAST_AUTO_TIMER();
-    toast::qarray::from_vectors(vec1, vec2, q );
+    toast::qarray::from_vectors(n, vec1, vec2, q );
     return;
 }
 

--- a/src/libtoast/capi/ctoast.h
+++ b/src/libtoast/capi/ctoast.h
@@ -157,10 +157,11 @@ void ctoast_qarray_to_rotmat ( double const * q, double * rotmat );
 
 void ctoast_qarray_from_rotmat ( const double * rotmat, double * q );
 
-void ctoast_qarray_from_vectors ( double const * vec1, double const * vec2, double * q );
+void ctoast_qarray_from_vectors ( size_t n, double const * vec1,
+    double const * vec2, double * q );
 
-void ctoast_qarray_from_angles ( size_t n, double const * theta, double const * phi,
-    double * const pa, double * quat, int IAU );
+void ctoast_qarray_from_angles ( size_t n, double const * theta,
+    double const * phi, double * const pa, double * quat, int IAU );
 
 void ctoast_qarray_to_angles ( size_t n, double const * quat, double * theta,
     double * phi, double * pa, int IAU );

--- a/src/libtoast/math/toast/qarray.hpp
+++ b/src/libtoast/math/toast/qarray.hpp
@@ -48,7 +48,8 @@ namespace toast { namespace qarray {
 
     void from_rotmat ( const double * rotmat, double * q );
 
-    void from_vectors ( double const * vec1, double const * vec2, double * q );
+    void from_vectors ( size_t n, double const * vec1, double const * vec2,
+        double * q );
 
     void from_angles ( size_t n, double const * theta, double const * phi,
         double * const pa, double * quat, bool IAU = false );

--- a/src/libtoast/math/toast_qarray.cpp
+++ b/src/libtoast/math/toast_qarray.cpp
@@ -637,23 +637,38 @@ void toast::qarray::from_rotmat ( const double * rotmat, double * q ) {
 
 // Creates the quaternion from two normalized vectors.
 
-void toast::qarray::from_vectors ( double const * vec1, double const * vec2, double * q ) {
-    double dotprod = vec1[0] * vec2[0] + vec1[1] * vec2[1] + vec1[2] * vec2[2];
-    double vec1prod = vec1[0] * vec1[0] + vec1[1] * vec1[1] + vec1[2] * vec1[2];
-    double vec2prod = vec2[0] * vec2[0] + vec2[1] * vec2[1] + vec2[2] * vec2[2];
+void toast::qarray::from_vectors ( size_t n, double const * vec1,
+    double const * vec2, double * q ) {
 
-    // shortcut for coincident vectors
-    if ( ::fabs ( dotprod - 1.0 ) < 1.0e-12 ) {
-        q[0] = 0.0;
-        q[1] = 0.0;
-        q[2] = 0.0;
-        q[3] = 1.0;
-    } else {
-        q[0] = vec1[1] * vec2[2] - vec1[2] * vec2[1];
-        q[1] = vec1[2] * vec2[0] - vec1[0] * vec2[2];
-        q[2] = vec1[0] * vec2[1] - vec1[1] * vec2[0];
-        q[3] = ::sqrt ( vec1prod * vec2prod ) + dotprod;
-        toast::qarray::normalize_inplace ( 1, 4, 4, q );
+    size_t vf;
+    size_t qf;
+    double dotprod;
+    double vec1prod;
+    double vec2prod;
+
+    for ( size_t i = 0; i < n; ++i ) {
+        vf = 3 * i;
+        qf = 4 * i;
+        dotprod = vec1[vf] * vec2[vf] + vec1[vf + 1] * vec2[vf + 1] +
+            vec1[vf + 2] * vec2[vf + 2];
+        vec1prod = vec1[vf] * vec1[vf] + vec1[vf + 1] * vec1[vf + 1] +
+            vec1[vf + 2] * vec1[vf + 2];
+        vec2prod = vec2[vf] * vec2[vf] + vec2[vf + 1] * vec2[vf + 1] +
+            vec2[vf + 2] * vec2[vf + 2];
+
+        // shortcut for coincident vectors
+        if ( ::fabs ( dotprod - 1.0 ) < 1.0e-12 ) {
+            q[qf] = 0.0;
+            q[qf + 1] = 0.0;
+            q[qf + 2] = 0.0;
+            q[qf + 3] = 1.0;
+        } else {
+            q[qf] = vec1[vf + 1] * vec2[vf + 2] - vec1[vf + 2] * vec2[vf + 1];
+            q[qf + 1] = vec1[vf + 2] * vec2[vf] - vec1[vf] * vec2[vf + 2];
+            q[qf + 2] = vec1[vf] * vec2[vf + 1] - vec1[vf + 1] * vec2[vf];
+            q[qf + 3] = ::sqrt ( vec1prod * vec2prod ) + dotprod;
+            toast::qarray::normalize_inplace ( 1, 4, 4, &(q[qf]) );
+        }
     }
 
     return;

--- a/src/libtoast/math/toast_qarray.cpp
+++ b/src/libtoast/math/toast_qarray.cpp
@@ -643,7 +643,7 @@ void toast::qarray::from_vectors ( double const * vec1, double const * vec2, dou
     double vec2prod = vec2[0] * vec2[0] + vec2[1] * vec2[1] + vec2[2] * vec2[2];
 
     // shortcut for coincident vectors
-    if ( ::fabs ( dotprod ) < 1.0e-12 ) {
+    if ( ::fabs ( dotprod - 1.0 ) < 1.0e-12 ) {
         q[0] = 0.0;
         q[1] = 0.0;
         q[2] = 0.0;

--- a/src/libtoast/test/toast_test_qarray.cpp
+++ b/src/libtoast/test/toast_test_qarray.cpp
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-All rights reserved.  Use of this source code is governed by 
+All rights reserved.  Use of this source code is governed by
 a BSD-style license that can be found in the LICENSE file.
 */
 
@@ -327,7 +327,7 @@ TEST_F( TOASTqarrayTest, fromvectors ) {
     double v1[3] = { 1.0, 0.0, 0.0 };
     double v2[3] = { ::cos(ang), ::sin(ang), 0.0 };
 
-    qarray::from_vectors ( v1, v2, result );
+    qarray::from_vectors ( 1, v1, v2, result );
 
     for ( size_t i = 0; i < 4; ++i ) {
         EXPECT_FLOAT_EQ( check[i], result[i] );
@@ -397,9 +397,9 @@ TEST_F( TOASTqarrayTest, thetaphipa ) {
 
         ASSERT_NEAR( check, phi[i], 1.0e-6 );
 
-        check = ::atan2 ( orient[0] * dir[1] - orient[1] * dir[0], 
-                - ( orient[0] * dir[2] * dir[0] ) 
-                - ( orient[1] * dir[2] * dir[1] ) 
+        check = ::atan2 ( orient[0] * dir[1] - orient[1] * dir[0],
+                - ( orient[0] * dir[2] * dir[0] )
+                - ( orient[1] * dir[2] * dir[1] )
                 + ( orient[2] * ( dir[0] * dir[0] + dir[1] * dir[1] ) ) );
 
         ASSERT_NEAR( check, pa[i], 1.0e-6 );
@@ -491,9 +491,9 @@ TEST_F( TOASTqarrayTest, thetaphipa ) {
 
         ASSERT_NEAR( check, phi[i], 1.0e-6 );
 
-        check = - ::atan2 ( orient[0] * dir[1] - orient[1] * dir[0], 
-                - ( orient[0] * dir[2] * dir[0] ) 
-                - ( orient[1] * dir[2] * dir[1] ) 
+        check = - ::atan2 ( orient[0] * dir[1] - orient[1] * dir[0],
+                - ( orient[0] * dir[2] * dir[0] )
+                - ( orient[1] * dir[2] * dir[1] )
                 + ( orient[2] * ( dir[0] * dir[0] + dir[1] * dir[1] ) ) );
 
         if ( ::fabs ( ::fabs ( check - pa[i] ) - toast::TWOPI ) < std::numeric_limits<float>::epsilon() ) {
@@ -529,5 +529,3 @@ TEST_F( TOASTqarrayTest, thetaphipa ) {
         ASSERT_NEAR( pa[i], check_pa[i], 1.0e-6 );
     }
 }
-
-

--- a/src/python/ctoast.py.in
+++ b/src/python/ctoast.py.in
@@ -595,13 +595,13 @@ def qarray_from_rotmat(rotmat):
     return q
 
 lib.ctoast_qarray_from_vectors.restype = None
-lib.ctoast_qarray_from_vectors.argtypes = [ npf64, npf64, npf64 ]
+lib.ctoast_qarray_from_vectors.argtypes = [ ct.c_ulong, npf64, npf64, npf64 ]
 
-def qarray_from_vectors(vec1, vec2):
-    q = np.zeros(4, dtype=np.float64)
+def qarray_from_vectors(n, vec1, vec2):
+    q = np.zeros(4*n, dtype=np.float64)
     vc1 = np.require(vec1, requirements=["C"])
     vc2 = np.require(vec2, requirements=["C"])
-    lib.ctoast_qarray_from_vectors(vc1, vc2, q)
+    lib.ctoast_qarray_from_vectors(n, vc1, vc2, q)
     return q
 
 lib.ctoast_qarray_from_angles.restype = None

--- a/src/python/qarray.py
+++ b/src/python/qarray.py
@@ -366,11 +366,31 @@ def from_vectors(v1, v2):
         v1 = np.array(v1, dtype=np.float64)
     if not isinstance(v2, np.ndarray):
         v2 = np.array(v2, dtype=np.float64)
-    if v1.ndim != 1 or v2.ndim != 1:
-        raise ValueError('from_vectors is not vectorized')
-    return ctoast.qarray_from_vectors(
+
+    nv1 = None
+    if v1.ndim == 1:
+        nv1 = 1
+    else:
+        nv1 = v1.shape[0]
+
+    nv2 = None
+    if v2.ndim == 1:
+        nv2 = 1
+    else:
+        nv2 = v2.shape[0]
+
+    if nv1 != nv2:
+        raise ValueError("Length of input vectors must be the same")
+
+    q = ctoast.qarray_from_vectors(nv1,
         v1.flatten().astype(np.float64, copy=False),
         v2.flatten().astype(np.float64, copy=False))
+
+    if nv1 > 1:
+        q = q.reshape((-1, 4))
+    else:
+        q = q.flatten()
+    return q
 
 
 def from_angles(theta, phi, pa, IAU=False):

--- a/src/python/tests/Makefile.am
+++ b/src/python/tests/Makefile.am
@@ -47,6 +47,7 @@ rng.py \
 fft.py \
 runner.py \
 tod.py \
+tod_satellite.py \
 sim_focalplane.py \
 tidas.py \
 timing.py

--- a/src/python/tests/qarray.py
+++ b/src/python/tests/qarray.py
@@ -187,6 +187,15 @@ class QarrayTest(MPITestCase):
         check = qarray.from_vectors(zaxis, zaxis)
         np.testing.assert_array_almost_equal(check, nulquat)
 
+        q = qarray.from_vectors(np.tile(v1, 3).reshape(-1, 3),
+            np.tile(v2, 3).reshape(-1, 3))
+
+        comp = np.tile(np.array([0, 0, np.sin(np.radians(15)),
+            np.cos(np.radians(15))]), 3).reshape(-1, 4)
+
+        np.testing.assert_array_almost_equal(q, comp)
+
+
     def test_fp(self):
         xaxis = np.array([1, 0, 0], dtype=np.float64)
         zaxis = np.array([0, 0, 1], dtype=np.float64)

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -41,6 +41,7 @@ from . import map_satellite as testmapsatellite
 from . import map_ground as testmapground
 from . import binned as testbinned
 from . import sim_focalplane as testsimfocalplane
+from . import tod_satellite as testtodsat
 
 from ..tod import tidas_available
 if tidas_available:
@@ -87,6 +88,7 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testdist) )
         suite.addTest( loader.loadTestsFromModule(testqarray) )
         suite.addTest( loader.loadTestsFromModule(testtod) )
+        suite.addTest( loader.loadTestsFromModule(testtodsat) )
         suite.addTest( loader.loadTestsFromModule(testpsdmath) )
         suite.addTest( loader.loadTestsFromModule(testsimfocalplane) )
         suite.addTest( loader.loadTestsFromModule(testintervals) )

--- a/src/python/tests/tod_satellite.py
+++ b/src/python/tests/tod_satellite.py
@@ -1,0 +1,240 @@
+# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+from ..mpi import MPI
+from .mpi import MPITestCase
+
+import sys
+import os
+import numpy as np
+
+import healpy as hp
+
+from ..dist import Comm
+
+from .. import healpix as hpx
+
+from .. import qarray as qa
+
+from ..tod.sim_tod import (slew_precession_axis, satellite_scanning,
+    TODSatellite)
+
+
+class TODSatelliteTest(MPITestCase):
+
+    def setUp(self):
+        self.outdir = "toast_test_output"
+        if self.comm.rank == 0:
+            if not os.path.isdir(self.outdir):
+                os.mkdir(self.outdir)
+
+    def tearDown(self):
+        pass
+
+
+    def test_precession(self):
+        start = MPI.Wtime()
+
+        # Test precession axis slew
+        slewrate = 1.0 / (24.0*3600.0)
+        degday = 360.0 / 365.0
+
+        qprec = slew_precession_axis(nsim=366, firstsamp=0,
+            samplerate=slewrate, degday=degday)
+
+        zaxis = np.array([0.0, 0.0, 1.0])
+
+        v = qa.rotate(qprec, zaxis)
+
+        dotprod = v[0][0] * v[-1][0] + v[0][1] * v[-1][1] + v[0][2] * v[-1][2]
+        np.testing.assert_almost_equal(dotprod, 1.0)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
+
+
+    def test_phase(self):
+        start = MPI.Wtime()
+
+        # Choose scan parameters so that we return to the origin.
+        nobs = 366
+        precangle = 35.0
+        spinangle = 55.0
+        spinperiod = 240
+        precperiod = 8640
+
+        # Precession axis slew
+        degday = 360.0 / 366.0
+
+        samplerate = 1.0 / 60.0
+
+        daysamps = 24 * 60
+        goodsamps = 24 * 60
+        #goodsamps = 22 * 60
+        badsamps = daysamps - goodsamps
+
+        # hit map
+        nside = 32
+        pix = hpx.Pixels(nside)
+        pdata = np.zeros(12*nside*nside, dtype=np.int32)
+
+        # Only simulate 22 out of 24 hours per observation, in order to test
+        # that the starting phase is propagated.  Put the "gap" at the start
+        # of each day, so that we can look at the final data point of the
+        # final observation.
+
+        zaxis = np.array([0.0, 0.0, 1.0])
+
+        vlast = None
+
+        for ob in range(nobs):
+            firstsamp = ob * daysamps + badsamps
+
+            # On the last observation, simulate one extra sample so we get
+            # back to the starting point.
+            nsim = goodsamps
+            if ob == nobs - 1:
+                nsim += 1
+
+            qprec = slew_precession_axis(nsim=nsim, firstsamp=firstsamp,
+                samplerate=samplerate, degday=degday)
+
+            boresight = satellite_scanning(nsim=nsim, firstsamp=firstsamp,
+                samplerate=samplerate, qprec=qprec, spinperiod=spinperiod,
+                spinangle=spinangle, precperiod=precperiod, precangle=precangle)
+
+            v = qa.rotate(boresight, zaxis)
+            p = pix.vec2ring(v)
+            pdata[p] += 1
+            vlast = v[-1]
+            # print("obs {}:  {} -->".format(ob, v[0]))
+            # print("obs {}:      {}".format(ob, v[-6]))
+            # print("obs {}:      {}".format(ob, v[-5]))
+            # print("obs {}:      {}".format(ob, v[-4]))
+            # print("obs {}:      {}".format(ob, v[-3]))
+            # print("obs {}:      {}".format(ob, v[-2]))
+            # print("obs {}:      {}".format(ob, v[-1]))
+
+        import matplotlib.pyplot as plt
+        hitsfile = os.path.join(self.outdir, 'tod_satellite_hits.fits')
+        if self.comm.rank == 0:
+            if os.path.isfile(hitsfile):
+                os.remove(hitsfile)
+        self.comm.barrier()
+        hp.write_map(hitsfile, pdata, nest=False, dtype=np.int32)
+
+        outfile = "{}.png".format(hitsfile)
+        hp.mollview(pdata, xsize=1600, nest=False)
+        plt.savefig(outfile)
+        plt.close()
+
+        np.testing.assert_almost_equal(vlast[0], 0.0)
+        np.testing.assert_almost_equal(vlast[1], -1.0)
+        np.testing.assert_almost_equal(vlast[2], 0.0)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
+
+
+    def test_todclass(self):
+        start = MPI.Wtime()
+
+        tcomm = Comm(world=self.comm, groupsize=self.comm.size)
+
+        # Choose scan parameters so that we return to the origin.
+        nobs = 366
+        precangle = 35.0
+        spinangle = 55.0
+        spinperiod = 240
+        precperiod = 8640
+
+        # Precession axis slew
+        degday = 360.0 / 366.0
+
+        samplerate = 1.0 / 60.0
+
+        daysamps = 24 * 60
+        goodsamps = 24 * 60
+        #goodsamps = 22 * 60
+        badsamps = daysamps - goodsamps
+
+        # hit map
+        nside = 32
+        pix = hpx.Pixels(nside)
+        pdata = np.zeros(12*nside*nside, dtype=np.int32)
+
+        # Only simulate 22 out of 24 hours per observation, in order to test
+        # that the starting phase is propagated.  Put the "gap" at the start
+        # of each day, so that we can look at the final data point of the
+        # final observation.
+
+        zaxis = np.array([0.0, 0.0, 1.0])
+
+        vlast = None
+
+        dets = {
+            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
+        }
+
+        for ob in range(nobs):
+            firstsamp = ob * daysamps + badsamps
+
+            # On the last observation, simulate one extra sample so we get
+            # back to the starting point.
+            nsim = goodsamps
+            if ob == nobs - 1:
+                nsim += 1
+
+            tod = TODSatellite(
+                tcomm.comm_group, dets, nsim,
+                firstsamp=firstsamp,
+                firsttime=(firstsamp / samplerate),
+                rate=samplerate,
+                spinperiod=spinperiod,
+                spinangle=spinangle,
+                precperiod=precperiod,
+                precangle=precangle
+            )
+
+            qprec = slew_precession_axis(nsim=nsim, firstsamp=firstsamp,
+                samplerate=samplerate, degday=degday)
+
+            tod.set_prec_axis(qprec=qprec)
+
+            boresight = tod.read_boresight()
+
+            v = qa.rotate(boresight, zaxis)
+            p = pix.vec2ring(v)
+            pdata[p] += 1
+            vlast = v[-1]
+            print("obs {}:  {} -->".format(ob, v[0]))
+            print("obs {}:      {}".format(ob, v[-6]))
+            print("obs {}:      {}".format(ob, v[-5]))
+            print("obs {}:      {}".format(ob, v[-4]))
+            print("obs {}:      {}".format(ob, v[-3]))
+            print("obs {}:      {}".format(ob, v[-2]))
+            print("obs {}:      {}".format(ob, v[-1]))
+
+        import matplotlib.pyplot as plt
+        hitsfile = os.path.join(self.outdir, 'tod_satellite_classhits.fits')
+        if self.comm.rank == 0:
+            if os.path.isfile(hitsfile):
+                os.remove(hitsfile)
+        self.comm.barrier()
+        hp.write_map(hitsfile, pdata, nest=False, dtype=np.int32)
+
+        outfile = "{}.png".format(hitsfile)
+        hp.mollview(pdata, xsize=1600, nest=False)
+        plt.savefig(outfile)
+        plt.close()
+
+        np.testing.assert_almost_equal(vlast[0], 0.0)
+        np.testing.assert_almost_equal(vlast[1], -1.0)
+        np.testing.assert_almost_equal(vlast[2], 0.0)
+
+        stop = MPI.Wtime()
+        elapsed = stop - start
+        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))

--- a/src/python/tests/tod_satellite.py
+++ b/src/python/tests/tod_satellite.py
@@ -109,13 +109,6 @@ class TODSatelliteTest(MPITestCase):
             p = pix.vec2ring(v)
             pdata[p] += 1
             vlast = v[-1]
-            # print("obs {}:  {} -->".format(ob, v[0]))
-            # print("obs {}:      {}".format(ob, v[-6]))
-            # print("obs {}:      {}".format(ob, v[-5]))
-            # print("obs {}:      {}".format(ob, v[-4]))
-            # print("obs {}:      {}".format(ob, v[-3]))
-            # print("obs {}:      {}".format(ob, v[-2]))
-            # print("obs {}:      {}".format(ob, v[-1]))
 
         import matplotlib.pyplot as plt
         hitsfile = os.path.join(self.outdir, 'tod_satellite_hits.fits')
@@ -210,13 +203,6 @@ class TODSatelliteTest(MPITestCase):
             p = pix.vec2ring(v)
             pdata[p] += 1
             vlast = v[-1]
-            print("obs {}:  {} -->".format(ob, v[0]))
-            print("obs {}:      {}".format(ob, v[-6]))
-            print("obs {}:      {}".format(ob, v[-5]))
-            print("obs {}:      {}".format(ob, v[-4]))
-            print("obs {}:      {}".format(ob, v[-3]))
-            print("obs {}:      {}".format(ob, v[-2]))
-            print("obs {}:      {}".format(ob, v[-1]))
 
         import matplotlib.pyplot as plt
         hitsfile = os.path.join(self.outdir, 'tod_satellite_classhits.fits')

--- a/src/python/tod/sim_tod.py
+++ b/src/python/tod/sim_tod.py
@@ -74,12 +74,7 @@ def slew_precession_axis(nsim=1000, firstsamp=0, samplerate=100.0, degday=1.0):
     sataxis = np.concatenate((cang.reshape(-1, 1), sang.reshape(-1, 1),
                               np.zeros((nsim, 1))), axis=1)
 
-    # Speed this up later, if needed, to avoid explicit loop.
-    satquat = np.empty((nsim, 4), dtype=np.float64)
-    for i in range(nsim):
-        satquat[i][:] = qa.from_vectors(zaxis, sataxis[i])
-
-    return satquat
+    return qa.from_vectors(np.tile(zaxis, nsim).reshape(-1, 3), sataxis)
 
 
 def satellite_scanning(nsim=1000, firstsamp=0, samplerate=100.0, qprec=None,

--- a/src/python/tod/sim_tod.py
+++ b/src/python/tod/sim_tod.py
@@ -52,6 +52,8 @@ def slew_precession_axis(nsim=1000, firstsamp=0, samplerate=100.0, degday=1.0):
         shape (nsim, 4).
     """
     autotimer = timing.auto_timer()
+    zaxis = np.array([0.0, 0.0, 1.0])
+
     # this is the increment in radians per sample
     angincr = degday * (np.pi / 180.0) / (24.0 * 3600.0 * samplerate)
 
@@ -62,7 +64,8 @@ def slew_precession_axis(nsim=1000, firstsamp=0, samplerate=100.0, degday=1.0):
 
     satang = np.arange(nsim, dtype=np.float64)
     satang *= angincr
-    satang += angincr * firstsamp + (np.pi / 2)
+    satang += angincr * firstsamp
+    #satang += angincr * firstsamp + (np.pi / 2)
 
     cang = np.cos(satang)
     sang = np.sin(satang)
@@ -71,15 +74,10 @@ def slew_precession_axis(nsim=1000, firstsamp=0, samplerate=100.0, degday=1.0):
     sataxis = np.concatenate((cang.reshape(-1, 1), sang.reshape(-1, 1),
                               np.zeros((nsim, 1))), axis=1)
 
-    # the rotation about the axis is always pi/2
-    csatrot = np.cos(0.25 * np.pi)
-    ssatrot = np.sin(0.25 * np.pi)
-
-    # now construct the axis-angle quaternions for the precession
-    # axis
-    sataxis = np.multiply(np.repeat(ssatrot, nsim).reshape(-1,1), sataxis)
-    satquat = np.concatenate((sataxis, np.repeat(csatrot, nsim).reshape(-1,1)),
-                             axis=1)
+    # Speed this up later, if needed, to avoid explicit loop.
+    satquat = np.empty((nsim, 4), dtype=np.float64)
+    for i in range(nsim):
+        satquat[i][:] = qa.from_vectors(zaxis, sataxis[i])
 
     return satquat
 
@@ -97,6 +95,9 @@ def satellite_scanning(nsim=1000, firstsamp=0, samplerate=100.0, qprec=None,
 
     Args:
         nsim (int) : The number of samples to simulate.
+        firstsamp (int): The offset in samples from the start
+            of rotation.
+        samplerate (float): The sampling rate in Hz.
         qprec (ndarray): If None (the default), then the
             precession axis will be fixed along the
             X axis.  If a 1D array of size 4 is given,
@@ -105,7 +106,6 @@ def satellite_scanning(nsim=1000, firstsamp=0, samplerate=100.0, qprec=None,
             precession axis.  If a 2D array of shape
             (nsim, 4) is given, this is the time-varying
             rotation of the Z axis to the precession axis.
-        samplerate (float): The sampling rate in Hz.
         spinperiod (float): The period (in minutes) of the
             rotation about the spin axis.
         spinangle (float): The opening angle (in degrees)
@@ -371,6 +371,8 @@ class TODSatellite(TOD):
         detectors (dictionary): each key is the detector name, and each value
             is a quaternion tuple.
         samples (int):  The total number of samples.
+        firstsamp (int): The offset in samples from the start
+            of the mission.
         firsttime (float): starting time of data.
         rate (float): sample rate in Hz.
         spinperiod (float): The period (in minutes) of the
@@ -384,13 +386,14 @@ class TODSatellite(TOD):
         All other keyword arguments are passed to the parent constructor.
 
     """
-    def __init__(self, mpicomm, detectors, samples, firsttime=0.0, rate=100.0,
-                 spinperiod=1.0, spinangle=85.0, precperiod=0.0, precangle=0.0,
-                 **kwargs):
+    def __init__(self, mpicomm, detectors, samples, firstsamp=0, firsttime=0.0,
+        rate=100.0, spinperiod=1.0, spinangle=85.0, precperiod=0.0,
+        precangle=0.0, **kwargs):
 
         self._fp = detectors
         self._detlist = sorted(list(self._fp.keys()))
 
+        self._firstsamp = firstsamp
         self._firsttime = firsttime
         self._rate = rate
         self._spinperiod = spinperiod
@@ -440,7 +443,8 @@ class TODSatellite(TOD):
 
         # generate and cache the boresight pointing
         self._boresight = satellite_scanning(
-            nsim=self.local_samples[1], firstsamp=self.local_samples[0],
+            nsim=self.local_samples[1],
+            firstsamp=(self._firstsamp + self.local_samples[0]),
             qprec=qprec, samplerate=self._rate, spinperiod=self._spinperiod,
             spinangle=self._spinangle, precperiod=self._precperiod,
             precangle=self._precangle)


### PR DESCRIPTION
This work expands the unit tests for satellite boresight simulations.  It fixes a bug in the slewing of the precession axis.  It also adds a constructor option to the TODSatellite class to specify the starting global offset of the observation.  This offset is then passed to the calculation functions for the precession axis and the boresight quaternions.  This ensures that the phase of the boresight pointing is correct, even if there are gaps between observations.  Closes #224.