### PR TITLE
sim_focalplane.py: plot_focalplane return fig instead of None

### DIFF
--- a/src/toast/tod/sim_focalplane.py
+++ b/src/toast/tod/sim_focalplane.py
@@ -610,4 +610,4 @@ def plot_focalplane(
     else:
         plt.savefig(outfile)
         plt.close()
-    return
+    return fig


### PR DESCRIPTION
Useful if people want to manipulate fig itself, and should be backward compatible.