### PR TITLE
new libaatm uses 64bit unsigned integers (size_t)

### DIFF
--- a/src/libtoast/src/toast_atm_utils.cpp
+++ b/src/libtoast/src/toast_atm_utils.cpp
@@ -173,7 +173,7 @@ int toast::atm_get_atmospheric_loading_vec(double altitude,
     atm::SkyStatus ss = get_sky_status_vec(altitude, temperature, pressure,
                                            freqmin, freqmax, nfreq);
     ss.setUserWH2O(pwv, "mm");
-    for (unsigned int i = 0; i < nfreq; ++i) {
+    for (size_t i = 0; i < nfreq; ++i) {
         loading[i] = ss.getTebbSky(i).get();
     }
 


### PR DESCRIPTION
Fix the `aatm` interface to work with https://github.com/hpc4cmb/libaatm

The modified source is not compatible with the old `aatm` from http://www.mrao.cam.ac.uk/~bn204/alma/atmomodel.html