### PR TITLE
use comm_group instead of comm_rank for OpSimPySM

### DIFF
--- a/src/toast/pipeline_tools/sky_signal.py
+++ b/src/toast/pipeline_tools/sky_signal.py
@@ -72,6 +72,14 @@ def add_pysm_args(parser):
         'it overrides any model defined in pysm_model"',
     )
 
+    parser.add_argument(
+        "--pysm-mpi-comm",
+        required=False,
+        help="MPI communicator used by the PySM operator, either 'rank' or 'group'",
+        dest="pysm_mpi_comm",
+    )
+    parser.set_defaults(pysm_mpi_comm="group")
+
     # The nside may already be added
     try:
         parser.add_argument(
@@ -145,7 +153,7 @@ def simulate_sky_signal(
     timer.start()
     # Convolve a signal TOD from PySM
     op_sim_pysm = OpSimPySM(
-        comm=comm.comm_group,
+        comm=getattr(comm, "comm_" + args.pysm_mpi_comm),
         out=cache_prefix,
         pysm_model=args.pysm_model.split(","),
         pysm_precomputed_cmb_K_CMB=args.pysm_precomputed_cmb_K_CMB,

--- a/src/toast/pipeline_tools/sky_signal.py
+++ b/src/toast/pipeline_tools/sky_signal.py
@@ -145,7 +145,7 @@ def simulate_sky_signal(
     timer.start()
     # Convolve a signal TOD from PySM
     op_sim_pysm = OpSimPySM(
-        comm=comm.comm_rank,
+        comm=comm.comm_group,
         out=cache_prefix,
         pysm_model=args.pysm_model.split(","),
         pysm_precomputed_cmb_K_CMB=args.pysm_precomputed_cmb_K_CMB,


### PR DESCRIPTION
This creates duplicate work but reduces heavily memory from node shared memory implementation in PySM https://github.com/healpy/pysm/pull/32

Not sure, do we want to make a command line option for this?