### PR TITLE
Printing improvements

### DIFF
--- a/pipelines/toast_env_test.py
+++ b/pipelines/toast_env_test.py
@@ -39,7 +39,7 @@ def main():
 
     mpiworld, procs, rank = get_world()
     if rank == 0:
-        env.print()
+        print(env)
         log.info("Numba threading layer set to '{}'".format(numba_threading_layer))
     if mpiworld is None:
         log.info("Running serially with one process")

--- a/src/libtoast/include/toast/sys_environment.hpp
+++ b/src/libtoast/include/toast/sys_environment.hpp
@@ -26,6 +26,7 @@ class Environment {
         std::string log_level() const;
         void set_log_level(char const * level);
         std::vector <std::string> signals() const;
+        std::vector <std::string> info() const;
         void print() const;
         bool use_mpi() const;
         bool function_timers() const;

--- a/src/libtoast/src/toast_sys_environment.cpp
+++ b/src/libtoast/src/toast_sys_environment.cpp
@@ -281,14 +281,17 @@ std::vector <std::string> toast::Environment::signals() const {
     return signals_avail_;
 }
 
-void toast::Environment::print() const {
-    std::string prefix("TOAST ENV");
+std::vector <std::string> toast::Environment::info() const {
+    std::vector <std::string> ret;
+    std::ostringstream o;
 
-    fprintf(stdout, "%s: Source code version = %s\n", prefix.c_str(),
-            version_.c_str());
+    o.str("");
+    o << "Source code version = " << version_;
+    ret.push_back(o.str());
 
-    fprintf(stdout, "%s: Logging level = %s\n", prefix.c_str(),
-            loglvl_.c_str());
+    o.str("");
+    o << "Logging level = " << loglvl_;
+    ret.push_back(o.str());
 
     std::vector <std::string> signals;
     for (auto const & sig : signals_avail_) {
@@ -299,29 +302,52 @@ void toast::Environment::print() const {
         }
     }
 
-    fprintf(stdout, "%s: Handling enabled for %lu signals:\n", prefix.c_str(),
-            signals.size());
+    o.str("");
+    o << "Handling enabled for " << signals.size() << " signals:";
+    ret.push_back(o.str());
 
     for (auto const & sig : signals) {
-        fprintf(stdout, "%s:   %9s\n", prefix.c_str(), sig.c_str());
+        o.str("");
+        o << "  " << sig;
+        ret.push_back(o.str());
     }
 
-    fprintf(stdout, "%s: Max threads = %d\n", prefix.c_str(),
-            max_threads_);
+    o.str("");
+    o << "Max threads = " << max_threads_;
+    ret.push_back(o.str());
+
+    o.str("");
     if (have_mpi_) {
-        fprintf(stdout, "%s: MPI build enabled\n", prefix.c_str());
+        o << "MPI build enabled";
     } else {
-        fprintf(stdout, "%s: MPI build disabled\n", prefix.c_str());
+        o << "MPI build disabled";
     }
+    ret.push_back(o.str());
+
+    o.str("");
     if (use_mpi_) {
-        fprintf(stdout, "%s: MPI runtime enabled\n", prefix.c_str());
+        o << "MPI runtime enabled";
     } else {
-        fprintf(stdout, "%s: MPI runtime disabled\n", prefix.c_str());
+        o << "MPI runtime disabled";
         if (at_nersc_ && !in_slurm_) {
-            fprintf(stdout, "%s:   Cannot use MPI on NERSC login nodes\n",
-                    prefix.c_str());
+            ret.push_back(o.str());
+            o.str("");
+            o << "Cannot use MPI on NERSC login nodes";
         }
     }
+    ret.push_back(o.str());
+
+    return ret;
+}
+
+void toast::Environment::print() const {
+    std::string prefix("TOAST ENV");
+
+    auto strngs = info();
+    for (auto const & str : strngs) {
+        fprintf(stdout, "%s: %s\n", prefix.c_str(), str.c_str());
+    }
+
     fflush(stdout);
     return;
 }

--- a/src/toast/_libtoast_sys.cpp
+++ b/src/toast/_libtoast_sys.cpp
@@ -50,10 +50,6 @@ void init_sys(py::module & m) {
          R"(
             Return a list of the currently available signals.
         )")
-    .def("print", &toast::Environment::print,
-         R"(
-            Print the current environment to STDOUT.
-        )")
     .def("use_mpi", &toast::Environment::use_mpi,
          R"(
             Return True if TOAST was compiled with MPI support **and** MPI
@@ -86,7 +82,18 @@ void init_sys(py::module & m) {
             Returns:
                 None
 
-        )");
+        )")
+    .def("__repr__",
+         [](toast::Environment const & self) {
+             std::ostringstream o;
+             o << "<toast.Environment" << std::endl;
+             auto strngs = self.info();
+             for (auto const & line : strngs) {
+                 o << "  " << line << std::endl;
+             }
+             o << ">";
+             return o.str();
+         });
 
     // Simple timer
 

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -234,6 +234,18 @@ class Comm(object):
         """
         return self._rcomm
 
+    def __repr__(self):
+        lines = [
+            "  World MPI communicator = {}".format(self._wcomm),
+            "  World MPI size = {}".format(self._wsize),
+            "  World MPI rank = {}".format(self._wrank),
+            "  Group MPI communicator = {}".format(self._gcomm),
+            "  Group MPI size = {}".format(self._gsize),
+            "  Group MPI rank = {}".format(self._grank),
+            "  Rank MPI communicator = {}".format(self._rcomm),
+        ]
+        return "<toast.Comm\n{}\n>".format("\n".join(lines))
+
 
 #
 # These general purpose MPI tools taken from:

--- a/src/toast/pipeline_tools/dist.py
+++ b/src/toast/pipeline_tools/dist.py
@@ -68,7 +68,7 @@ def get_comm():
     env = Environment.get()
     mpiworld, procs, rank = get_world()
     if rank == 0:
-        env.print()
+        print(env)
     if mpiworld is None:
         log.info("Running serially with one process at {}".format(str(datetime.now())))
     else:

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ install(FILES
     _helpers.py
     runner.py
     mpi.py
+    env.py
     dist.py
     timing.py
     cache.py

--- a/src/toast/tests/env.py
+++ b/src/toast/tests/env.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2015-2019 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+from .mpi import MPITestCase
+
+from ..utils import Environment
+
+from ._helpers import create_comm
+
+
+class EnvTest(MPITestCase):
+    def setUp(self):
+        self.rank = 0
+        self.nproc = 1
+        if self.comm is not None:
+            self.rank = self.comm.rank
+            self.nproc = self.comm.size
+
+    def test_env(self):
+        env = Environment.get()
+        if self.rank == 0:
+            print(env, flush=True)
+
+    def test_comm(self):
+        comm = create_comm(self.comm)
+        for p in range(self.nproc):
+            if p == self.rank:
+                print(comm, flush=True)
+            if self.comm is not None:
+                self.comm.barrier()

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -14,6 +14,7 @@ from ..vis import set_backend
 
 from .._libtoast import libtoast_tests
 
+from . import env as testenv
 from . import cache as testcache
 from . import timing as testtiming
 from . import rng as testrng
@@ -108,6 +109,7 @@ def test(name=None, verbosity=2):
     suite = unittest.TestSuite()
 
     if name is None:
+        suite.addTest(loader.loadTestsFromModule(testenv))
         suite.addTest(loader.loadTestsFromModule(testcache))
         suite.addTest(loader.loadTestsFromModule(testtiming))
         suite.addTest(loader.loadTestsFromModule(testrng))

--- a/src/toast/tests/tod.py
+++ b/src/toast/tests/tod.py
@@ -49,6 +49,15 @@ class TODTest(MPITestCase):
         pass
 
     def test_props(self):
+        comm = self.tod.mpicomm
+        if comm is None:
+            print(self.tod, flush=True)
+        else:
+            for p in range(comm.size):
+                if p == comm.rank:
+                    print(self.tod, flush=True)
+                comm.barrier()
+
         self.assertEqual(sorted(self.tod.detectors), sorted(self.dets))
         self.assertEqual(sorted(self.tod.local_dets), sorted(self.dets))
         self.assertEqual(self.tod.total_samples, self.totsamp)

--- a/src/toast/tod/tod.py
+++ b/src/toast/tod/tod.py
@@ -168,6 +168,30 @@ class TOD(object):
 
         self.cache = Cache()
 
+    def __repr__(self):
+        clsname = self.__class__.__name__
+        csize = self.cache.report(silent=True)
+        lsamp = self._dist_samples[self._rank_samp]
+        ldet = self._dist_dets[self._rank_det]
+        ldetstr = ["      {}".format(x) for x in ldet]
+        lines = [
+            "  {} total detectors and {} total samples".format(
+                len(self._dets), self._nsamp
+            ),
+            "  Using MPI communicator {}".format(self._mpicomm),
+            "    In grid dimensions {} sample ranks x {} detranks".format(
+                self._sampranks, self._detranks
+            ),
+            "  Process at ({}, {}) in grid has data for:".format(
+                self._rank_samp, self._rank_det
+            ),
+            "    Samples {} - {} (inclusive)".format(lsamp[0], lsamp[0] + lsamp[1] - 1),
+            "    Detectors:",
+        ]
+        lines.extend(ldetstr)
+        lines.append("    Cache contains {} bytes".format(csize))
+        return "<{}\n{}\n>".format(clsname, "\n".join(lines))
+
     @property
     def detectors(self):
         """


### PR DESCRIPTION
This adds` __repr__` methods for the Environment, Comm, and TOD classes.  Travis tests will fail, but I tested these locally:
```
$ mpirun -np 4 python -c 'import toast.tests; toast.tests.run("env")'

test_comm (toast.tests.env.EnvTest) ... <toast.Comm
  World MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f6f5b48cb40>
  World MPI size = 4
  World MPI rank = 0
  Group MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f6f6ccf7528>
  Group MPI size = 2
  Group MPI rank = 0
  Rank MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f6f6ccf7540>
>
<toast.Comm
  World MPI communicator = <mpi4py.MPI.Intracomm object at 0x7fbe4f16cb40>
  World MPI size = 4
  World MPI rank = 1
  Group MPI communicator = <mpi4py.MPI.Intracomm object at 0x7fbe635cf4f8>
  Group MPI size = 2
  Group MPI rank = 1
  Rank MPI communicator = <mpi4py.MPI.Intracomm object at 0x7fbe635cf510>
>
<toast.Comm
  World MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f1895699b40>
  World MPI size = 4
  World MPI rank = 2
  Group MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f18807964f8>
  Group MPI size = 2
  Group MPI rank = 0
  Rank MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f1880796510>
>
<toast.Comm
  World MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f74b19c5b40>
  World MPI size = 4
  World MPI rank = 3
  Group MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f74cb7734f8>
  Group MPI size = 2
  Group MPI rank = 1
  Rank MPI communicator = <mpi4py.MPI.Intracomm object at 0x7f74cb773510>
>
[0]ok [1]ok [3]ok [2]ok 
test_env (toast.tests.env.EnvTest) ... [2]ok [3]ok [1]ok <toast.Environment
  Source code version = 2.3.0.dev1421
  Logging level = INFO
  Handling enabled for 0 signals:
  Max threads = 12
  MPI build enabled
  MPI runtime enabled
>
[0]ok 

----------------------------------------------------------------------
Ran 2 tests in 0.002s

[0] OK
[1] OK
[2] OK
[3] OK
```
And also:
```
$ mpirun -np 4 python -c 'import toast.tests; toast.tests.run("tod")'
test_cached_read (toast.tests.tod.TODTest) ... [3]ok [1]ok [0]ok [2]ok 
test_local_intervals (toast.tests.tod.TODTest) ... [1]ok [3]ok [2]ok [0]ok 
test_local_signal (toast.tests.tod.TODTest) ... [3]ok [1]ok [0]ok [2]ok 
test_props (toast.tests.tod.TODTest) ... <TODCache
  4 total detectors and 40 total samples
  Using MPI communicator <mpi4py.MPI.Intracomm object at 0x7f8290877b40>
    In grid dimensions 4 sample ranks x 1 detranks
  Process at (0, 0) in grid has data for:
    Samples 0 - 9 (inclusive)
    Detectors:
      1a
      1b
      2a
      2b
    Cache contains 1730 bytes
>
<TODCache
  4 total detectors and 40 total samples
  Using MPI communicator <mpi4py.MPI.Intracomm object at 0x7ff750594b40>
    In grid dimensions 4 sample ranks x 1 detranks
  Process at (1, 0) in grid has data for:
    Samples 10 - 19 (inclusive)
    Detectors:
      1a
      1b
      2a
      2b
    Cache contains 1730 bytes
>
<TODCache
  4 total detectors and 40 total samples
  Using MPI communicator <mpi4py.MPI.Intracomm object at 0x7f616d016b40>
    In grid dimensions 4 sample ranks x 1 detranks
  Process at (2, 0) in grid has data for:
    Samples 20 - 29 (inclusive)
    Detectors:
      1a
      1b
      2a
      2b
    Cache contains 1730 bytes
>
<TODCache
  4 total detectors and 40 total samples
  Using MPI communicator <mpi4py.MPI.Intracomm object at 0x7f0240e59b40>
    In grid dimensions 4 sample ranks x 1 detranks
  Process at (3, 0) in grid has data for:
    Samples 30 - 39 (inclusive)
    Detectors:
      1a
      1b
      2a
      2b
    Cache contains 1730 bytes
>
[0]ok [1]ok [2]ok [3]ok 
test_read (toast.tests.tod.TODTest) ... [1]ok [3]ok [0]ok [2]ok 
test_read_pntg (toast.tests.tod.TODTest) ... [1]ok [3]ok [0]ok [2]ok 

----------------------------------------------------------------------
Ran 6 tests in 0.010s

[0] OK
[1] OK
[2] OK
[3] OK
```