### PR TITLE
Store local submap information in the data object

### DIFF
--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -429,17 +429,13 @@ def main():
 
     # Prepare auxiliary information for distributed map objects
 
-    _, localsm, subnpix = pipeline_tools.get_submaps(args, comm, data)
-
     if args.pysm_model:
         focalplanes = [s.telescope.focalplane.detector_data for s in schedules]
         signalname = pipeline_tools.simulate_sky_signal(
-            args, comm, data, focalplanes, subnpix, localsm, "signal"
+            args, comm, data, focalplanes, "signal"
         )
     else:
-        signalname = pipeline_tools.scan_sky_signal(
-            args, comm, data, localsm, subnpix, "signal"
-        )
+        signalname = pipeline_tools.scan_sky_signal(args, comm, data, "signal")
 
     # Set up objects to take copies of the TOD at appropriate times
 

--- a/pipelines/toast_ground_sim_simple.py
+++ b/pipelines/toast_ground_sim_simple.py
@@ -42,12 +42,10 @@ from toast.pipeline_tools import (
     add_atmosphere_args,
     add_noise_args,
     simulate_noise,
-    get_analytic_noise,
     add_gainscrambler_args,
     scramble_gains,
     add_pointing_args,
     expand_pointing,
-    get_submaps,
     add_madam_args,
     setup_madam,
     apply_madam,
@@ -55,9 +53,6 @@ from toast.pipeline_tools import (
     add_pysm_args,
     scan_sky_signal,
     simulate_sky_signal,
-    add_sss_args,
-    simulate_sss,
-    add_signal,
     copy_signal,
     add_tidas_args,
     output_tidas,
@@ -65,12 +60,8 @@ from toast.pipeline_tools import (
     output_spt3g,
     add_todground_args,
     get_breaks,
-    Telescope,
     Focalplane,
-    Site,
-    CES,
     load_schedule,
-    load_weather,
     add_mc_args,
     add_binner_args,
     init_binner,
@@ -411,13 +402,9 @@ def main():
 
     expand_pointing(args, comm, data)
 
-    # Prepare auxiliary information for distributed map objects
-
-    localpix, localsm, subnpix = get_submaps(args, comm, data)
-
     # Scan input map
 
-    signalname = scan_sky_signal(args, comm, data, localsm, subnpix, "signal")
+    signalname = scan_sky_signal(args, comm, data, "signal")
 
     # Simulate noise
 
@@ -430,9 +417,7 @@ def main():
 
     signalname_madam, sigcopy_madam, sigclear = setup_sigcopy(args, comm, signalname)
 
-    npp, zmap = init_binner(
-        args, comm, data, detweights, subnpix=subnpix, localsm=localsm
-    )
+    npp, zmap = init_binner(args, comm, data, detweights)
 
     output_tidas(args, comm, data, signalname)
 

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -48,7 +48,6 @@ from toast.pipeline_tools import (
     add_signal,
     add_noise_args,
     simulate_noise,
-    get_submaps,
     add_pointing_args,
     expand_pointing,
     get_analytic_noise,
@@ -279,9 +278,9 @@ def create_observations(args, comm, focalplane, groupsize):
             precangle=args.prec_angle_deg,
             detindx=detindx,
             detranks=comm.group_size,
-            hwprpm=hwprpm,
-            hwpstep=hwpstep,
-            hwpsteptime=hwpsteptime,
+            hwprpm=args.hwp_rpm,
+            hwpstep=args.hwp_step_deg,
+            hwpsteptime=args.hwp_step_time_s,
         )
 
         obs = {}
@@ -358,12 +357,8 @@ def main():
 
     expand_pointing(args, comm, data)
 
-    localpix, localsm, subnpix = get_submaps(args, comm, data)
-
     signalname = None
-    skyname = simulate_sky_signal(
-        args, comm, data, [focalplane], subnpix, localsm, "signal"
-    )
+    skyname = simulate_sky_signal(args, comm, data, [focalplane], "signal")
     if skyname is not None:
         signalname = skyname
 
@@ -377,9 +372,7 @@ def main():
         if comm.world_rank == 0:
             log.info("Not using Madam, will only make a binned map")
 
-        npp, zmap = init_binner(
-            args, comm, data, detweights, subnpix=subnpix, localsm=localsm
-        )
+        npp, zmap = init_binner(args, comm, data, detweights)
 
         # Loop over Monte Carlos
 

--- a/src/toast/_libtoast_todmap_scanning.cpp
+++ b/src/toast/_libtoast_todmap_scanning.cpp
@@ -9,7 +9,7 @@
 template <typename T>
 void register_scan_map(py::module & m, char const * name) {
     m.def(name,
-          [](int64_t subnpix, int64_t nmap, py::buffer submap, py::buffer subpix,
+          [](int64_t npix_submap, int64_t nmap, py::buffer submap, py::buffer subpix,
              py::buffer mapdata, py::buffer weights, py::buffer tod) {
               pybuffer_check_1D <int64_t> (submap);
               pybuffer_check_1D <int64_t> (subpix);
@@ -43,10 +43,10 @@ void register_scan_map(py::module & m, char const * name) {
               T * rawmapdata = reinterpret_cast <T *> (info_mapdata.ptr);
               double * rawweights = reinterpret_cast <double *> (info_weights.ptr);
               double * rawtod = reinterpret_cast <double *> (info_tod.ptr);
-              toast::scan_local_map <T> (rawsubmap, subnpix, rawweights, nmap,
+              toast::scan_local_map <T> (rawsubmap, npix_submap, rawweights, nmap,
                                          rawsubpix, rawmapdata, rawtod, nsamp);
               return;
-          }, py::arg("subnpix"), py::arg("nmap"), py::arg("submap"), py::arg("subpix"),
+          }, py::arg("npix_submap"), py::arg("nmap"), py::arg("submap"), py::arg("subpix"),
           py::arg("mapdata"), py::arg("weights"), py::arg(
               "tod"), R"(
         Sample a map into a timestream.
@@ -55,7 +55,7 @@ void register_scan_map(py::module & m, char const * name) {
         to generate timestream values.
 
         Args:
-            subnpix (int):  The number of pixels in each submap.
+            npix_submap (int):  The number of pixels in each submap.
             nmap (int):  The number of non-zeros in each row of the pointing matrix.
             submap (array, int64):  For each time domain sample, the submap index
                 within the local map (i.e. including only submap)

--- a/src/toast/dist.py
+++ b/src/toast/dist.py
@@ -277,6 +277,16 @@ class Data(object):
         self.obs = []
         """The list of observations.
         """
+        self._metadata = {}
+
+    def __contains__(self, key):
+        return key in self._metadata
+
+    def __getitem__(self, key):
+        return self._metadata[key]
+
+    def __setitem__(self, key, value):
+        self._metadata[key] = value
 
     @property
     def comm(self):

--- a/src/toast/pipeline_tools/__init__.py
+++ b/src/toast/pipeline_tools/__init__.py
@@ -28,7 +28,7 @@ from .filters import (
 from .gain import add_gainscrambler_args, scramble_gains
 from .madam import add_madam_args, setup_madam, apply_madam
 from .noise import add_noise_args, simulate_noise, get_analytic_noise
-from .pointing import add_pointing_args, expand_pointing, get_submaps
+from .pointing import add_pointing_args, expand_pointing
 from .sky_signal import (
     add_sky_map_args,
     add_pysm_args,

--- a/src/toast/pipeline_tools/todground.py
+++ b/src/toast/pipeline_tools/todground.py
@@ -229,7 +229,7 @@ def add_todground_args(parser):
     # Modulate noise PSD by observing elevation
     parser.add_argument(
         "--elevation-noise-a",
-        required=False,
+        default=0,
         type=np.float,
         help="Evaluate noise PSD as (a / sin(el) + b) ** 2 * fsample * 1e-12",
     )

--- a/src/toast/tests/map_satellite.py
+++ b/src/toast/tests/map_satellite.py
@@ -22,7 +22,6 @@ from ..todmap import (
     slew_precession_axis,
     satellite_scanning,
     OpSimScan,
-    OpLocalPixels,
     OpMadam,
 )
 
@@ -73,6 +72,7 @@ class MapSatelliteTest(MPITestCase):
         # Pixelization
         self.sim_nside = 64
         self.map_nside = 64
+        self.nside_submap = 16
 
         # Scan strategy
         self.spinperiod = 10.0
@@ -373,35 +373,17 @@ class MapSatelliteTest(MPITestCase):
         pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(self.data)
 
-        # get locally hit pixels
-        lc = OpLocalPixels()
-        localpix = lc.exec(self.data)
-
         # construct a sky gradient operator, just to get the signal
         # map- we are not going to use the operator on the data.
         grad = OpSimGradient(nside=self.sim_nside, nest=True)
         sig = grad.sigmap()
 
-        # pick a submap size and find the local submaps.
-        submapsize = np.floor_divide(self.sim_nside, 16)
-        localsm = np.unique(np.floor_divide(localpix, submapsize))
-
         # construct a distributed map which has the gradient
-        npix = 12 * self.sim_nside * self.sim_nside
         distsig = DistPixels(
-            comm=self.data.comm.comm_group,
-            size=npix,
-            nnz=1,
-            dtype=np.float64,
-            submap=submapsize,
-            local=localsm,
+            self.data, comm=self.data.comm.comm_group, nnz=1, dtype=np.float64,
         )
 
-        lsub, lpix = distsig.global_to_local(localpix)
-
-        distsig.data[lsub, lpix, :] = np.array([sig[x] for x in localpix]).reshape(
-            -1, 1
-        )
+        distsig.broadcast_healpix_map(sig)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)
@@ -481,36 +463,15 @@ class MapSatelliteTest(MPITestCase):
         pointing = OpPointingHpix(nside=self.map_nside, nest=True)
         pointing.exec(data)
 
-        # get locally hit pixels
-        lc = OpLocalPixels()
-        localpix = lc.exec(data)
-
         # construct a sky gradient operator, just to get the signal
         # map- we are not going to use the operator on the data.
         grad = OpSimGradient(nside=self.sim_nside, nest=True)
         sig = grad.sigmap()
 
-        # pick a submap size and find the local submaps.
-        submapsize = np.floor_divide(self.sim_nside, 16)
-        localsm = np.unique(np.floor_divide(localpix, submapsize))
-
         # construct a distributed map which has the gradient
-        npix = 12 * self.sim_nside * self.sim_nside
+        distsig = DistPixels(data, comm=data.comm.comm_group, nnz=1, dtype=np.float64,)
 
-        distsig = DistPixels(
-            comm=data.comm.comm_group,
-            size=npix,
-            nnz=1,
-            dtype=np.float64,
-            submap=submapsize,
-            local=localsm,
-        )
-
-        lsub, lpix = distsig.global_to_local(localpix)
-
-        distsig.data[lsub, lpix, :] = np.array([sig[x] for x in localpix]).reshape(
-            -1, 1
-        )
+        distsig.broadcast_healpix_map(sig)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)
@@ -587,39 +548,20 @@ class MapSatelliteTest(MPITestCase):
             rank = self.comm.rank
         # make a pointing matrix with a HWP that is constant
         data = self.data_const_hwp
-        pointing = OpPointingHpix(nside=self.map_nside, nest=True)
+        pointing = OpPointingHpix(
+            nside=self.map_nside, nest=True, nside_submap=self.nside_submap
+        )
         pointing.exec(data)
-
-        # get locally hit pixels
-        lc = OpLocalPixels()
-        localpix = lc.exec(data)
 
         # construct a sky gradient operator, just to get the signal
         # map- we are not going to use the operator on the data.
         grad = OpSimGradient(nside=self.sim_nside, nest=True)
         sig = grad.sigmap()
 
-        # pick a submap size and find the local submaps.
-        submapsize = np.floor_divide(self.sim_nside, 16)
-        localsm = np.unique(np.floor_divide(localpix, submapsize))
-
         # construct a distributed map which has the gradient
-        npix = 12 * self.sim_nside * self.sim_nside
+        distsig = DistPixels(data, comm=data.comm.comm_group, nnz=1, dtype=np.float64,)
 
-        distsig = DistPixels(
-            comm=data.comm.comm_group,
-            size=npix,
-            nnz=1,
-            dtype=np.float64,
-            submap=submapsize,
-            local=localsm,
-        )
-
-        lsub, lpix = distsig.global_to_local(localpix)
-
-        distsig.data[lsub, lpix, :] = np.array([sig[x] for x in localpix]).reshape(
-            -1, 1
-        )
+        distsig.broadcast_healpix_map(sig)
 
         # create TOD from map
         scansim = OpSimScan(distmap=distsig)

--- a/src/toast/tests/ops_dipole.py
+++ b/src/toast/tests/ops_dipole.py
@@ -18,7 +18,6 @@ from ..todmap import (
     OpPointingHpix,
     OpSimDipole,
     dipole,
-    OpLocalPixels,
     OpAccumDiag,
 )
 
@@ -54,10 +53,6 @@ class OpSimDipoleTest(MPITestCase):
         # Pixelization
         self.nside = 64
         self.npix = 12 * self.nside ** 2
-        self.subnside = 16
-        if self.subnside > self.nside:
-            self.subnside = self.nside
-        self.subnpix = 12 * self.subnside * self.subnside
 
         # Samples per observation
         self.totsamp = self.npix
@@ -151,47 +146,16 @@ class OpSimDipoleTest(MPITestCase):
 
         # make a binned map
 
-        # get locally hit pixels
-        lc = OpLocalPixels()
-        localpix = lc.exec(self.data)
-
-        # find the locally hit submaps.
-        localsm = np.unique(np.floor_divide(localpix, self.subnpix))
-
         # construct distributed maps to store the covariance,
         # noise weighted map, and hits
 
-        invnpp = DistPixels(
-            comm=self.data.comm.comm_world,
-            size=self.npix,
-            nnz=1,
-            dtype=np.float64,
-            submap=self.subnpix,
-            local=localsm,
-            nest=False,
-        )
+        invnpp = DistPixels(self.data, nnz=1, dtype=np.float64, nest=False,)
         invnpp.data.fill(0.0)
 
-        zmap = DistPixels(
-            comm=self.data.comm.comm_world,
-            size=self.npix,
-            nnz=1,
-            dtype=np.float64,
-            submap=self.subnpix,
-            local=localsm,
-            nest=False,
-        )
+        zmap = DistPixels(self.data, nnz=1, dtype=np.float64, nest=False,)
         zmap.data.fill(0.0)
 
-        hits = DistPixels(
-            comm=self.data.comm.comm_world,
-            size=self.npix,
-            nnz=1,
-            dtype=np.int64,
-            submap=self.subnpix,
-            local=localsm,
-            nest=False,
-        )
+        hits = DistPixels(self.data, nnz=1, dtype=np.int64, nest=False,)
         hits.data.fill(0)
 
         # accumulate the inverse covariance and noise weighted map.

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -22,7 +22,6 @@ from ..todmap import (
     OpPointingHpix,
     OpMadam,
     OpMapMaker,
-    get_submaps_nested,
     OpSimScan,
 )
 from ..todmap.mapmaker import TemplateMatrix, OffsetTemplate, Signal
@@ -224,7 +223,6 @@ class OpMapMakerTest(MPITestCase):
         )
         pointing.exec(self.data)
 
-        localpix, localsm, subnpix = get_submaps_nested(self.data, self.sim_nside)
         # Scan the signal from a map
         distmap = DistPixels(
             comm=self.comm,
@@ -356,16 +354,8 @@ class OpMapMakerTest(MPITestCase):
         )
         pointing.exec(self.data)
 
-        localpix, localsm, subnpix = get_submaps_nested(self.data, self.sim_nside)
         # Scan the signal from a map
-        distmap = DistPixels(
-            comm=self.comm,
-            size=self.npix,
-            nnz=self.nnz,
-            dtype=np.float32,
-            submap=subnpix,
-            local=localsm,
-        )
+        distmap = DistPixels(self.data, nnz=self.nnz, dtype=np.float32)
         distmap.read_healpix_fits(self.inmapfile)
         scansim = OpSimScan(distmap=distmap, out=name)
         scansim.exec(self.data)

--- a/src/toast/tests/ops_pmat.py
+++ b/src/toast/tests/ops_pmat.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from .._libtoast import pointing_matrix_healpix
 from ..healpix import HealpixPixels
-from ..todmap import TODHpixSpiral, OpPointingHpix, OpLocalPixels
+from ..todmap import TODHpixSpiral, OpPointingHpix
 from .. import qarray as qa
 
 from ._helpers import create_outdir, create_distdata, boresight_focalplane
@@ -171,9 +171,6 @@ class OpPointingHpixTest(MPITestCase):
             rank = self.comm.rank
         op = OpPointingHpix()
         op.exec(self.data)
-
-        lc = OpLocalPixels()
-        local = lc.exec(self.data)
 
         handle = None
         if rank == 0:

--- a/src/toast/tests/ops_sim_pysm.py
+++ b/src/toast/tests/ops_sim_pysm.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .mpi import MPITestCase
 
-from ..todmap import OpPointingHpix, TODHpixSpiral, pysm, OpLocalPixels
+from ..todmap import OpPointingHpix, TODHpixSpiral, pysm
 
 from ._helpers import create_outdir, create_distdata, uniform_chunks
 
@@ -163,14 +163,6 @@ class OpSimPySMTest(MPITestCase):
         pointing = OpPointingHpix(nside=self.nside, nest=False, mode="IQU")
         pointing.exec(self.data)
 
-        # Get locally hit pixels.  Only do this if the PySM operator
-        # needs local pixels...
-        lc = OpLocalPixels()
-        localpix = lc.exec(self.data)
-        # subnpix = np.floor_divide(self.nside, 4)
-        # localsm = np.unique(np.floor_divide(localpix, subnpix))
-
-        subnpix, localsm = 64, np.arange(12)
         focalplane = {
             "fake_0A": {
                 "bandcenter_ghz": 22.5,
@@ -180,13 +172,11 @@ class OpSimPySMTest(MPITestCase):
             }
         }
         op_sim_pysm = OpSimPySM(
+            self.data,
             comm=self.comm,
             out="signal",
             pysm_model=["a1", "f1", "s1"],
             focalplanes=[focalplane],
-            nside=self.nside,
-            subnpix=subnpix,
-            localsm=localsm,
             apply_beam=False,
             nest=False,
             units="uK_RJ",
@@ -227,18 +217,15 @@ class OpSimPySMTestSmooth(MPITestCase):
         pointing = OpPointingHpix(nside=self.nside, nest=False, mode="IQU")
         pointing.exec(self.data)
 
-        subnpix, localsm = self.nside ** 2, np.arange(12)
         focalplane = {
             "fake_0A": {"bandcenter_ghz": 22.5, "bandwidth_ghz": 5, "fwhm": 600}
         }  # fwhm is in arcmin
         op_sim_pysm = OpSimPySM(
+            self.data,
             comm=self.comm,
             out="signal",
             pysm_model=["a1", "f1", "s1"],
             focalplanes=[focalplane],
-            nside=self.nside,
-            subnpix=subnpix,
-            localsm=localsm,
             apply_beam=True,
             nest=False,
             units="uK_RJ",

--- a/src/toast/todmap/__init__.py
+++ b/src/toast/todmap/__init__.py
@@ -10,12 +10,10 @@ if pysm is not None:
     from .pysm import PySMSky
 
 from .todmap_math import (
-    OpLocalPixels,
     OpAccumDiag,
     OpScanScale,
     OpScanMask,
     dipole,
-    get_submaps_nested,
 )
 
 from .pointing import OpPointingHpix

--- a/src/toast/todmap/sim_det_map.py
+++ b/src/toast/todmap/sim_det_map.py
@@ -197,7 +197,7 @@ class OpSimScan(Operator):
                 gt.start("OpSimScan.exec.scan_map")
                 if maptype.char == "d":
                     scan_map_float64(
-                        self._map.submap,
+                        self._map.npix_submap,
                         nnz,
                         sm.astype(np.int64),
                         lpix.astype(np.int64),
@@ -207,7 +207,7 @@ class OpSimScan(Operator):
                     )
                 elif maptype.char == "f":
                     scan_map_float32(
-                        self._map.submap,
+                        self._map.npix_submap,
                         nnz,
                         sm.astype(np.int64),
                         lpix.astype(np.int64),


### PR DESCRIPTION
This PR moves the identification of local submaps from a separate operator into the pixelization operator, such as `OpPointingHpix`. Since the submap information is not specific to any single observation, it establishes new, dictionary-like storage at the `data` object level for pixelization metadata, such has total number of pixels, size of a submap and the locally hit submaps. This information is stored with the same prefix as the pixel vectors in the TOD caches so multiple parallel pixelizations can be supported.

The PR removes some boiler plate from the pipelines as the locally hit submaps are now transparent to the user. This is also reflected in changes to the `DistPixels` class which can now be instantiated with the `data` object, without specifying the submap metadata explicitly.