### PR TITLE
global_to_local was failing unless pixels were int64.

### DIFF
--- a/src/libtoast/include/toast.hpp
+++ b/src/libtoast/include/toast.hpp
@@ -15,6 +15,7 @@
 #include <toast/math_fft.hpp>
 #include <toast/math_healpix.hpp>
 #include <toast/fod_psd.hpp>
+#include <toast/map_pixels.hpp>
 #include <toast/map_cov.hpp>
 #include <toast/tod_mapscan.hpp>
 #include <toast/tod_filter.hpp>

--- a/src/libtoast/include/toast/map_pixels.hpp
+++ b/src/libtoast/include/toast/map_pixels.hpp
@@ -1,0 +1,45 @@
+
+// Copyright (c) 2015-2019 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
+
+#ifndef TOAST_MAP_PIXELS_HPP
+#define TOAST_MAP_PIXELS_HPP
+
+
+namespace toast {
+template <typename T>
+void global_to_local(size_t nsamp,
+                     T const * global_pixels,
+                     size_t npix_submap,
+                     int64_t const * global2local,
+                     T * local_submaps,
+                     T * local_pixels) {
+    double npix_submap_inv = 1.0 / static_cast <double> (npix_submap);
+
+    // Note:  there is not much work in this loop, so it might benefit from
+    // omp simd instead.  However, that would only be enabled if the input
+    // memory buffers were aligned.  That could be ensured with care in the
+    // calling code.  To be revisited if this code is ever the bottleneck.
+
+    #pragma omp parallel for default(shared) schedule(static, 64)
+    for (size_t i = 0; i < nsamp; ++i) {
+        T pixel = global_pixels[i];
+        T submap = 0;
+        if (pixel < 0) {
+            pixel = -1;
+        } else {
+            submap = static_cast <T> (
+                static_cast <double> (pixel) * npix_submap_inv
+                );
+            pixel -= submap * static_cast <T> (npix_submap);
+        }
+        local_pixels[i] = pixel;
+        submap = static_cast <T> (global2local[submap]);
+        local_submaps[i] = submap;
+    }
+    return;
+}
+}
+
+#endif // ifndef TOAST_MAP_PIXELS_HPP

--- a/src/toast/_libtoast_pixels.cpp
+++ b/src/toast/_libtoast_pixels.cpp
@@ -15,8 +15,8 @@ py::tuple global_to_local(
     // Get raw pointers to input.
     py::buffer_info gpinfo = global_pixels.request();
     py::buffer_info glinfo = global2local.request();
-    T * rawgpdata = reinterpret_cast <T *> (gpinfo.ptr);
-    int64_t * rawgldata = reinterpret_cast <int64_t *> (glinfo.ptr);
+    T * global_pixels_raw = reinterpret_cast <T *> (gpinfo.ptr);
+    int64_t * global_to_local_raw = reinterpret_cast <int64_t *> (glinfo.ptr);
 
     size_t nsamp = gpinfo.size;
 
@@ -29,13 +29,13 @@ py::tuple global_to_local(
     // Get raw pointers to outputs
     py::buffer_info lsinfo = local_submaps.request();
     py::buffer_info lpinfo = local_pixels.request();
-    T * rawlsdata = reinterpret_cast <T *> (lsinfo.ptr);
-    T * rawlpdata = reinterpret_cast <T *> (lpinfo.ptr);
+    T * local_submaps_raw = reinterpret_cast <T *> (lsinfo.ptr);
+    T * local_pixels_raw = reinterpret_cast <T *> (lpinfo.ptr);
 
     // Call internal function
     toast::global_to_local <T> (
-        nsamp, rawgpdata, npix_submap,
-        rawgldata, rawlsdata, rawlpdata
+        nsamp, global_pixels_raw, npix_submap,
+        global_to_local_raw, local_submaps_raw, local_pixels_raw
         );
     return py::make_tuple(local_submaps, local_pixels);
 }

--- a/src/toast/map/pixels.py
+++ b/src/toast/map/pixels.py
@@ -269,19 +269,9 @@ class DistPixels(object):
         """
         from .._libtoast import global_to_local
 
-        lsm = np.zeros_like(gl)
-        pix = np.zeros_like(gl)
-        global_to_local(gl, self._submap, self._glob2loc, lsm, pix)
-        """
-        safe_gl = np.zeros(len(gl), dtype=np.int64)
-        good = gl >= 0
-        bad = gl < 0
-        safe_gl[good] = gl[good]
-        sm = np.floor_divide(safe_gl, self._submap)
-        pix = np.mod(safe_gl, self._submap)
-        pix[bad] = -1
-        lsm = self._glob2loc[sm]
-        """
+        lsm = np.zeros(gl.size, dtype=np.int64)
+        pix = np.zeros(gl.size, dtype=np.int64)
+        global_to_local(gl.astype(np.int64), self._submap, self._glob2loc, lsm, pix)
         return (lsm, pix)
 
     @function_timer

--- a/src/toast/map/pixels.py
+++ b/src/toast/map/pixels.py
@@ -16,7 +16,7 @@ from ..op import Operator
 
 from ..cache import Cache
 
-from .._libtoast import global_to_local as libtoast_g2l
+from .._libtoast import global_to_local as libtoast_global_to_local
 
 
 class OpLocalPixels(Operator):
@@ -269,7 +269,7 @@ class DistPixels(object):
                 pixel index local to that submap (int).
 
         """
-        return libtoast_g2l(gl, self._submap, self._glob2loc)
+        return libtoast_global_to_local(gl, self._submap, self._glob2loc)
 
     @function_timer
     def duplicate(self):

--- a/src/toast/map/pixels.py
+++ b/src/toast/map/pixels.py
@@ -16,6 +16,8 @@ from ..op import Operator
 
 from ..cache import Cache
 
+from .._libtoast import global_to_local as libtoast_g2l
+
 
 class OpLocalPixels(Operator):
     """Operator which computes the set of locally hit pixels.
@@ -267,12 +269,7 @@ class DistPixels(object):
                 pixel index local to that submap (int).
 
         """
-        from .._libtoast import global_to_local
-
-        lsm = np.zeros(gl.size, dtype=np.int64)
-        pix = np.zeros(gl.size, dtype=np.int64)
-        global_to_local(gl.astype(np.int64), self._submap, self._glob2loc, lsm, pix)
-        return (lsm, pix)
+        return libtoast_g2l(gl, self._submap, self._glob2loc)
 
     @function_timer
     def duplicate(self):
@@ -432,8 +429,9 @@ class DistPixels(object):
             if "ordering" in h[1].header and "NEST" in h[1].header["ordering"].upper():
                 map_nested = True
             if map_nested != self._nest:
-                errors += "Wrong ordering: {} has nest={}, expected nest={}\n" "".format(
-                    path, map_nested, self._nest
+                errors += (
+                    "Wrong ordering: {} has nest={}, expected nest={}\n"
+                    "".format(path, map_nested, self._nest)
                 )
             map_nnz = h[1].header["tfields"]
             if map_nnz != self._nnz:
@@ -704,9 +702,7 @@ class DistPixels(object):
             while submap_off < nsubmap:
                 if submap_off + ncomm > nsubmap:
                     ncomm = nsubmap - submap_off
-                if (
-                    np.any(allowners[submap_off : submap_off + ncomm] != NO_OWNER)
-                ):
+                if np.any(allowners[submap_off : submap_off + ncomm] != NO_OWNER):
                     # at least one submap has some hits.  reduce.
                     for c in range(ncomm):
                         if allowners[submap_off + c] == self._comm.rank:

--- a/src/toast/todmap/sim_det_map.py
+++ b/src/toast/todmap/sim_det_map.py
@@ -199,8 +199,8 @@ class OpSimScan(Operator):
                     scan_map_float64(
                         self._map.submap,
                         nnz,
-                        sm,
-                        lpix,
+                        sm.astype(np.int64),
+                        lpix.astype(np.int64),
                         self._map.flatdata,
                         weights.astype(np.float64).reshape(-1),
                         maptod,
@@ -209,8 +209,8 @@ class OpSimScan(Operator):
                     scan_map_float32(
                         self._map.submap,
                         nnz,
-                        sm,
-                        lpix,
+                        sm.astype(np.int64),
+                        lpix.astype(np.int64),
                         self._map.flatdata,
                         weights.astype(np.float64).reshape(-1),
                         maptod,


### PR DESCRIPTION
This is a short term fix to a recent bug in `DistPixels.global_to_local()`.  Long term, we need a good way of checking for `NDarray` data type and write functions that can handle multiple types without unnecessarily repeating code.