### PR TITLE
Add debug-level logging to the code that sets the numba threading layer.

### DIFF
--- a/etc/numba_test/numba_threads.py
+++ b/etc/numba_test/numba_threads.py
@@ -2,8 +2,6 @@
 
 from toast.mpi import MPI
 
-import os
-
 import numpy as np
 
 from numba import njit, config
@@ -101,8 +99,8 @@ def test_numba(comm):
     ydata = 0.001 * np.arange(1000001.0)
     out = outer_numba(xdata, ydata)
     print(
-        "test_numba post:  NUMBA_NUM_THREADS = {} / {}"
-        .format(os.environ["NUMBA_NUM_THREADS"], config.NUMBA_NUM_THREADS),
+        "test_numba post:  NUMBA_NUM_THREADS = {}"
+        .format(config.NUMBA_NUM_THREADS),
         flush=True
     )
     # out = outer(xdata, ydata)
@@ -110,8 +108,8 @@ def test_numba(comm):
 
 def main():
     print(
-        "main:  NUMBA_NUM_THREADS = {} / {}"
-        .format(os.environ["NUMBA_NUM_THREADS"], config.NUMBA_NUM_THREADS),
+        "main:  NUMBA_NUM_THREADS = {}"
+        .format(config.NUMBA_NUM_THREADS),
         flush=True
     )
     comm = None

--- a/etc/numba_test/numba_threads.py
+++ b/etc/numba_test/numba_threads.py
@@ -6,7 +6,7 @@ import os
 
 import numpy as np
 
-from numba import njit
+from numba import njit, config
 
 # This function mimics the pysm use of the inner nested njit call to
 # compute_spdust_scaling_numba.  In particular, it calls a numpy.interp,
@@ -100,11 +100,23 @@ def test_numba(comm):
     xdata = np.arange(1000001.0)
     ydata = 0.001 * np.arange(1000001.0)
     out = outer_numba(xdata, ydata)
+    print(
+        "test_numba post:  NUMBA_NUM_THREADS = {} / {}"
+        .format(os.environ["NUMBA_NUM_THREADS"], config.NUMBA_NUM_THREADS),
+        flush=True
+    )
     # out = outer(xdata, ydata)
 
 
 def main():
-    comm = MPI.COMM_WORLD
+    print(
+        "main:  NUMBA_NUM_THREADS = {} / {}"
+        .format(os.environ["NUMBA_NUM_THREADS"], config.NUMBA_NUM_THREADS),
+        flush=True
+    )
+    comm = None
+    if MPI is not None:
+        comm = MPI.COMM_WORLD
     test_numba(comm)
 
 

--- a/etc/numba_test/numba_threads.py
+++ b/etc/numba_test/numba_threads.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+from toast.mpi import MPI
+
+import os
+
+import numpy as np
+
+from numba import njit
+
+# This function mimics the pysm use of the inner nested njit call to
+# compute_spdust_scaling_numba.  In particular, it calls a numpy.interp,
+# which might be parallelized in external compiled code.
+@njit
+def inner_numba_numpy(xdata, ydata, x1, x2):
+    # Calling numpy within this function triggers an error
+    y1 = np.interp(x1, xdata, ydata)
+    y2 = np.interp(x2, xdata, ydata)
+    return (y1, y2)
+
+
+@njit
+def inner_numba_nonumpy(xdata, ydata, x1, x2):
+    y1 = np.zeros_like(x1)
+    y2 = np.zeros_like(x2)
+
+    indx = 0
+    for i, x in enumerate(x1):
+        # find bounds
+        while x < xdata[indx + 1]:
+            indx += 1
+        while x > xdata[indx + 1]:
+            indx -= 1
+        y1[i] = ydata[indx] + (x - xdata[indx]) * (ydata[indx + 1] - ydata[indx]) / (
+            xdata[indx + 1] - xdata[indx]
+        )
+    indx = 0
+    for i, x in enumerate(x2):
+        # find bounds
+        while x < xdata[indx + 1]:
+            indx += 1
+        while x > xdata[indx + 1]:
+            indx -= 1
+        y2[i] = ydata[indx] + (x - xdata[indx]) * (ydata[indx + 1] - ydata[indx]) / (
+            xdata[indx + 1] - xdata[indx]
+        )
+
+    return (y1, y2)
+
+
+# This function mimics the pysm use of a njit parallel calling another njit
+# in compute_spdust_emission_pol_numba.
+@njit(parallel=True)
+def outer_numba(xdata, ydata):
+    inp1 = [0.5 + np.arange(1000000.0) for x in range(10)]
+    inp2 = [0.25 + np.arange(1000000.0) for x in range(10)]
+    out = list()
+    for x1, x2 in zip(inp1, inp2):
+        # Calling this with numpy causes OMP issue
+        # y1, y2 = inner_numba_numpy(xdata, ydata, x1, x2)
+        # Calling version without numpy works
+        y1, y2 = inner_numba_nonumpy(xdata, ydata, x1, x2)
+        out.append((y1, y2))
+    return
+
+
+@njit(parallel=True)
+def outer(xdata, ydata):
+    inp1 = [0.5 + np.arange(1000000.0) for x in range(10)]
+    inp2 = [0.25 + np.arange(1000000.0) for x in range(10)]
+    out = list()
+    for x1, x2 in zip(inp1, inp2):
+        y1 = np.zeros_like(x1)
+        y2 = np.zeros_like(x2)
+        indx = 0
+        for i, x in enumerate(x1):
+            # find bounds
+            while x < xdata[indx + 1]:
+                indx += 1
+            while x > xdata[indx + 1]:
+                indx -= 1
+            y1[i] = ydata[indx] + (x - xdata[indx]) * (
+                ydata[indx + 1] - ydata[indx]
+            ) / (xdata[indx + 1] - xdata[indx])
+        indx = 0
+        for i, x in enumerate(x2):
+            # find bounds
+            while x < xdata[indx + 1]:
+                indx += 1
+            while x > xdata[indx + 1]:
+                indx -= 1
+            y2[i] = ydata[indx] + (x - xdata[indx]) * (
+                ydata[indx + 1] - ydata[indx]
+            ) / (xdata[indx + 1] - xdata[indx])
+        out.append((y1, y2))
+    return
+
+
+def test_numba(comm):
+    xdata = np.arange(1000001.0)
+    ydata = 0.001 * np.arange(1000001.0)
+    out = outer_numba(xdata, ydata)
+    # out = outer(xdata, ydata)
+
+
+def main():
+    comm = MPI.COMM_WORLD
+    test_numba(comm)
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/numba_test/run.slurm
+++ b/etc/numba_test/run.slurm
@@ -16,7 +16,6 @@ export OMP_PROC_BIND=spread
 
 let nnode=2
 let ntask_node=64/$OMP_NUM_THREADS
-#let ntask_node=32/$OMP_NUM_THREADS
 let ntask=$nnode*$ntask_node
 let ncore=4*$OMP_NUM_THREADS
 

--- a/etc/numba_test/run.slurm
+++ b/etc/numba_test/run.slurm
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --partition=debug
+#SBATCH --time=00:10:00
+#SBATCH --nodes=2
+#SBATCH --job-name=test-numba
+#SBATCH --licenses=SCRATCH
+#SBATCH --constraint=knl
+#SBATCH --core-spec=4
+#SBATCH --account=mp107
+
+ulimit -c unlimited
+
+export OMP_NUM_THREADS=8
+export OMP_PLACES=threads
+export OMP_PROC_BIND=spread
+
+let nnode=2
+let ntask_node=64/$OMP_NUM_THREADS
+let ntask=$nnode*$ntask_node
+let ncore=4*$OMP_NUM_THREADS
+
+com="srun -n $ntask -c $ncore --cpu_bind=cores numba_threads.py"
+echo ${com}
+eval ${com}

--- a/etc/numba_test/run.slurm
+++ b/etc/numba_test/run.slurm
@@ -16,8 +16,11 @@ export OMP_PROC_BIND=spread
 
 let nnode=2
 let ntask_node=64/$OMP_NUM_THREADS
+#let ntask_node=32/$OMP_NUM_THREADS
 let ntask=$nnode*$ntask_node
 let ncore=4*$OMP_NUM_THREADS
+
+#export NUMBA_NUM_THREADS=$OMP_NUM_THREADS
 
 com="srun -n $ntask -c $ncore --cpu_bind=cores numba_threads.py"
 echo ${com}

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -64,7 +64,7 @@ def set_numba_threading():
     toastthreads = env.max_threads()
 
     rank = 0
-    if env.use_mpi:
+    if env.use_mpi():
         from .mpi import MPI
 
         rank = MPI.COMM_WORLD.rank

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -91,7 +91,7 @@ def set_numba_threading():
             if rank == 0:
                 log.debug("Numba does not support TBB")
     try:
-        from numba import vectorize, threading_layer
+        from numba import vectorize, config, threading_layer
 
         # Set threading layer and number of threads by way of
         # the environment.
@@ -110,6 +110,14 @@ def set_numba_threading():
         numba_threading_layer = threading_layer()
         if rank == 0:
             log.debug("Numba threading layer set to {}".format(numba_threading_layer))
+            log.debug(
+                "Numba original max threads = {}".format(
+                    config.NUMBA_DEFAULT_NUM_THREADS
+                )
+            )
+            log.debug(
+                "Numba max threads now forced to {}".format(config.NUMBA_NUM_THREADS)
+            )
     except ImportError:
         # Numba not available at all
         if rank == 0:

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -93,9 +93,15 @@ def set_numba_threading():
     try:
         from numba import vectorize, config, threading_layer
 
-        # Set threading layer and number of threads by way of
-        # the environment.
+        # Set threading layer and number of threads.  Note that this still
+        # does not always work.  The conf structure is repopulated from the
+        # environment on every compilation if any of the NUMBA_* variables
+        # have changed.
+        config.THREADING_LAYER = threading
+        config.NUMBA_DEFAULT_NUM_THREADS = toastthreads
+        config.NUMBA_NUM_THREADS = toastthreads
         os.environ["NUMBA_THREADING_LAYER"] = threading
+        os.environ["NUMBA_DEFAULT_NUM_THREADS"] = "{:d}".format(toastthreads)
         os.environ["NUMBA_NUM_THREADS"] = "{:d}".format(toastthreads)
 
         # In order to get numba to actually select a threading layer, we must
@@ -110,11 +116,6 @@ def set_numba_threading():
         numba_threading_layer = threading_layer()
         if rank == 0:
             log.debug("Numba threading layer set to {}".format(numba_threading_layer))
-            log.debug(
-                "Numba original max threads = {}".format(
-                    config.NUMBA_DEFAULT_NUM_THREADS
-                )
-            )
             log.debug(
                 "Numba max threads now forced to {}".format(config.NUMBA_NUM_THREADS)
             )


### PR DESCRIPTION
Log the threading layer selection process if TOAST_LOGLEVEL=DEBUG.