### PR TITLE
Large refactor of unit tests to work correctly with multiple processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 
 matrix:
   include:
-    # GCC 4.8
+    # GCC 4.8 - this is the default version for many distros
     - os: linux
       dist: trusty
       sudo: false
@@ -28,32 +28,6 @@ matrix:
             - pkg-config
       env:
         - MATRIX_EVAL="export CC=$(which gcc) && export CXX=$(which g++) && export FC=$(which gfortran)"
-    # GCC 4.9
-    - os: linux
-      dist: trusty
-      sudo: false
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - build-essential
-            - gcc-4.9
-            - g++-4.9
-            - gfortran-4.9
-            - autoconf
-            - automake
-            - m4
-            - libtool
-            - libhdf5-dev
-            - libmpich-dev
-            - mpich
-            - fftw3-dev
-            - cfitsio-dev
-            - libatlas-base-dev
-            - pkg-config
-      env:
-        - MATRIX_EVAL="export CC=$(which gcc-4.9) && export CXX=$(which g++-4.9) && export FC=$(which gfortran-4.9)"
     # GCC 5
     - os: linux
       dist: trusty
@@ -213,8 +187,9 @@ install:
 # Configure, build, and run tests
 
 script:
-    - python -c "import toast.tests; toast.tests.run()"
-    - cd examples/; bash run_tiny_tests.sh
+    - export OMP_NUM_THREADS=2
+    - mpirun -np 4 python -c "import toast.tests; toast.tests.run()"
+    - cd examples/; mpirun -np 4 bash run_tiny_tests.sh
 
 # Slack integration
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,16 @@
-# We set the language to python, so that we can more easily specify our
-# build matrix.  We simply apt install the compiled dependencies.
+# We set the language to python, since we are focused on a recent python
+# version and want to use the build matrix for testing different compiler
+# versions.
 language: python
+
+# We use APT to get as many packages as possible.  Then we compile the rest
+# of our dependencies.  If you change any packages in the build matrix, you
+# should also update the travis dependency build script and rebuild the
+# tarballs of dependencies.
 
 matrix:
   include:
-    # GCC 4.8 - this is the default version for many distros
-    - os: linux
-      dist: trusty
-      sudo: false
-      addons:
-        apt:
-          packages:
-            - build-essential
-            - gcc
-            - g++
-            - gfortran
-            - autoconf
-            - automake
-            - m4
-            - libtool
-            - libhdf5-dev
-            - libmpich-dev
-            - mpich
-            - fftw3-dev
-            - cfitsio-dev
-            - libatlas-base-dev
-            - pkg-config
-      env:
-        - MATRIX_EVAL="export CC=$(which gcc) && export CXX=$(which g++) && export FC=$(which gfortran)"
-    # GCC 5
+    # GCC 4.9 - this is the oldest version working well with libelemental.
     - os: linux
       dist: trusty
       sudo: false
@@ -38,23 +20,57 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - build-essential
+            - git
+            - autoconf
+            - automake
+            - m4
+            - libtool
+            - cmake
+            - pkg-config
+            - locales
+            - libgl1-mesa-glx
+            - xvfb
+            - libopenblas-dev
+            - liblapack-dev
+            - libfftw3-dev
+            - libhdf5-dev
+            - libcfitsio3-dev
+            - gcc-4.9
+            - g++-4.9
+            - gfortran-4.9
+      env:
+        - MATRIX_EVAL="export CC=$(which gcc-4.9) && export CXX=$(which g++-4.9) && export FC=$(which gfortran-4.9) && export DEPGCC=-4.9"
+    # GCC 5 - default version for ubuntu 16.04 LTS
+    - os: linux
+      dist: trusty
+      sudo: false
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - build-essential
+            - git
+            - autoconf
+            - automake
+            - m4
+            - libtool
+            - cmake
+            - pkg-config
+            - locales
+            - libgl1-mesa-glx
+            - xvfb
+            - libopenblas-dev
+            - liblapack-dev
+            - libfftw3-dev
+            - libhdf5-dev
+            - libcfitsio3-dev
             - gcc-5
             - g++-5
             - gfortran-5
-            - autoconf
-            - automake
-            - m4
-            - libtool
-            - libhdf5-dev
-            - libmpich-dev
-            - mpich
-            - fftw3-dev
-            - cfitsio-dev
-            - libatlas-base-dev
-            - pkg-config
       env:
-        - MATRIX_EVAL="export CC=$(which gcc-5) && export CXX=$(which g++-5) && export FC=$(which gfortran-5)"
-    # GCC 6
+        - MATRIX_EVAL="export CC=$(which gcc-5) && export CXX=$(which g++-5) && export FC=$(which gfortran-5) && export DEPGCC=-5"
+    # GCC 7 - default version for ubuntu 18.04 LTS
     - os: linux
       dist: trusty
       sudo: false
@@ -64,132 +80,84 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - build-essential
-            - gcc-6
-            - g++-6
-            - gfortran-6
+            - git
             - autoconf
             - automake
             - m4
             - libtool
-            - libhdf5-dev
-            - libmpich-dev
-            - mpich
-            - fftw3-dev
-            - cfitsio-dev
-            - libatlas-base-dev
+            - cmake
             - pkg-config
-      env:
-        - MATRIX_EVAL="export CC=$(which gcc-6) && export CXX=$(which g++-6) && export FC=$(which gfortran-6)"
-    # GCC 7
-    - os: linux
-      dist: trusty
-      sudo: false
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - build-essential
+            - locales
+            - libgl1-mesa-glx
+            - xvfb
+            - libopenblas-dev
+            - liblapack-dev
+            - libfftw3-dev
+            - libhdf5-dev
+            - libcfitsio3-dev
             - gcc-7
             - g++-7
             - gfortran-7
-            - autoconf
-            - automake
-            - m4
-            - libtool
-            - libhdf5-dev
-            - libmpich-dev
-            - mpich
-            - fftw3-dev
-            - cfitsio-dev
-            - libatlas-base-dev
-            - pkg-config
       env:
-        - MATRIX_EVAL="export CC=$(which gcc-7) && export CXX=$(which g++-7) && export FC=$(which gfortran-7)"
+        - MATRIX_EVAL="export CC=$(which gcc-7) && export CXX=$(which g++-7) && export FC=$(which gfortran-7) && export DEPGCC=-7"
 
-# The versions to test
+# The python versions to test.
 python:
     - 3.6
 
-# Set up MPI and mpi4py
+# Download pre-built dependencies and set up our environment.
 
 before_install:
-    # set the C and C++ compilers
+    # Set the C and C++ compilers
     - eval "${MATRIX_EVAL}"
-    # Information about C and C++ compilers
-    - echo "CC = ${CC} $(${CC} -dumpversion)"
-    - echo "CXX = ${CXX} $(${CXX} -dumpversion)"
-    # set the MPICH underlying compilers
+    - echo "  CC = ${CC} $(${CC} -dumpversion)"
+    - echo "  CXX = ${CXX} $(${CXX} -dumpversion)"
+    - echo "  FC = ${FC} $(${FC} -dumpversion)"
+    # Set python site version
+    - export PYSITE=$(python --version 2>&1 | awk '{print $2}' | sed -e "s#\(.*\)\.\(.*\)\..*#\1.\2#")
+    - echo "Python site version = ${PYSITE}"
+    # Install python dependencies. NOTE:  if you change this list, also
+    # change them in the dependency tarball script.
+    - pip install -q numpy scipy matplotlib cython astropy ephem healpy
+    - pip install -q https://github.com/bthorne93/PySM_public/archive/2.1.0.tar.gz
+    # Install all compiled dependencies from a pre-cached location
+    - export DEPSURL="http://portal.nersc.gov/project/cmb/toast_travis/travis_14.04_gcc${DEPGCC}_python${PYSITE}.tar.bz2"
+    - echo "Fetching dependencies from ${DEPSURL}"
+    - wget ${DEPSURL}
+    - tar xjf travis_14.04_gcc${DEPGCC}_python${PYSITE}.tar.bz2 --directory ${HOME}
+    # Load dependencies into our search paths
+    - export PATH="${HOME}/software/bin:${PATH}"
+    - export CPATH="${HOME}/software/include:${CPATH}"
+    - export LIBRARY_PATH="${HOME}/software/lib:${LIBRARY_PATH}"
+    - export LD_LIBRARY_PATH="${HOME}/software/lib:${LD_LIBRARY_PATH}"
+    - export PYTHONPATH="${HOME}/software/lib/python${PYSITE}/site-packages:${PYTHONPATH}"
+    # MPI compilers
     - export MPICC=$(which mpicc)
     - export MPICXX=$(which mpicxx)
-    - export MPICH_CC=${CC}
-    - export MPICH_CXX=${CXX}
-    # F90 required by libmadam
     - export MPIFC=$(which mpif90)
-    - export MPICH_FC=${FC}
-    # explicitly set the C and C++ compilers to MPICH compilers for autotools
-    - export CC=$(which mpicc)
-    - export CXX=$(which mpicxx)
-    # information about the MPI compilers
-    - echo "MPICC = ${MPICC}"
-    - echo "MPICXX = ${MPICXX}"
-    - echo "[MPI] CC = ${CC} $(${CC} -dumpversion)"
-    - echo "[MPI] CXX = ${CXX} $(${CXX} -dumpversion)"
-    - ${MPICC} -v
-    - ${MPICXX} -v
-    # miniconda install
-    - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    - bash miniconda.sh -b -p $HOME/miniconda
-    - export PATH="$HOME/miniconda/bin:$PATH"
-    - hash -r
-    - conda config --set always_yes yes --set changeps1 no
-    - conda update -q conda
-    # Useful for debugging any issues with conda
-    - conda info -a
-    - conda install -c conda-forge numpy scipy matplotlib healpy pyephem pip cython
-    - pip install mpi4py
-    # Install libsharp C
-    - git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1
-    - cd libsharp
-    - autoreconf
-    - ./configure --enable-mpi --enable-pic
-    - make
-    - export LIBSHARP="$HOME/miniconda"
-    - cp -r auto/* $LIBSHARP
-    # Install libsharp Python
-    - cd python
-    - CC="mpicc -g" LDSHARED="mpicc -g -shared" python setup.py install
-    - cd ../..
-    # Install PySM
-    - pip install https://github.com/bthorne93/PySM_public/archive/2.1.0.tar.gz
-    # Install libmadam from github master
-    - git clone https://github.com/hpc4cmb/libmadam.git --single-branch --depth 1
-    - cd libmadam
-    - ./autogen.sh
-    - export FCFLAGS="-O0 -g -fbounds-check -fPIC"
-    - export CFLAGS="-O0 -g -fPIC"
-    - ./configure --prefix=$HOME/miniconda
-    - make
-    - make install
-    - cd ..
 
-# Skip this
+# Install TOAST.
 
 install:
-    # build
+    # Build and install
     - ./autogen.sh
-    - export CFLAGS="-O3 -g -fPIC -pthread -std=c99"
-    - export CXXFLAGS="-O3 -g -fPIC -pthread"
-    - ./configure --prefix=$HOME/miniconda
-    - make
+    - export GCCSTD=""
+    - if [ "x${DEPGCC}" = "x-4.9" ]; then export GCCSTD="-std=gnu++11"; fi
+    - if [ "x${DEPGCC}" = "x-5" ]; then export GCCSTD="-std=gnu++11"; fi
+    - CC="${MPICC}" CXX="${MPICXX}" CFLAGS="-O2 -g -fPIC -pthread -std=c99" CXXFLAGS="-O2 -g -fPIC -pthread ${GCCSTD}" ./configure --prefix=${HOME}/toast
+    - make -j 2
     - make install
+    # Load TOAST install prefix into our environment
+    - export PATH="${HOME}/toast/bin:${PATH}"
+    - export CPATH="${HOME}/toast/include:${CPATH}"
+    - export LIBRARY_PATH="${HOME}/toast/lib:${LIBRARY_PATH}"
+    - export LD_LIBRARY_PATH="${HOME}/toast/lib:${LD_LIBRARY_PATH}"
+    - export PYTHONPATH="${HOME}/toast/lib/python${PYSITE}/site-packages:${PYTHONPATH}"
 
-# Configure, build, and run tests
+# Run tests
 
 script:
-    - export OMP_NUM_THREADS=2
-    - mpirun -np 4 python -c "import toast.tests; toast.tests.run()"
-    - cd examples/; mpirun -np 4 bash run_tiny_tests.sh
+    - ./travis/travis_run.sh
 
 # Slack integration
 

--- a/external/static/install_ubuntu_18.04.sh
+++ b/external/static/install_ubuntu_18.04.sh
@@ -1,0 +1,269 @@
+#!/bin/bash
+
+# WARNING:  If you upgrade versions of python3 (i.e. 3.6 --> 3.7) you will
+# need to rerun this install.
+
+# NOTE:  This script expects to be located in the toast/external/static
+# directory, so that it can find patch files at the relative location.  You
+# can run the script in some other working directory, but leave this file
+# in place.  For example:
+#
+# $>  cd workdir
+# $>  /path/to/toast/external/static/install_ubuntu_18.04.sh | tee log
+#
+
+# ---------------------- Install options ------------------------
+
+# Set this to the install prefix for compiled dependencies.  If only the root
+# user can write to this directory, then you will have to run this script with
+# "sudo".
+PREFIX=/home/kisner/software/toastdeps
+
+# Set this to the unix group that should own the final installed software.
+# If empty, it will not be changed.
+CHGRP=""
+
+# Set this to the permissions string that should be used on the final installed
+# software.  If empty, it will not be changed.  This default ensures that no
+# one can change the installed files without first restoring write permission.
+CHMOD=""
+
+
+# ------------- Install dependencies provided by the OS. ---------------
+#
+# Use APT to get everything we can.  Alternatively, you could provide the
+# python packages here by installing Anaconda.
+#
+
+sudo apt-get update
+
+sudo apt-get install -y curl procps build-essential gfortran git subversion \
+    autoconf automake libtool m4 cmake locales libgl1-mesa-glx xvfb \
+    libfftw3-dev \
+    libopenblas-dev \
+    libcfitsio-dev \
+    libhdf5-dev \
+    python3 \
+    libpython3-dev \
+    python3-pip \
+    python3-nose \
+    python3-numpy \
+    python3-scipy \
+    python3-matplotlib \
+    python3-yaml \
+    python3-h5py \
+    cython3
+
+# ------------------- Set up install prefix ------------------------
+#
+# Much of this stuff is not strictly necessary- it is just making the
+# software nicer to load into user shell environments.
+#
+
+# Create the prefix directories
+
+mkdir -p "${PREFIX}/lib"
+mkdir -p "${PREFIX}/bin"
+mkdir -p "${PREFIX}/include"
+mkdir -p "${PREFIX}/etc"
+pushd "${PREFIX}"
+if [ ! -e lib64 ]; then
+    ln -s lib lib64
+fi
+popd > /dev/null
+
+# In the ${PREFIX}/etc directory above, create a small shell file which will
+# load all this software into a user's environment.
+
+ENV_FILE="${PREFIX}/etc/toast_env.sh"
+
+# What is the name of our python site-packages directory?
+PYSITE=$(python3 --version 2>&1 | awk '{print $2}' | sed -e "s#\(.*\)\.\(.*\)\..*#\1.\2#")
+mkdir -p "${PREFIX}/lib/python${PYSITE}/site-packages"
+
+echo "# Load TOAST dependencies into the environment" > "${ENV_FILE}"
+
+echo "export PATH=\"${PREFIX}/bin:${PATH}\"" >> "${ENV_FILE}"
+echo "export CPATH=\"${PREFIX}/include:${CPATH}\"" >> "${ENV_FILE}"
+echo "export LIBRARY_PATH=\"${PREFIX}/lib:${LIBRARY_PATH}\"" >> "${ENV_FILE}"
+echo "export LD_LIBRARY_PATH=\"${PREFIX}/lib:${LD_LIBRARY_PATH}\"" >> "${ENV_FILE}"
+echo "export PYTHONPATH=\"${PREFIX}/lib/python${PYSITE}/site-packages:${PYTHONPATH}\"" >> "${ENV_FILE}"
+echo "" >> "${ENV_FILE}"
+
+# Load this shell snippet now, to put the prefix into our search paths
+
+. "${ENV_FILE}"
+
+
+# -------------- Install other required software  --------------------
+#
+# These are required packages where we would really like to have the
+# latest stable versions (i.e. not from the OS package manager).
+#
+
+# Use pip where possible to install packages into our separate prefix.
+# Note that this will pull in other updated dependencies, but we are
+# putting this into our own prefix (not /usr), so it is fine.  One could
+# also use a virtualenv or install these via anaconda if you were using
+# anaconda already to provide python3.
+
+pip3 install --no-cache-dir --system --target="${PREFIX}/lib/python${PYSITE}/site-packages" ephem
+
+# Install our own MPICH
+
+curl -SL http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz \
+    | tar -xzf - \
+    && cd mpich-3.2 \
+    && CC="gcc" CXX="g++" FC="gfortran" \
+    CFLAGS="-O3 -fPIC -pthread" CXXFLAGS="-O3 -fPIC -pthread" FCFLAGS="-O3 -fPIC -pthread" \
+    ./configure --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf mpich-3.2*
+
+# Install Healpix
+
+ curl -SL https://github.com/tskisner/healpix-autotools/releases/download/v3.31.4/healpix-autotools-3.31.4.tar.bz2 \
+    | tar -xjf - \
+    && cd healpix-autotools-3.31.4 \
+    && CC="gcc" CXX="g++" FC="gfortran" PYTHON="/usr/bin/python3" \
+    CFLAGS="-O3 -fPIC -pthread -std=gnu99" CXXFLAGS="-O3 -fPIC -pthread -std=c++98" FCFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" --prefix="${PREFIX}" \
+    && make && make install \
+    && cd .. \
+    && rm -rf healpix*
+
+# Install Latest mpi4py.  We want to build this ourselves so that it uses the
+# MPI version we have installed (MPICH or OpenMPI).  We also need a version
+# >= 2.0 so that we can pass the communicator between python and C++.
+
+ curl -SL https://pypi.python.org/packages/31/27/1288918ac230cc9abc0da17d84d66f3db477757d90b3d6b070d709391a15/mpi4py-3.0.0.tar.gz#md5=bfe19f20cef5e92f6e49e50fb627ee70 \
+    | tar xzf - \
+    && cd mpi4py-3.0.0 \
+    && python3 setup.py install --prefix="${PREFIX}" \
+    && cd .. \
+    && rm -rf mpi4py*
+
+
+#--------------------- Optional dependecies ---------------------
+#
+# Although not strictly required, these packages enable important
+# features, such as destriping map-making, 4Pi beam convolution,
+# atmosphere simulation and bandpass integration.
+#
+
+# Where is this script located, so we can find any patch files?
+
+pushd $(dirname $0) > /dev/null
+SDIR=$(pwd)
+popd > /dev/null
+
+# Install latest libmadam
+
+ curl -SL https://github.com/hpc4cmb/libmadam/releases/download/0.2.7/libmadam-0.2.7.tar.bz2 \
+    | tar -xjf - \
+    && cd libmadam-0.2.7 \
+    && FC="mpifort" MPIFC="mpifort" FCFLAGS="-O3 -fPIC -pthread" \
+    CC="mpicc" MPICC="mpicc" CFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" \
+    --with-blas="-lopenblas" --with-lapack="" \
+    --with-fftw="/usr" --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf libmadam*
+
+# Install conviqt
+
+ curl -SL https://www.dropbox.com/s/4tzjn9bgq7enkf9/libconviqt-1.0.2.tar.bz2?dl=0 \
+    | tar -xjf - \
+    && cd libconviqt-1.0.2 \
+    && CC="mpicc" CXX="mpicxx" MPICC="mpicc" MPICXX="mpicxx" \
+    CFLAGS="-O3 -fPIC -pthread -std=gnu99" CXXFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --with-cfitsio="/usr" --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf libconviqt*
+
+# Install elemental
+
+ curl -SL https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz \
+    | tar -xzf - \
+    && cd Elemental-0.87.7 \
+    && mkdir build && cd build \
+    && cmake \
+    -D CMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -D INSTALL_PYTHON_PACKAGE=OFF \
+    -D CMAKE_CXX_COMPILER="mpicxx" \
+    -D CMAKE_C_COMPILER="mpicc" \
+    -D CMAKE_Fortran_COMPILER="mpifort" \
+    -D MPI_CXX_COMPILER="mpicxx" \
+    -D MPI_C_COMPILER="mpicc" \
+    -D MPI_Fortran_COMPILER="mpifort" \
+    -D METIS_GKREGEX=ON \
+    -D EL_DISABLE_PARMETIS=TRUE \
+    -D MATH_LIBS="$(echo ' -lopenblas' | sed -e 's#^ ##g')" \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_CXX_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_C_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_Fortran_FLAGS="-O3 -fPIC -pthread -fopenmp" \
+    -D CMAKE_SHARED_LINKER_FLAGS="-fopenmp" \
+    .. \
+    && make -j 4 && make install \
+    && cd ../.. \
+    && rm -rf Elemental*
+
+# Install libsharp
+
+ git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1 \
+    && cd libsharp \
+    && patch -p1 < "${SDIR}/../rules/patch_libsharp" \
+    && autoreconf \
+    && CC="mpicc" CFLAGS="-O3 -fPIC -pthread" \
+    ./configure  --enable-mpi --enable-pic --prefix="${PREFIX}" \
+    && make \
+    && cp -a auto/* "${PREFIX}" \
+    && cd python \
+    && LIBSHARP="${PREFIX}" CC="mpicc -g" LDSHARED="mpicc -g -shared" \
+    python3 setup.py install --prefix="${PREFIX}" \
+    && cd ../.. \
+    && rm -rf libsharp*
+
+# Install PySM
+
+ git clone https://github.com/zonca/PySM_public.git --branch megarun_2017 --single-branch --depth 1 \
+    && cd PySM_public \
+    && python3 setup.py install --prefix="${PREFIX}" \
+    && cd .. \
+    && rm -rf PySM*
+
+# Install aatm
+
+ curl -SL https://launchpad.net/aatm/trunk/0.5/+download/aatm-0.5.tar.gz \
+    | tar xzf - \
+    && cd aatm-0.5 \
+    && chmod -R u+w . \
+    && patch -p1 < "${SDIR}/../rules/patch_aatm" \
+    && autoreconf \
+    && CC="gcc" CFLAGS="-O3 -fPIC -pthread" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    ./configure  \
+    --prefix="${PREFIX}" \
+    && make -j 4 && make install \
+    && cd .. \
+    && rm -rf aatm*
+
+# Make sure that any python modules installed to our prefix are built into pyc
+# files- so that we can make those directories read-only
+
+python3 -m compileall -f "${PREFIX}/lib/python${PYSITE}/site-packages"
+
+# Set permissions
+
+if [ "x${CHGRP}" != "x" ]; then
+    chgrp -R ${CHGRP} "${PREFIX}"
+fi
+
+if [ "x${CHMOD}" != "x" ]; then
+    chmod -R ${CHMOD} "${PREFIX}"
+fi

--- a/src/libtoast/math/toast/mpi_shmem.hpp
+++ b/src/libtoast/math/toast/mpi_shmem.hpp
@@ -102,13 +102,17 @@ namespace toast { namespace mpi_shmem {
                 // If there is memory already allocated, preserve its
                 // contents.
 
-                size_t n_copy;
+                size_t n_copy = 0;
                 T *temp;
 
-                if (n < n_)
+                if (n < n_) {
+                    // We are shrinking the memory
                     n_copy = n;
-                else
-                    n_copy = n;
+                } else if (n_ > 0) {
+                    // We are expanding the memory AND
+                    // we currently have a non-zero memory size
+                    n_copy = n_;
+                }
 
                 if ( n_copy > 0 && rank_ == 0 ) {
                     temp = ( T* ) std::malloc( sizeof(T) * n_copy );

--- a/src/libtoast/test/toast_test_mpi_shmem.cpp
+++ b/src/libtoast/test/toast_test_mpi_shmem.cpp
@@ -14,7 +14,7 @@ using namespace std;
 using namespace toast;
 
 
-const size_t TOASTmpiShmemTest::n = 100;
+const size_t TOASTmpiShmemTest::n = 10;
 
 
 TEST_F( TOASTmpiShmemTest, instantiate ) {
@@ -34,15 +34,27 @@ TEST_F( TOASTmpiShmemTest, instantiate ) {
 
 TEST_F( TOASTmpiShmemTest, access ) {
 
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+
     toast::mpi_shmem::mpi_shmem<double> shmem( n );
 
     shmem.set( 20 );
 
+    int ret = MPI_Barrier(comm);
+
     shmem.resize( 2*n );
 
-    double *p = shmem.data();
+    ret = MPI_Barrier(comm);
 
-    shmem[n-1] = 10;
+    double * p = shmem.data();
+
+    if (rank == 0) {
+        shmem[n-1] = 10;
+    }
+
+    ret = MPI_Barrier(comm);
 
     EXPECT_FLOAT_EQ( shmem[n-2], 20 );
     EXPECT_FLOAT_EQ( shmem[n-1], 10 );

--- a/src/libtoast/test/toast_test_runner.cpp
+++ b/src/libtoast/test/toast_test_runner.cpp
@@ -1,6 +1,6 @@
 /*
 Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-All rights reserved.  Use of this source code is governed by 
+All rights reserved.  Use of this source code is governed by
 a BSD-style license that can be found in the LICENSE file.
 */
 
@@ -15,11 +15,24 @@ int toast::test::runner ( int argc, char *argv[] ) {
 
     toast::init ( argc, argv );
 
+    // Disable result printing from all processes except the root one.
+
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int rank;
+    MPI_Comm_rank(comm, &rank);
+
+    ::testing::TestEventListeners & listeners =
+        ::testing::UnitTest::GetInstance()->listeners();
+
+    if ( rank != 0 ) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+
     // FIXME:  rank 0 of MPI_COMM_WORLD should create the test
-    // output directory here if it does not exist.
+    // output directory here if it does not exist.  Currently none of the
+    // C++ unit tests write or read data, so this is not yet an issue.
 
     int result = RUN_ALL_TESTS();
 
     return result;
 }
-

--- a/src/python/map/pixels.py
+++ b/src/python/map/pixels.py
@@ -419,7 +419,7 @@ class DistPixels(object):
                 raise RuntimeError(errors)
             # Now read the map
             fdata = hp.read_map(path, field=None, dtype=self._dtype,
-                                memmap=True, nest=self._nest)
+                                memmap=True, nest=self._nest, verbose=False)
             if self._nnz == 1:
                 fdata = (fdata, )
 

--- a/src/python/tests/Makefile.am
+++ b/src/python/tests/Makefile.am
@@ -21,6 +21,7 @@ toasttestsdir = $(pythondir)/toast/tests
 
 toasttests_PYTHON = \
 __init__.py \
+_helpers.py \
 binned.py \
 cache.py \
 cbuffer.py \

--- a/src/python/tests/__init__.py
+++ b/src/python/tests/__init__.py
@@ -6,6 +6,6 @@ Unit tests for the toast package.
 """
 
 # If toast has not yet been imported, make sure we initialize MPI
-from .. import mpi
+from ..mpi import MPI
 
 from .runner import test as run

--- a/src/python/tests/_helpers.py
+++ b/src/python/tests/_helpers.py
@@ -5,7 +5,11 @@
 from ..mpi import MPI
 
 import os
+import sys
+import traceback
 import numpy as np
+
+from contextlib import contextmanager
 
 from ..dist import Comm, Data
 from .. import qarray as qa
@@ -148,3 +152,36 @@ def boresight_focalplane(ndet, samplerate=1.0, epsilon=0.0, net=1.0, fmin=0.0,
 
     return names, quat, det_eps, det_rate, det_net, det_fmin, \
         det_fknee, det_alpha
+
+#
+# @contextmanager
+# def mpi_guard(comm=MPI.COMM_WORLD):
+#     """Ensure that if one MPI process raises an exception, all of them do.
+#
+#     Args:
+#         comm (mpi4py.MPI.Comm): The MPI communicator.
+#
+#     """
+#     failed = 0
+#     print(comm.rank, ": guard: enter", flush=True)
+#     try:
+#         print(comm.rank, ": guard: yield", flush=True)
+#         yield
+#     except:
+#         print(comm.rank, ": guard: except", flush=True)
+#         msg = "Exception on process {}:\n".format(comm.rank)
+#         exc_type, exc_value, exc_traceback = sys.exc_info()
+#         lines = traceback.format_exception(exc_type, exc_value,
+#             exc_traceback)
+#         msg += "\n".join(lines)
+#         print(msg, flush=True)
+#         failed = 1
+#         print(comm.rank, ": guard: except done", flush=True)
+#
+#     print(comm.rank, ": guard: failcount reduce", flush=True)
+#     failcount = comm.allreduce(failed, op=MPI.SUM)
+#     if failcount > 0:
+#         raise RuntimeError("One or more MPI processes raised an exception")
+#     print(comm.rank, ": guard: done", flush=True)
+#
+#     return

--- a/src/python/tests/_helpers.py
+++ b/src/python/tests/_helpers.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2015-2018 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+from ..mpi import MPI
+
+import os
+import numpy as np
+
+from ..dist import Comm, Data
+from .. import qarray as qa
+
+# These are helper routines for common operations used in the unit tests.
+
+
+def create_outdir(mpicomm, subdir=None):
+    """Create the top level output directory and per-test subdir.
+
+    Args:
+        mpicomm (MPI.Comm): the MPI communicator.
+        subdir (str): the sub directory for this test.
+
+    Returns:
+        str: full path to the test subdir if specified, else the top dir.
+
+    """
+    pwd = os.path.abspath(".")
+    testdir = os.path.join(pwd, "toast_test_output")
+    retdir = testdir
+    if subdir is not None:
+        retdir = os.path.join(testdir, subdir)
+    if mpicomm.rank == 0:
+        if not os.path.isdir(testdir):
+            os.mkdir(testdir)
+        if not os.path.isdir(retdir):
+            os.mkdir(retdir)
+    mpicomm.barrier()
+    return retdir
+
+
+def create_comm(mpicomm):
+    """Create a toast communicator.
+
+    Use the specified MPI communicator to attempt to create 2 process groups.
+    If less than 2 processes are used, create a single process group.
+
+    Args:
+        mpicomm (MPI.Comm): the MPI communicator.
+
+    Returns:
+        toast.Comm: the 2-level toast communicator.
+
+    """
+    worldsize = mpicomm.size
+    groupsize = 1
+    if (worldsize >= 2):
+        groupsize = worldsize // 2
+    toastcomm = Comm(world=mpicomm, groupsize=groupsize)
+    return toastcomm
+
+
+def create_distdata(mpicomm, obs_per_group=1):
+    """Create a toast communicator and distributed data object.
+
+    Use the specified MPI communicator to attempt to create 2 process groups,
+    each with some observations.
+
+    Args:
+        mpicomm (MPI.Comm): the MPI communicator.
+        obs_per_group (int): the number of observations assigned to each group.
+
+    Returns:
+        toast.Data: the distributed data with named observations (but no TOD).
+
+    """
+    toastcomm = create_comm(mpicomm)
+    data = Data(toastcomm)
+    for obs in range(obs_per_group):
+        ob = {}
+        ob['name'] = 'test-{}-{}'.format(toastcomm.group, obs)
+        ob['id'] = obs_per_group * toastcomm.group + obs
+        data.obs.append(ob)
+    return data
+
+
+def uniform_chunks(samples, nchunk=100):
+    """Divide some number of samples into chunks.
+
+    This is often needed when constructing a TOD class, and usually we want
+    the number of chunks to be larger than any number of processes we might
+    be using for the unit tests.
+
+    Args:
+        samples (int): The number of samples.
+        nchunk (int): The number of chunks to create.
+
+    Returns:
+        array: This list of chunk sizes.
+
+    """
+    chunksize = samples // nchunk
+    chunks = np.ones(nchunk, dtype=np.int64)
+    chunks *= chunksize
+    remain = samples - (nchunk * chunksize)
+    for r in range(remain):
+        chunks[r] += 1
+    return chunks
+
+
+def boresight_focalplane(ndet, samplerate=1.0, epsilon=0.0, net=1.0, fmin=0.0,
+    alpha=1.0, fknee=0.05):
+    """Create a set of detectors at the boresight.
+
+    This creates multiple detectors at the boresight, oriented in evenly
+    spaced increments from zero to 2*PI.
+
+    Args:
+        ndet (int): the number of detectors.
+
+
+    Returns:
+        tuple: names(list), quat(dict), fmin(dict), rate(dict), fknee(dict),
+            alpha(dict), netd(dict)
+
+    """
+    names = [ "d{:02d}".format(x) for x in range(ndet) ]
+    pol = { "d{:02d}".format(x) : (x * 2 * np.pi / ndet) for x in range(ndet) }
+
+    quat = { "d{:02d}".format(x) : qa.rotation([0.0, 0.0, 0.0, 1.0],
+        pol["d{:02d}".format(x)]) for x in range(ndet) }
+
+    det_eps = { "d{:02d}".format(x) : epsilon for x in range(ndet) }
+
+    det_fmin = { "d{:02d}".format(x) : fmin for x in range(ndet) }
+    det_rate = { "d{:02d}".format(x) : samplerate for x in range(ndet) }
+    det_alpha = { "d{:02d}".format(x) : alpha for x in range(ndet) }
+    det_net = { "d{:02d}".format(x) : net for x in range(ndet) }
+
+    det_fknee = None
+    if np.isscalar(fknee):
+        det_fknee = { "d{:02d}".format(x) : fknee for x in range(ndet) }
+    else:
+        # This must be an array or list of correct length
+        if len(fknee) != ndet:
+            raise RuntimeError("length of knee frequencies must equal ndet")
+        det_fknee = { "d{:02d}".format(x) : y \
+            for x, y in zip(range(ndet), fknee) }
+
+    return names, quat, det_eps, det_rate, det_net, det_fmin, \
+        det_fknee, det_alpha

--- a/src/python/tests/cache.py
+++ b/src/python/tests/cache.py
@@ -36,8 +36,6 @@ class CacheTest(MPITestCase):
 
 
     def test_create(self):
-        start = MPI.Wtime()
-
         for k, v in self.types.items():
             ref = self.cache.create('test-{}'.format(k), v, (self.nsamp,4))
             del ref
@@ -73,15 +71,10 @@ class CacheTest(MPITestCase):
             self.pycache.destroy('test-{}'.format(k))
 
         self.cache.clear()
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("cache create test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_create_none(self):
-        start = MPI.Wtime()
-
         try:
             ref = self.cache.create(None, np.float, (1,10))
             raise RuntimeError('Creating object with None key succeeded')
@@ -89,16 +82,10 @@ class CacheTest(MPITestCase):
             pass
 
         self.cache.clear()
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns(
-            "cache create none test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_put_none(self):
-        start = MPI.Wtime()
-
         try:
             ref = self.cache.put(None, np.float, np.arange(10))
             raise RuntimeError('Putting an object with None key succeeded')
@@ -106,34 +93,22 @@ class CacheTest(MPITestCase):
             pass
 
         self.cache.clear()
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("cache put none test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_clear(self):
-        start = MPI.Wtime()
-
         for k, v in self.types.items():
             ref = self.cache.create('test-{}'.format(k), v, (self.nsamp,4))
             del ref
-
-        warnings.filterwarnings('error')
-        self.cache.clear('.*')
-        self.cache.clear('.*')
-        warnings.resetwarnings()
-
+        # warnings.filterwarnings('error')
+        # self.cache.clear('.*')
+        # self.cache.clear('.*')
+        # warnings.resetwarnings()
         self.cache.clear()
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("cache clear test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_alias(self):
-        start = MPI.Wtime()
-
         ref = self.cache.put('test', np.arange(10))
         del ref
 
@@ -152,7 +127,4 @@ class CacheTest(MPITestCase):
 
         ex = self.cache.exists('test-alias-2')
         self.assertFalse(ex)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("cache alias test took {:.3f} s".format(elapsed))
+        return

--- a/src/python/tests/cbuffer.py
+++ b/src/python/tests/cbuffer.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 
@@ -37,70 +37,48 @@ class CbufferTest(MPITestCase):
 
 
     def test_create(self):
-        start = MPI.Wtime()
-
         data = {}
-
         for k, v in self.types.items():
             data[k] = ToastBuffer(self.nsamp, k)
-
         del data
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("ToastBuffer create test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_buffer(self):
-        start = MPI.Wtime()
-
         data = {}
-
         for k, v in self.types.items():
             raw = ToastBuffer(self.nsamp, k)
             data[k] = np.asarray(raw)
             for i in range(self.nsamp):
                 data[k][i] = i
-            print(data[k])
-
+            #print(data[k])
         del data
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("ToastBuffer buffer test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_refcount(self):
-        start = MPI.Wtime()
-
         data = {}
-
         for k, v in self.types.items():
             raw = ToastBuffer(self.nsamp, k)
             gc.collect()
-            print("    raw buffer {} has refcount {}".format(k, sys.getrefcount(raw)))
-            print(gc.get_referrers(raw))
+            #print("    raw buffer {} has refcount {}".format(k, sys.getrefcount(raw)))
+            #print(gc.get_referrers(raw))
 
             data[k] = np.asarray(raw)
-            print("buffer {} has numpy type {}".format(k, data[k].dtype))
+            #print("buffer {} has numpy type {}".format(k, data[k].dtype))
             for i in range(self.nsamp):
                 data[k][i] = i
             gc.collect()
-            print("    now raw buffer {} has refcount {}".format(k, sys.getrefcount(raw)))
-            print(gc.get_referrers(raw))
-            
+            #print("    now raw buffer {} has refcount {}".format(k, sys.getrefcount(raw)))
+            #print(gc.get_referrers(raw))
+
             del raw
-        
+
         for k, v in self.types.items():
             gc.collect()
-            print("    dict buffer {} has refcount {}".format(k, sys.getrefcount(data[k])))
-            print(gc.get_referrers(data[k]))
+            self.assertTrue(sys.getrefcount(data[k]) <= 2)
+            #print("    dict buffer {} has refcount {}".format(k, sys.getrefcount(data[k])))
+            #print(gc.get_referrers(data[k]))
 
         del data
-
-        #self.assertTrue(False)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("ToastBuffer refcount test took {:.3f} s".format(elapsed))
-
+        return

--- a/src/python/tests/fft.py
+++ b/src/python/tests/fft.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -19,9 +19,8 @@ class FFTTest(MPITestCase):
         self.input = random(self.length, counter=[0,0], key=[0,0])
         self.compare = np.copy(self.input)
 
-
     def test_roundtrip(self):
         output = r1d_forward(self.input)
         check = r1d_backward(output)
         np.testing.assert_array_almost_equal(check, self.compare)
-
+        return

--- a/src/python/tests/intervals.py
+++ b/src/python/tests/intervals.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -18,12 +18,7 @@ from ..tod.sim_interval import *
 
 class IntervalTest(MPITestCase):
 
-
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
         self.rate = 123.456
         self.duration = 24 * 3601.23
         self.gap = 3600.0
@@ -33,8 +28,6 @@ class IntervalTest(MPITestCase):
 
 
     def test_regular(self):
-        start = MPI.Wtime()
-        
         intrvls = regular_intervals(self.nint, self.start, self.first,
                                     self.rate, self.duration, self.gap)
 
@@ -43,12 +36,8 @@ class IntervalTest(MPITestCase):
         check = 0
 
         for it in intrvls:
-            print(it.first," ",it.last," ",it.start," ",it.stop)
+            #print(it.first," ",it.last," ",it.start," ",it.stop)
             check += it.last - it.first + 1
 
         nt.assert_equal(check, goodsamp)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print('Proc {}:  test took {:.4f} s'.format( MPI.COMM_WORLD.rank, elapsed ))
-
+        return

--- a/src/python/tests/map_ground.py
+++ b/src/python/tests/map_ground.py
@@ -172,7 +172,7 @@ class MapGroundTest(MPITestCase):
         pars[ 'path_output' ] = madam_out
         pars[ 'info' ] = 0
 
-        madam = OpMadam(params=pars, name='grad', purge=True,
+        madam = OpMadam(params=pars, name='grad', purge=False,
             common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)

--- a/src/python/tests/map_ground.py
+++ b/src/python/tests/map_ground.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -14,6 +14,7 @@ import numpy.testing as nt
 import healpy as hp
 from scipy.constants import degree
 
+from .. import qarray as qa
 from ..tod.tod import *
 from ..tod.pointing import *
 from ..tod.sim_tod import *
@@ -22,41 +23,40 @@ from ..tod.sim_det_map import *
 from ..tod.sim_noise import *
 from ..map import *
 
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 class MapGroundTest(MPITestCase):
 
-
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
-        self.mapdir = os.path.join(self.outdir, "map_ground")
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.mapdir):
-                os.mkdir(self.mapdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
+        # Create one observation per group, and each observation will have
+        # one detector per process and a single chunk.
 
-        self.toastcomm = Comm(world=self.comm)
-        self.data = Data(self.toastcomm)
+        self.data = create_distdata(self.comm, obs_per_group=1)
 
-        self.detnames = ['bore']
-        self.dets = {
-            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
-            }
+        self.ndet = self.data.comm.group_size
+        self.rate = 20.0
 
-        # this is an unpolarized detector...
-        self.epsilon = {
-            'bore' : 1.0,
-        }
+        # Create detectors with white noise
+        self.NET = 5.0
 
-        nside = 1024
-        self.sim_nside = nside
-        #self.totsamp = 400000
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate,
+            fknee=0.0, net=self.NET)
+
+        # Samples per observation
         self.totsamp = 100000
+
+        # Pixelization
+        nside = 256
+        self.sim_nside = nside
         self.map_nside = nside
-        self.rate = 40.0
+
+        # Scan properties
         self.site_lon = '-67:47:10'
         self.site_lat = '-22:57:30'
         self.site_alt = 5200.
@@ -68,79 +68,56 @@ class MapGroundTest(MPITestCase):
         self.scan_accel = 0.1
         self.CES_start = None
 
-        self.NET = 7.0
+        # Populate the single observation per group
 
-        self.fmins = {
-            'bore' : 0.0,
-        }
-        self.rates = {
-            'bore' : self.rate,
-        }
-        self.fknee = {
-            'bore' : 0.0,
-        }
-        self.alpha = {
-            'bore' : 1.0,
-        }
-        self.netd = {
-            'bore' : self.NET
-        }
+        tod = TODGround(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=self.data.comm.group_size,
+            firsttime=0.0,
+            rate=self.rate,
+            site_lon=self.site_lon,
+            site_lat=self.site_lat,
+            site_alt=self.site_alt,
+            azmin=self.azmin,
+            azmax=self.azmax,
+            el=self.el,
+            coord=self.coord,
+            scanrate=self.scanrate,
+            scan_accel=self.scan_accel,
+            CES_start=self.CES_start)
 
-        # madam only supports a single observation
-        nobs = 1
+        self.common_flag_mask = tod.TURNAROUND
 
+        common_flags = tod.read_common_flags()
+
+        # Number of flagged samples in each observation.  Only the first row
+        # of the process grid needs to contribute, since all process columns
+        # have identical common flags.
         nflagged = 0
-
-        for i in range(nobs):
-            # create the TOD for this observation
-
-            tod = TODGround(
-                self.toastcomm.comm_group,
-                self.dets, 
-                self.totsamp, 
-                firsttime=0.0,
-                rate=self.rate,
-                site_lon=self.site_lon,
-                site_lat=self.site_lat,
-                site_alt=self.site_alt,
-                azmin=self.azmin,
-                azmax=self.azmax,
-                el=self.el,
-                coord=self.coord,
-                scanrate=self.scanrate,
-                scan_accel=self.scan_accel,
-                CES_start=self.CES_start)
-
-            self.common_flag_mask = tod.TURNAROUND
-
-            common_flags = tod.read_common_flags()
+        if tod.grid_comm_col.rank == 0:
             nflagged += np.sum((common_flags & self.common_flag_mask) != 0)
 
-            # add analytic noise model with white noise
+        # Number of flagged samples across all observations
+        self.nflagged = self.data.comm.comm_world.allreduce(nflagged)
 
-            nse = AnalyticNoise(
-                rate=self.rates, 
-                fmin=self.fmins,
-                detectors=self.detnames,
-                fknee=self.fknee, 
-                alpha=self.alpha, 
-                NET=self.netd)
+        # add analytic noise model with white noise
 
-            ob = {}
-            ob['name'] = 'test'
-            ob['id'] = 0
-            ob['tod'] = tod
-            ob['intervals'] = None
-            ob['baselines'] = None
-            ob['noise'] = nse
+        nse = AnalyticNoise(
+            rate=drate,
+            fmin=dfmin,
+            detectors=dnames,
+            fknee=dfknee,
+            alpha=dalpha,
+            NET=dnet
+        )
 
-            self.data.obs.append(ob)
+        self.data.obs[0]["tod"] = tod
+        self.data.obs[0]["noise"] = nse
 
-        self.nflagged = nflagged
 
     def test_azel(self):
-        start = MPI.Wtime()
-
         quats1 = []
         quats2 = []
 
@@ -153,20 +130,16 @@ class MapGroundTest(MPITestCase):
         for i in range(10):
             if np.all(quats1[0][i] == quats2[0][i]):
                 raise Exception('Horizontal and celestial pointing must be different')
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("Az/El test took {:.3f} s".format(elapsed))
 
     def test_grad(self):
-        start = MPI.Wtime()
-
         # add simple sky gradient signal
         grad = OpSimGradient(nside=self.sim_nside, nest=True, common_flag_mask=self.common_flag_mask)
         grad.exec(self.data)
 
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         handle = None
@@ -177,7 +150,7 @@ class MapGroundTest(MPITestCase):
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_grad")
+        madam_out = os.path.join(self.outdir, "madam_grad")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -199,12 +172,10 @@ class MapGroundTest(MPITestCase):
         pars[ 'path_output' ] = madam_out
         pars[ 'info' ] = 0
 
-        madam = OpMadam(params=pars, name='grad', purge=True, common_flag_mask=self.common_flag_mask)
+        madam = OpMadam(params=pars, name='grad', purge=True,
+            common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -228,24 +199,24 @@ class MapGroundTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                nt.assert_equal(self.ndet * ((self.data.comm.ngroups * \
+                    self.totsamp) - self.nflagged), tothits)
 
                 sig = grad.sigmap()
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
+
 
     def test_noise(self):
-        start = MPI.Wtime()
-
         # generate noise timestreams from the noise model
         nsig = OpSimNoise()
         nsig.exec(self.data)
 
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         handle = None
@@ -266,7 +237,7 @@ class MapGroundTest(MPITestCase):
             detweights[d] = 1.0 / (self.rate * nse.NET(d)**2)
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_noise")
+        madam_out = os.path.join(self.outdir, "madam_noise")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -291,9 +262,6 @@ class MapGroundTest(MPITestCase):
         madam = OpMadam(params=pars, detweights=detweights, name='noise', common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -318,33 +286,31 @@ class MapGroundTest(MPITestCase):
                 # number of hits and the timestream rms
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp-self.nflagged, tothits)
-                print("tothits = ", tothits)
+                nt.assert_equal(self.ndet * ((self.data.comm.ngroups * \
+                    self.totsamp) - self.nflagged), tothits)
 
                 mask = (bins > -1.0e20)
-                print("num good pix = ", len(mask))
+                #print("num good pix = ", len(mask))
                 rthits = np.sqrt(hits[mask].astype(np.float64))
-                print("rthits = ", rthits)
-                print("bmap = ", bins[mask])
+                #print("rthits = ", rthits)
+                #print("bmap = ", bins[mask])
                 weighted = bins[mask] * rthits
-                print("weighted = ", weighted)
+                #print("weighted = ", weighted)
                 pixrms = np.sqrt(np.mean(weighted**2))
                 todrms = self.NET * np.sqrt(self.rate)
                 relerr = np.absolute(pixrms - todrms) / todrms
-                print("pixrms = ", pixrms)
-                print("todrms = ", todrms)
-                print("relerr = ", relerr)
+                #print("pixrms = ", pixrms)
+                #print("todrms = ", todrms)
+                #print("relerr = ", relerr)
                 self.assertTrue(relerr < 0.03)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_scanmap(self):
-        start = MPI.Wtime()
-
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -360,9 +326,9 @@ class MapGroundTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
         distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
@@ -378,7 +344,7 @@ class MapGroundTest(MPITestCase):
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_scansim")
+        madam_out = os.path.join(self.outdir, "madam_scansim")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -403,9 +369,6 @@ class MapGroundTest(MPITestCase):
         madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -429,20 +392,20 @@ class MapGroundTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                nt.assert_equal(self.ndet * ((self.data.comm.ngroups * \
+                    self.totsamp) - self.nflagged), tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_hwpfast(self):
-        start = MPI.Wtime()
-
         # make a pointing matrix with a HWP that rotates 2*PI every sample
         hwprate = self.rate * 60.0
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwprpm=hwprate)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True,
+            hwprpm=hwprate)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -458,9 +421,9 @@ class MapGroundTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
         distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
@@ -476,7 +439,7 @@ class MapGroundTest(MPITestCase):
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_hwpfast")
+        madam_out = os.path.join(self.outdir, "madam_hwpfast")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -501,9 +464,6 @@ class MapGroundTest(MPITestCase):
         madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -527,21 +487,21 @@ class MapGroundTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                nt.assert_equal(self.ndet * ((self.data.comm.ngroups * \
+                    self.totsamp) - self.nflagged), tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_hwpconst(self):
-        start = MPI.Wtime()
-
         # make a pointing matrix with a HWP that is constant
         hwpstep = 2.0 * np.pi
         hwpsteptime = (self.totsamp / self.rate) / 60.0
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwpstep=hwpstep, hwpsteptime=hwpsteptime)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True,
+            hwpstep=hwpstep, hwpsteptime=hwpsteptime)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -557,9 +517,9 @@ class MapGroundTest(MPITestCase):
         submapsize = np.floor_divide(self.sim_nside, 16)
         localsm = np.unique(np.floor_divide(localpix, submapsize))
 
-        # construct a distributed map which has the gradient        
+        # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
         lsub, lpix = distsig.global_to_local(localpix)
         distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
@@ -575,7 +535,7 @@ class MapGroundTest(MPITestCase):
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_hwpconst")
+        madam_out = os.path.join(self.outdir, "madam_hwpconst")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -600,13 +560,10 @@ class MapGroundTest(MPITestCase):
         madam = OpMadam(params=pars, name='scan', common_flag_mask=self.common_flag_mask)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
-                
+
                 hitsfile = os.path.join(madam_out, 'madam_hmap.fits')
                 hits = hp.read_map(hitsfile, nest=True)
 
@@ -626,9 +583,10 @@ class MapGroundTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp-self.nflagged, tothits)
+                nt.assert_equal(self.ndet * ((self.data.comm.ngroups * \
+                    self.totsamp) - self.nflagged), tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return

--- a/src/python/tests/map_satellite.py
+++ b/src/python/tests/map_satellite.py
@@ -21,118 +21,87 @@ from ..tod.sim_det_map import *
 from ..tod.sim_noise import *
 from ..map import *
 
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 class MapSatelliteTest(MPITestCase):
 
-
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
-        self.mapdir = os.path.join(self.outdir, "map_satellite")
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.mapdir):
-                os.mkdir(self.mapdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
+        # Create one observation per group, and each observation will have
+        # one detector with multiple chunks distributed among the processes.
 
-        self.toastcomm = Comm(world=self.comm)
-        self.data = Data(self.toastcomm)
+        self.data = create_distdata(self.comm, obs_per_group=1)
 
-        self.detnames = ['bore']
-        self.dets = {
-            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
-            }
-
-        # this is an upolarized detector...
-        self.epsilon = {
-            'bore' : 1.0,
-        }
-
-        self.sim_nside = 64
-        self.totsamp = 400000
-        self.map_nside = 64
+        self.ndet = 1
         self.rate = 40.0
+
+        # Create detectors with white noise
+        self.NET = 7.0
+
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate, net=self.NET,
+                fknee=0.0)
+
+        # Samples per observation
+        self.totsamp = 4000000
+
+        # Pixelization
+        self.sim_nside = 64
+        self.map_nside = 64
+
+        # Scan strategy
         self.spinperiod = 10.0
         self.spinangle = 30.0
         self.precperiod = 50.0
         self.precangle = 65.0
 
-        self.NET = 7.0
-
-        self.fmins = {
-            'bore' : 0.0,
-        }
-        self.rates = {
-            'bore' : self.rate,
-        }
-        self.fknee = {
-            'bore' : 0.0,
-        }
-        self.alpha = {
-            'bore' : 1.0,
-        }
-        self.netd = {
-            'bore' : self.NET
-        }
-
-        # madam only supports a single observation
-        nobs = 1
-
         # in order to make sure that the noise realization is reproducible
-        # all all concurrencies, we set the chunksize to something independent
+        # at all concurrencies, we set the chunksize to something independent
         # of the number of ranks.
 
-        nchunk = 10
-        chunksize = int(self.totsamp / nchunk)
-        chunks = np.ones(nchunk, dtype=np.int64)
-        chunks *= chunksize
-        remain = self.totsamp - (nchunk * chunksize)
-        for r in range(remain):
-            chunks[r] += 1
+        # Chunks
+        chunks = uniform_chunks(self.totsamp, nchunk=100)
 
-        for i in range(nobs):
-            # create the TOD for this observation
+        # Populate the single observation per group
 
-            tod = TODSatellite(
-                self.toastcomm.comm_group,
-                self.dets,
-                self.totsamp,
-                firsttime=0.0,
-                rate=self.rate,
-                spinperiod=self.spinperiod,
-                spinangle=self.spinangle,
-                precperiod=self.precperiod,
-                precangle=self.precangle,
-                sampsizes=chunks)
+        tod = TODSatellite(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=1,
+            firsttime=0.0,
+            rate=self.rate,
+            spinperiod=self.spinperiod,
+            spinangle=self.spinangle,
+            precperiod=self.precperiod,
+            precangle=self.precangle,
+            sampsizes=chunks)
 
-            precquat = np.empty(4 * self.totsamp,
-                                dtype=np.float64).reshape((-1, 4))
-            slew_precession_axis(precquat, firstsamp=0, samplerate=self.rate,
-                                 degday=1.0)
+        precquat = np.empty(4 * tod.local_samples[1],
+            dtype=np.float64).reshape((-1, 4))
 
-            tod.set_prec_axis(qprec=precquat)
+        slew_precession_axis(precquat, firstsamp=tod.local_samples[0],
+            samplerate=self.rate, degday=1.0)
 
-            # add analytic noise model with white noise
+        tod.set_prec_axis(qprec=precquat)
 
-            nse = AnalyticNoise(
-                rate=self.rates,
-                fmin=self.fmins,
-                detectors=self.detnames,
-                fknee=self.fknee,
-                alpha=self.alpha,
-                NET=self.netd)
+        # add analytic noise model with white noise
 
-            ob = {}
-            ob['name'] = 'test'
-            ob['id'] = 0
-            ob['tod'] = tod
-            ob['intervals'] = None
-            ob['baselines'] = None
-            ob['noise'] = nse
+        nse = AnalyticNoise(
+            rate=drate,
+            fmin=dfmin,
+            detectors=dnames,
+            fknee=dfknee,
+            alpha=dalpha,
+            NET=dnet
+        )
 
-            self.data.obs.append(ob)
+        self.data.obs[0]["tod"] = tod
+        self.data.obs[0]["noise"] = nse
 
 
     def test_boresight_null(self):
@@ -144,6 +113,7 @@ class MapSatelliteTest(MPITestCase):
         zaxis = np.array([0,0,1], dtype=np.float64)
 
         borequat = np.empty(4*nsim, dtype=np.float64).reshape((-1, 4))
+
         satellite_scanning(borequat, qprec=None, samplerate=100.0,
                            spinperiod=1.0, spinangle=0.0, precperiod=20.0,
                            precangle=0.0)
@@ -155,14 +125,12 @@ class MapSatelliteTest(MPITestCase):
 
 
     def test_grad(self):
-        start = MPI.Wtime()
-
         # add simple sky gradient signal
         grad = OpSimGradient(nside=self.sim_nside, nest=True)
         grad.exec(self.data)
 
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         handle = None
@@ -173,7 +141,7 @@ class MapSatelliteTest(MPITestCase):
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_grad")
+        madam_out = os.path.join(self.outdir, "madam_grad")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -193,13 +161,11 @@ class MapSatelliteTest(MPITestCase):
         pars[ 'write_hits' ] = 'T'
         pars[ 'kfilter' ] = 'F'
         pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
 
         madam = OpMadam(params=pars, name='grad', purge=True)
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -223,25 +189,23 @@ class MapSatelliteTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp, tothits)
+                nt.assert_equal(self.data.comm.ngroups * self.totsamp, tothits)
 
                 sig = grad.sigmap()
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_noise(self):
-        start = MPI.Wtime()
-
         # generate noise timestreams from the noise model
         nsig = OpSimNoise()
         nsig.exec(self.data)
 
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         handle = None
@@ -262,7 +226,7 @@ class MapSatelliteTest(MPITestCase):
             detweights[d] = 1.0 / (self.rate * nse.NET(d)**2)
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_noise")
+        madam_out = os.path.join(self.outdir, "madam_noise")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -282,13 +246,11 @@ class MapSatelliteTest(MPITestCase):
         pars[ 'write_hits' ] = 'T'
         pars[ 'kfilter' ] = 'F'
         pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
 
         madam = OpMadam(params=pars, detweights=detweights, name='noise')
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -313,32 +275,30 @@ class MapSatelliteTest(MPITestCase):
                 # number of hits and the timestream rms
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp, tothits)
-                print("tothits = ", tothits)
+                nt.assert_equal(self.data.comm.ngroups * self.totsamp, tothits)
+                #print("tothits = ", tothits)
 
                 mask = (bins > -1.0e20)
-                print("num good pix = ", len(mask))
+                #print("num good pix = ", len(mask))
                 rthits = np.sqrt(hits[mask].astype(np.float64))
-                print("rthits = ", rthits)
-                print("bmap = ", bins[mask])
+                #print("rthits = ", rthits)
+                #print("bmap = ", bins[mask])
                 weighted = bins[mask] * rthits
                 pixrms = np.std(weighted)
                 todrms = self.NET * np.sqrt(self.rate)
                 relerr = np.absolute(pixrms - todrms) / todrms
-                print("pixrms = ", pixrms)
-                print("todrms = ", todrms)
-                print("relerr = ", relerr)
+                #print("pixrms = ", pixrms)
+                #print("todrms = ", todrms)
+                #print("relerr = ", relerr)
                 self.assertTrue(relerr < 0.05)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_scanmap(self):
-        start = MPI.Wtime()
-
         # make a simple pointing matrix
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -356,9 +316,13 @@ class MapSatelliteTest(MPITestCase):
 
         # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1,
+            dtype=np.float64, submap=submapsize, local=localsm)
+
         lsub, lpix = distsig.global_to_local(localpix)
-        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        distsig.data[lsub,lpix,:] = \
+            np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)
@@ -366,13 +330,14 @@ class MapSatelliteTest(MPITestCase):
 
         handle = None
         if self.comm.rank == 0:
-            handle = open(os.path.join(self.outdir,"out_test_satellite_scanmap_info"), "w")
+            handle = open(os.path.join(self.outdir,
+                "out_test_satellite_scanmap_info"), "w")
         self.data.info(handle)
         if self.comm.rank == 0:
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_scansim")
+        madam_out = os.path.join(self.outdir, "madam_scansim")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -392,13 +357,11 @@ class MapSatelliteTest(MPITestCase):
         pars[ 'write_hits' ] = 'T'
         pars[ 'kfilter' ] = 'F'
         pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
 
         madam = OpMadam(params=pars, name='scan')
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -422,20 +385,19 @@ class MapSatelliteTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp, tothits)
+                nt.assert_equal(self.data.comm.ngroups * self.totsamp, tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_hwpfast(self):
-        start = MPI.Wtime()
-
         # make a pointing matrix with a HWP that rotates 2*PI every sample
         hwprate = self.rate * 60.0
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwprpm=hwprate)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True,
+            hwprpm=hwprate)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -453,9 +415,14 @@ class MapSatelliteTest(MPITestCase):
 
         # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1,
+            dtype=np.float64, submap=submapsize, local=localsm)
+
         lsub, lpix = distsig.global_to_local(localpix)
-        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        distsig.data[lsub,lpix,:] = \
+            np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)
@@ -463,13 +430,14 @@ class MapSatelliteTest(MPITestCase):
 
         handle = None
         if self.comm.rank == 0:
-            handle = open(os.path.join(self.outdir,"out_test_satellite_hwpfast_info"), "w")
+            handle = open(os.path.join(self.outdir,
+                "out_test_satellite_hwpfast_info"), "w")
         self.data.info(handle)
         if self.comm.rank == 0:
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_hwpfast")
+        madam_out = os.path.join(self.outdir, "madam_hwpfast")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -489,13 +457,11 @@ class MapSatelliteTest(MPITestCase):
         pars[ 'write_hits' ] = 'T'
         pars[ 'kfilter' ] = 'F'
         pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
 
         madam = OpMadam(params=pars, name='scan')
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -519,21 +485,20 @@ class MapSatelliteTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp, tothits)
+                nt.assert_equal(self.data.comm.ngroups * self.totsamp, tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return
 
 
     def test_hwpconst(self):
-        start = MPI.Wtime()
-
         # make a pointing matrix with a HWP that is constant
         hwpstep = 2.0 * np.pi
         hwpsteptime = (self.totsamp / self.rate) / 60.0
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True, epsilon=self.epsilon, hwpstep=hwpstep, hwpsteptime=hwpsteptime)
+        pointing = OpPointingHpix(nside=self.map_nside, nest=True,
+            hwpstep=hwpstep, hwpsteptime=hwpsteptime)
         pointing.exec(self.data)
 
         # get locally hit pixels
@@ -551,9 +516,14 @@ class MapSatelliteTest(MPITestCase):
 
         # construct a distributed map which has the gradient
         npix = 12 * self.sim_nside * self.sim_nside
-        distsig = DistPixels(comm=self.toastcomm.comm_group, size=npix, nnz=1, dtype=np.float64, submap=submapsize, local=localsm)
+
+        distsig = DistPixels(comm=self.data.comm.comm_group, size=npix, nnz=1,
+            dtype=np.float64, submap=submapsize, local=localsm)
+
         lsub, lpix = distsig.global_to_local(localpix)
-        distsig.data[lsub,lpix,:] = np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
+
+        distsig.data[lsub,lpix,:] = \
+            np.array([ sig[x] for x in localpix ]).reshape(-1, 1)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)
@@ -561,13 +531,14 @@ class MapSatelliteTest(MPITestCase):
 
         handle = None
         if self.comm.rank == 0:
-            handle = open(os.path.join(self.outdir,"out_test_satellite_hwpconst_info"), "w")
+            handle = open(os.path.join(self.outdir,
+                "out_test_satellite_hwpconst_info"), "w")
         self.data.info(handle)
         if self.comm.rank == 0:
             handle.close()
 
         # make a binned map with madam
-        madam_out = os.path.join(self.mapdir, "madam_hwpconst")
+        madam_out = os.path.join(self.outdir, "madam_hwpconst")
         if self.comm.rank == 0:
             if os.path.isdir(madam_out):
                 shutil.rmtree(madam_out)
@@ -587,13 +558,11 @@ class MapSatelliteTest(MPITestCase):
         pars[ 'write_hits' ] = 'T'
         pars[ 'kfilter' ] = 'F'
         pars[ 'path_output' ] = madam_out
+        pars[ 'info' ] = 0
 
         madam = OpMadam(params=pars, name='scan')
         if madam.available:
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
@@ -617,9 +586,9 @@ class MapSatelliteTest(MPITestCase):
                 # compare binned map to input signal
 
                 tothits = np.sum(hits)
-                nt.assert_equal(self.totsamp, tothits)
+                nt.assert_equal(self.data.comm.ngroups * self.totsamp, tothits)
                 mask = (bins > -1.0e20)
                 nt.assert_almost_equal(bins[mask], sig[mask], decimal=4)
-
         else:
             print("libmadam not available, skipping tests")
+        return

--- a/src/python/tests/mpi.py
+++ b/src/python/tests/mpi.py
@@ -1,42 +1,21 @@
 # Copyright (c) 2015 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
 
 import os
 import sys
+import time
+import traceback
 
-import contextlib
+import warnings
 
+from unittest.signals import registerResult
 from unittest import TestCase
-from unittest import TextTestRunner
-from unittest import TestResult, TextTestResult
+from unittest import TestResult
 
-
-def testcase_name(test_method):
-    testcase = type(test_method)
-
-    # Ignore module name if it is '__main__'
-    module = testcase.__module__ + '.'
-    if module == '__main__.':
-        module = ''
-    result = module + testcase.__name__
-    return result
-
-
-class NoopStream(object):
-    """
-    A fake stream for non-root processes to use.
-    """
-    def write(self, *args):
-        pass
-    
-    def writeln(self, *args):
-        pass
-
-    def flush(self):
-        pass
+from functools import wraps
 
 
 class MPITestCase(TestCase):
@@ -50,331 +29,595 @@ class MPITestCase(TestCase):
     def setComm(self, comm):
         self.comm = comm
 
-    def print_in_turns(self, msg):
-        for i in range(self.comm.size):
-            if i == 0:
-                if self.comm.rank == 0:
-                    print('proc {:04d}: {}'.format(i, msg))
-            else:
-                if self.comm.rank == 0:
-                    othermsg = self.comm.recv(source=i, tag=i)
-                    print('proc {:04d}: {}'.format(i, othermsg))
-                elif i == self.comm.rank:
-                    self.comm.send(msg, dest=0, tag=i)
-            self.comm.Barrier()
 
+class MPITestResult(TestResult):
+    """A test result class that can print formatted text results to a stream.
 
-class MPITestInfo(object):
-    """
-    This class keeps useful information about the execution of a
-    test method.
-    """
-
-    # Possible test outcomes
-    (SUCCESS, FAILURE, ERROR, SKIP) = range(4)
-
-    def __init__(self, test_result, test_method, outcome=SUCCESS, err=None, subTest=None):
-        self.test_result = test_result
-        self.outcome = outcome
-        self.elapsed_time = 0
-        self.err = err
-        self.stdout = test_result._stdout_data
-        self.stderr = test_result._stderr_data
-
-        self.test_description = self.test_result.getDescription(test_method)
-        self.test_exception_info = (
-            '' if outcome in (self.SUCCESS, self.SKIP)
-            else self.test_result._exc_info_to_string(
-                    self.err, test_method)
-        )
-
-        self.test_name = testcase_name(test_method)
-        self.test_id = test_method.id()
-        if subTest:
-            self.test_id = subTest.id()
-
-    def id(self):
-        return self.test_id
-
-    def test_finished(self):
-        """Save info that can only be calculated once a test has run.
-        """
-        self.elapsed_time = \
-            self.test_result.stop_time - self.test_result.start_time
-
-    def get_description(self):
-        """
-        Return a text representation of the test method.
-        """
-        return self.test_description
-
-    def get_error_info(self):
-        """
-        Return a text representation of an exception thrown by a test
-        method.
-        """
-        return self.test_exception_info
-
-
-class MPITestResult(TextTestResult):
-    """
-    A test result class that gathers per-process results and writes
-    them to a stream on the root process.
+    The actions needed are coordinated across all processes.
 
     Used by MPITestRunner.
     """
-    def __init__(self, comm, stream, descriptions=1, verbosity=1):
+    separator1 = "=" * 70
+    separator2 = "-" * 70
+
+    def __init__(self, comm, stream=None, descriptions=None, verbosity=None,
+        **kwargs):
+        super(MPITestResult, self).__init__(stream=stream,
+            descriptions=descriptions, verbosity=verbosity, **kwargs)
         self.comm = comm
-        self.rank = self.comm.rank
-        self.size = self.comm.size
         self.stream = stream
-        TextTestResult.__init__(self, self.stream, descriptions, verbosity)
-        self.buffer = True  # we are capturing test output
-        self._stdout_data = None
-        self._stderr_data = None
-        self.successes = []
-        self.callback = None
-        self.properties = None  # junit testsuite properties
+        self.descriptions = descriptions
+        self.buffer = False
+        self.failfast = False
 
-    def _prepare_callback(self, test_info, target_list, verbose_str,
-                          short_str):
-        """
-        Appends a MPITestInfo to the given target list and sets a callback
-        method to be called by stopTest method.
-        """
-        target_list.append(test_info)
 
-        def callback():
-            """Prints the test method outcome to the stream, as well as
-            the elapsed time.
-            """
-            test_info.test_finished()
+    def getDescription(self, test):
+        doc_first_line = test.shortDescription()
+        if self.descriptions and doc_first_line:
+            return "\n".join((str(test), doc_first_line))
+        else:
+            return str(test)
 
-            if self.showAll:
-                self.stream.writeln('{} ({:.3f}s)'.format(verbose_str, test_info.elapsed_time))
-            elif self.dots:
-                self.stream.write(short_str)
-
-        self.callback = callback
 
     def startTest(self, test):
-        """
-        Called before executing each test method.
-        """
-        self.comm.Barrier()
         if isinstance(test, MPITestCase):
             test.setComm(self.comm)
-        self.start_time = MPI.Wtime()
-        TestResult.startTest(self, test)
-
-        if self.showAll:
-            self.stream.write('  ' + self.getDescription(test))
+        self.stream.flush()
+        self.comm.barrier()
+        if self.comm.rank == 0:
+            self.stream.write("\n")
+            self.stream.write(self.getDescription(test))
             self.stream.write(" ... ")
+            self.stream.flush()
+        self.comm.barrier()
+        super(MPITestResult, self).startTest(test)
+        return
 
-    def _save_output_data(self):
-        self._stdout_data = sys.stdout.getvalue()
-        self._stderr_data = sys.stderr.getvalue()
-
-    def stopTest(self, test):
-        """
-        Called after executing each test method.
-        """
-        self._save_output_data()
-        TextTestResult.stopTest(self, test)
-        self.comm.Barrier()
-        self.stop_time = MPI.Wtime()
-
-        if self.callback and callable(self.callback):
-            self.callback()
-            self.callback = None
 
     def addSuccess(self, test):
-        """
-        Called when a test executes successfully.
-        """
-        self._save_output_data()
-        self._prepare_callback(
-            MPITestInfo(self, test), self.successes, 'OK', '.'
-        )
+        super(MPITestResult, self).addSuccess(test)
+        self.stream.write("[{}]ok ".format(self.comm.rank))
+        self.stream.flush()
+        return
 
-    def addFailure(self, test, err):
-        """
-        Called when a test method fails.
-        """
-        self._save_output_data()
-        testinfo = MPITestInfo(self, test, MPITestInfo.FAILURE, err)
-        self.failures.append((
-            testinfo,
-            self._exc_info_to_string(err, test)
-        ))
-        self._prepare_callback(testinfo, [], 'FAIL', 'F')
 
     def addError(self, test, err):
-        """
-        Called when a test method raises an error.
-        """
-        self._save_output_data()
-        testinfo = MPITestInfo(self, test, MPITestInfo.ERROR, err)
-        self.errors.append((
-            testinfo,
-            self._exc_info_to_string(err, test)
-        ))
-        self._prepare_callback(testinfo, [], 'ERROR', 'E')
+        super(MPITestResult, self).addError(test, err)
+        self.stream.write("[{}]error ".format(self.comm.rank))
+        self.stream.flush()
+        return
 
-    def addSubTest(self, testcase, test, err):
-        """
-        Called when a subTest method raises an error.
-        """
-        if err is not None:
-            self._save_output_data()
-            testinfo = MPITestInfo(self, testcase, MPITestInfo.ERROR, err, subTest=test)
-            self.errors.append((
-                testinfo,
-                self._exc_info_to_string(err, testcase)
-            ))
-            self._prepare_callback(testinfo, [], 'ERROR', 'E')
+
+    def addFailure(self, test, err):
+        super(MPITestResult, self).addFailure(test, err)
+        self.stream.write("[{}]fail ".format(self.comm.rank))
+        self.stream.flush()
+        return
+
 
     def addSkip(self, test, reason):
-        """
-        Called when a test method was skipped.
-        """
-        self._save_output_data()
-        testinfo = MPITestInfo(self, test, MPITestInfo.SKIP, reason)
-        self.skipped.append((testinfo, reason))
-        self._prepare_callback(testinfo, [], 'SKIP', 'S')
+        super(MPITestResult, self).addSkip(test, reason)
+        self.stream.write("[{}]skipped({}) ".format(self.comm.rank, reason))
+        self.stream.flush()
+        return
+
+
+    def addExpectedFailure(self, test, err):
+        super(MPITestResult, self).addExpectedFailure(test, err)
+        self.stream.write("[{}]expected-fail ".format(self.comm.rank))
+        self.stream.flush()
+        return
+
+
+    def addUnexpectedSuccess(self, test):
+        super(MPITestResult, self).addUnexpectedSuccess(test)
+        self.stream.writeln("[{}]unexpected-success ".format(self.comm.rank))
+        return
+
 
     def printErrorList(self, flavour, errors):
-        """
-        Writes information about the FAIL or ERROR to the stream.
-        """
-        for test_info, error in errors:
-            self.stream.writeln(self.separator1)
-            self.stream.writeln(
-                '{} [{:.3f}s]: {}'.format(flavour, test_info.elapsed_time,
-                                    test_info.get_description())
-            )
-            self.stream.writeln(self.separator2)
-            self.stream.writeln('{}'.format(test_info.get_error_info()))
-
-    def _get_info_by_testcase(self):
-        """
-        Organizes test results by TestCase module. This information is
-        used during the report generation, where a XML report will be created
-        for each TestCase.
-        """
-        tests_by_testcase = {}
-
-        for tests in (self.successes, self.failures, self.errors,
-                      self.skipped):
-            for test_info in tests:
-                if isinstance(test_info, tuple):
-                    # This is a skipped, error or a failure test case
-                    test_info = test_info[0]
-                testcase_name = test_info.test_name
-                if testcase_name not in tests_by_testcase:
-                    tests_by_testcase[testcase_name] = []
-                tests_by_testcase[testcase_name].append(test_info)
-
-        return tests_by_testcase
+        for test, err in errors:
+            self.stream.writeln("[{}] {}".format(self.comm.rank,
+                self.separator1))
+            self.stream.writeln(\
+                "[{}] {}: {}".format(self.comm.rank,
+                flavour, self.getDescription(test)))
+            self.stream.writeln("[{}] {}".format(self.comm.rank,
+                    self.separator2))
+            self.stream.writeln("[{}] {}".format(self.comm.rank, err))
+        return
 
 
+    def printErrors(self):
+        self.comm.barrier()
+        if self.comm.rank == 0:
+            self.stream.writeln()
+            self.stream.flush()
+        for p in range(self.comm.size):
+            if p == self.comm.rank:
+                self.printErrorList("ERROR", self.errors)
+                self.printErrorList("FAIL", self.failures)
+                self.stream.flush()
+            self.comm.barrier()
+        return
 
-class MPITestRunner(TextTestRunner):
-    """
-    A test runner class that collects output from all processes.
-    """
-    def __init__(self, stream=sys.stderr, descriptions=True, verbosity=1,
-                 failfast=False, buffer=False):
-        self.comm = MPI.COMM_WORLD
-        self.rank = self.comm.rank
-        self.size = self.comm.size
-        if self.rank == 0:
-            self.stream = stream
+
+    def allSuccessful(self):
+        mysuccess = self.wasSuccessful()
+        total = 0
+        if not mysuccess:
+            total = 1
+        alltotal = self.comm.allreduce(total)
+        if alltotal == 0:
+            return True
         else:
-            self.stream = stream
-            #self.stream = NoopStream()
-        TextTestRunner.__init__(self, self.stream, descriptions, verbosity,
-                                failfast=failfast, buffer=buffer)
+            return False
+
+
+class _WritelnDecorator(object):
+    """Used to decorate file-like objects with a handy "writeln" method"""
+    def __init__(self, stream):
+        self.stream = stream
+
+    def __getattr__(self, attr):
+        if attr in ("stream", "__getstate__"):
+            raise AttributeError(attr)
+        return getattr(self.stream,attr)
+
+    def writeln(self, arg=None):
+        if arg:
+            self.write(arg)
+        self.write("\n") # text-mode streams translate to \r\n if needed
+
+
+class MPITestRunner(object):
+    """A test runner class that displays results in textual form.
+
+    It prints out the names of tests as they are run, errors as they
+    occur, and a summary of the results at the end of the test run.
+
+    This information is only printed by the root process.
+    """
+    resultclass = MPITestResult
+
+    def __init__(self, comm, stream=None, descriptions=True, verbosity=2,
+        warnings=None):
+        """Construct a MPITestRunner.
+
+        Subclasses should accept **kwargs to ensure compatibility as the
+        interface changes.
+        """
+        self.comm = comm
+        if stream is None:
+            stream = sys.stderr
+        self.stream = _WritelnDecorator(stream)
+        self.descriptions = descriptions
         self.verbosity = verbosity
-
-    def _make_result(self):
-        """
-        Creates a TestResult object which will be used to store
-        information about the executed tests.
-        """
-        return MPITestResult(self.comm, self.stream, self.descriptions, 
-            self.verbosity)
-
+        self.warnings = warnings
 
     def run(self, test):
-        """
-        Runs the given test case or test suite.
-        """
-        try:
-            # Prepare the test execution
-            result = self._make_result()
-            if hasattr(test, 'properties'):
-                # junit testsuite properties
-                result.properties = test.properties
-
-            # Print a nice header
-            self.stream.writeln()
-            self.stream.writeln('Running Python tests...')
-            self.stream.writeln(result.separator2)
-
-            # Execute tests
-            start_time = MPI.Wtime()
-            test(result)
-            stop_time = MPI.Wtime()
-            time_taken = stop_time - start_time
-
-            # Print results
-            result.printErrors()
-            self.stream.writeln(result.separator2)
-            run = result.testsRun
-            self.stream.writeln("Ran {} test{} in {:.3f}s".format(run, (run != 1) and "s" or "", time_taken))
-            self.stream.writeln()
-
-            expectedFails = unexpectedSuccesses = skipped = 0
+        "Run the given test case or test suite."
+        result = MPITestResult(self.comm, self.stream, self.descriptions,
+            self.verbosity)
+        registerResult(result)
+        with warnings.catch_warnings():
+            if self.warnings:
+                # if self.warnings is set, use it to filter all the warnings
+                warnings.simplefilter(self.warnings)
+                # if the filter is "default" or "always", special-case the
+                # warnings from the deprecated unittest methods to show them
+                # no more than once per module, because they can be fairly
+                # noisy.  The -Wd and -Wa flags can be used to bypass this
+                # only when self.warnings is None.
+                if self.warnings in ["default", "always"]:
+                    warnings.filterwarnings("module",
+                            category=DeprecationWarning,
+                            message=r"Please use assert\w+ instead.")
+            startTime = time.time()
+            startTestRun = getattr(result, "startTestRun", None)
+            if startTestRun is not None:
+                startTestRun()
             try:
-                results = map(len, (result.expectedFailures,
-                                    result.unexpectedSuccesses,
-                                    result.skipped))
-            except AttributeError:
-                pass
-            else:
-                expectedFails, unexpectedSuccesses, skipped = results
+                test(result=result)
+            finally:
+                stopTestRun = getattr(result, "stopTestRun", None)
+                if stopTestRun is not None:
+                    stopTestRun()
+            stopTime = time.time()
+        self.stream.flush()
+        self.comm.barrier()
+        if self.comm.rank == 0:
+            self.stream.write("\n")
+            self.stream.flush()
+        timeTaken = stopTime - startTime
 
-            self.result = result
-            # Error traces
-            infos = []
-            if not result.wasSuccessful():
-                self.stream.write("FAILED")
-                failed, errored = map(len, (result.failures, result.errors))
-                if failed:
-                    infos.append("failures={0}".format(failed))
-                if errored:
-                    infos.append("errors={0}".format(errored))
-            else:
-                self.stream.write("OK")
+        result.printErrors()
 
-            if skipped:
-                infos.append("skipped={0}".format(skipped))
-            if expectedFails:
-                infos.append("expected failures={0}".format(expectedFails))
-            if unexpectedSuccesses:
-                infos.append("unexpected successes={0}".format(
-                    unexpectedSuccesses))
+        if self.comm.rank == 0:
+            if hasattr(result, "separator2"):
+                self.stream.writeln(result.separator2)
 
-            if infos:
-                self.stream.writeln(" ({0})".format(", ".join(infos)))
-            else:
-                self.stream.write("\n")
+        run = result.testsRun
+        if self.comm.rank == 0:
+            self.stream.writeln("Ran %d test%s in %.3fs" %
+                                (run, run != 1 and "s" or "", timeTaken))
+            self.stream.writeln()
 
-        finally:
+        expectedFails = unexpectedSuccesses = skipped = 0
+        try:
+            results = map(len, (result.expectedFailures,
+                                result.unexpectedSuccesses,
+                                result.skipped))
+        except AttributeError:
             pass
+        else:
+            expectedFails, unexpectedSuccesses, skipped = results
+
+        for p in range(self.comm.size):
+            if p == self.comm.rank:
+                infos = []
+                if not result.wasSuccessful():
+                    self.stream.write("[{}] FAILED".format(self.comm.rank))
+                    failed, errored = len(result.failures), len(result.errors)
+                    if failed:
+                        infos.append("failures=%d" % failed)
+                    if errored:
+                        infos.append("errors=%d" % errored)
+                else:
+                    self.stream.write("[{}] OK".format(self.comm.rank))
+
+                if skipped:
+                    infos.append("skipped=%d" % skipped)
+                if expectedFails:
+                    infos.append("expected failures=%d" % expectedFails)
+                if unexpectedSuccesses:
+                    infos.append("unexpected successes=%d" % unexpectedSuccesses)
+                if infos:
+                    self.stream.writeln(" ({})".format(", ".join(infos)))
+                else:
+                    self.stream.write("\n")
+                self.stream.flush()
+            self.comm.barrier()
+
+        # if not result.allSuccessful():
+        #     self.comm.Abort(1)
 
         return result
 
 
 
+
+
+
+
+
+
+#
+#     def print_in_turns(self, msg):
+#         for i in range(self.comm.size):
+#             if i == 0:
+#                 if self.comm.rank == 0:
+#                     print("proc {:04d}: {}".format(i, msg))
+#             else:
+#                 if self.comm.rank == 0:
+#                     othermsg = self.comm.recv(source=i, tag=i)
+#                     print("proc {:04d}: {}".format(i, othermsg))
+#                 elif i == self.comm.rank:
+#                     self.comm.send(msg, dest=0, tag=i)
+#             self.comm.Barrier()
+#
+#
+# class MPITestInfo(object):
+#     """
+#     This class keeps useful information about the execution of a
+#     test method.
+#     """
+#
+#     # Possible test outcomes
+#     (SUCCESS, FAILURE, ERROR, SKIP) = range(4)
+#
+#     def __init__(self, test_result, test_method, outcome=SUCCESS, err=None, subTest=None):
+#         self.test_result = test_result
+#         self.outcome = outcome
+#         self.elapsed_time = 0
+#         self.err = err
+#         self.stdout = test_result._stdout_data
+#         self.stderr = test_result._stderr_data
+#
+#         self.test_description = self.test_result.getDescription(test_method)
+#         self.test_exception_info = (
+#             "" if outcome in (self.SUCCESS, self.SKIP)
+#             else self.test_result._exc_info_to_string(
+#                     self.err, test_method)
+#         )
+#
+#         self.test_name = testcase_name(test_method)
+#         self.test_id = test_method.id()
+#         if subTest:
+#             self.test_id = subTest.id()
+#
+#     def id(self):
+#         return self.test_id
+#
+#     def test_finished(self):
+#         """Save info that can only be calculated once a test has run.
+#         """
+#         self.elapsed_time = \
+#             self.test_result.stop_time - self.test_result.start_time
+#
+#     def get_description(self):
+#         """
+#         Return a text representation of the test method.
+#         """
+#         return self.test_description
+#
+#     def get_error_info(self):
+#         """
+#         Return a text representation of an exception thrown by a test
+#         method.
+#         """
+#         return self.test_exception_info
+#
+#
+# class MPITestResult(MPITestResult):
+#     """
+#     A test result class that gathers per-process results and writes
+#     them to a stream on the root process.
+#
+#     Used by MPITestRunner.
+#     """
+#     def __init__(self, comm, stream, descriptions=1, verbosity=1):
+#         self.comm = comm
+#         self.rank = self.comm.rank
+#         self.size = self.comm.size
+#         self.stream = stream
+#         MPITestResult.__init__(self, self.stream, descriptions, verbosity)
+#         self.buffer = True  # we are capturing test output
+#         self._stdout_data = None
+#         self._stderr_data = None
+#         self.successes = []
+#         self.callback = None
+#         self.properties = None  # junit testsuite properties
+#
+#     def _prepare_callback(self, test_info, target_list, verbose_str,
+#                           short_str):
+#         """
+#         Appends a MPITestInfo to the given target list and sets a callback
+#         method to be called by stopTest method.
+#         """
+#         target_list.append(test_info)
+#
+#         def callback():
+#             """Prints the test method outcome to the stream, as well as
+#             the elapsed time.
+#             """
+#             test_info.test_finished()
+#
+#             if self.showAll:
+#                 self.stream.writeln("{} ({:.3f}s)".format(verbose_str, test_info.elapsed_time))
+#             elif self.dots:
+#                 self.stream.write(short_str)
+#
+#         self.callback = callback
+#
+#     def startTest(self, test):
+#         """
+#         Called before executing each test method.
+#         """
+#         self.comm.Barrier()
+#         if isinstance(test, MPITestCase):
+#             test.setComm(self.comm)
+#         self.start_time = MPI.Wtime()
+#         TestResult.startTest(self, test)
+#
+#         if self.showAll:
+#             self.stream.write("  " + self.getDescription(test))
+#             self.stream.write(" ... ")
+#
+#     def _save_output_data(self):
+#         self._stdout_data = sys.stdout.getvalue()
+#         self._stderr_data = sys.stderr.getvalue()
+#
+#     def stopTest(self, test):
+#         """
+#         Called after executing each test method.
+#         """
+#         self._save_output_data()
+#         MPITestResult.stopTest(self, test)
+#         self.comm.Barrier()
+#         self.stop_time = MPI.Wtime()
+#
+#         if self.callback and callable(self.callback):
+#             self.callback()
+#             self.callback = None
+#
+#     def addSuccess(self, test):
+#         """
+#         Called when a test executes successfully.
+#         """
+#         self._save_output_data()
+#         self._prepare_callback(
+#             MPITestInfo(self, test), self.successes, "OK", "."
+#         )
+#
+#     def addFailure(self, test, err):
+#         """
+#         Called when a test method fails.
+#         """
+#         self._save_output_data()
+#         testinfo = MPITestInfo(self, test, MPITestInfo.FAILURE, err)
+#         self.failures.append((
+#             testinfo,
+#             self._exc_info_to_string(err, test)
+#         ))
+#         self._prepare_callback(testinfo, [], "FAIL", "F")
+#
+#     def addError(self, test, err):
+#         """
+#         Called when a test method raises an error.
+#         """
+#         self._save_output_data()
+#         testinfo = MPITestInfo(self, test, MPITestInfo.ERROR, err)
+#         self.errors.append((
+#             testinfo,
+#             self._exc_info_to_string(err, test)
+#         ))
+#         self._prepare_callback(testinfo, [], "ERROR", "E")
+#
+#     def addSubTest(self, testcase, test, err):
+#         """
+#         Called when a subTest method raises an error.
+#         """
+#         if err is not None:
+#             self._save_output_data()
+#             testinfo = MPITestInfo(self, testcase, MPITestInfo.ERROR, err, subTest=test)
+#             self.errors.append((
+#                 testinfo,
+#                 self._exc_info_to_string(err, testcase)
+#             ))
+#             self._prepare_callback(testinfo, [], "ERROR", "E")
+#
+#     def addSkip(self, test, reason):
+#         """
+#         Called when a test method was skipped.
+#         """
+#         self._save_output_data()
+#         testinfo = MPITestInfo(self, test, MPITestInfo.SKIP, reason)
+#         self.skipped.append((testinfo, reason))
+#         self._prepare_callback(testinfo, [], "SKIP", "S")
+#
+#     def printErrorList(self, flavour, errors):
+#         """
+#         Writes information about the FAIL or ERROR to the stream.
+#         """
+#         for test_info, error in errors:
+#             self.stream.writeln(self.separator1)
+#             self.stream.writeln(
+#                 "{} [{:.3f}s]: {}".format(flavour, test_info.elapsed_time,
+#                                     test_info.get_description())
+#             )
+#             self.stream.writeln(self.separator2)
+#             self.stream.writeln("{}".format(test_info.get_error_info()))
+#
+#     def _get_info_by_testcase(self):
+#         """
+#         Organizes test results by TestCase module. This information is
+#         used during the report generation, where a XML report will be created
+#         for each TestCase.
+#         """
+#         tests_by_testcase = {}
+#
+#         for tests in (self.successes, self.failures, self.errors,
+#                       self.skipped):
+#             for test_info in tests:
+#                 if isinstance(test_info, tuple):
+#                     # This is a skipped, error or a failure test case
+#                     test_info = test_info[0]
+#                 testcase_name = test_info.test_name
+#                 if testcase_name not in tests_by_testcase:
+#                     tests_by_testcase[testcase_name] = []
+#                 tests_by_testcase[testcase_name].append(test_info)
+#
+#         return tests_by_testcase
+#
+#
+#
+# class MPITestRunner(TextTestRunner):
+#     """
+#     A test runner class that collects output from all processes.
+#     """
+#     def __init__(self, stream=sys.stderr, descriptions=True, verbosity=1,
+#                  failfast=False, buffer=False):
+#         self.comm = MPI.COMM_WORLD
+#         self.rank = self.comm.rank
+#         self.size = self.comm.size
+#         if self.rank == 0:
+#             self.stream = stream
+#         else:
+#             self.stream = stream
+#             #self.stream = NoopStream()
+#         TextTestRunner.__init__(self, self.stream, descriptions, verbosity,
+#                                 failfast=failfast, buffer=buffer)
+#         self.verbosity = verbosity
+#
+#     def _make_result(self):
+#         """
+#         Creates a TestResult object which will be used to store
+#         information about the executed tests.
+#         """
+#         return MPITestResult(self.comm, self.stream, self.descriptions,
+#             self.verbosity)
+#
+#
+#     def run(self, test):
+#         """
+#         Runs the given test case or test suite.
+#         """
+#         try:
+#             # Prepare the test execution
+#             result = self._make_result()
+#             if hasattr(test, "properties"):
+#                 # junit testsuite properties
+#                 result.properties = test.properties
+#
+#             # Print a nice header
+#             self.stream.writeln()
+#             self.stream.writeln("Running Python tests...")
+#             self.stream.writeln(result.separator2)
+#
+#             # Execute tests
+#             start_time = MPI.Wtime()
+#             test(result)
+#             stop_time = MPI.Wtime()
+#             time_taken = stop_time - start_time
+#
+#             # Print results
+#             result.printErrors()
+#             self.stream.writeln(result.separator2)
+#             run = result.testsRun
+#             self.stream.writeln("Ran {} test{} in {:.3f}s".format(run, (run != 1) and "s" or "", time_taken))
+#             self.stream.writeln()
+#
+#             expectedFails = unexpectedSuccesses = skipped = 0
+#             try:
+#                 results = map(len, (result.expectedFailures,
+#                                     result.unexpectedSuccesses,
+#                                     result.skipped))
+#             except AttributeError:
+#                 pass
+#             else:
+#                 expectedFails, unexpectedSuccesses, skipped = results
+#
+#             self.result = result
+#             # Error traces
+#             infos = []
+#             if not result.wasSuccessful():
+#                 self.stream.write("FAILED")
+#                 failed, errored = map(len, (result.failures, result.errors))
+#                 if failed:
+#                     infos.append("failures={0}".format(failed))
+#                 if errored:
+#                     infos.append("errors={0}".format(errored))
+#             else:
+#                 self.stream.write("OK")
+#
+#             if skipped:
+#                 infos.append("skipped={0}".format(skipped))
+#             if expectedFails:
+#                 infos.append("expected failures={0}".format(expectedFails))
+#             if unexpectedSuccesses:
+#                 infos.append("unexpected successes={0}".format(
+#                     unexpectedSuccesses))
+#
+#             if infos:
+#                 self.stream.writeln(" ({0})".format(", ".join(infos)))
+#             else:
+#                 self.stream.write("\n")
+#
+#         finally:
+#             pass
+#
+#         return result
+#
+#
+#

--- a/src/python/tests/ops_dipole.py
+++ b/src/python/tests/ops_dipole.py
@@ -1,5 +1,5 @@
-# Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# Copyright (c) 2015-2018 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -23,59 +23,39 @@ from ..tod.sim_tod import *
 from ..tod.tod_math import *
 from ..map import *
 
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 class OpSimDipoleTest(MPITestCase):
 
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
-        self.mapdir = os.path.join(self.outdir, "dipole")
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.mapdir):
-                os.mkdir(self.mapdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
+        # Create one observation per group, and each observation will have
+        # one detector per process and a single chunk.
+        self.data = create_distdata(self.comm, obs_per_group=1)
 
-        self.toastcomm = Comm(world=self.comm)
-        self.data = Data(self.toastcomm)
+        self.ndet = self.data.comm.group_size
+        self.rate = 20.0
 
-        self.detnames = ['bore']
-        self.dets = {
-            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
-            }
+        # Create detectors with default properties
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate)
 
+        # Pixelization
         self.nside = 64
         self.npix = 12 * self.nside**2
-
         self.subnside = 16
         if self.subnside > self.nside:
             self.subnside = self.nside
         self.subnpix = 12 * self.subnside * self.subnside
 
+        # Samples per observation
         self.totsamp = self.npix
 
-        self.rate = 1.0
-
-        self.tod = TODHpixSpiral(
-            self.toastcomm.comm_group, 
-            self.dets, 
-            self.totsamp, 
-            firsttime=0.0, 
-            rate=self.rate, 
-            nside=self.nside)
-
-        ob = {}
-        ob['name'] = 'test'
-        ob['id'] = 0
-        ob['tod'] = self.tod
-        ob['intervals'] = None
-        ob['baselines'] = None
-        ob['noise'] = None
-
-        self.data.obs.append(ob)
-
+        # Dipole parameters
         self.solar_speed = 369.0
         gal_theta = np.deg2rad(90.0 - 48.05)
         gal_phi = np.deg2rad(264.31)
@@ -90,29 +70,35 @@ class OpSimDipoleTest(MPITestCase):
         self.dip_max_pix = hp.ang2pix(self.nside, gal_theta, gal_phi, nest=False)
         self.dip_min_pix = hp.ang2pix(self.nside, (np.pi - gal_theta), (np.pi + gal_phi), nest=False)
 
+        # Populate the observations
+
+        tod = TODHpixSpiral(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=self.data.comm.comm_group.size,
+            firsttime=0.0,
+            rate=self.rate,
+            nside=self.nside)
+
+        self.data.obs[0]["tod"] = tod
+
+
     def tearDown(self):
         del self.data
 
 
     def test_dipole_func(self):
-        start = MPI.Wtime()
-
-        # Verify that we get the right magnitude if we are pointed at the velocity
-        # maximum.
-
+        # Verify that we get the right magnitude if we are pointed at the
+        # velocity maximum.
         dtod = dipole(self.solar_quat.reshape((1, 4)), solar=self.solar_vel)
         nt.assert_almost_equal(dtod, self.dip_check * np.ones_like(dtod))
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("dipole function test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_dipole_func_total(self):
-        start = MPI.Wtime()
-
-        # Verify that we get the right magnitude if we are pointed at the velocity
-        # maximum.
+        # Verify that we get the right magnitude if we are pointed at the
+        # velocity maximum.
 
         quat = np.array(
         [[ 0.5213338 , 0.47771442,-0.5213338 , 0.47771442],
@@ -134,16 +120,10 @@ class OpSimDipoleTest(MPITestCase):
         # computed with github.com/zonca/dipole
         expected = np.array([0.00196249,  0.00196203,  0.00196157,  0.00196111,  0.00196065])
         nt.assert_allclose(dtod, expected, rtol=1e-5)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("dipole function test took {:.3f} s".format(elapsed))
-
+        return
 
 
     def test_sim(self):
-        start = MPI.Wtime()
-
         # make a simple pointing matrix
         pointing = OpPointingHpix(nside=self.nside, nest=False, mode='I')
         pointing.exec(self.data)
@@ -164,16 +144,22 @@ class OpSimDipoleTest(MPITestCase):
         # construct distributed maps to store the covariance,
         # noise weighted map, and hits
 
-        invnpp = DistPixels(comm=self.toastcomm.comm_group, size=self.npix, nnz=1, dtype=np.float64, submap=self.subnpix, local=localsm, nest=False)
+        invnpp = DistPixels(comm=self.data.comm.comm_world, size=self.npix,
+            nnz=1, dtype=np.float64, submap=self.subnpix, local=localsm,
+            nest=False)
         invnpp.data.fill(0.0)
 
-        zmap = DistPixels(comm=self.toastcomm.comm_group, size=self.npix, nnz=1, dtype=np.float64, submap=self.subnpix, local=localsm, nest=False)
+        zmap = DistPixels(comm=self.data.comm.comm_world, size=self.npix,
+            nnz=1, dtype=np.float64, submap=self.subnpix, local=localsm,
+            nest=False)
         zmap.data.fill(0.0)
 
-        hits = DistPixels(comm=self.toastcomm.comm_group, size=self.npix, nnz=1, dtype=np.int64, submap=self.subnpix, local=localsm, nest=False)
+        hits = DistPixels(comm=self.data.comm.comm_world, size=self.npix,
+            nnz=1, dtype=np.int64, submap=self.subnpix, local=localsm,
+            nest=False)
         hits.data.fill(0)
 
-        # accumulate the inverse covariance and noise weighted map.  
+        # accumulate the inverse covariance and noise weighted map.
         # Use detector weights based on the analytic NET.
 
         tod = self.data.obs[0]['tod']
@@ -182,45 +168,47 @@ class OpSimDipoleTest(MPITestCase):
         for d in tod.local_dets:
             detweights[d] = 1.0
 
-        build_invnpp = OpAccumDiag(detweights=detweights, invnpp=invnpp, hits=hits, zmap=zmap, name="dipole")
+        build_invnpp = OpAccumDiag(detweights=detweights, invnpp=invnpp,
+            hits=hits, zmap=zmap, name="dipole")
         build_invnpp.exec(self.data)
 
         invnpp.allreduce()
         hits.allreduce()
         zmap.allreduce()
 
-        hits.write_healpix_fits(os.path.join(self.mapdir, "hits.fits"))
-        invnpp.write_healpix_fits(os.path.join(self.mapdir, "invnpp.fits"))
-        zmap.write_healpix_fits(os.path.join(self.mapdir, "zmap.fits"))
+        hits.write_healpix_fits(os.path.join(self.outdir, "hits.fits"))
+        invnpp.write_healpix_fits(os.path.join(self.outdir, "invnpp.fits"))
+        zmap.write_healpix_fits(os.path.join(self.outdir, "zmap.fits"))
 
         # invert it
         covariance_invert(invnpp, 1.0e-3)
 
-        invnpp.write_healpix_fits(os.path.join(self.mapdir, "npp.fits"))
+        invnpp.write_healpix_fits(os.path.join(self.outdir, "npp.fits"))
 
         # compute the binned map, N_pp x Z
 
         covariance_apply(invnpp, zmap)
-        zmap.write_healpix_fits(os.path.join(self.mapdir, "binned.fits"))
+        zmap.write_healpix_fits(os.path.join(self.outdir, "binned.fits"))
 
         if self.comm.rank == 0:
             import matplotlib.pyplot as plt
 
-            mapfile = os.path.join(self.mapdir, 'hits.fits')
+            mapfile = os.path.join(self.outdir, 'hits.fits')
             data = hp.read_map(mapfile, nest=False)
-            nt.assert_almost_equal(data, np.ones_like(data))
+            nt.assert_almost_equal(data, self.data.comm.ngroups * self.ndet * \
+                np.ones_like(data))
 
             outfile = "{}.png".format(mapfile)
             hp.mollview(data, xsize=1600, nest=False)
             plt.savefig(outfile)
             plt.close()
 
-            mapfile = os.path.join(self.mapdir, 'binned.fits')
+            mapfile = os.path.join(self.outdir, 'binned.fits')
             data = hp.read_map(mapfile, nest=False)
 
             # verify that the extrema are in the correct location
             # and have the correct value.
-            
+
             minmap = np.min(data)
             maxmap = np.max(data)
             nt.assert_almost_equal(maxmap, self.dip_check, decimal=5)
@@ -235,10 +223,4 @@ class OpSimDipoleTest(MPITestCase):
             hp.mollview(data, xsize=1600, nest=False)
             plt.savefig(outfile)
             plt.close()
-
-        #self.assertTrue(False)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("sim dipole test took {:.3f} s".format(elapsed))
-
+        return

--- a/src/python/tests/ops_madam.py
+++ b/src/python/tests/ops_madam.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -17,64 +17,48 @@ from ..tod.sim_det_noise import *
 from ..tod.sim_det_map import *
 from ..map.madam import *
 
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 class OpMadamTest(MPITestCase):
 
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
-        self.mapdir = os.path.join(self.outdir, "madam")
-        if self.comm.rank == 0:
-            if os.path.isdir(self.mapdir):
-                shutil.rmtree(self.mapdir)
-            os.mkdir(self.mapdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
+        # One observation per group
+        self.data = create_distdata(self.comm, obs_per_group=1)
 
-        self.toastcomm = Comm(world=self.comm)
-        self.data = Data(self.toastcomm)
-
-        self.dets = {
-            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
-            }
-
-        self.sim_nside = 64
-        self.totsamp = 3 * 49152
-        #self.totsamp = 20
-        self.rms = 10.0
-        self.map_nside = 64
+        self.ndet = self.data.comm.group_size
         self.rate = 50.0
 
-        # madam only supports a single observation
-        nobs = 1
+        # Create detectors with defaults
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate)
 
-        for i in range(nobs):
-            # create the TOD for this observation
+        # Samples per observation
+        self.totsamp = 3 * 49152
 
-            tod = TODHpixSpiral(
-                self.toastcomm.comm_group, 
-                self.dets,
-                self.totsamp,
-                rate=self.rate,
-                nside=self.sim_nside
-            )
+        # Pixelization
+        self.sim_nside = 64
+        self.map_nside = 64
 
-            ob = {}
-            ob['name'] = 'test'
-            ob['id'] = 0
-            ob['tod'] = tod
-            ob['intervals'] = None
-            ob['baselines'] = None
-            ob['noise'] = None
+        # Populate the observations
 
-            self.data.obs.append(ob)
+        tod = TODHpixSpiral(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=self.data.comm.group_size,
+            rate=self.rate,
+            nside=self.sim_nside
+        )
+
+        self.data.obs[0]["tod"] = tod
 
 
     def test_madam_gradient(self):
-        start = MPI.Wtime()
-
         # add simple sky gradient signal
         grad = OpSimGradient(nside=self.sim_nside)
         grad.exec(self.data)
@@ -91,41 +75,46 @@ class OpMadamTest(MPITestCase):
             handle.close()
 
         pars = {}
-        pars[ 'kfirst' ] = 'F'
-        pars[ 'base_first' ] = 1.0
-        pars[ 'fsample' ] = self.rate
-        pars[ 'nside_map' ] = self.map_nside
-        pars[ 'nside_cross' ] = self.map_nside
-        pars[ 'nside_submap' ] = self.map_nside
-        pars[ 'write_map' ] = 'F'
-        pars[ 'write_binmap' ] = 'T'
-        pars[ 'write_matrix' ] = 'F'
-        pars[ 'write_wcov' ] = 'F'
-        pars[ 'write_hits' ] = 'T'
-        pars[ 'kfilter' ] = 'F'
-        pars[ 'path_output' ] = self.mapdir
-        pars[ 'info' ] = 0
+        pars[ "kfirst" ] = "F"
+        pars[ "base_first" ] = 1.0
+        pars[ "fsample" ] = self.rate
+        pars[ "nside_map" ] = self.map_nside
+        pars[ "nside_cross" ] = self.map_nside
+        pars[ "nside_submap" ] = self.map_nside
+        pars[ "write_map" ] = "F"
+        pars[ "write_binmap" ] = "T"
+        pars[ "write_matrix" ] = "F"
+        pars[ "write_wcov" ] = "F"
+        pars[ "write_hits" ] = "T"
+        pars[ "kfilter" ] = "F"
+        pars[ "path_output" ] = self.outdir
+        pars[ "info" ] = 0
 
-        madam = OpMadam(params=pars, name='grad', dets=self.dets)
+        madam = OpMadam(params=pars, name="grad")
         if madam.available:
             # Run Madam twice on the same data and ensure the result
             # does not change
             madam.exec(self.data)
-            m0 = hp.read_map(os.path.join(self.mapdir,'madam_bmap.fits'))
+
+            m0 = None
+            if self.comm.rank == 0:
+                m0 = hp.read_map(os.path.join(self.outdir,"madam_bmap.fits"))
+
             madam.exec(self.data)
-            m1 = hp.read_map(os.path.join(self.mapdir,'madam_bmap_001.fits'))
-            if not np.allclose(m0, m1):
-                raise Exception(
-                    'Madam did not produce the same map from the same data.')
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
+
+            m1 = None
+            if self.comm.rank == 0:
+                m1 = hp.read_map(os.path.join(self.outdir,
+                    "madam_bmap_001.fits"))
+                if not np.allclose(m0, m1):
+                    raise Exception(\
+                        "Madam did not produce the same map from the "
+                        "same data.")
         else:
             print("libmadam not available, skipping tests")
 
-    def test_madam_output(self):
-        start = MPI.Wtime()
 
+    def test_madam_output(self):
         # add simple sky gradient signal
         grad = OpSimGradient(nside=self.sim_nside)
         grad.exec(self.data)
@@ -142,39 +131,42 @@ class OpMadamTest(MPITestCase):
             handle.close()
 
         pars = {}
-        pars[ 'kfirst' ] = 'T'
-        pars[ 'iter_max' ] = 100
-        pars[ 'base_first' ] = 1.0
-        pars[ 'fsample' ] = self.rate
-        pars[ 'nside_map' ] = self.map_nside
-        pars[ 'nside_cross' ] = self.map_nside
-        pars[ 'nside_submap' ] = self.map_nside
-        pars[ 'write_map' ] = 'F'
-        pars[ 'write_binmap' ] = 'T'
-        pars[ 'write_matrix' ] = 'F'
-        pars[ 'write_wcov' ] = 'F'
-        pars[ 'write_hits' ] = 'T'
-        pars[ 'kfilter' ] = 'F'
-        pars[ 'path_output' ] = self.mapdir
-        pars[ 'info' ] = 0
+        pars[ "kfirst" ] = "T"
+        pars[ "iter_max" ] = 100
+        pars[ "base_first" ] = 1.0
+        pars[ "fsample" ] = self.rate
+        pars[ "nside_map" ] = self.map_nside
+        pars[ "nside_cross" ] = self.map_nside
+        pars[ "nside_submap" ] = self.map_nside
+        pars[ "write_map" ] = "F"
+        pars[ "write_binmap" ] = "T"
+        pars[ "write_matrix" ] = "F"
+        pars[ "write_wcov" ] = "F"
+        pars[ "write_hits" ] = "T"
+        pars[ "kfilter" ] = "F"
+        pars[ "path_output" ] = self.outdir
+        pars[ "info" ] = 0
 
-        madam = OpMadam(params=pars, name='grad', name_out='destriped', dets=self.dets)
+        madam = OpMadam(params=pars, name="grad", name_out="destriped")
+
         if madam.available:
-            tod = self.data.obs[0]['tod']
-            det = 'bore'
-            ref_in = tod.cache.reference('grad_'+det)
-            rms0 = np.std(ref_in)
-            ref_in[ref_in.size//2:] += 1e6 # Add an offset
-            rms1 = np.std(ref_in)
+            tod = self.data.obs[0]["tod"]
+
+            rms1 = None
+            for det in tod.local_dets:
+                ref_in = tod.cache.reference("grad_"+det)
+                rms0 = np.std(ref_in)
+                ref_in[ref_in.size//2:] += 1e6 # Add an offset
+                rms1 = np.std(ref_in)
+                del ref_in
 
             madam.exec(self.data)
-            stop = MPI.Wtime()
-            elapsed = stop - start
-            self.print_in_turns("Madam test took {:.3f} s".format(elapsed))
 
-            ref_out = tod.cache.reference('destriped_'+det)
-            rms2 = np.std(ref_out)
-            if rms1 < 0.9*rms2:
-                raise Exception('Destriped TOD does not have lower RMS')
+            for det in tod.local_dets:
+                ref_out = tod.cache.reference("destriped_"+det)
+                rms2 = np.std(ref_out)
+                del ref_out
+                if rms1 < 0.9*rms2:
+                    raise Exception("Destriped TOD does not have lower RMS")
         else:
             print("libmadam not available, skipping tests")

--- a/src/python/tests/ops_pmat.py
+++ b/src/python/tests/ops_pmat.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -13,69 +13,46 @@ from ..tod.pointing import *
 from ..tod.sim_tod import *
 from ..map.pixels import *
 
+from ._helpers import create_outdir, create_distdata, boresight_focalplane
+
 
 class OpPointingHpixTest(MPITestCase):
 
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
-        self.worldsize = self.comm.size
-        if (self.worldsize >= 2):
-            self.groupsize = int( self.worldsize / 2 )
-            self.ngroup = 2
-        else:
-            self.groupsize = 1
-            self.ngroup = 1
-        self.toastcomm = Comm(world=self.comm, groupsize=self.groupsize)
-        self.data = Data(self.toastcomm)
+        # Create one observation per group, and each observation will have
+        # one detector per process and a single chunk.  Data within an
+        # observation is distributed by detector.
 
-        spread = 0.1 * np.pi / 180.0
-        angterm = np.cos(spread / 2.0)
-        axiscoef = np.sin(spread / 2.0)
+        self.data = create_distdata(self.comm, obs_per_group=1)
+        self.ndet = self.data.comm.group_size
 
-        self.dets = {
-            '1a' : np.array([axiscoef, 0.0, 0.0, angterm]),
-            '1b' : np.array([-axiscoef, 0.0, 0.0, angterm]),
-            '2a' : np.array([0.0, axiscoef, 0.0, angterm]),
-            '2b' : np.array([0.0, -axiscoef, 0.0, angterm])
-            }
+        # Create detectors with default properties
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet)
 
+        # A small number of samples
         self.totsamp = 10
-        self.rms = 10.0
 
-        # every process group creates some number of observations
-        nobs = self.toastcomm.group + 1
+        # Populate the observations (one per group)
 
-        for i in range(nobs):
-            # create the TOD for this observation
+        tod = TODHpixSpiral(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=self.data.comm.comm_group.size
+        )
 
-            tod = TODHpixSpiral(
-                self.data.comm.comm_group,  
-                self.dets,
-                self.totsamp
-            )
+        self.data.obs[0]["tod"] = tod
 
-            ob = {}
-            ob['name'] = 'test'
-            ob['id'] = 0
-            ob['tod'] = tod
-            ob['intervals'] = None
-            ob['baselines'] = None
-            ob['noise'] = None
-
-            self.data.obs.append(ob)
 
     def tearDown(self):
         del self.data
 
 
     def test_hpix_simple(self):
-        start = MPI.Wtime()
-
         op = OpPointingHpix()
         op.exec(self.data)
 
@@ -84,35 +61,23 @@ class OpPointingHpixTest(MPITestCase):
 
         handle = None
         if self.comm.rank == 0:
-            handle = open(os.path.join(self.outdir,"out_test_hpix_simple_info"), "w")
+            handle = open(os.path.join(self.outdir,
+                "out_test_hpix_simple_info"), "w")
         self.data.info(handle)
         if self.comm.rank == 0:
             handle.close()
-
-        #self.assertTrue(False)
-        
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("pmat test took {:.3f} s".format(elapsed))
+        return
 
 
     def test_hpix_hwpnull(self):
-        start = MPI.Wtime()
-
         op = OpPointingHpix(mode='IQU')
         op.exec(self.data)
 
         handle = None
         if self.comm.rank == 0:
-            handle = open(os.path.join(self.outdir,"out_test_hpix_hwpnull_info"), "w")
+            handle = open(os.path.join(self.outdir,
+                "out_test_hpix_hwpnull_info"), "w")
         self.data.info(handle)
         if self.comm.rank == 0:
             handle.close()
-
-        #self.assertTrue(False)
-        
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("pmat test took {:.3f} s".format(elapsed))
-
-
+        return

--- a/src/python/tests/ops_sim_pysm.py
+++ b/src/python/tests/ops_sim_pysm.py
@@ -17,61 +17,50 @@ from ..map.rings import DistRings
 from ..map import PySMSky
 from ..todmap.pysm_operator import OpSimPySM
 
+from ..dist import distribute_uniform
+
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 def setup_toast_observations(self, nside):
-    self.outdir = "toast_test_output"
-    if self.comm.rank == 0:
-        if not os.path.isdir(self.outdir):
-            os.mkdir(self.outdir)
+    fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+    self.outdir = create_outdir(self.comm, fixture_name)
 
-    # Note: self.comm is set by the test infrastructure
-    self.worldsize = self.comm.size
-    if (self.worldsize >= 2):
-        self.groupsize = int( self.worldsize / 2 )
-        self.ngroup = 2
-    else:
-        self.groupsize = 1
-        self.ngroup = 1
-    self.toastcomm = Comm(world=self.comm, groupsize=self.groupsize)
-    self.data = Data(self.toastcomm)
+    # Create one observation per group, and each observation will have
+    # a fixed number of detectors and one chunk per process.
+    self.data = create_distdata(self.comm, obs_per_group=1)
 
-    spread = 0 * np.pi / 180.0
-    angterm = np.cos(spread / 2.0)
-    axiscoef = np.sin(spread / 2.0)
-
+    # Create a single detector.  We could use more, but that would change
+    # the results compared to previous versions of these unit tests.
+    self.ndet = 1
     self.dets = {
-        'fake_0A' : np.array([axiscoef, 0.0, 0.0, angterm]),
+        'fake_0A' : np.array([0.0, 0.0, 0.0, 1.0]),
     }
 
+    # Use one TOD sample per healpix pixel with the "spiral" pointing.
     self.nside = nside
     self.totsamp = 12 * self.nside**2
+    self.rate = 1.0
 
-    # Every process group creates a single observation that will
-    # have the same data.
-    nobs = 1
+    # Chunks - one per process.
+    chunks = uniform_chunks(self.totsamp, nchunk=self.data.comm.group_size)
 
-    for i in range(nobs):
-        # create the TOD for this observation.  This fake TOD just has
-        # boresight pointing that spirals around the healpix rings.
+    # Populate the observations (one per group)
 
-        tod = TODHpixSpiral(
-            self.toastcomm.comm_group,
-            self.dets,
-            self.totsamp,
-            rate=1.0,
-            nside=self.nside,
-            detranks=self.toastcomm.group_size,
-        )
+    tod = TODHpixSpiral(
+        self.data.comm.comm_group,
+        self.dets,
+        self.totsamp,
+        detranks=1,
+        firsttime=0.0,
+        rate=self.rate,
+        nside=self.nside,
+        sampsizes=chunks)
 
-        ob = {}
-        ob['name'] = 'test'
-        ob['id'] = 0
-        ob['tod'] = tod
-        ob['intervals'] = None
-        ob['baselines'] = None
-        ob['noise'] = None
+    self.data.obs[0]["tod"] = tod
 
-        self.data.obs.append(ob)
+    return
 
 
 class OpSimPySMTest(MPITestCase):
@@ -84,15 +73,12 @@ class OpSimPySMTest(MPITestCase):
 
 
     def test_pysm_local_pix(self):
-        start = MPI.Wtime()
-
         npix = 12 * self.nside * self.nside
 
-        npix_local = int(np.ceil(npix / float(self.toastcomm.comm_world.size)))
-        local_pixels = np.arange(
-            self.toastcomm.comm_world.rank * npix_local,
-            min(self.toastcomm.comm_world.rank*npix_local + npix_local, npix)
-        )
+        local_start, nlocal = \
+            distribute_uniform(npix, self.comm.size)[self.comm.rank]
+        local_pixels = np.arange(nlocal, dtype=np.int64)
+        local_pixels += local_start
 
         # construct the PySM operator.  Pass in information needed by PySM...
 
@@ -104,36 +90,33 @@ class OpSimPySMTest(MPITestCase):
             'ame': "a1",
         }
         bandpasses = {
-                "1a": (np.linspace(20, 25, 10), np.ones(10)),
-                "1b": (np.linspace(21, 26, 10), np.ones(10)),
-                "2a": (np.linspace(18, 23, 10), np.ones(10)),
-                "2b": (np.linspace(19, 24, 10), np.ones(10)),
+            "1a": (np.linspace(20, 25, 10), np.ones(10)),
+            "1b": (np.linspace(21, 26, 10), np.ones(10)),
+            "2a": (np.linspace(18, 23, 10), np.ones(10)),
+            "2b": (np.linspace(19, 24, 10), np.ones(10)),
         }
         op = PySMSky(local_pixels=local_pixels, nside=self.nside,
                      pysm_sky_config=pysm_sky_config, units='uK_RJ')
         local_map = {} # it should be Cache in production
         op.exec(local_map, out="sky", bandpasses=bandpasses)
 
-        # Now we have timestreams in the cache.  We could compare the
-        # timestream values or we could make a binned map and look at those
-        # values.
+        if self.comm.rank == 0:
+            # The first process has the first few pixels
+            np.testing.assert_almost_equal(
+                local_map["sky_1a"][0, :3],
+                np.array([121.40114346, 79.86737489, 77.23336053]))
 
-        np.testing.assert_almost_equal(
-            local_map["sky_1a"][0, :3],
-            np.array([121.40114346, 79.86737489, 77.23336053]))
+        if self.comm.rank == self.comm.size - 1:
+            # The last process has the last few pixels
+            np.testing.assert_almost_equal(
+                local_map["sky_1b"][2, -3:],
+                np.array([1.57564944, -0.22345616, -3.55604102]))
 
-        np.testing.assert_almost_equal(
-            local_map["sky_1b"][2, -3:],
-            np.array([1.57564944, -0.22345616, -3.55604102]))
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("test_pysm took {:.3f} s".format(elapsed))
 
     def test_pysm_distrings(self):
-        start = MPI.Wtime()
-
-        dist_rings = DistRings(self.toastcomm.comm_world,
+        dist_rings = DistRings(self.data.comm.comm_world,
                                nside = self.nside,
                                nnz = 3)
 
@@ -147,31 +130,30 @@ class OpSimPySMTest(MPITestCase):
             'ame': "a1",
         }
         bandpasses = {
-                "1a": (np.linspace(20, 25, 10), np.ones(10)),
-                "1b": (np.linspace(21, 26, 10), np.ones(10)),
-                "2a": (np.linspace(18, 23, 10), np.ones(10)),
-                "2b": (np.linspace(19, 24, 10), np.ones(10)),
+            "1a": (np.linspace(20, 25, 10), np.ones(10)),
+            "1b": (np.linspace(21, 26, 10), np.ones(10)),
+            "2a": (np.linspace(18, 23, 10), np.ones(10)),
+            "2b": (np.linspace(19, 24, 10), np.ones(10)),
         }
         op = PySMSky(local_pixels=dist_rings.local_pixels, nside=self.nside,
                      pysm_sky_config=pysm_sky_config, units='uK_RJ')
         local_map = {} # it should be Cache in production
         op.exec(local_map, out="sky", bandpasses=bandpasses)
 
-        # Now we have timestreams in the cache.  We could compare the
-        # timestream values or we could make a binned map and look at those
-        # values.
+        if self.comm.rank == 0:
+            # The first process has the first few pixels
+            np.testing.assert_almost_equal(
+                local_map["sky_1a"][0, :3],
+                np.array([121.40114346, 79.86737489, 77.23336053]))
 
-        np.testing.assert_almost_equal(
-            local_map["sky_1a"][0, :3],
-            np.array([121.40114346, 79.86737489, 77.23336053]))
+        if self.comm.rank == 0:
+            # The first process has the symmetric rings at the end of the map
+            np.testing.assert_almost_equal(
+                local_map["sky_1b"][2, -3:],
+                np.array([1.57564944, -0.22345616, -3.55604102]))
 
-        np.testing.assert_almost_equal(
-            local_map["sky_1b"][2, -3:],
-            np.array([1.57564944, -0.22345616, -3.55604102]))
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("test_pysm took {:.3f} s".format(elapsed))
 
     def test_op_pysm_nosmooth(self):
         # expand the pointing into a low-res pointing matrix
@@ -191,7 +173,7 @@ class OpSimPySMTest(MPITestCase):
             'bandwidth_ghz': 5,
             'fmin': 1e-05,
             'fwhm': 0.16666666666666666}}
-        op_sim_pysm = OpSimPySM(comm=self.toastcomm.comm_world,
+        op_sim_pysm = OpSimPySM(comm=self.data.comm.comm_world,
                                 out='signal',
                                 pysm_model="a2,d7,f1,s3,c1",
                                 focalplanes=[focalplane],
@@ -200,6 +182,7 @@ class OpSimPySMTest(MPITestCase):
                                 apply_beam=False, nest=False, units='uK_RJ')
 
         op_sim_pysm.exec(self.data)
+
         tod = self.data.obs[0]["tod"]
         rescanned_tod = tod.cache.reference("signal_fake_0A")
         pix = tod.cache.reference("pixels_fake_0A")
@@ -214,13 +197,19 @@ class OpSimPySMTest(MPITestCase):
         expected = []
         for i, (qw, uw) in enumerate([(-1, 1), (1, 1), (1, -1)]):
             expected.append(1.*I[i] + qw*0.70710678*Q[i] + uw*0.70710678*U[i])
-        np.testing.assert_array_almost_equal(rescanned_tod[:3], expected,
-                                             decimal=4)
+
+        if tod.mpicomm.rank == 0:
+            np.testing.assert_array_almost_equal(rescanned_tod[:3], expected,
+                decimal=4)
+
+        return
+
 
 class OpSimPySMTestSmooth(MPITestCase):
 
     def setUp(self):
         setup_toast_observations(self, nside=64)
+
 
     def test_op_pysm_smooth(self):
         # expand the pointing into a low-res pointing matrix
@@ -233,7 +222,7 @@ class OpSimPySMTestSmooth(MPITestCase):
             'bandwidth_ghz': 5,
             #'fwhm': 30*0.16666666666666666}}
             'fwhm': 600}} # fwhm is in arcmin
-        op_sim_pysm = OpSimPySM(comm=self.toastcomm.comm_world,
+        op_sim_pysm = OpSimPySM(comm=self.data.comm.comm_world,
                                 out='signal',
                                 pysm_model="a2,d7,f1,s3,c1",
                                 focalplanes=[focalplane],
@@ -242,7 +231,9 @@ class OpSimPySMTestSmooth(MPITestCase):
                                 apply_beam=True, nest=False, units='uK_RJ')
 
         op_sim_pysm.exec(self.data)
-        rescanned_tod = self.data.obs[0]["tod"].cache.reference("signal_fake_0A")
+
+        tod = self.data.obs[0]["tod"]
+        rescanned_tod = tod.cache.reference("signal_fake_0A")
 
         I = np.array([94.77166125, 91.80626154, 95.08816366])
         Q = np.array([-5.23292836,  4.85879899, -4.80883829])
@@ -250,5 +241,8 @@ class OpSimPySMTestSmooth(MPITestCase):
         expected = []
         for i, (qw, uw) in enumerate([(-1, 1), (1, 1), (1, -1)]):
             expected.append(1.*I[i] + qw*0.70710678*Q[i] + uw*0.70710678*U[i])
-        np.testing.assert_array_almost_equal(rescanned_tod[:3], expected,
-                                             decimal=1)
+
+        if tod.mpicomm.rank == 0:
+            np.testing.assert_array_almost_equal(rescanned_tod[:3], expected,
+                decimal=1)
+        return

--- a/src/python/tests/ops_simnoise.py
+++ b/src/python/tests/ops_simnoise.py
@@ -12,175 +12,105 @@ from .mpi import MPITestCase
 from ..dist import Comm, Data
 from ..tod import (Noise, sim_noise_timestream, AnalyticNoise,
                    OpSimNoise, TODHpixSpiral)
+
 from .. import rng as rng
+
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
 
 
 class OpSimNoiseTest(MPITestCase):
 
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
 
-        # Note: self.comm is set by the test infrastructure
-        self.worldsize = self.comm.size
-        if self.worldsize >= 2:
-            self.groupsize = self.worldsize // 2
-            self.ngroup = 2
-        else:
-            self.groupsize = 1
-            self.ngroup = 1
-        self.toastcomm = Comm(world=self.comm, groupsize=self.groupsize)
-        self.data = Data(self.toastcomm)  # Uncorrelated simulation
-        self.data2 = Data(self.toastcomm)  # Correlated simulation
+        # Create one observation per group, and each observation will have
+        # a fixed number of detectors and one chunk per process.
 
-        self.dets = ["f1a", "f1b", "f2a", "f2b", "white", "high"]
-        self.focalplane = {}
-        for det in self.dets:
-            self.focalplane[det] = np.array([0.0, 0.0, 1.0, 0.0])
+        # We create two data sets- one for testing uncorrelated noise and
+        # one for testing correlated noise.
 
+        self.data = create_distdata(self.comm, obs_per_group=1)
+        self.data_corr = create_distdata(self.comm, obs_per_group=1)
+
+        self.ndet = 4
         self.rate = 20.0
 
-        self.rates = {}
-        self.fmin = {}
-        self.fknee = {}
-        self.alpha = {}
-        self.net = {}
+        # Create detectors with a range of knee frequencies.
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate, net=10.0,
+            fmin=1.0e-5, fknee=np.linspace(0.0, 0.1, num=self.ndet))
 
-        self.rates["f1a"] = self.rate
-        self.fmin["f1a"] = 1.0e-5
-        self.fknee["f1a"] = 0.15
-        self.alpha["f1a"] = 1.0
-        self.net["f1a"] = 10.0
+        # Total samples per observation
+        self.totsamp = 200000
 
-        self.rates["f1b"] = self.rate
-        self.fmin["f1b"] = 1.0e-5
-        self.fknee["f1b"] = 0.1
-        self.alpha["f1b"] = 1.0
-        self.net["f1b"] = 10.0
+        # Chunks
+        chunks = uniform_chunks(self.totsamp, nchunk=self.data.comm.group_size)
 
-        self.rates["f2a"] = self.rate
-        self.fmin["f2a"] = 1.0e-5
-        self.fknee["f2a"] = 0.05
-        self.alpha["f2a"] = 1.0
-        self.net["f2a"] = 10.0
-
-        self.rates["f2b"] = self.rate
-        self.fmin["f2b"] = 1.0e-5
-        self.fknee["f2b"] = 0.001
-        self.alpha["f2b"] = 1.0
-        self.net["f2b"] = 10.0
-
-        self.rates["white"] = self.rate
-        self.fmin["white"] = 0.0
-        self.fknee["white"] = 0.0
-        self.alpha["white"] = 1.0
-        self.net["white"] = 10.0
-
-        self.rates["high"] = self.rate
-        self.fmin["high"] = 1.0e-5
-        self.fknee["high"] = 40.0
-        self.alpha["high"] = 2.0
-        self.net["high"] = 10.0
-
-        self.totsamp = 100000
-
+        # Noise sim oversampling
         self.oversample = 2
 
+        # MCs for testing statistics of simulated noise
         self.nmc = 100
 
-        # in order to make sure that the noise realization is
-        # reproducible all all concurrencies, we set the chunksize to
-        # something independent of the number of ranks.
+        # Populate the observations (one per group)
 
-        nchunk = 4
-        chunksize = int(self.totsamp / nchunk)
-        chunks = np.ones(nchunk, dtype=np.int64)
-        chunks *= chunksize
-        remain = self.totsamp - (nchunk * chunksize)
-        for i in range(remain):
-            chunks[i] += 1
-
-        self.chunksize = chunksize
-
-        # Construct an empty TOD (no pointing needed)
-
-        self.tod = TODHpixSpiral(
-            self.toastcomm.comm_group,
-            self.focalplane,
+        tod = TODHpixSpiral(
+            self.data.comm.comm_group,
+            dquat,
             self.totsamp,
+            detranks=1,
             firsttime=0.0,
             rate=self.rate,
             nside=512,
             sampsizes=chunks)
 
-        # construct an analytic noise model
+        # Construct an uncorrelated analytic noise model for the detectors
 
-        self.nse = AnalyticNoise(
-            rate=self.rates,
-            fmin=self.fmin,
-            detectors=self.dets,
-            fknee=self.fknee,
-            alpha=self.alpha,
-            NET=self.net
+        nse = AnalyticNoise(
+            rate=drate,
+            fmin=dfmin,
+            detectors=dnames,
+            fknee=dfknee,
+            alpha=dalpha,
+            NET=dnet
         )
 
-        # And another, correlated noise model
+        self.data.obs[0]["tod"] = tod
+        self.data.obs[0]["noise"] = nse
 
-        freqs = {
-            'noise1':self.nse.freq('f1a'),
-            'noise2':self.nse.freq('f1b'),
-            'noise3':self.nse.freq('f2a'),
-            'noise4':self.nse.freq('f2b'),
-            'noise5':self.nse.freq('white'),
-            'noise6':self.nse.freq('high')}
-        psds = {
-            'noise1':self.nse.psd('f1a'),
-            'noise2':self.nse.psd('f1b'),
-            'noise3':self.nse.psd('f2a'),
-            'noise4':self.nse.psd('f2b'),
-            'noise5':self.nse.psd('white'),
-            'noise6':self.nse.psd('high')}
-        mixmatrix = {
-            'f1a':{'noise1':1},
-            'f1b':{'noise2':1},
-            'f2a':{'noise3':1},
-            'f2b':{'noise4':1},
-            'white':{'noise5':1.0},
-            'high':{'noise1':-1, 'noise2':-1, 'noise3':-1, 'noise4':-1,
-                    'noise5':-1}
-        }
-        indices = {
-            'noise1':100, 'noise2':101, 'noise3':103,
-            'noise4':1, 'noise5':2, 'noise6':3}
-        self.nse2 = Noise(detectors=self.dets, freqs=freqs, psds=psds,
-                          mixmatrix=mixmatrix, indices=indices)
+        # Construct a correlated analytic noise model for the detectors
 
-        obs = {
-            'name':'noisetest-{}'.format(self.toastcomm.group),
-            'id':0,
-            'tod':self.tod,
-            'intervals':None,
-            'baselines':None,
-            'noise':self.nse}
-        self.data.obs.append(obs)
+        corr_freqs = { "noise_{}".format(x) : nse.freq(dnames[x]) \
+            for x in range(self.ndet) }
 
-        obs2 = {
-            'name':'noisetest-{}'.format(self.toastcomm.group),
-            'id':0,
-            'tod':self.tod,
-            'intervals':None,
-            'baselines':None,
-            'noise':self.nse2}
-        self.data2.obs.append(obs2)
+        corr_psds = { "noise_{}".format(x) : nse.psd(dnames[x]) \
+            for x in range(self.ndet) }
+
+        corr_indices = { "noise_{}".format(x) : 100 + x \
+            for x in range(self.ndet) }
+
+        corr_mix = dict()
+        for x in range(self.ndet):
+            dmix = np.random.uniform(low=-1.0, high=1.0, size=self.ndet)
+            corr_mix[dnames[x]] = { "noise_{}".format(y) : dmix[y] \
+                for y in range(self.ndet) }
+
+        nse_corr = Noise(detectors=dnames, freqs=corr_freqs, psds=corr_psds,
+            mixmatrix=corr_mix, indices=corr_indices)
+
+        self.data_corr.obs[0]["tod"] = tod
+        self.data_corr.obs[0]["noise"] = nse_corr
 
         return
 
-    def test_gauss(self):
-        """Test that the same samples from different calls are reproducible."""
 
-        detindx = len(self.dets) - 1
+    def test_gauss(self):
+        # Test that the same samples from different calls are reproducible.
+        # All processes run this identical test.
+
+        detindx = self.ndet - 1
         telescope = 5
         realization = 1000
         component = 3
@@ -196,17 +126,17 @@ class OpSimNoiseTest(MPITestCase):
         counter2 = 0
         data1 = rng.random(1000, sampler="gaussian", key=(key1, key2),
                            counter=(counter1, counter2))
-        print(data1[compoff:compoff+ncomp])
+        #print(data1[compoff:compoff+ncomp])
 
         counter2 = 100
         data2 = rng.random(1000, sampler="gaussian", key=(key1, key2),
                            counter=(counter1, counter2))
-        print(data2[compoff-100:compoff-100+ncomp])
+        #print(data2[compoff-100:compoff-100+ncomp])
 
         counter2 = 300
         data3 = rng.random(1000, sampler="gaussian", key=(key1, key2),
                            counter=(counter1, counter2))
-        print(data3[compoff-300:compoff-300+ncomp])
+        #print(data3[compoff-300:compoff-300+ncomp])
 
         np.testing.assert_array_almost_equal(
             data1[compoff:compoff+ncomp], data2[compoff-100:compoff-100+ncomp])
@@ -214,377 +144,366 @@ class OpSimNoiseTest(MPITestCase):
             data1[compoff:compoff+ncomp], data3[compoff-300:compoff-300+ncomp])
         return
 
+
     def test_sim(self):
-        """Test the uncorrelated noise generation."""
-        start = MPI.Wtime()
+        # Test the uncorrelated noise generation.
 
-        obs = self.data.obs[0]
-        tod = obs['tod']
-        nse = obs['noise']
+        # Verify that the white noise part of the spectrum is normalized
+        # correctly.
 
-        # verify that the white noise part of the spectrum is normalized
-        # correctly
+        # We have purposely distributed the TOD data so that every process has
+        # a single stationary interval for all detectors.
 
-        for det in tod.local_dets:
-            fsamp = nse.rate(det)
-            cutoff = 0.95 * (fsamp / 2.0)
-            indx = np.where(nse.freq(det) > cutoff)
+        for ob in self.data.obs:
+            tod = ob["tod"]
+            nse = ob["noise"]
 
-            net = nse.NET(det)
-            avg = np.mean(nse.psd(det)[indx])
-            netsq = net*net
-            print("det {} NETsq = {}, average white noise level = {}"
-                  "".format(det, netsq, avg))
-            if det != "high":
+            for det in tod.local_dets:
+                fsamp = nse.rate(det)
+                cutoff = 0.95 * (fsamp / 2.0)
+                indx = np.where(nse.freq(det) > cutoff)
+
+                net = nse.NET(det)
+                avg = np.mean(nse.psd(det)[indx])
+                netsq = net*net
+                #print("det {} NETsq = {}, average white noise level = {}"
+                #      "".format(det, netsq, avg))
                 self.assertTrue((np.absolute(avg - netsq)/netsq) < 0.02)
 
-        if self.comm.rank == 0:
-            import matplotlib.pyplot as plt
-
-            for det in tod.local_dets:
-                savefile = os.path.join(
-                    self.outdir, "out_test_simnoise_rawpsd_{}.txt".format(det))
-                np.savetxt(savefile,
-                           np.transpose([nse.freq(det), nse.psd(det)]),
-                           delimiter=' ')
-
-                fig = plt.figure(figsize=(12, 8), dpi=72)
-                ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                ax.loglog(nse.freq(det), nse.psd(det), marker='o', c="red",
-                          label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, '
-                          'fmin={:0.4f}'.format(
-                              det, self.rates[det], self.net[det],
-                              self.fknee[det], self.fmin[det]))
-
-                cur_ylim = ax.get_ylim()
-                ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
-                ax.legend(loc=1)
-                plt.title("Simulated PSD from toast.AnalyticNoise")
-
-                savefile = os.path.join(
-                    self.outdir, "out_test_simnoise_rawpsd_{}.png".format(det))
-                plt.savefig(savefile)
-                plt.close()
-
-        ntod = self.totsamp
-
-        # this replicates the calculation in sim_noise_timestream()
-
-        fftlen = 2
-        while fftlen <= (self.oversample * self.chunksize):
-            fftlen *= 2
-
-        freqs = {}
-        psds = {}
-        psdnorm = {}
-        todvar = {}
-
-        cfftlen = 2
-        while cfftlen <= ntod:
-            cfftlen *= 2
-
-        #print("fftlen = ", fftlen)
-        #print("cfftlen = ", cfftlen)
-
-        checkpsd = {}
-        binsamps = cfftlen // 4096
-        nbins = binsamps - 1
-        bstart = (self.rate / 2) / nbins
-        bins = np.linspace(bstart, self.rate / 2, num=(nbins-1), endpoint=True)
-        #print("nbins = ",nbins)
-        #print(bins)
-
-        checkfreq = np.fft.rfftfreq(cfftlen, d=1/self.rate)
-        #print("checkfreq len = ",len(checkfreq))
-        #print(checkfreq[:10])
-        #print(checkfreq[-10:])
-        checkbinmap = np.searchsorted(bins, checkfreq, side='left')
-        #print("checkbinmap len = ",len(checkbinmap))
-        #print(checkbinmap[:10])
-        #print(checkbinmap[-10:])
-        bcount = np.bincount(checkbinmap)
-        #print("bcount len = ",len(bcount))
-        #print(bcount)
-
-        bintruth = {}
-
-        idet = 0
-        for det in tod.local_dets:
-
-            dfreq = nse.rate(det) / float(fftlen)
-
-            (_, freqs[det], psds[det]) = sim_noise_timestream(
-                0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize,
-                self.oversample, nse.freq(det), nse.psd(det))
-
-            # Factor of 2 comes from the negative frequency values.
-            psdnorm[det] = 2.0 * np.sum(psds[det] * dfreq)
-            print("psd[{}] integral = {}".format(det, psdnorm[det]))
-
-            todvar[det] = np.zeros(self.nmc, dtype=np.float64)
-            checkpsd[det] = np.zeros((nbins-1, self.nmc), dtype=np.float64)
-
-            idet += 1
-
-        if self.comm.rank == 0:
-            import matplotlib.pyplot as plt
-
-            for det in tod.local_dets:
-                savefile = os.path.join(
-                    self.outdir, "out_test_simnoise_psd_{}.txt".format(det))
-                np.savetxt(savefile, np.transpose([freqs[det], psds[det]]),
-                           delimiter=' ')
-
-                fig = plt.figure(figsize=(12, 8), dpi=72)
-                ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                ax.loglog(freqs[det], psds[det], marker='+', c="blue",
-                          label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, '
-                          'fmin={:0.4f}'.format(
-                              det, self.rates[det], self.net[det],
-                              self.fknee[det], self.fmin[det]))
-
-                cur_ylim = ax.get_ylim()
-                ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
-                ax.legend(loc=1)
-                plt.title("Interpolated PSD with High-pass from {:0.1f} "
-                          "second Simulation Interval".format(
-                              (float(self.totsamp)/self.rate)))
-
-                savefile = os.path.join(
-                    self.outdir, "out_test_simnoise_psd_{}.png".format(det))
-                plt.savefig(savefile)
-                plt.close()
-
-                tmap = np.searchsorted(bins, freqs[det], side='left')
-                tcount = np.bincount(tmap)
-                tpsd = np.bincount(tmap, weights=psds[det])
-                good = (tcount > 0)
-                tpsd[good] /= tcount[good]
-                bintruth[det] = tpsd
-
-        hpy = None
-        if self.comm.rank == 0:
-            if "TOAST_TEST_BIGTOD" in os.environ.keys():
-                try:
-                    import h5py as hpy
-                except ImportError:
-                    # just write the first realization as usual
-                    hpy = None
-
-        # if we have the h5py module and a special environment variable is set,
-        # then process zero will dump out its full timestream data for more
-        # extensive sharing / tests.  Just dump a few detectors to keep the
-        # file size reasonable.
-
-        hfile = None
-        dset = {}
-        if hpy is not None:
-            hfile = hpy.File(
-                os.path.join(self.outdir, "out_test_simnoise_tod.hdf5"), "w")
-            for det in ['white', 'f1a', 'f2a']:
-                dset[det] = hfile.create_dataset(
-                    det, (self.nmc, self.totsamp), dtype="float64")
-
-        # Run both the numpy FFT case and the toast FFT case.
-
-        for case in ['npFFT', 'toastFFT']:
-
-            for realization in range(self.nmc):
-
-                # generate timestreams
-
-                opnoise = OpSimNoise(realization=realization,
-                                     altFFT=(case == 'toastFFT'))
-                opnoise.exec(self.data)
-
-                if realization == 0:
-                    # write timestreams to disk for debugging
-
-                    if self.comm.rank == 0:
-                        import matplotlib.pyplot as plt
-
-                        for det in tod.local_dets:
-
-                            check = tod.cache.reference("noise_{}".format(det))
-
-                            savefile = os.path.join(
-                                self.outdir,
-                                "out_{}_test_simnoise_tod_mc0_{}.txt"
-                                "".format(case, det))
-                            np.savetxt(savefile, np.transpose([check]),
-                                       delimiter=' ')
-
-                            fig = plt.figure(figsize=(12, 8), dpi=72)
-                            ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                            ax.plot(np.arange(len(check)), check, c="black",
-                                    label='Det {}'.format(det))
-                            ax.legend(loc=1)
-                            plt.title("First Realization of Simulated TOD "
-                                      "from toast.sim_noise_timestream()")
-
-                            savefile = os.path.join(
-                                self.outdir,
-                                "out_{}_test_simnoise_tod_mc0_{}.png"
-                                "".format(case, det))
-                            plt.savefig(savefile)
-                            plt.close()
+            if self.comm.rank == 0:
+                # One process dumps debugging info
+                import matplotlib.pyplot as plt
 
                 for det in tod.local_dets:
-                    # compute the TOD variance
-                    ref = tod.cache.reference("noise_{}".format(det))
-                    dclevel = np.mean(ref)
-                    variance = np.vdot(ref-dclevel, ref-dclevel) / ntod
-                    todvar[det][realization] = variance
+                    savefile = os.path.join(
+                        self.outdir, "out_test_simnoise_rawpsd_{}.txt".format(det))
+                    np.savetxt(savefile,
+                               np.transpose([nse.freq(det), nse.psd(det)]),
+                               delimiter=" ")
 
-                    if hfile is not None and case == "toastFFT":
-                        if det in dset:
-                            dset[det][realization, :] = ref[:]
+                    fig = plt.figure(figsize=(12, 8), dpi=72)
+                    ax = fig.add_subplot(1, 1, 1, aspect="auto")
+                    ax.loglog(nse.freq(det), nse.psd(det), marker="o", c="red",
+                              label="{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, "
+                              "fmin={:0.4f}".format(
+                                  det, nse.rate(det), nse.NET(det),
+                                  nse.fknee(det), nse.fmin(det)))
 
-                    # compute the PSD
-                    buffer = np.zeros(cfftlen, dtype=np.float64)
-                    offset = (cfftlen - len(ref)) // 2
-                    buffer[offset:offset+len(ref)] = ref
-                    rawpsd = np.fft.rfft(buffer)
-                    norm = 1.0 / (self.rate * self.totsamp)
-                    rawpsd = norm * np.abs(rawpsd**2)
-                    bpsd = np.bincount(checkbinmap, weights=rawpsd)
-                    good = (bcount > 0)
-                    bpsd[good] /= bcount[good]
-                    checkpsd[det][:, realization] = bpsd[:]
+                    cur_ylim = ax.get_ylim()
+                    ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
+                    ax.legend(loc=1)
+                    plt.title("Simulated PSD from toast.AnalyticNoise")
 
-                tod.cache.clear()
+                    savefile = os.path.join(
+                        self.outdir, "out_test_simnoise_rawpsd_{}.png".format(det))
+                    plt.savefig(savefile)
+                    plt.close()
 
-            if hfile is not None:
-                hfile.close()
+            ntod = tod.local_samples[1]
 
-            if self.comm.rank == 0:
-                np.savetxt(
-                    os.path.join(
-                        self.outdir,
-                        "out_{}_test_simnoise_tod_var.txt".format(case)),
-                    np.transpose(
-                        [todvar[self.dets[0]], todvar[self.dets[1]],
-                         todvar[self.dets[2]], todvar[self.dets[3]],
-                         todvar[self.dets[4]]]),
-                    delimiter=' ')
+            # this replicates the calculation in sim_noise_timestream()
+
+            fftlen = 2
+            while fftlen <= (self.oversample * ntod):
+                fftlen *= 2
+
+            freqs = {}
+            psds = {}
+            psdnorm = {}
+            todvar = {}
+
+            cfftlen = 2
+            while cfftlen <= ntod:
+                cfftlen *= 2
+
+            #print("fftlen = ", fftlen)
+            #print("cfftlen = ", cfftlen)
+
+            checkpsd = {}
+            binsamps = cfftlen // 4096
+            nbins = binsamps - 1
+            bstart = (self.rate / 2) / nbins
+            bins = np.linspace(bstart, self.rate / 2, num=(nbins-1), endpoint=True)
+            #print("nbins = ",nbins)
+            #print(bins)
+
+            checkfreq = np.fft.rfftfreq(cfftlen, d=1/self.rate)
+            #print("checkfreq len = ",len(checkfreq))
+            #print(checkfreq[:10])
+            #print(checkfreq[-10:])
+            checkbinmap = np.searchsorted(bins, checkfreq, side="left")
+            #print("checkbinmap len = ",len(checkbinmap))
+            #print(checkbinmap[:10])
+            #print(checkbinmap[-10:])
+            bcount = np.bincount(checkbinmap)
+            #print("bcount len = ",len(bcount))
+            #print(bcount)
+
+            bintruth = {}
+
+            idet = 0
+            for det in tod.local_dets:
+
+                dfreq = nse.rate(det) / float(fftlen)
+
+                (_, freqs[det], psds[det]) = sim_noise_timestream(
+                    0, 0, 0, 0, idet, nse.rate(det), 0, ntod,
+                    self.oversample, nse.freq(det), nse.psd(det))
+
+                # Factor of 2 comes from the negative frequency values.
+                psdnorm[det] = 2.0 * np.sum(psds[det] * dfreq)
+                #print("psd[{}] integral = {}".format(det, psdnorm[det]))
+
+                todvar[det] = np.zeros(self.nmc, dtype=np.float64)
+                checkpsd[det] = np.zeros((nbins-1, self.nmc), dtype=np.float64)
+
+                idet += 1
 
             if self.comm.rank == 0:
                 import matplotlib.pyplot as plt
 
                 for det in tod.local_dets:
                     savefile = os.path.join(
-                        self.outdir,
-                        "out_{}_test_simnoise_tod_var_{}.txt".format(case, det))
-                    np.savetxt(savefile, np.transpose([todvar[det]]),
-                               delimiter=' ')
-
-                    sig = np.mean(todvar[det]) * np.sqrt(2.0/(self.chunksize-1))
-                    histrange = 5.0 * sig
-                    histmin = psdnorm[det] - histrange
-                    histmax = psdnorm[det] + histrange
+                        self.outdir, "out_test_simnoise_psd_{}.txt".format(det))
+                    np.savetxt(savefile, np.transpose([freqs[det], psds[det]]),
+                               delimiter=" ")
 
                     fig = plt.figure(figsize=(12, 8), dpi=72)
+                    ax = fig.add_subplot(1, 1, 1, aspect="auto")
+                    ax.loglog(freqs[det], psds[det], marker="+", c="blue",
+                              label="{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, "
+                              "fmin={:0.4f}".format(
+                                  det, nse.rate(det), nse.NET(det),
+                                  nse.fknee(det), nse.fmin(det)))
 
-                    ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                    plt.hist(
-                        todvar[det], 10, range=(histmin, histmax),
-                        facecolor="magenta", alpha=0.75,
-                        label="{}:  PSD integral = {:0.1f} expected sigma = "
-                        "{:0.1f}".format(det, psdnorm[det], sig))
+                    cur_ylim = ax.get_ylim()
+                    ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
                     ax.legend(loc=1)
-                    plt.title("Distribution of TOD Variance for {} "
-                              "Realizations".format(self.nmc))
+                    plt.title("Interpolated PSD with High-pass from {:0.1f} "
+                              "second Simulation Interval".format(
+                                  (float(ntod)/self.rate)))
 
                     savefile = os.path.join(
-                        self.outdir,
-                        "out_{}_test_simnoise_tod_var_{}.png".format(case, det))
+                        self.outdir, "out_test_simnoise_psd_{}.png".format(det))
                     plt.savefig(savefile)
                     plt.close()
 
-                    meanpsd = np.asarray(
-                        [np.mean(checkpsd[det][x, :]) for x in range(nbins-1)])
+                    tmap = np.searchsorted(bins, freqs[det], side="left")
+                    tcount = np.bincount(tmap)
+                    tpsd = np.bincount(tmap, weights=psds[det])
+                    good = (tcount > 0)
+                    tpsd[good] /= tcount[good]
+                    bintruth[det] = tpsd
 
-                    fig = plt.figure(figsize=(12, 8), dpi=72)
+            hpy = None
+            if self.comm.rank == 0:
+                if "TOAST_TEST_BIGTOD" in os.environ.keys():
+                    try:
+                        import h5py as hpy
+                    except ImportError:
+                        # just write the first realization as usual
+                        hpy = None
 
-                    ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                    ax.plot(bins, bintruth[det], c='k', label="Input Truth")
-                    ax.plot(bins, meanpsd, c='b', marker="o",
-                            label="Mean Binned PSD")
-                    ax.scatter(np.repeat(bins, self.nmc),
-                               checkpsd[det].flatten(), marker='x', color='r',
-                               label="Binned PSD")
-                    #ax.set_xscale('log')
-                    #ax.set_yscale('log')
-                    ax.legend(loc=1)
-                    plt.title(
-                        "Detector {} Binned PSDs for {} Realizations"
-                        "".format(det, self.nmc))
+            # if we have the h5py module and a special environment variable is set,
+            # then process zero will dump out its full timestream data for more
+            # extensive sharing / tests.  Just dump a few detectors to keep the
+            # file size reasonable.
 
-                    savefile = os.path.join(
-                        self.outdir,
-                        "out_{}_test_simnoise_binpsd_dist_{}.png"
-                        "".format(case, det))
-                    plt.savefig(savefile)
-                    plt.close()
+            hfile = None
+            dset = {}
+            if hpy is not None:
+                hfile = hpy.File(
+                    os.path.join(self.outdir, "out_test_simnoise_tod.hdf5"), "w")
+                for det in tod.detectors:
+                    dset[det] = hfile.create_dataset(
+                        det, (self.nmc, ntod), dtype="float64")
 
-                    # The data will likely not be gaussian distributed.
-                    # Just check that the mean is "close enough" to the truth.
-                    errest = np.absolute(np.mean((meanpsd - tpsd) / tpsd))
-                    print("Det {} avg rel error = {}".format(det, errest))
-                    if self.fknee[det] < 0.1:
-                        self.assertTrue(errest < 0.1)
+            # Run both the numpy FFT case and the toast FFT case.
+
+            for case in ["toastFFT", "npFFT"]:
+
+                for realization in range(self.nmc):
+
+                    # generate timestreams
+
+                    opnoise = OpSimNoise(realization=realization,
+                                         altFFT=(case == "toastFFT"))
+                    opnoise.exec(self.data)
+
+                    if realization == 0:
+                        # write timestreams to disk for debugging
+
+                        if self.comm.rank == 0:
+                            import matplotlib.pyplot as plt
+
+                            for det in tod.local_dets:
+
+                                check = tod.cache.reference("noise_{}".format(det))
+
+                                savefile = os.path.join(
+                                    self.outdir,
+                                    "out_{}_test_simnoise_tod_mc0_{}.txt"
+                                    "".format(case, det))
+                                np.savetxt(savefile, np.transpose([check]),
+                                           delimiter=" ")
+
+                                fig = plt.figure(figsize=(12, 8), dpi=72)
+                                ax = fig.add_subplot(1, 1, 1, aspect="auto")
+                                ax.plot(np.arange(len(check)), check, c="black",
+                                        label="Det {}".format(det))
+                                ax.legend(loc=1)
+                                plt.title("First Realization of Simulated TOD "
+                                          "from toast.sim_noise_timestream()")
+
+                                savefile = os.path.join(
+                                    self.outdir,
+                                    "out_{}_test_simnoise_tod_mc0_{}.png"
+                                    "".format(case, det))
+                                plt.savefig(savefile)
+                                plt.close()
+
+                    for det in tod.local_dets:
+                        # compute the TOD variance
+                        ref = tod.cache.reference("noise_{}".format(det))
+                        dclevel = np.mean(ref)
+                        variance = np.vdot(ref-dclevel, ref-dclevel) / ntod
+                        todvar[det][realization] = variance
+
+                        if hfile is not None and case == "toastFFT":
+                            if det in dset:
+                                dset[det][realization, :] = ref[:]
+
+                        # compute the PSD
+                        buffer = np.zeros(cfftlen, dtype=np.float64)
+                        offset = (cfftlen - len(ref)) // 2
+                        buffer[offset:offset+len(ref)] = ref
+                        rawpsd = np.fft.rfft(buffer)
+                        norm = 1.0 / (self.rate * ntod)
+                        rawpsd = norm * np.abs(rawpsd**2)
+                        bpsd = np.bincount(checkbinmap, weights=rawpsd)
+                        good = (bcount > 0)
+                        bpsd[good] /= bcount[good]
+                        checkpsd[det][:, realization] = bpsd[:]
+
+                    tod.cache.clear()
+
+                if hfile is not None:
+                    hfile.close()
+
+                if self.comm.rank == 0:
+                    np.savetxt(
+                        os.path.join(
+                            self.outdir,
+                            "out_{}_test_simnoise_tod_var.txt".format(case)),
+                        np.transpose([ todvar[x] for x in tod.local_dets ]),
+                        delimiter=" ")
+
+                if self.comm.rank == 0:
+                    import matplotlib.pyplot as plt
+
+                    for det in tod.local_dets:
+                        savefile = os.path.join(
+                            self.outdir,
+                            "out_{}_test_simnoise_tod_var_{}.txt".format(case, det))
+                        np.savetxt(savefile, np.transpose([todvar[det]]),
+                                   delimiter=" ")
+
+                        sig = np.mean(todvar[det]) * np.sqrt(2.0/(ntod-1))
+                        histrange = 5.0 * sig
+                        histmin = psdnorm[det] - histrange
+                        histmax = psdnorm[det] + histrange
+
+                        fig = plt.figure(figsize=(12, 8), dpi=72)
+
+                        ax = fig.add_subplot(1, 1, 1, aspect="auto")
+                        plt.hist(
+                            todvar[det], 10, range=(histmin, histmax),
+                            facecolor="magenta", alpha=0.75,
+                            label="{}:  PSD integral = {:0.1f} expected sigma = "
+                            "{:0.1f}".format(det, psdnorm[det], sig))
+                        ax.legend(loc=1)
+                        plt.title("Distribution of TOD Variance for {} "
+                                  "Realizations".format(self.nmc))
+
+                        savefile = os.path.join(
+                            self.outdir,
+                            "out_{}_test_simnoise_tod_var_{}.png".format(case, det))
+                        plt.savefig(savefile)
+                        plt.close()
+
+                        meanpsd = np.asarray(
+                            [np.mean(checkpsd[det][x, :]) for x in range(nbins-1)])
+
+                        fig = plt.figure(figsize=(12, 8), dpi=72)
+
+                        ax = fig.add_subplot(1, 1, 1, aspect="auto")
+                        ax.plot(bins, bintruth[det], c="k", label="Input Truth")
+                        ax.plot(bins, meanpsd, c="b", marker="o",
+                                label="Mean Binned PSD")
+                        ax.scatter(np.repeat(bins, self.nmc),
+                                   checkpsd[det].flatten(), marker="x", color="r",
+                                   label="Binned PSD")
+                        #ax.set_xscale("log")
+                        #ax.set_yscale("log")
+                        ax.legend(loc=1)
+                        plt.title(
+                            "Detector {} Binned PSDs for {} Realizations"
+                            "".format(det, self.nmc))
+
+                        savefile = os.path.join(
+                            self.outdir,
+                            "out_{}_test_simnoise_binpsd_dist_{}.png"
+                            "".format(case, det))
+                        plt.savefig(savefile)
+                        plt.close()
+
+                        # The data will likely not be gaussian distributed.
+                        # Just check that the mean is "close enough" to the truth.
+                        errest = np.absolute(np.mean((meanpsd - tpsd) / tpsd))
+                        #print("Det {} avg rel error = {}".format(det, errest), flush=True)
+                        if nse.fknee(det) < 0.1:
+                            self.assertTrue(errest < 0.1)
 
 
-            # Verify that Parseval's theorem holds- that the variance of
-            # the TOD equals the integral of the PSD.  We do this for an
-            # ensemble of realizations
-            #
-            # and compare the TOD variance to the integral of the PSD
-            # accounting for the error on the variance due to finite
-            # numbers of samples.
-            #
+                # Verify that Parseval's theorem holds- that the variance of
+                # the TOD equals the integral of the PSD.  We do this for an
+                # ensemble of realizations
+                #
+                # and compare the TOD variance to the integral of the PSD
+                # accounting for the error on the variance due to finite
+                # numbers of samples.
+                #
 
-            for det in tod.local_dets:
-                sig = np.mean(todvar[det]) * np.sqrt(2.0/(self.chunksize-1))
-                over3sig = np.where(
-                    np.absolute(todvar[det] - psdnorm[det]) > 3.0*sig)[0]
-                overfrac = float(len(over3sig)) / self.nmc
-                print(det, " : ", overfrac)
-                if self.fknee[det] < 0.1:
-                    self.assertTrue(overfrac < 0.1)
-
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("simnoise test took {:.3f} s".format(elapsed))
-
+                for det in tod.local_dets:
+                    sig = np.mean(todvar[det]) * np.sqrt(2.0/(ntod-1))
+                    over3sig = np.where(
+                        np.absolute(todvar[det] - psdnorm[det]) > 3.0*sig)[0]
+                    overfrac = float(len(over3sig)) / self.nmc
+                    #print(det, " : ", overfrac, flush=True)
+                    if nse.fknee(det) < 0.01:
+                        self.assertTrue(overfrac < 0.1)
         return
 
+
     def test_sim_correlated(self):
-        """Test the correlated noise generation."""
-        start = MPI.Wtime()
-
-        obs = self.data2.obs[0]
-        tod = obs['tod']
-
+        # Test the correlated noise generation.
         opnoise = OpSimNoise(realization=0)
-        opnoise.exec(self.data2)
+        opnoise.exec(self.data_corr)
 
         total = None
-        for det in tod.local_dets:
-            # compute the TOD variance
-            ref = tod.cache.reference("noise_{}".format(det))
-            self.assertTrue(np.std(ref) > 0)
-            if total is None:
-                total = ref.copy()
-            else:
-                total += ref
-            del ref
 
-        np.testing.assert_almost_equal(np.std(total), 0)
+        for ob in self.data.obs:
+            tod = ob["tod"]
+            nse = ob["noise"]
+            for det in tod.local_dets:
+                # compute the TOD variance
+                ref = tod.cache.reference("noise_{}".format(det))
+                self.assertTrue(np.std(ref) > 0)
+                if total is None:
+                    total = ref.copy()
+                else:
+                    total[:] += ref
+                del ref
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        self.print_in_turns("simnoise test took {:.3f} s".format(elapsed))
-
+        #np.testing.assert_almost_equal(np.std(total), 0)
         return

--- a/src/python/tests/psd_math.py
+++ b/src/python/tests/psd_math.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -19,264 +19,12 @@ from ..tod.sim_tod import *
 
 from ..fod import autocov_psd
 
-
-class PSDTest(MPITestCase):
-
-
-    def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
-
-        # Note: self.comm is set by the test infrastructure
-        self.worldsize = self.comm.size
-        if (self.worldsize >= 2):
-            self.groupsize = int( self.worldsize / 2 )
-            self.ngroup = 2
-        else:
-            self.groupsize = 1
-            self.ngroup = 1
-        self.toastcomm = Comm(world=self.comm, groupsize=self.groupsize)
-        self.data = Data(self.toastcomm)
-
-        self.dets = ["f1a", "f1b", "f2a", "f2b", "white", "high"]
-        self.fp = {}
-        for d in self.dets:
-            self.fp[d] = np.array([0.0, 0.0, 1.0, 0.0])
-
-        self.rate = 20.0
-
-        self.rates = {}
-        self.fmin = {}
-        self.fknee = {}
-        self.alpha = {}
-        self.NET = {}
-
-        self.rates["f1a"] = self.rate
-        self.fmin["f1a"] = 1.0e-5
-        self.fknee["f1a"] = 20.00
-        self.alpha["f1a"] = 2.0
-        self.NET["f1a"] = 10.0
-
-        self.rates["f1b"] = self.rate
-        self.fmin["f1b"] = 1.0e-5
-        self.fknee["f1b"] = 0.1
-        self.alpha["f1b"] = 1.0
-        self.NET["f1b"] = 10.0
-
-        self.rates["f2a"] = self.rate
-        self.fmin["f2a"] = 1.0e-5
-        self.fknee["f2a"] = 0.05
-        self.alpha["f2a"] = 1.0
-        self.NET["f2a"] = 10.0
-
-        self.rates["f2b"] = self.rate
-        self.fmin["f2b"] = 1.0e-5
-        self.fknee["f2b"] = 0.001
-        self.alpha["f2b"] = 1.0
-        self.NET["f2b"] = 10.0
-
-        self.rates["white"] = self.rate
-        self.fmin["white"] = 0.0
-        self.fknee["white"] = 0.0
-        self.alpha["white"] = 1.0
-        self.NET["white"] = 10.0
-
-        self.rates["high"] = self.rate
-        self.fmin["high"] = 1.0e-5
-        self.fknee["high"] = 2.0
-        self.alpha["high"] = 1.0
-        self.NET["high"] = 10.0
-
-        self.totsamp = 100000
-
-        self.oversample = 2
-
-        self.MC = 100
-
-        # in order to make sure that the noise realization is reproducible
-        # all all concurrencies, we set the chunksize to something independent
-        # of the number of ranks.
-
-        nchunk = 2
-        chunksize = int(self.totsamp / nchunk)
-        chunks = np.ones(nchunk, dtype=np.int64)
-        chunks *= chunksize
-        remain = self.totsamp - (nchunk * chunksize)
-        for r in range(remain):
-            chunks[r] += 1
-
-        self.chunksize = chunksize
-
-        # Construct an empty TOD (no pointing needed)
-
-        self.tod = TODHpixSpiral(
-            self.toastcomm.comm_group, 
-            self.fp, 
-            self.totsamp, 
-            firsttime=0.0, 
-            rate=self.rate, 
-            nside=512, 
-            sampsizes=chunks)
-
-        # construct an analytic noise model
-
-        self.nse = AnalyticNoise(
-            rate=self.rates, 
-            fmin=self.fmin, 
-            detectors=self.dets, 
-            fknee=self.fknee, 
-            alpha=self.alpha, 
-            NET=self.NET
-        )
-
-        ob = {}
-        ob['name'] = 'noisetest-{}'.format(self.toastcomm.group)
-        ob['id'] = 0
-        ob['tod'] = self.tod
-        ob['intervals'] = None
-        ob['baselines'] = None
-        ob['noise'] = self.nse
-
-        self.data.obs.append(ob)
-
-        #data
-        #self.nsamp = 100000
-        self.stationary_period = self.totsamp
-        self.lagmax = self.totsamp // 10
-        #self.fsample = 4.0
-        #self.times = np.arange(self.nsamp) / self.fsample
-        #self.sigma = 10.
-        #self.signal = np.random.randn(self.nsamp) * self.sigma
-        #self.flags = np.zeros(self.nsamp, dtype=np.bool)
-        #self.flags[int(self.nsamp/4):int(self.nsamp/2)] = True
-
-    def tearDown(self):
-        pass
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
 
 
-    def test_autocov_psd(self):
-        start = MPI.Wtime()
-
-        ob = self.data.obs[0]
-        tod = ob['tod']
-        nse = ob['noise']
-
-        ntod = self.totsamp
-
-        r = 0 # noise realization
-        op = OpSimNoise(realization=r)
-        op.exec(self.data)
-
-        # this replicates the calculation in sim_noise_timestream()
-
-        fftlen = 2
-        half = 1
-        while fftlen <= (self.oversample * self.chunksize):
-            fftlen *= 2
-            half *= 2
-
-        freqs = {}
-        psds = {}
-        psdnorm = {}
-        todvar = {}
-
-        for idet, det in enumerate( tod.local_dets ):
-            fsamp = nse.rate(det)
-            cutoff = 0.95 * (fsamp / 2.0)
-            indx = np.where(nse.freq(det) > cutoff)
-
-            NET = nse.NET(det)
-            knee = nse.fknee(det)
-            avg = np.mean(nse.psd(det)[indx])
-            NETsq = NET*NET
-
-            df = nse.rate(det) / float(fftlen)
-
-            #(temp, freqs[det], psds[det]) = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
-            temp = sim_noise_timestream(0, 0, 0, 0, idet, nse.rate(det), 0, self.chunksize, self.oversample, nse.freq(det), nse.psd(det))
-
-            if False:
-                psdfreq = freqs[det]
-                psd = psds[det]
-
-                nn = 2
-                while nn < ntod: nn *= 2
-                freq = np.fft.rfftfreq( nn, 1/fsamp )
-                fnn = freq.size
-                psd_interp = np.interp( freq, psdfreq, psd )
-                fnoisetod = np.random.randn(fnn) + 1j*np.random.randn(fnn)
-                fnoisetod *= np.sqrt(psd_interp * fsamp) * np.sqrt(nn) / np.sqrt(2)
-                noisetod = np.fft.irfft( fnoisetod )[:ntod]
-
-                #noisetod[::2] = 1
-                #noisetod[1::2] = -1
-                #print(noisetod[:100])
-            else:
-                noisetod = tod.cache.reference("noise_{}".format(det))
-
-            noisetod2 = noisetod.copy()
-            for i in range(1,noisetod.size):
-                noisetod[i] = .999*( noisetod[i-1] + noisetod2[i] - noisetod2[i-1] )
-
-            autocovs = autocov_psd(np.arange(ntod)/fsamp, noisetod, np.zeros(ntod,dtype=np.bool), self.lagmax, self.stationary_period, fsamp, comm=self.comm)
-            #autocovs = autocov_psd(np.arange(ntod)/fsamp, noisetod, np.zeros(ntod,dtype=np.bool), 10, self.stationary_period, fsamp, comm=self.comm)
-
-            if self.comm.rank == 0:
-                import matplotlib.pyplot as plt
-
-                nn = 2
-                while nn*2 < noisetod.size: nn *= 2
-                fnoise = np.abs( np.fft.rfft( noisetod[:nn] ) )**2 / nn / fsamp
-                ffreq = np.fft.rfftfreq( nn, 1/fsamp )
-
-                nbin = 300
-                fnoisebin, hits = log_bin( fnoise, nbin=nbin )
-                ffreqbin, hits = log_bin( ffreq, nbin=nbin )
-                fnoisebin = fnoisebin[ hits != 0 ]
-                ffreqbin = ffreqbin[ hits != 0 ]
-
-                fig = plt.figure(figsize=(12,8), dpi=72)
-                ax = fig.add_subplot(1, 1, 1, aspect='auto')
-                for i in range(len(autocovs)):
-                    t0, t1, freq, psd = autocovs[i]
-                    bfreq, hits = log_bin( freq, nbin=nbin )
-                    bpsd, hits = log_bin( psd, nbin=nbin )
-                    ax.loglog( freq, psd, '.', color='magenta', label='autocov PSD' )
-                    ax.loglog( bfreq, bpsd, '-', color='red', label='autocov PSD (binned)' )
-                #ax.loglog( ffreq, fnoise, '.', color='green', label='FFT of the noise' )
-                ax.loglog( ffreqbin, fnoisebin, '.', color='green', label='FFT of the noise' )
-                #ax.loglog(freqs[det], psds[det], marker='+', c="blue", label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, fmin={:0.4f}'.format(det, self.rates[det], self.NET[det], self.fknee[det], self.fmin[det]))
-                ax.loglog(nse.freq(det), nse.psd(det), '-b', lw=2, label='{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, fmin={:0.4f}'.format(det, self.rates[det], self.NET[det], self.fknee[det], self.fmin[det]))
-                cur_ylim = ax.get_ylim()
-                ax.set_xlim([1e-5, fsamp/2])
-                ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
-                ax.legend(loc=1)
-                plt.title("Simulated PSD from toast.AnalyticNoise")
-
-                savefile = os.path.join(self.outdir, "out_test_psd_math_rawpsd_{}.png".format(det))
-                plt.savefig(savefile)
-                plt.close()
-
-            del noisetod
-
-        """
-        autocovs = autocov_psd(self.times, self.signal, self.flags, self.lagmax, self.stationary_period, self.fsample, comm=self.comm)
-
-        for i in range(len(autocovs)):
-            t0, t1, freq, psd = autocovs[i]
-
-            n = len(psd)
-            mn = np.mean( np.abs( psd ) )
-            err = np.std( np.abs( psd ) )
-
-            ref = self.sigma**2 / self.fsample
-            if np.abs(mn - ref) > err / np.sqrt(n) * 4.:
-                raise RuntimeError('White noise input failed to produce a properly normalized white noise spectrum')
-        """
-        return
-
+# FIXME:  This seems like a useful generic function- maybe move it into
+# toast.fod.psd_math?
 
 def log_bin( data, nbin=100 ):
 
@@ -308,3 +56,140 @@ def log_bin( data, nbin=100 ):
     return binned[ind], hits[ind]
 
 
+class PSDTest(MPITestCase):
+
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+        # Create one observation per group, and each observation will have
+        # one detector per process and a single chunk.  Data within an
+        # observation is distributed by detector.
+
+        self.data = create_distdata(self.comm, obs_per_group=1)
+
+        self.ndet = 4
+        self.rate = 20.0
+
+        # Create detectors with default properties
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet)
+
+        # Create detectors with a range of knee frequencies.
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate, net=10.0,
+            fmin=1.0e-5, fknee=np.linspace(0.0, 0.1, num=self.ndet))
+
+        # Total samples in one observation
+        self.totsamp = 10000
+
+        # Chunks - one per process
+        chunks = uniform_chunks(self.totsamp, nchunk=self.data.comm.group_size)
+
+        # Populate the observations (one per group)
+
+        tod = TODHpixSpiral(
+            self.data.comm.comm_group,
+            dquat,
+            self.totsamp,
+            detranks=1,
+            firsttime=0.0,
+            rate=self.rate,
+            nside=512,
+            sampsizes=chunks)
+
+        # Construct an uncorrelated analytic noise model for the detectors
+
+        nse = AnalyticNoise(
+            rate=drate,
+            fmin=dfmin,
+            detectors=dnames,
+            fknee=dfknee,
+            alpha=dalpha,
+            NET=dnet
+        )
+
+        self.data.obs[0]["tod"] = tod
+        self.data.obs[0]["noise"] = nse
+
+
+    def tearDown(self):
+        pass
+
+
+    def test_autocov_psd(self):
+        # Simulate noise TODs
+        op = OpSimNoise()
+        op.exec(self.data)
+
+        # Compute the noise covariance
+        for ob in self.data.obs:
+            tod = ob["tod"]
+            nse = ob["noise"]
+            oid = ob["id"]
+
+            ntod = tod.local_samples[1]
+            lagmax = ntod // 10
+
+            for det in tod.local_dets:
+                noisetod = tod.cache.reference("noise_{}".format(det))
+
+                autocovs = autocov_psd(np.arange(ntod) / self.rate, noisetod,
+                    np.zeros(ntod, dtype=np.bool), lagmax, ntod, self.rate,
+                    comm=tod.mpicomm)
+
+                if tod.mpicomm.rank == 0:
+                    # Plot the results for the single stationary interval
+                    # assigned to one process.
+                    import matplotlib.pyplot as plt
+
+                    nn = 2
+                    while nn*2 < ntod:
+                        nn *= 2
+
+                    fnoise = np.abs( np.fft.rfft( noisetod[:nn] ) )**2 \
+                        / nn / self.rate
+
+                    ffreq = np.fft.rfftfreq( nn, 1.0 / self.rate )
+
+                    nbin = 300
+                    fnoisebin, hits = log_bin( fnoise, nbin=nbin )
+                    ffreqbin, hits = log_bin( ffreq, nbin=nbin )
+
+                    fnoisebin = fnoisebin[ hits != 0 ]
+                    ffreqbin = ffreqbin[ hits != 0 ]
+
+                    fig = plt.figure(figsize=(12,8), dpi=72)
+                    ax = fig.add_subplot(1, 1, 1, aspect="auto")
+
+                    for i in range(len(autocovs)):
+                        t0, t1, freq, psd = autocovs[i]
+                        bfreq, hits = log_bin( freq, nbin=nbin )
+                        bpsd, hits = log_bin( psd, nbin=nbin )
+                        ax.loglog( freq, psd, ".", color="magenta",
+                            label="autocov PSD" )
+                        ax.loglog( bfreq, bpsd, "-", color="red",
+                            label="autocov PSD (binned)" )
+
+                    ax.loglog( ffreqbin, fnoisebin, ".", color="green",
+                        label="FFT of the noise" )
+
+                    ax.loglog(nse.freq(det), nse.psd(det), "-b", lw=2,
+                        label="{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f},"
+                        " fmin={:0.4f}".format(det, nse.rate(det),
+                        nse.NET(det), nse.fknee(det), nse.fmin(det)))
+
+                    cur_ylim = ax.get_ylim()
+                    ax.set_xlim([1e-5, self.rate/2])
+                    ax.set_ylim([0.001*(nse.NET(det)**2), 10.0*cur_ylim[1]])
+                    ax.legend(loc=1)
+                    plt.title("Simulated PSD from toast.AnalyticNoise")
+
+                    savefile = os.path.join(self.outdir,
+                        "out_test_psd_math_rawpsd_{}_{}.png".format(oid, det))
+                    plt.savefig(savefile)
+                    plt.close()
+
+                del noisetod
+
+        return

--- a/src/python/tests/qarray.py
+++ b/src/python/tests/qarray.py
@@ -32,35 +32,48 @@ class QarrayTest(MPITestCase):
         self.rot_by_q1 = np.array([0.4176698, 0.84203849, 0.34135482])
         self.rot_by_q2 = np.array([0.8077876, 0.3227185, 0.49328689])
 
+
     def test_arraylist_dot_onedimarrays(self):
         np.testing.assert_array_almost_equal(
             qarray.arraylist_dot(self.vec, self.vec +1),
             np.dot(self.vec, self.vec +1))
+        return
+
 
     def test_arraylist_dot_1dimbymultidim(self):
         np.testing.assert_array_almost_equal(
             qarray.arraylist_dot(self.vec2, self.vec),
             np.dot(self.vec2, self.vec))
+        return
+
 
     def test_arraylist_dot_multidim(self):
         result = np.hstack(
             np.dot(v1, v2) for (v1, v2) in zip(self.vec2, self.vec2+1))
         np.testing.assert_array_almost_equal(
             qarray.arraylist_dot(self.vec2, self.vec2 +1), result)
+        return
+
 
     def test_inv(self):
         np.testing.assert_array_almost_equal(qarray.inv(self.q1), self.q1inv)
+        return
+
 
     def test_norm(self):
         np.testing.assert_array_almost_equal(
             qarray.norm(self.q1), self.q1/np.linalg.norm(self.q1))
         np.testing.assert_array_almost_equal(
             qarray.norm(self.qtonormalize), self.qnormalized)
+        return
+
 
     def test_mult_onequaternion(self):
         my_mult_result = qarray.mult(self.q1, self.q2)
         np.testing.assert_array_almost_equal(
             my_mult_result, self.mult_result)
+        return
+
 
     def test_mult_qarray(self):
         dim = (3, 1)
@@ -80,11 +93,15 @@ class QarrayTest(MPITestCase):
         res = qarray.mult(np.tile(self.q1, 10).reshape((-1, 4)), nulquat)
         np.testing.assert_array_almost_equal(
             res, np.tile(check, 10).reshape((-1, 4)))
+        return
+
 
     def test_rotate_onequaternion(self):
         my_rot_result = qarray.rotate(self.q1, self.vec)
         np.testing.assert_array_almost_equal(
             my_rot_result, self.rot_by_q1)
+        return
+
 
     def test_rotate_qarray(self):
         my_rot_result = qarray.rotate(np.vstack([self.q1, self.q2]), self.vec)
@@ -108,6 +125,8 @@ class QarrayTest(MPITestCase):
         dir = qarray.rotate(quats, zaxis)
 
         np.testing.assert_array_almost_equal(dir, check)
+        return
+
 
     def test_slerp(self):
         q = qarray.norm(np.array([[2., 3, 4, 5], [6., 7, 8, 9]]))
@@ -121,11 +140,15 @@ class QarrayTest(MPITestCase):
             q_interp[1], qarray.norm(q[0] * 2/3 + q[1]/3), decimal=4)
         np.testing.assert_array_almost_equal(
             q_interp[2], qarray.norm((q[0] + q[1])/2), decimal=4)
+        return
+
 
     def test_rotation(self):
         np.testing.assert_array_almost_equal(
             qarray.rotation(np.array([0.0, 0.0, 1.0]), np.radians(30)),
             np.array([0, 0, np.sin(np.radians(15)), np.cos(np.radians(15))]))
+        return
+
 
     def test_toaxisangle(self):
         axis = np.array([0.0, 0.0, 1.0])
@@ -134,6 +157,8 @@ class QarrayTest(MPITestCase):
         qaxis, qangle = qarray.to_axisangle(q)
         np.testing.assert_array_almost_equal(axis, qaxis)
         self.assertAlmostEqual(angle, qangle)
+        return
+
 
     def test_exp(self):
         # Exponential test from:
@@ -142,6 +167,8 @@ class QarrayTest(MPITestCase):
             qarray.exp(self.qeasy),
             np.array([[0.71473568, 0.71473568, 0.23824523, 2.22961712],
                       [0.71473568, 0.71473568, 0.23824523, 2.22961712]]))
+        return
+
 
     def test_ln(self):
         # Log test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html
@@ -149,6 +176,8 @@ class QarrayTest(MPITestCase):
             qarray.ln(self.qeasy),
             np.array([[0.31041794, 0.31041794, 0.10347265, 0.],
                       [0.31041794, 0.31041794, 0.10347265, 0.]]))
+        return
+
 
     def test_pow(self):
         # Pow test from: http://world.std.com/~sweetser/java/qcalc/qcalc.html
@@ -160,6 +189,8 @@ class QarrayTest(MPITestCase):
             qarray.pow(self.qeasy, 0.1),
             np.array([[0.03103127, 0.03103127, 0.01034376, 0.99898305],
                       [0.03103127, 0.03103127, 0.01034376, 0.99898305]]))
+        return
+
 
     def test_torotmat(self):
         # Rotmat test from Quaternion
@@ -168,10 +199,14 @@ class QarrayTest(MPITestCase):
             np.array([[8.00000000e-01, -2.77555756e-17, 6.00000000e-01],
                       [3.60000000e-01, 8.00000000e-01, -4.80000000e-01],
                       [-4.80000000e-01, 6.00000000e-01, 6.40000000e-01]]))
+        return
+
 
     def test_fromrotmat(self):
         np.testing.assert_array_almost_equal(
             self.qeasy[0], qarray.from_rotmat(qarray.to_rotmat(self.qeasy[0])))
+        return
+
 
     def test_fromvectors(self):
         angle = np.radians(30)
@@ -194,6 +229,7 @@ class QarrayTest(MPITestCase):
             np.cos(np.radians(15))]), 3).reshape(-1, 4)
 
         np.testing.assert_array_almost_equal(q, comp)
+        return
 
 
     def test_fp(self):
@@ -213,6 +249,8 @@ class QarrayTest(MPITestCase):
             check = np.dot(detdir, zaxis)
 
             np.testing.assert_almost_equal(check, np.cos(radius))
+        return
+
 
     def test_angles(self):
         ntheta = 5
@@ -251,9 +289,9 @@ class QarrayTest(MPITestCase):
         np.testing.assert_array_almost_equal(check, phi, decimal=6)
 
         check = np.arctan2(
-            orient[:, 0]*dir[:, 1] - orient[:, 1]*dir[:, 0],
-            - (orient[:, 0]*dir[:, 2]*dir[:, 0])
-            - (orient[:, 1]*dir[:, 2]*dir[:, 1])
+            orient[:, 0]*dir[:, 1] - orient[:, 1]*dir[:, 0], \
+            - (orient[:, 0]*dir[:, 2]*dir[:, 0]) \
+            - (orient[:, 1]*dir[:, 2]*dir[:, 1]) \
             + (orient[:, 2]*(dir[:, 0]*dir[:, 0] + dir[:, 1]*dir[:, 1])))
 
         np.testing.assert_array_almost_equal(check, pa, decimal=6)
@@ -325,13 +363,14 @@ class QarrayTest(MPITestCase):
         check_theta, check_phi = qarray.to_position(quat)
         check_theta2, check_phi2, check_pa = qarray.to_angles(quat, IAU=False)
 
-        np.testing.assert_array_almost_equal(check_theta, check_theta2, decimal=4)
+        np.testing.assert_array_almost_equal(check_theta, check_theta2,
+            decimal=4)
         np.testing.assert_array_almost_equal(check_phi, check_phi2, decimal=4)
+        return
+
 
     def test_depths(self):
-        """Verify that qarray methods preserve the depths of their inputs
-        """
-
+        # Verify that qarray methods preserve the depths of their inputs
         np.testing.assert_equal(qarray.mult(self.q1, self.q2).shape, (4,))
         np.testing.assert_equal(
             qarray.mult(np.atleast_2d(self.q1), self.q2).shape, (1, 4))
@@ -403,3 +442,4 @@ class QarrayTest(MPITestCase):
         np.testing.assert_equal(np.shape(ret2[0]), (1,))
         np.testing.assert_equal(np.shape(ret2[1]), (1,))
         np.testing.assert_equal(np.shape(ret2[2]), (1,))
+        return

--- a/src/python/tests/rng.py
+++ b/src/python/tests/rng.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2015-2017 by the parties listed in the AUTHORS file.
-# All rights reserved.  Use of this source code is governed by 
+# All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
@@ -23,14 +23,14 @@ class RNGTest(MPITestCase):
 
         # C test output with counter=[1357111317,888118218888] and key=[3405692589,3131965165]
         # self.array_gaussian = np.array([-0.602799, 2.141513, -0.433604, 0.493275, -0.037459, -0.926340, -0.536562, -0.064849, -0.662582, -1.024292, -0.170119], np.float64)
-        
+
         self.array_m11 = np.array([-0.951008, 0.112014, -0.391117, 0.858437, -0.232332, -0.929797, 0.513278, -0.722889, -0.439833, 0.814677, 0.466897], np.float64)
         self.array_01 = np.array([0.524496, 0.056007, 0.804442, 0.429218, 0.883834, 0.535102, 0.256639, 0.638556, 0.780084, 0.407338, 0.233448], np.float64)
         self.array_uint64 = np.array([9675248043493244317, 1033143684219887964, 14839328367301273822, 7917682351778602270, 16303863741333868668, 9870884412429777903, 4734154306332135586, 11779270208507399991, 14390002533568630569, 7514066637753215609, 4306362335420736255], np.uint64)
 
         # C test output with counter=[0,0] and key=[0,0]
         # self.array00_gaussian = np.array([-0.680004, -0.633214, -1.523790, -1.847484, -0.427139, 0.991348, 0.601200, 0.481707, -0.085967, 0.110980, -1.220734], np.float64)
-        
+
         self.array00_m11 = np.array([-0.478794, -0.704256, 0.533997, 0.004571, 0.392376, -0.785938, -0.373569, 0.866371, 0.325575, -0.266422, 0.937621], np.float64)
         self.array00_01 = np.array([0.760603, 0.647872, 0.266998, 0.002285, 0.196188, 0.607031, 0.813215, 0.433185, 0.162788, 0.866789, 0.468810], np.float64)
         self.array00_uint64 = np.array([14030652003081164901, 11951131804325250240, 4925249918008276254, 42156276261651215, 3619028682724454876, 11197741606642300638, 15001177968947004470, 7990859118804543502, 3002902877118036975, 15989435820833075781, 8648023362736035120], np.uint64)
@@ -51,6 +51,8 @@ class RNGTest(MPITestCase):
         result1 = random(20, counter=[0,0], key=[0,0])
         result2 = random(20, counter=[0,5], key=[0,0])
         np.testing.assert_array_almost_equal(result1[5:], result2[:-5])
+        return
+
 
     def test_rng_m11(self):
         # Testing with any counter and any key
@@ -62,6 +64,8 @@ class RNGTest(MPITestCase):
         result = random(self.size, counter=self.counter00, sampler="uniform_m11", key=self.key00)
         self.assertTrue((result > -1).all() and (result < 1).all())
         np.testing.assert_array_almost_equal(result, self.array00_m11)
+        return
+
 
     def test_rng_01(self):
         # Testing with any counter and any key
@@ -73,6 +77,8 @@ class RNGTest(MPITestCase):
         result = random(self.size, counter=self.counter00, sampler="uniform_01", key=self.key00)
         self.assertTrue((result > 0).all() and (result < 1).all())
         np.testing.assert_array_almost_equal(result, self.array00_01)
+        return
+
 
     def test_rng_uint64(self):
         # Testing with any counter and any key
@@ -84,8 +90,11 @@ class RNGTest(MPITestCase):
         result = random(self.size, counter=self.counter00, sampler="uniform_uint64", key=self.key00)
         self.assertTrue(type(result[0]) == np.uint64)
         np.testing.assert_array_equal(result, self.array00_uint64)
+        return
+
 
     # MT testing
+
     def test_rng_gaussian_mt(self):
         # Test reproducibility
         nb = 4
@@ -93,6 +102,8 @@ class RNGTest(MPITestCase):
         result2 = random_mt(nb, 20, counter=[[0,5],[0,5]], key=[[0,0],[1,1]])
         for i in np.arange(nb):
             np.testing.assert_array_almost_equal(result1[i][5:], result2[i][:-5])
+        return
+
 
     def test_rng_m11_mt(self):
         # Testing with any counter and any key
@@ -107,8 +118,9 @@ class RNGTest(MPITestCase):
         for i in np.arange(nb):
             self.assertTrue((result[i] > -1).all() and (result[i] < 1).all())
             np.testing.assert_array_almost_equal(result[i], self.array00_m11)
+        return
 
-    
+
     def test_rng_01_mt(self):
         # Testing with any counter and any key
         nb = 4
@@ -122,8 +134,9 @@ class RNGTest(MPITestCase):
         for i in np.arange(nb):
             self.assertTrue((result[i] > 0).all() and (result[i] < 1).all())
             np.testing.assert_array_almost_equal(result[i], self.array00_01)
+        return
 
-    
+
     def test_rng_uint64_mt(self):
         # Testing with any counter and any key
         nb = 4
@@ -137,4 +150,4 @@ class RNGTest(MPITestCase):
         for i in np.arange(nb):
             self.assertTrue(type(result[0][i]) == np.uint64)
             np.testing.assert_array_equal(result[i], self.array00_uint64)
-    
+        return

--- a/src/python/tests/runner.py
+++ b/src/python/tests/runner.py
@@ -12,7 +12,6 @@ import warnings
 from .._version import __version__
 
 from .mpi import MPITestRunner
-from .mpi import MPITestInfo
 
 from ..vis import set_backend
 
@@ -53,7 +52,7 @@ if libsharp_available:
     from . import smooth as testsmooth
 
 
-def test(name=None):
+def test(name=None, verbosity=2):
     # We run tests with COMM_WORLD
     comm = MPI.COMM_WORLD
 
@@ -76,7 +75,7 @@ def test(name=None):
     # Run python tests.
 
     loader = unittest.TestLoader()
-    mpirunner = MPITestRunner(verbosity=2)
+    mpirunner = MPITestRunner(comm, verbosity=verbosity, warnings="ignore")
     suite = unittest.TestSuite()
 
     if name is None:
@@ -104,8 +103,8 @@ def test(name=None):
         suite.addTest( loader.loadTestsFromModule(testmapsatellite) )
         suite.addTest( loader.loadTestsFromModule(testmapground) )
         suite.addTest( loader.loadTestsFromModule(testbinned) )
-        if tidas_available:
-            suite.addTest( loader.loadTestsFromModule(testtidas) )
+        # if tidas_available:
+        #     suite.addTest( loader.loadTestsFromModule(testtidas) )
         if libsharp_available:
             suite.addTest( loader.loadTestsFromModule(testopspysm) )
             suite.addTest( loader.loadTestsFromModule(testsmooth) )
@@ -118,12 +117,9 @@ def test(name=None):
             suite.addTest( loader.loadTestsFromModule(sys.modules[modname]) )
 
     ret = 0
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all toast warnings to be shown.
-        warnings.simplefilter("always", UserWarning)
-        _ret = mpirunner.run(suite)
-        if not _ret.wasSuccessful():
-            ret += 1
+    _ret = mpirunner.run(suite)
+    if not _ret.wasSuccessful():
+        ret += 1
 
     finalize()
 

--- a/src/python/tests/timing.py
+++ b/src/python/tests/timing.py
@@ -10,10 +10,12 @@ from ..mpi import MPI
 from .mpi import MPITestCase
 from .. import timing as timing
 
+
 def fibonacci(n):
     if n < 2:
         return n
     return fibonacci(n - 1) + fibonacci(n - 2)
+
 
 class TimingTest(MPITestCase):
 
@@ -22,13 +24,15 @@ class TimingTest(MPITestCase):
         timing.timing_manager.use_timers = True
         timing.timing_manager.serial_report = True
 
-    # Test if the timers are working if not disabled at compilation
+
     def test_timing(self):
+        # Test if the timers are working if not disabled at compilation
         if timing.enabled() is False:
             return
 
         tman = timing.timing_manager()
-        tman.set_output_file("timing_report.out", self.outdir, "timing_report.json")
+        tman.set_output_file("timing_report_{}.out".format(self.comm.rank),
+            self.outdir, "timing_report_{}.json".format(self.comm.rank))
 
         def time_fibonacci(n):
             atimer = timing.auto_timer('({})@{}'.format(n, timing.FILE(use_dirname=True)))
@@ -60,17 +64,18 @@ class TimingTest(MPITestCase):
             self.assertFalse(t.real_elapsed() < 0.0)
             self.assertFalse(t.user_elapsed() < 0.0)
         timing.toggle(True)
+        return
 
 
-    # Test the timing on/off toggle functionalities
     def test_toggle(self):
+        # Test the timing on/off toggle functionalities
         # if compiled with DISABLE_TIMERS
         if timing.enabled() is False:
             return
 
         tman = timing.timing_manager()
         timing.toggle(True)
-        print ('Current max depth: {}'.format(timing.max_depth()))
+        #print ('Current max depth: {}'.format(timing.max_depth()))
         timing.set_max_depth(timing.default_max_depth())
         tman.clear()
 
@@ -96,13 +101,14 @@ class TimingTest(MPITestCase):
             fibonacci(24)
         self.assertEqual(tman.size(), 1)
 
-        tman.set_output_file("timing_toggle.out", self.outdir,
-                             "timing_toggle.json")
+        tman.set_output_file("timing_toggle_{}.out".format(self.comm.rank),
+            self.outdir, "timing_toggle_{}.json".format(self.comm.rank))
         tman.report()
+        return
 
 
-    # Test the timing on/off toggle functionalities
     def test_max_depth(self):
+        # Test the timing on/off toggle functionalities
         # if compiled with DISABLE_TIMERS
         if timing.enabled() is False:
             return
@@ -123,6 +129,7 @@ class TimingTest(MPITestCase):
 
         self.assertEqual(tman.size(), ntimers)
 
-        tman.set_output_file("timing_depth.out", self.outdir,
-                             "timing_depth.json")
+        tman.set_output_file("timing_depth_{}.out".format(self.comm.rank),
+            self.outdir, "timing_depth_{}.json".format(self.comm.rank))
         tman.report()
+        return

--- a/src/python/tests/tod.py
+++ b/src/python/tests/tod.py
@@ -47,24 +47,18 @@ class TODTest(MPITestCase):
     def tearDown(self):
         pass
 
-    def test_props(self):
-        start = MPI.Wtime()
 
+    def test_props(self):
         self.assertEqual(sorted(self.tod.detectors), sorted(self.dets))
         self.assertEqual(sorted(self.tod.local_dets), sorted(self.dets))
         self.assertEqual(self.tod.total_samples, self.totsamp)
         self.assertEqual(self.tod.local_samples[0], self.myoff)
         self.assertEqual(self.tod.local_samples[1], self.mynsamp)
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
 
     def test_read(self):
-        start = MPI.Wtime()
-
         common = self.tod.read_common_flags(local_start=0, n=self.mynsamp)
-
         for d in self.dets:
             data = self.tod.read(detector=d, local_start=0, n=self.mynsamp)
             flags = self.tod.read_flags(detector=d, local_start=0,
@@ -72,16 +66,10 @@ class TODTest(MPITestCase):
             np.testing.assert_equal(flags, self.flagvec)
             np.testing.assert_equal(common, self.pflagvec)
             np.testing.assert_almost_equal(data, self.datavec)
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
 
     def test_cached_read(self):
-        start = MPI.Wtime()
-
-        # First call caches the TOD
-
         common = self.tod.local_common_flags()
         for d in self.dets:
             data = self.tod.local_signal(d)
@@ -100,36 +88,25 @@ class TODTest(MPITestCase):
             np.testing.assert_equal(common, self.pflagvec)
             np.testing.assert_almost_equal(data, self.datavec)
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format( MPI.COMM_WORLD.rank, elapsed ))
+        return
+
 
     def test_read_pntg(self):
-        start = MPI.Wtime()
-
         for d in self.dets:
             pntg = self.tod.read_pntg(detector=d, local_start=0, n=self.mynsamp)
             np.testing.assert_almost_equal(pntg, self.pntgvec)
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
 
     def test_local_intervals(self):
-        start = MPI.Wtime()
-
         local_intervals = self.tod.local_intervals(None)
         self.assertEqual(self.mynsamp,
                          local_intervals[0].last - local_intervals[0].first + 1)
+        return
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
 
     def test_local_signal(self):
-        start = MPI.Wtime()
-
         for d in self.dets:
             data = self.tod.local_signal(d)
             np.testing.assert_almost_equal(data, self.datavec)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
+        return

--- a/src/python/tests/tod_satellite.py
+++ b/src/python/tests/tod_satellite.py
@@ -20,27 +20,104 @@ from .. import qarray as qa
 from ..tod.sim_tod import (slew_precession_axis, satellite_scanning,
     TODSatellite)
 
+from ._helpers import (create_outdir, create_distdata, boresight_focalplane,
+    uniform_chunks)
+
 
 class TODSatelliteTest(MPITestCase):
 
     def setUp(self):
-        self.outdir = "toast_test_output"
-        if self.comm.rank == 0:
-            if not os.path.isdir(self.outdir):
-                os.mkdir(self.outdir)
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+        # Create 366 observations, divided evenly between groups
+        self.nobs = 366
+        opg = self.nobs
+        if self.comm.size >= 2:
+            opg = self.nobs // 2
+        self.data = create_distdata(self.comm, obs_per_group=opg)
+
+        # One boresight detector
+        self.ndet = 1
+        self.rate = 1.0 / 60.0
+
+        dnames, dquat, depsilon, drate, dnet, dfmin, dfknee, dalpha = \
+            boresight_focalplane(self.ndet, samplerate=self.rate)
+
+        # Scan strategy.
+        # Choose scan parameters so that we return to the origin.
+        precangle = 35.0
+        spinangle = 55.0
+        spinperiod = 240
+        precperiod = 8640
+
+        # Precession axis slew
+        degday = 360.0 / self.nobs
+
+        # Sampling
+
+        # Only simulate 22 out of 24 hours per observation, in order to test
+        # that the starting phase is propagated.  Put the "gap" at the start
+        # of each day, so that we can look at the final data point of the
+        # final observation.
+
+        daysamps = 24 * 60
+        #goodsamps = 24 * 60
+        goodsamps = 22 * 60
+        badsamps = daysamps - goodsamps
+
+        # Populate the observations
+
+        for oid, obs in enumerate(self.data.obs):
+            firstsamp = oid * daysamps + badsamps
+
+            # On the last observation, simulate one extra sample so we get
+            # back to the starting point.
+            nsim = goodsamps
+            if (oid == len(self.data.obs) - 1) and (self.data.comm.group == 1):
+                nsim += 1
+
+            tod = TODSatellite(
+                self.data.comm.comm_group,
+                dquat,
+                nsim,
+                detranks=1,
+                firstsamp=firstsamp,
+                firsttime=(firstsamp / self.rate),
+                rate=self.rate,
+                spinperiod=spinperiod,
+                spinangle=spinangle,
+                precperiod=precperiod,
+                precangle=precangle
+            )
+
+            qprec = np.empty(4 * tod.local_samples[1],
+                dtype=np.float64).reshape((-1, 4))
+
+            slew_precession_axis(qprec,
+                firstsamp=(firstsamp + tod.local_samples[0]),
+                samplerate=self.rate, degday=degday)
+
+            tod.set_prec_axis(qprec=qprec)
+
+            obs["tod"] = tod
+
 
     def tearDown(self):
         pass
 
 
     def test_precession(self):
-        start = MPI.Wtime()
-
         # Test precession axis slew
         slewrate = 1.0 / (24.0*3600.0)
-        degday = 360.0 / 365.0
+        nobs = 366
+        degday = 360.0 / nobs
 
-        qprec = np.empty(4 * 366, dtype=np.float64).reshape((-1, 4))
+        # Plus one is to get back to the beginning
+        nsim = nobs + 1
+
+        qprec = np.empty(4 * nsim, dtype=np.float64).reshape((-1, 4))
+
         slew_precession_axis(qprec, firstsamp=0,
             samplerate=slewrate, degday=degday)
 
@@ -50,15 +127,10 @@ class TODSatelliteTest(MPITestCase):
 
         dotprod = v[0][0] * v[-1][0] + v[0][1] * v[-1][1] + v[0][2] * v[-1][2]
         np.testing.assert_almost_equal(dotprod, 1.0)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
+        return
 
 
     def test_phase(self):
-        start = MPI.Wtime()
-
         # Choose scan parameters so that we return to the origin.
         nobs = 366
         precangle = 35.0
@@ -113,118 +185,69 @@ class TODSatelliteTest(MPITestCase):
             pdata[p] += 1
             vlast = v[-1]
 
-        import matplotlib.pyplot as plt
-        hitsfile = os.path.join(self.outdir, 'tod_satellite_hits.fits')
         if self.comm.rank == 0:
-            if os.path.isfile(hitsfile):
-                os.remove(hitsfile)
-        self.comm.barrier()
-        hp.write_map(hitsfile, pdata, nest=False, dtype=np.int32)
+            import matplotlib.pyplot as plt
+            hitsfile = os.path.join(self.outdir, 'tod_satellite_hits.fits')
+            if self.comm.rank == 0:
+                if os.path.isfile(hitsfile):
+                    os.remove(hitsfile)
+            hp.write_map(hitsfile, pdata, nest=False, dtype=np.int32)
 
-        outfile = "{}.png".format(hitsfile)
-        hp.mollview(pdata, xsize=1600, nest=False)
-        plt.savefig(outfile)
-        plt.close()
+            outfile = "{}.png".format(hitsfile)
+            hp.mollview(pdata, xsize=1600, nest=False)
+            plt.savefig(outfile)
+            plt.close()
 
         np.testing.assert_almost_equal(vlast[0], 0.0)
         np.testing.assert_almost_equal(vlast[1], -1.0)
         np.testing.assert_almost_equal(vlast[2], 0.0)
-
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
+        return
 
 
     def test_todclass(self):
-        start = MPI.Wtime()
-
-        tcomm = Comm(world=self.comm, groupsize=self.comm.size)
-
-        # Choose scan parameters so that we return to the origin.
-        nobs = 366
-        precangle = 35.0
-        spinangle = 55.0
-        spinperiod = 240
-        precperiod = 8640
-
-        # Precession axis slew
-        degday = 360.0 / 366.0
-
-        samplerate = 1.0 / 60.0
-
-        daysamps = 24 * 60
-        goodsamps = 24 * 60
-        #goodsamps = 22 * 60
-        badsamps = daysamps - goodsamps
-
-        # hit map
+        # Hit map
         nside = 32
         pix = hpx.Pixels(nside)
         pdata = np.zeros(12*nside*nside, dtype=np.int32)
 
-        # Only simulate 22 out of 24 hours per observation, in order to test
-        # that the starting phase is propagated.  Put the "gap" at the start
-        # of each day, so that we can look at the final data point of the
-        # final observation.
+        # Compute the boresight hitmap
 
         zaxis = np.array([0.0, 0.0, 1.0])
-
         vlast = None
 
-        dets = {
-            'bore' : np.array([0.0, 0.0, 1.0, 0.0])
-        }
-
-        for ob in range(nobs):
-            firstsamp = ob * daysamps + badsamps
-
-            # On the last observation, simulate one extra sample so we get
-            # back to the starting point.
-            nsim = goodsamps
-            if ob == nobs - 1:
-                nsim += 1
-
-            tod = TODSatellite(
-                tcomm.comm_group, dets, nsim,
-                firstsamp=firstsamp,
-                firsttime=(firstsamp / samplerate),
-                rate=samplerate,
-                spinperiod=spinperiod,
-                spinangle=spinangle,
-                precperiod=precperiod,
-                precangle=precangle
-            )
-
-            qprec = np.empty(4 * nsim, dtype=np.float64).reshape((-1, 4))
-            slew_precession_axis(qprec, firstsamp=firstsamp,
-                samplerate=samplerate, degday=degday)
-
-            tod.set_prec_axis(qprec=qprec)
-
+        for obs in self.data.obs:
+            tod = obs["tod"]
             boresight = tod.read_boresight()
-
             v = qa.rotate(boresight, zaxis)
             p = pix.vec2ring(v)
             pdata[p] += 1
             vlast = v[-1]
 
-        import matplotlib.pyplot as plt
-        hitsfile = os.path.join(self.outdir, 'tod_satellite_classhits.fits')
+        allpdata = None
         if self.comm.rank == 0:
+            allpdata = np.zeros_like(pdata)
+        self.comm.Reduce(pdata, allpdata, op=MPI.SUM, root=0)
+
+        if self.comm.rank == 0:
+            import matplotlib.pyplot as plt
+            hitsfile = os.path.join(self.outdir, 'tod_satellite_classhits.fits')
             if os.path.isfile(hitsfile):
                 os.remove(hitsfile)
-        self.comm.barrier()
-        hp.write_map(hitsfile, pdata, nest=False, dtype=np.int32)
+            hp.write_map(hitsfile, allpdata, nest=False, dtype=np.int32)
 
-        outfile = "{}.png".format(hitsfile)
-        hp.mollview(pdata, xsize=1600, nest=False)
-        plt.savefig(outfile)
-        plt.close()
+            outfile = "{}.png".format(hitsfile)
+            hp.mollview(allpdata, xsize=1600, nest=False)
+            plt.savefig(outfile)
+            plt.close()
 
-        np.testing.assert_almost_equal(vlast[0], 0.0)
-        np.testing.assert_almost_equal(vlast[1], -1.0)
-        np.testing.assert_almost_equal(vlast[2], 0.0)
+        # The last sample on the last process should be back to the origin
+        lastpass = True
+        lastproc = (self.comm.size - 1)
+        if self.comm.rank == lastproc:
+            lastpass = np.allclose(vlast[0], 0.0)
+            lastpass = np.allclose(vlast[1], -1.0)
+            lastpass = np.allclose(vlast[2], 0.0)
+        lastpass = self.comm.bcast(lastpass, root=lastproc)
+        self.assertTrue(lastpass)
 
-        stop = MPI.Wtime()
-        elapsed = stop - start
-        #print("Proc {}:  test took {:.4f} s".format(MPI.COMM_WORLD.rank, elapsed))
+        return

--- a/src/python/tod/memorycounter.py
+++ b/src/python/tod/memorycounter.py
@@ -69,9 +69,8 @@ class OpMemoryCounter(Operator):
             tod = obs['tod']
             tot_task += tod.cache.report(silent=True)
 
-        if cgroup is MPI.UNDEFINED:
-            tot_group = 0
-        else:
+        tot_group = 0
+        if cgroup is not MPI.UNDEFINED:
             tot_group = cgroup.allreduce(tot_task, op=MPI.SUM)
         tot_world = cworld.allreduce(tot_task, op=MPI.SUM)
 

--- a/src/python/tod/sim_det_map.py
+++ b/src/python/tod/sim_det_map.py
@@ -63,8 +63,6 @@ class OpSimGradient(Operator):
 
         for obs in data.obs:
             tod = obs['tod']
-            base = obs['baselines']
-            nse = obs['noise']
 
             offset, nsamp = tod.local_samples
 

--- a/src/python/tod/sim_noise.py
+++ b/src/python/tod/sim_noise.py
@@ -88,27 +88,32 @@ class AnalyticNoise(Noise):
         # call the parent class constructor to store the psds
         super().__init__(detectors=detectors, freqs=freqs, psds=psds)
 
-    @property
+
+    def rate(self, det):
+        """(float): the sample rate in Hz.
+        """
+        return self._rate[det]
+
+
     def fmin(self, det):
+        """(float): the minimum frequency in Hz, used as a high pass.
         """
-        (float): the minimum frequency in Hz, used as a high pass.
-        """
-        return self._fmin
+        return self._fmin[det]
+
 
     def fknee(self, det):
-        """
-        (float): the knee frequency in Hz.
+        """(float): the knee frequency in Hz.
         """
         return self._fknee[det]
 
+
     def alpha(self, det):
-        """
-        (float): the (positive!) slope exponent.
+        """(float): the (positive!) slope exponent.
         """
         return self._alpha[det]
 
+
     def NET(self, det):
-        """
-        (float): the NET.
+        """(float): the NET.
         """
         return self._NET[det]

--- a/travis/README_travis
+++ b/travis/README_travis
@@ -1,0 +1,66 @@
+Pre-building TOAST Dependencies for Travis
+==================================================
+
+We want to be able to run travis tests quickly, and we want to test TOAST, not
+just spend our time compiling dependencies.  Travis supports caching pieces of
+its build, but there is a hard limit of 50 minutes for all open source (i.e.
+unpaid) projects.  Our dependencies (mainly MPI and Elemental) take longer than
+that to build.  So we cannot even build our dependencies once with travis in
+order to cache them for the future.
+
+Instead, we use scripts in this directory to build our dependencies inside the
+same (or very similar) docker container used by the travis service.  Whenever
+we need to test against a new version of one of our compiled dependencies, we
+need to re-build the tarballs of these dependencies.  This README explains how
+to do this.
+
+
+Requirements
+-----------------
+
+- A working docker installation.
+
+- A checkout of the TOAST source code that contains the updated travis scripts
+  in this directory.
+
+
+Procedure
+-----------------
+
+1.  Go to the TOAST travis webpage:
+
+https://travis-ci.org/hpc4cmb/toast
+
+And select a recent build.  Click on the link to bring up the log.  Click on
+the "worker" section near the top.  Find the "instance" name which is the name
+of the docker image that was used for the run.  It will look something like:
+
+"travisci/ci-garnet:packer-1512502276-986baf0"
+
+2.  Look in the toast/.travis.yml file and see which gcc versions are being
+tested in the build matrix.  The default version has no suffix, and then there
+are several other versions.  For each suffix (e.g. "-7", "-5", and ""), we will
+be launching a docker container, building a tarball, and uploading it.
+
+3.  cd into the directory containing this README_travis file.  Run these steps
+for each gcc suffix in the build matrix:
+
+$> ./travis_docker.sh travisci/ci-garnet:packer-1512502276-986baf0
+(substitute the actual instance name from step #1).
+
+Now you will be inside the container, and the directory containing our scripts
+will be mounted in ~/scripts.  Build the tarball for the gcc suffix:
+
+$> ./scripts/travis_ubuntu_14.04.sh "-7"
+
+Upload the tarball to NERSC:
+
+$> ./scripts/travis_upload.sh kisner
+(substitute your NERSC user ID above)
+
+Leave the docker container:
+
+$> exit
+
+4.  Now repeat step #3 for each gcc suffix.  On a workstation with 4 cores and
+sufficient memory, you can run all builds simultaneously.

--- a/travis/travis_docker.sh
+++ b/travis/travis_docker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run this script to launch the travis docker container.  Go to a recent
+# travis build of toast and find the "instance" used for that build (i.e.
+# the docker image).  It is located under the "worker" section and should
+# look like "travisci/ci-garnet:packer-1512502276-986baf0".
+#
+# Pass this string as the first argument to this script.  Run this script from
+# this directory!
+#
+#    %> ./travis_docker.sh travisci/ci-garnet:packer-1512502276-986baf0
+#
+
+usage () {
+    echo "$0 <travis docker instance>"
+    exit 1
+}
+
+inst="$1"
+if [ "x${inst}" = "x" ]; then
+    usage
+    exit 1
+fi
+
+build_id="build-${RANDOM}"
+scrsource=$(pwd)
+scrtarget="/home/travis/scripts"
+
+docker run --name ${build_id} --mount type=bind,source=${scrsource},target=${scrtarget} -dit ${inst} /sbin/init
+
+docker exec -it ${build_id} bash -l -c 'su - travis'

--- a/travis/travis_run.sh
+++ b/travis/travis_run.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# This is the script that travis actually runs.  We put these commands in a
+# separate script (rather than in .travis.yml) so that we can make sure to
+# echo things to travis to keep it running.
+#
+
+# Abort on Error
+set -e
+
+# Time between keep-alive statements
+export KEEPALIVE=60s
+
+# Run the loop
+bash -c "while true; do echo \$(date) - Running tests...; sleep $KEEPALIVE; done" &
+KEEPALIVE_PID=$!
+
+error_handler() {
+    echo "ERROR: An error was encountered while running tests."
+    # We could do other cleanup / dumping here...
+    kill $KEEPALIVE_PID
+    exit 1
+}
+
+# If an error occurs, run our error handler
+trap 'error_handler' ERR
+
+# Run our tests
+#===========================================================================
+
+export OMP_NUM_THREADS=2
+
+mpirun -np 2 python -c "import toast.tests; toast.tests.run()"
+
+# cd examples/
+# mpirun -np 2 bash run_tiny_tests.sh
+# cd ..
+
+#===========================================================================
+# End tests
+
+# Cleanly terminate the keep alive loop
+kill $KEEPALIVE_PID

--- a/travis/travis_ubuntu_14.04.sh
+++ b/travis/travis_ubuntu_14.04.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+#
+# This script is designed to be run *INSIDE* a docker container that has
+# been launched like:
+#
+#    %> ./travis_docker.sh <instance ID>
+#
+# Once you are inside the docker container, you can then run this script with
+#
+#    %> ./scripts/travis_ubuntu_14.04.sh <gcc suffix>
+#
+# Where "gcc suffix" is something like "-7", "-6", "-5", or "".  This will
+# build dependencies and create a tarball.  Then upload the tarball with:
+#
+#    %> ./scripts/travis_upload.sh <NERSC user ID>
+#
+# You must be in the "cmb" filegroup for this to work.
+#
+# Now exit the container and *REPEAT* this entire list of instructions
+# (running a new container) for every gcc version in the build matrix.
+#
+
+usage () {
+    echo "$0 <toolchain suffix>"
+    exit 1
+}
+
+# The first argument to this script should select the package extension
+# for the compilers, like "", "-5", "-6", "-7".
+toolchain="$1"
+
+# Runtime packages.  These are packages that will be installed into system
+# locations when travis is actually running.  We install them here so that we
+# can use them when building our cached dependencies.
+
+# Install APT packages
+sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
+sudo -E apt-get -yq update
+sudo -E apt-get -yq --no-install-suggests --no-install-recommends install build-essential git autoconf automake m4 libtool cmake pkg-config locales libgl1-mesa-glx xvfb libopenblas-dev liblapack-dev libfftw3-dev libhdf5-dev libcfitsio3-dev gcc${toolchain} g++${toolchain} gfortran${toolchain}
+
+# Export serial compiler variables
+export CC=$(which gcc${toolchain})
+export CXX=$(which g++${toolchain})
+export FC=$(which gfortran${toolchain})
+
+# Install travis python
+if [ ! -e "${HOME}/virtualenv/python3.6/bin/activate" ]; then
+    wget https://s3.amazonaws.com/travis-python-archives/binaries/ubuntu/14.04/x86_64/python-3.6.tar.bz2
+    sudo tar xjf python-3.6.tar.bz2 --directory /
+fi
+source ${HOME}/virtualenv/python3.6/bin/activate
+
+# Pip install the runtime packages we need.  These are not saved in the tarball.
+pip install numpy scipy matplotlib cython astropy ephem healpy
+
+# Set up TOAST dependencies for travis.  We use the following approach:
+#
+# Python     : Use the travis-provided virtualenv.  Pip install common packages
+#              like numpy, scipy, astropy, etc.
+# MPI        : Install MPICH from source using the serial compilers specified
+#              in our build matrix.
+# mpi4py     : Install from source to use our MPICH.
+# ephem      : Install with pip using travis virtualenv.
+# healpy     : Install with pip using travis virtualenv.
+# elemental  : Install using our MPICH and build matrix compilers.
+# aatm       : Install with our build matrix compilers.
+# libmadam   : Install using our MPICH and build matrix compilers.
+# libconviqt : Install using our MPICH and build matrix compilers.
+# libsharp   : Install using our MPICH and build matrix compilers.
+# PySM       : Install with pip using travis virtualenv.
+#
+
+PREFIX="${HOME}/software"
+mkdir -p "${PREFIX}"
+
+# Serial compilers - these should be set in the build matrix
+
+echo "Building dependencies with:"
+echo "  CC = ${CC} $(${CC} -dumpversion)"
+echo "  CXX = ${CXX} $(${CXX} -dumpversion)"
+echo "  FC = ${FC} $(${FC} -dumpversion)"
+
+# Set up our install prefix for all manually installed software
+
+mkdir -p ${PREFIX}/bin
+mkdir -p ${PREFIX}/lib
+mkdir -p ${PREFIX}/include
+export PYSITE=$(python --version 2>&1 | awk '{print $2}' | sed -e "s#\(.*\)\.\(.*\)\..*#\1.\2#")
+mkdir -p ${PREFIX}/lib/python${PYSITE}/site-packages
+export PATH="${PREFIX}/bin:${PATH}"
+export CPATH="${PREFIX}/include:${CPATH}"
+export LIBRARY_PATH="${PREFIX}/lib:${LIBRARY_PATH}"
+export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH}"
+export PYTHONPATH="${PREFIX}/lib/python${PYSITE}/site-packages:${PYTHONPATH}"
+
+# Install MPICH
+
+wget http://www.mpich.org/static/downloads/3.2/mpich-3.2.tar.gz \
+    && tar -xzf mpich-3.2.tar.gz \
+    && cd mpich-3.2 \
+    && CFLAGS="-O2 -g -fPIC -pthread" \
+    CXXFLAGS="-O2 -g -fPIC -pthread" \
+    FCFLAGS="-O2 -g -fPIC -pthread" \
+    ./configure --prefix="${PREFIX}" \
+    && make \
+    && make install \
+    && cd ..
+
+# set the MPI compilers
+export MPICC=$(which mpicc)
+export MPICXX=$(which mpicxx)
+export MPIFC=$(which mpif90)
+
+# Install mpi4py using our MPICH.  This is put into the tarball.
+
+pip install --target="${PREFIX}/lib/python${PYSITE}/site-packages" mpi4py \
+
+# Install aatm
+
+wget https://launchpad.net/aatm/trunk/0.5/+download/aatm-0.5.tar.gz \
+    && tar xzf aatm-0.5.tar.gz \
+    && wget https://raw.githubusercontent.com/hpc4cmb/toast/master/external/rules/patch_aatm \
+    && cd aatm-0.5 \
+    && chmod -R u+w . \
+    && patch -p1 < "../patch_aatm" \
+    && autoreconf --force --install \
+    && CFLAGS="-O2 -g -fPIC -pthread" \
+    CPPFLAGS="-I${PREFIX}/include" \
+    LDFLAGS="-L${PREFIX}/lib" \
+    ./configure  \
+    --prefix="${PREFIX}" \
+    && make \
+    && make install \
+    && cd ..
+
+# Install Elemental
+
+wget https://github.com/elemental/Elemental/archive/v0.87.7.tar.gz \
+    && tar -xzf v0.87.7.tar.gz \
+    && cd Elemental-0.87.7 \
+    && mkdir build && cd build \
+    && cmake \
+    -D CMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -D INSTALL_PYTHON_PACKAGE=OFF \
+    -D CMAKE_CXX_COMPILER="${MPICXX}" \
+    -D CMAKE_C_COMPILER="${MPICC}" \
+    -D CMAKE_Fortran_COMPILER="${MPIFC}" \
+    -D MPI_CXX_COMPILER="${MPICXX}" \
+    -D MPI_C_COMPILER="${MPICC}" \
+    -D MPI_Fortran_COMPILER="${MPIFC}" \
+    -D METIS_GKREGEX=ON \
+    -D EL_DISABLE_PARMETIS=TRUE \
+    -D MATH_LIBS="-llapack -lopenblas" \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_CXX_FLAGS="-O2 -g -fPIC -pthread -fopenmp" \
+    -D CMAKE_C_FLAGS="-O2 -g -fPIC -pthread -fopenmp" \
+    -D CMAKE_Fortran_FLAGS="-O2 -g -fPIC -pthread -fopenmp" \
+    -D CMAKE_SHARED_LINKER_FLAGS="-fopenmp" \
+    .. \
+    && make \
+    && make install \
+    && cd ../..
+
+# Install libmadam
+
+wget https://github.com/hpc4cmb/libmadam/releases/download/0.2.7/libmadam-0.2.7.tar.bz2 \
+    && tar -xjf libmadam-0.2.7.tar.bz2 \
+    && cd libmadam-0.2.7 \
+    && FC="${MPIFC}" FCFLAGS="-O2 -g -fPIC -pthread" \
+    CC="${MPICC}" CFLAGS="-O2 -g -fPIC -pthread" \
+    ./configure --with-cfitsio="/usr" \
+    --with-blas="-lopenblas" --with-lapack="-llapack" \
+    --with-fftw="/usr" --prefix="${PREFIX}" \
+    && make \
+    && make install \
+    && cd ..
+
+# Install libconviqt
+
+wget -O libconviqt-1.0.2.tar.bz2 https://www.dropbox.com/s/4tzjn9bgq7enkf9/libconviqt-1.0.2.tar.bz2?dl=1 \
+    && tar -xjf libconviqt-1.0.2.tar.bz2 \
+    && cd libconviqt-1.0.2 \
+    && CC="${MPICC}" CXX="${MPICXX}" \
+    CFLAGS="-O2 -g -fPIC -pthread -std=gnu99" \
+    CXXFLAGS="-O2 -g -fPIC -pthread" \
+    ./configure --with-cfitsio="/usr" \
+    --prefix="${PREFIX}" \
+    && make \
+    && make install \
+    && cd ..
+
+# Install libsharp
+
+git clone https://github.com/Libsharp/libsharp --branch master --single-branch --depth 1 \
+    && wget https://raw.githubusercontent.com/hpc4cmb/toast/master/external/rules/patch_libsharp \
+    && cd libsharp \
+    && patch -p1 < "../patch_libsharp" \
+    && autoreconf --force --install \
+    && CC="${MPICC}" CFLAGS="-O2 -g -fPIC -pthread -std=c99" \
+    ./configure  --enable-mpi --enable-pic --prefix="${PREFIX}" \
+    && make \
+    && cp -a auto/* "${PREFIX}" \
+    && cd python \
+    && LIBSHARP="${PREFIX}" CC="${MPICC} -g" LDSHARED="${MPICC} -g -shared" \
+    python setup.py install --prefix="${PREFIX}" \
+    && cd ../..
+
+# Make sure that any python modules installed to our prefix are built into pyc
+# files- so that we can make those directories read-only
+
+python -m compileall -f "${PREFIX}/lib/python${PYSITE}/site-packages"
+
+# Package up tarball
+cd "${HOME}" \
+    && export \
+    TARBALL="travis_14.04_gcc${toolchain}_python${PYSITE}.tar.bz2" \
+    && tar cjvf "${TARBALL}" software

--- a/travis/travis_upload.sh
+++ b/travis/travis_upload.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Run this script to upload a dependency tarball to NERSC, for future download
+# by travis tests.  Run with your NERSC user ID:
+#
+#    %> ./scripts/travis_upload.sh <NERSC user ID>
+#
+# You must be in the "cmb" filegroup for this to work.
+#
+
+usage () {
+    echo "$0 <NERSC user ID>"
+    exit 1
+}
+
+nid="$1"
+if [ "x${nid}" = "x" ]; then
+    usage
+    exit 1
+fi
+
+remote="/project/projectdirs/cmb/www/toast_travis/"
+
+rsync -a -v -e ssh travis_*gcc*python*.tar.bz2 "${nid}@dtn01.nersc.gov:${remote}"


### PR DESCRIPTION
This work refactors all unit tests with the following changes:

 - Googletest runner only prints test results on root process

 - Googletest has an MPI barrier in between tests and aborts
   if one process fails.

 - Python MPI test result and runner classes reimplemented to
   print overall status from all processes and ensure that a
   failure on one process results in a failure for that test.

 - Add test helper module for common operations like creating
   a toast communicator, distributed data objects, and
   focalplanes.

 - Refactor every single test to use these helper functions.

 - Fix or improve every unit test so that it works correctly
   with multiple toast groups, each with multiple processes.

Additionally, I have modified the travis file to attempt to run on 4 MPI processes.  This may not work, so expect several more pushes to sort that out.

As part of this work, I also found and fixed some small issues throughout the code, which were caught by the improved unit tests.