### PR TITLE
Use buffered operations in all places where detector pointing is used.

### DIFF
--- a/src/python/tests/map_satellite.py
+++ b/src/python/tests/map_satellite.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -96,29 +96,32 @@ class MapSatelliteTest(MPITestCase):
             # create the TOD for this observation
 
             tod = TODSatellite(
-                self.toastcomm.comm_group, 
-                self.dets, 
-                self.totsamp, 
-                firsttime=0.0, 
-                rate=self.rate, 
+                self.toastcomm.comm_group,
+                self.dets,
+                self.totsamp,
+                firsttime=0.0,
+                rate=self.rate,
                 spinperiod=self.spinperiod,
                 spinangle=self.spinangle,
-                precperiod=self.precperiod, 
-                precangle=self.precangle, 
+                precperiod=self.precperiod,
+                precangle=self.precangle,
                 sampsizes=chunks)
 
-            precquat = slew_precession_axis(nsim=self.totsamp, firstsamp=0, samplerate=self.rate, degday=1.0)
+            precquat = np.empty(4 * self.totsamp,
+                                dtype=np.float64).reshape((-1, 4))
+            slew_precession_axis(precquat, firstsamp=0, samplerate=self.rate,
+                                 degday=1.0)
 
             tod.set_prec_axis(qprec=precquat)
 
             # add analytic noise model with white noise
 
             nse = AnalyticNoise(
-                rate=self.rates, 
+                rate=self.rates,
                 fmin=self.fmins,
                 detectors=self.detnames,
-                fknee=self.fknee, 
-                alpha=self.alpha, 
+                fknee=self.fknee,
+                alpha=self.alpha,
                 NET=self.netd)
 
             ob = {}
@@ -140,7 +143,10 @@ class MapSatelliteTest(MPITestCase):
 
         zaxis = np.array([0,0,1], dtype=np.float64)
 
-        borequat = satellite_scanning(nsim=1000, qprec=None, samplerate=100.0, spinperiod=1.0, spinangle=0.0, precperiod=20.0, precangle=0.0)
+        borequat = np.empty(4*nsim, dtype=np.float64).reshape((-1, 4))
+        satellite_scanning(borequat, qprec=None, samplerate=100.0,
+                           spinperiod=1.0, spinangle=0.0, precperiod=20.0,
+                           precangle=0.0)
 
         data = qa.rotate(borequat, np.tile(zaxis, nsim).reshape(-1,3))
 
@@ -348,7 +354,7 @@ class MapSatelliteTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
         distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
@@ -445,7 +451,7 @@ class MapSatelliteTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
         distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
@@ -543,7 +549,7 @@ class MapSatelliteTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
         distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
@@ -591,7 +597,7 @@ class MapSatelliteTest(MPITestCase):
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
-                
+
                 hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
                 hits = hp.read_map(hitsfile, nest=True)
 
@@ -617,4 +623,3 @@ class MapSatelliteTest(MPITestCase):
 
         else:
             print("libmadam not available, skipping tests")
-

--- a/src/python/tests/tod_satellite.py
+++ b/src/python/tests/tod_satellite.py
@@ -40,7 +40,8 @@ class TODSatelliteTest(MPITestCase):
         slewrate = 1.0 / (24.0*3600.0)
         degday = 360.0 / 365.0
 
-        qprec = slew_precession_axis(nsim=366, firstsamp=0,
+        qprec = np.empty(4 * 366, dtype=np.float64).reshape((-1, 4))
+        slew_precession_axis(qprec, firstsamp=0,
             samplerate=slewrate, degday=degday)
 
         zaxis = np.array([0.0, 0.0, 1.0])
@@ -98,10 +99,12 @@ class TODSatelliteTest(MPITestCase):
             if ob == nobs - 1:
                 nsim += 1
 
-            qprec = slew_precession_axis(nsim=nsim, firstsamp=firstsamp,
+            qprec = np.empty(4 * nsim, dtype=np.float64).reshape((-1, 4))
+            slew_precession_axis(qprec, firstsamp=firstsamp,
                 samplerate=samplerate, degday=degday)
 
-            boresight = satellite_scanning(nsim=nsim, firstsamp=firstsamp,
+            boresight = np.empty(4 * nsim, dtype=np.float64).reshape((-1, 4))
+            satellite_scanning(boresight, firstsamp=firstsamp,
                 samplerate=samplerate, qprec=qprec, spinperiod=spinperiod,
                 spinangle=spinangle, precperiod=precperiod, precangle=precangle)
 
@@ -192,7 +195,8 @@ class TODSatelliteTest(MPITestCase):
                 precangle=precangle
             )
 
-            qprec = slew_precession_axis(nsim=nsim, firstsamp=firstsamp,
+            qprec = np.empty(4 * nsim, dtype=np.float64).reshape((-1, 4))
+            slew_precession_axis(qprec, firstsamp=firstsamp,
                 samplerate=samplerate, degday=degday)
 
             tod.set_prec_axis(qprec=qprec)

--- a/src/python/tod/sim_det_dipole.py
+++ b/src/python/tod/sim_det_dipole.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 
@@ -15,6 +15,10 @@ from .tod import TOD
 from ..op import Operator
 
 from .tod_math import dipole
+
+# FIXME: Once the global package control interface is added,
+# move this to that unified location.
+tod_buffer_length = 1048576
 
 
 class OpSimDipole(Operator):
@@ -41,20 +45,20 @@ class OpSimDipole(Operator):
             otherwise add it (default).
         out (str): accumulate data to the cache with name <out>_<detector>.
             If the named cache objects do not exist, then they are created.
-        cmb (float): CMB monopole in Kelvin.  Default value from Fixsen 
+        cmb (float): CMB monopole in Kelvin.  Default value from Fixsen
             2009 (see arXiv:0911.1955)
-        solar_speed (float): the amplitude of the solarsystem barycenter 
-            velocity with respect to the CMB in Km/s.  The default value is 
+        solar_speed (float): the amplitude of the solarsystem barycenter
+            velocity with respect to the CMB in Km/s.  The default value is
             based on http://arxiv.org/abs/0803.0732.
-        solar_gal_lat (float): the latitude in degrees in galactic 
-            coordinates for the direction of motion of the solarsystem with 
+        solar_gal_lat (float): the latitude in degrees in galactic
+            coordinates for the direction of motion of the solarsystem with
             respect to the CMB rest frame.
-        solar_gal_lon (float): the longitude in degrees in galactic 
-            coordinates for the direction of motion of the solarsystem with 
+        solar_gal_lon (float): the longitude in degrees in galactic
+            coordinates for the direction of motion of the solarsystem with
             respect to the CMB rest frame.
         freq (float): optional observing frequency in Hz (not GHz).
     """
-    def __init__(self, mode='total', coord='C', subtract=False, out='dipole', 
+    def __init__(self, mode='total', coord='C', subtract=False, out='dipole',
                  cmb=2.72548, solar_speed=369.0, solar_gal_lat=48.26,
                  solar_gal_lon=263.99, freq=0, keep_quats=False, keep_vel=False,
                  flag_mask=255, common_flag_mask=255):
@@ -94,7 +98,7 @@ class OpSimDipole(Operator):
         Create the timestreams.
 
         This loops over all observations and detectors and uses the pointing,
-        the telescope motion, and the solar system motion to compute the 
+        the telescope motion, and the solar system motion to compute the
         observed dipole.
 
         Args:
@@ -122,8 +126,12 @@ class OpSimDipole(Operator):
 
             if (self._mode == 'solar') or (self._mode == 'total'):
                 sol = self._solar_vel
+
             if (self._mode == 'orbital') or (self._mode == 'total'):
-                vel = tod.local_velocity()
+                if self._keep_vel:
+                    vel = tod.local_velocity()
+                else:
+                    vel = tod.read_velocity()
 
             common = tod.local_common_flags() & self._common_flag_mask
 
@@ -133,32 +141,49 @@ class OpSimDipole(Operator):
                 totflags = (flags | common)
                 del flags
 
-                pdata = tod.local_pointing(det).copy()
-                pdata[(totflags != 0), :] = nullquat
+                pdata = None
+                if self._keep_quats:
+                    # We are keeping the detector quaternions, so cache
+                    # them now for the full sample range.
+                    pdata = tod.local_pointing(det)
 
-                dipoletod = dipole(pdata, vel=vel, solar=sol, cmb=self._cmb,
-                                   freq=self._freq)
-                del pdata
-
+                # Set up output cache
                 cachename = "{}_{}".format(self._out, det)
                 if not tod.cache.exists(cachename):
                     tod.cache.create(cachename, np.float64, (nsamp, ))
-                
                 ref = tod.cache.reference(cachename)
-                if self._subtract:
-                    ref[:] -= dipoletod
-                else:
-                    ref[:] += dipoletod
+
+                buf_off = 0
+                buf_n = tod_buffer_length
+                while buf_off < nsamp:
+                    if buf_off + buf_n > nsamp:
+                        buf_n = nsamp - buf_off
+                    bslice = slice(buf_off, buf_off + buf_n)
+
+                    detp = None
+                    if pdata is None:
+                        # Read and discard
+                        detp = tod.read_pntg(detector=det, local_start=buf_off,
+                                             n=buf_n)
+                    else:
+                        # Use cached version
+                        detp = pdata[bslice,:]
+
+                    # Make sure that flagged pointing is well defined
+                    detp[(totflags[bslice] != 0), :] = nullquat
+
+                    dipoletod = dipole(detp, vel=vel[bslice], solar=sol,
+                                       cmb=self._cmb, freq=self._freq)
+                    if self._subtract:
+                        ref[bslice] -= dipoletod
+                    else:
+                        ref[bslice] += dipoletod
+                    buf_off += buf_n
+
+                del pdata
                 del ref
 
-                if not self._keep_quats:
-                    cachename = 'quat_{}'.format(det)
-                    tod.cache.destroy(cachename)
-
+            del vel
             del common
-
-            if vel is not None and not self._keep_vel:
-                del vel
-                tod.cache.destroy('velocity')
 
         return

--- a/src/python/tod/sim_det_dipole.py
+++ b/src/python/tod/sim_det_dipole.py
@@ -172,7 +172,11 @@ class OpSimDipole(Operator):
                     # Make sure that flagged pointing is well defined
                     detp[(totflags[bslice] != 0), :] = nullquat
 
-                    dipoletod = dipole(detp, vel=vel[bslice], solar=sol,
+                    vslice = None
+                    if vel is not None:
+                        vslice = vel[bslice]
+
+                    dipoletod = dipole(detp, vel=vslice, solar=sol,
                                        cmb=self._cmb, freq=self._freq)
                     if self._subtract:
                         ref[bslice] -= dipoletod

--- a/src/python/tod/tod_math.py
+++ b/src/python/tod/tod_math.py
@@ -266,18 +266,18 @@ def dipole(pntg, vel=None, solar=None, cmb=2.72548, freq=0):
 
     beta = inv_light * speed.flatten()
 
-    dir = qa.rotate(pntg, zaxis)
+    direct = qa.rotate(pntg, zaxis)
 
     dipoletod = None
     if freq == 0:
         inv_gamma = np.sqrt(1.0 - beta**2)
-        num = 1.0 - beta * np.sum(v * dir, axis=1)
+        num = 1.0 - beta * np.sum(v * direct, axis=1)
         dipoletod = cmb * (inv_gamma / num - 1.0)
     else:
         # Use frequency for quadrupole correction
         fx = constants.h * freq / (constants.k * cmb)
         fcor = (fx / 2) * (np.exp(fx) + 1) / (np.exp(fx) - 1)
-        bt = beta * np.sum(v * dir, axis=1)
+        bt = beta * np.sum(v * direct, axis=1)
         dipoletod = cmb * (bt + fcor * bt**2)
 
     return dipoletod

--- a/src/python/todmap/pysm_operator.py
+++ b/src/python/todmap/pysm_operator.py
@@ -138,7 +138,7 @@ class OpSimPySM(Operator):
 
         lmax = 3 * self.nside - 1
 
-        if self.comm.rank == 0:
+        if self.comm.rank == 0 and self._debug:
             print('Collecting, Broadcasting map', flush=True)
         start = MPI.Wtime()
         local_maps = dict()  # FIXME use Cache instead


### PR DESCRIPTION
This makes several changes:

- If pointing quaternions are not to be cached, then read the pointing directly, rather than caching it and then deleting it.

- Perform all operations with the pointing in buffered chunks, with a buffer size that will eventually be set in the control.py file to be added in a separate PR.

- Do not cache detector quaternions in the satellite example pipeline.

See comments in #199 with results on a low-sample rate sim.  The impact will be even larger with higher sample rates and fewer detectors per process (since every process has a copy of the boresight).