### PR TITLE
Fix coordinates satellitesim pipeline

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -461,7 +461,7 @@ def main():
                 keep_quats=True,
                 keep_vel=False,
                 subtract=False,
-                coord="G",
+                coord="E",
                 freq=0,  # we could use frequency for quadrupole correction
                 flag_mask=255, common_flag_mask=255)
         op_sim_dipole.exec(data)

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -106,7 +106,8 @@ def simulate_sky_signal(args, comm, data, mem_counter, focalplanes, subnpix, loc
                                nside=args.nside,
                                subnpix=subnpix, localsm=localsm,
                                apply_beam=args.apply_beam,
-                               debug=args.debug)
+                               debug=args.debug,
+                               coord="E")
     op_sim_pysm.exec(data)
     stop = MPI.Wtime()
     if comm.comm_world.rank == 0:

--- a/src/python/todmap/pysm_operator.py
+++ b/src/python/todmap/pysm_operator.py
@@ -72,7 +72,7 @@ class OpSimPySM(Operator):
                  out='signal', pysm_model='', pysm_precomputed_cmb_K_CMB=None,
                  focalplanes=None, nside=None,
                  subnpix=None, localsm=None, apply_beam=False, nest=True,
-                 units='K_CMB', debug=False):
+                 units='K_CMB', debug=False, coord="G"):
         autotimer = timing.auto_timer(type(self).__name__)
         # We call the parent class constructor, which currently does nothing
         super().__init__()
@@ -84,6 +84,7 @@ class OpSimPySM(Operator):
         self.dist_rings = DistRings(comm,
                                     nside=nside,
                                     nnz=3)
+        self.coord = coord
 
         pysm_sky_components = [
             'synchrotron',
@@ -186,6 +187,12 @@ class OpSimPySM(Operator):
             self.comm.Barrier()
             if self.comm.rank == 0 and self._debug:
                 print('Communication completed', flush=True)
+            if self.comm.rank == 0 and self.coord != "G":
+                # PySM is always in Galactic, make rotation to Ecliptic or Equatorial
+                rot = hp.Rotator(coord = [self.coord, "G"])
+                theta_gal, phi_gal = rot(hp.pix2ang(self.nside, np.arange(self.npix)))
+                for pol in range(3):
+                    full_map_rank0[pol] = hp.get_interp_val(full_map_rank0[pol], theta_gal, phi_gal)
             if self.comm.rank == 0 and self._nest:
                 # PySM is RING, toast is NEST
                 full_map_rank0 = hp.reorder(full_map_rank0, r2n=True)


### PR DESCRIPTION
@ziotom78 and I noticed that the satellite pipeline was in Ecliptic coordinates, while PySM and Dipole were in Galactic coordinates.
These 2 commits fix the issue, we have tested them in PICO simulations, see https://github.com/zonca/pico-simulations/issues/11