### PR TITLE
Change python bindings for Aligned object types

### DIFF
--- a/src/toast/_libtoast.hpp
+++ b/src/toast/_libtoast.hpp
@@ -40,7 +40,10 @@ void register_aligned(py::module & m, char const * name) {
                            const typename C::value_type &)) & C::push_back)
     .def("resize", (void (C::*)(typename C::size_type count)) & C::resize)
     .def("size", &C::size)
-    .def("clear", &C::clear)
+    .def("clear", [](C & self) {
+            C().swap(self);
+            return;
+        })
     .def("address", [](C & self) {
             return (int64_t)((void*)self.data());
         })


### PR DESCRIPTION
These objects are std::vectors with custom aligned memory allocators.  When using these in python (for example in the toast.Cache class), we want to be able to really free the memory.  The clear() method in the python bindings previously just called the std::vector::clear() method which does not actually free memory.  This work changes the clear() method in the bindings to swap the memory with an empty vector.  This ensures that the memory is really freed.

The ability to free the memory explicitly is the main driver of these wrapped objects (the other is memory alignment).

The "unit test" for this just prints the used memory before and after allocation.  Trying to use these numbers in some kind of check is difficult since other processes on the system affect the memory use.