### PR TITLE
allow disabling sky signal from the command line

### DIFF
--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -195,6 +195,7 @@ def load_focalplane(args, comm):
 def create_observations(args, comm, focalplane, groupsize):
     timer = Timer()
     timer.start()
+    log = Logger.get()
 
     if groupsize > len(focalplane.keys()):
         if comm.world_rank == 0:

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -41,6 +41,7 @@ if not _have_set_numba_threading:
     set_numba_threading()
     _have_set_numba_threading = True
 
+
 def get_world():
     """Retrieve the default world communicator and its properties.
 

--- a/src/toast/pipeline_tools/sky_signal.py
+++ b/src/toast/pipeline_tools/sky_signal.py
@@ -249,10 +249,13 @@ def add_conviqt_args(parser):
 
 @function_timer
 def apply_conviqt(args, comm, data, cache_prefix="signal", verbose=True):
-    if args.conviqt_sky_file is None or args.conviqt_beam_file is None:
-        return
-    if not args.simulate_sky:
-        return
+    if (
+        args.conviqt_sky_file is None
+        or args.conviqt_beam_file is None
+        or not args.simulate_sky
+    ):
+        return None
+
     log = Logger.get()
     timer = Timer()
     timer.start()


### PR DESCRIPTION
Most pipeline_tools packages allow disabling the module from the command line. This PR adds that functionality to PySM, conviqt and map sampling: regardless of what arguments are specified before, if the user extends the command line with `--no-sky` or `--no-simulate-sky`, then the sky simulation is disabled.