### PR TITLE
Add elapsed_seconds method to Timer

### DIFF
--- a/src/libtoast/include/toast/sys_utils.hpp
+++ b/src/libtoast/include/toast/sys_utils.hpp
@@ -86,6 +86,7 @@ class Timer {
         void stop();
         void clear();
         double seconds() const;
+        double elapsed_seconds() const;
         size_t calls() const;
         void report(char const * message);
         void report_clear(char const * message);

--- a/src/libtoast/src/toast_sys_utils.cpp
+++ b/src/libtoast/src/toast_sys_utils.cpp
@@ -93,6 +93,24 @@ double toast::Timer::seconds() const {
     return total_;
 }
 
+double toast::Timer::elapsed_seconds() const {
+    /* Return the current reading on the timer without incrementing
+       the calls_ counter or stopping the timer
+     */
+    if (not running_) {
+        auto here = TOAST_HERE();
+        auto log = toast::Logger::get();
+        std::string msg("Timer is not running!");
+        log.error(msg.c_str(), here);
+        throw std::runtime_error(msg.c_str());
+    }
+    auto now = std::chrono::high_resolution_clock::now();
+    std::chrono::duration <double> elapsed =
+        std::chrono::duration_cast <std::chrono::duration <double> >
+        (now - start_);
+    return total_ + elapsed.count();
+}
+
 size_t toast::Timer::calls() const {
     if (running_) {
         auto here = TOAST_HERE();

--- a/src/toast/_libtoast_sys.cpp
+++ b/src/toast/_libtoast_sys.cpp
@@ -147,6 +147,17 @@ void init_sys(py::module & m) {
                 (float): The elapsed seconds (if timer is stopped) else -1.
 
         )")
+    .def("elapsed_seconds",
+         [](toast::Timer const & self) {
+             return self.elapsed_seconds();
+         }, R"(
+            Return the elapsed seconds from a running timer without
+            modifying the timer state.
+
+            Returns:
+                (float): The elapsed seconds (if timer is running).
+
+        )")
     .def("calls",
          [](toast::Timer const & self) {
              if (self.is_running()) {

--- a/src/toast/tests/timing.py
+++ b/src/toast/tests/timing.py
@@ -36,7 +36,13 @@ class TimingTest(MPITestCase):
         self.assertFalse(tm.is_running())
         tm.start()
         time.sleep(dincr)
+        elapsed = tm.elapsed_seconds()
         tm.stop()
+        try:
+            tm.elapsed_seconds()
+        except:
+            print("Successful exception:  elapsed_seconds() from a stopped timer")
+        np.testing.assert_almost_equal(tm.seconds(), elapsed, decimal=prec)
         np.testing.assert_almost_equal(tm.seconds(), dincr, decimal=prec)
         tm.report("Test timer stopped")
         tm.clear()


### PR DESCRIPTION
Certain use cases of the timer call for repeatedly checking if a given length of time has passed since the start of the timer. Currently this would require stopping the timer, calling Timer.seconds() and then starting the timer again. The stops-start would also increment the calls_ member of the timer.

Timer.elapsed_seconds() allows checking the elapsed time from a running timer without disturbing its state.