### PR TITLE
Add OpenMP compile / link flags to the toast_test and toast_mpi_test executables

### DIFF
--- a/src/libtoast/CMakeLists.txt
+++ b/src/libtoast/CMakeLists.txt
@@ -188,6 +188,11 @@ add_executable(toast_test
     toast_test.cpp
 )
 
+if(OpenMP_CXX_FOUND)
+    target_compile_options(toast_test PRIVATE "${OpenMP_CXX_FLAGS}")
+    set_target_properties(toast_test PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+endif(OpenMP_CXX_FOUND)
+
 target_include_directories(toast_test BEFORE PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/src/libtoast/CMakeLists.txt
+++ b/src/libtoast/CMakeLists.txt
@@ -170,6 +170,11 @@ else()
 #    SET(TOASTCORELIB -Wl,--whole-archive toastcore -Wl,--no-whole-archive)
 endif(APPLE)
 
+if(OpenMP_CXX_FOUND)
+    target_compile_options(toast PRIVATE "${OpenMP_CXX_FLAGS}")
+    set_target_properties(toast PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+endif(OpenMP_CXX_FOUND)
+
 target_link_libraries(toast ${TOASTTESTLIB} ${TOASTCORELIB})
 
 # Installation

--- a/src/libtoast/include/toast/tod_mapscan.hpp
+++ b/src/libtoast/include/toast/tod_mapscan.hpp
@@ -18,8 +18,7 @@ void scan_local_map(int64_t const * submap, int64_t subnpix, double const * weig
     // packed into "weights".
     //
     // The TOD is *NOT* set to zero, to allow accumulation.
-    #pragma \
-    omp parallel for schedule(static) default(none) shared(submap, subnpix, weights, nmap, subpix, map, tod, nsamp)
+    #pragma omp parallel for schedule(static) default(none) shared(submap, subnpix, weights, nmap, subpix, map, tod, nsamp)
     for (int64_t i = 0; i < nsamp; ++i) {
         if ((subpix[i] < 0) || (submap[i] < 0)) {
             continue;

--- a/src/libtoast_mpi/CMakeLists.txt
+++ b/src/libtoast_mpi/CMakeLists.txt
@@ -133,6 +133,11 @@ add_executable(toast_mpi_test
     toast_mpi_test.cpp
 )
 
+if(OpenMP_CXX_FOUND)
+    target_compile_options(toast_mpi_test PRIVATE "${OpenMP_CXX_FLAGS}")
+    set_target_properties(toast_mpi_test PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+endif(OpenMP_CXX_FOUND)
+
 target_include_directories(toast_mpi_test BEFORE PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}/../libtoast"
     "${CMAKE_CURRENT_SOURCE_DIR}/../libtoast/include"

--- a/src/libtoast_mpi/CMakeLists.txt
+++ b/src/libtoast_mpi/CMakeLists.txt
@@ -116,6 +116,11 @@ else()
 #    SET(TOASTMPICORELIB -Wl,--whole-archive toastcore_mpi -Wl,--no-whole-archive)
 endif(APPLE)
 
+if(OpenMP_CXX_FOUND)
+    target_compile_options(toast_mpi PRIVATE "${OpenMP_CXX_FLAGS}")
+    set_target_properties(toast_mpi PROPERTIES LINK_FLAGS "${OpenMP_CXX_FLAGS}")
+endif(OpenMP_CXX_FOUND)
+
 target_link_libraries(toast_mpi ${TOASTMPITESTLIB} ${TOASTMPICORELIB} toast "${MPI_CXX_LIBRARIES}")
 
 # Public headers


### PR DESCRIPTION
@keskitalo, does this fix the pragma warnings you were seeing?