### PR TITLE
High cadence scans

### DIFF
--- a/examples/run_tiny_tests.sh
+++ b/examples/run_tiny_tests.sh
@@ -17,7 +17,7 @@ set -e
 # * updated `TOASTDATACOMMIT` below to the latest commit
 # * run `run_tiny_tests.sh` again and check that the test passes
 
-TOASTDATACOMMIT=d50dfea8a1d939bfc4681171198f5c31eed5fee7
+TOASTDATACOMMIT=6db99526a590fbbbd858eddbdcc5cd54f1e6d385
 
 if [ "x${TYPES}" = "x" ]; then
     TYPES="satellite ground ground_simple ground_multisite"

--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -235,6 +235,7 @@ def create_observation(args, comm, telescope, ces, verbose=True):
             el=ces.el,
             scanrate=args.scan_rate,
             scan_accel=args.scan_accel,
+            sinc_modulation=args.scan_sinc_modulate,
             CES_start=None,
             CES_stop=None,
             sun_angle_min=args.sun_angle_min,

--- a/pipelines/toast_ground_sim_simple.py
+++ b/pipelines/toast_ground_sim_simple.py
@@ -280,6 +280,7 @@ def create_observations(args, comm, schedule):
                 el=ces.el,
                 scanrate=args.scan_rate,
                 scan_accel=args.scan_accel,
+                sinc_modulation=args.scan_sinc_modulate,
                 CES_start=None,
                 CES_stop=None,
                 sun_angle_min=args.sun_angle_min,

--- a/src/toast/pipeline_tools/madam.py
+++ b/src/toast/pipeline_tools/madam.py
@@ -338,6 +338,16 @@ def setup_madam(args):
     pars["fsample"] = args.sample_rate
     pars["iter_max"] = args.madam_iter_max
     pars["file_root"] = args.madam_prefix
+
+    # Translate boolean values.  Madam knows how to do this but it
+    # simplifies pipeline_tools/madam.py
+
+    for key, value in pars.items():
+        if value == "T":
+            pars[key] = True
+        elif value == "F":
+            pars[key] = False
+
     return pars
 
 

--- a/src/toast/pipeline_tools/todground.py
+++ b/src/toast/pipeline_tools/todground.py
@@ -125,6 +125,22 @@ def add_todground_args(parser):
         help="Scanning rate change [deg / s^2]",
     )
     parser.add_argument(
+        "--scan-sinc-modulate",
+        required=False,
+        action="store_true",
+        help="Modulate scan rate so integration depth is constant at "
+        "all declinations.  The --scan-rate becomes the *minimum* scan rate.",
+        dest="scan_sinc_modulate",
+    )
+    parser.add_argument(
+        "--no-scan-sinc-modulate",
+        required=False,
+        action="store_false",
+        help="Use constant sky scan rate according to --scan-rate.",
+        dest="scan_sinc_modulate",
+    )
+    parser.set_defaults(scan_sinc_modulate=False)
+    parser.add_argument(
         "--sun-angle-min",
         required=False,
         default=30.0,
@@ -183,7 +199,7 @@ def add_todground_args(parser):
         "--sort-schedule",
         required=False,
         action="store_true",
-        help="Reorder the observing schedule so that observations of the"
+        help="Reorder the observing schedule so that observations of the "
         "same patch are consecutive.  This will reduce the sky area observed "
         "by individual process groups.",
         dest="sort_schedule",
@@ -192,7 +208,7 @@ def add_todground_args(parser):
         "--no-sort-schedule",
         required=False,
         action="store_false",
-        help="Do not reorder the observing schedule so that observations of the"
+        help="Do not reorder the observing schedule so that observations of the "
         "same patch are consecutive.",
         dest="sort_schedule",
     )

--- a/src/toast/todmap/sim_tod.py
+++ b/src/toast/todmap/sim_tod.py
@@ -727,6 +727,8 @@ class TODGround(TOD):
         scanrate (float): Sky scanning rate in degrees / second.
         scan_accel (float): Sky scanning rate acceleration in
             degrees / second^2 for the turnarounds.
+        sinc_modulation (bool): Modulate the scan rate according to
+             1/sin(az) to achieve uniform integration depth.
         CES_start (float): Start time of the constant elevation scan
         CES_stop (float): Stop time of the constant elevation scan
         sun_angle_min (float): Minimum angular distance for the scan and
@@ -745,8 +747,6 @@ class TODGround(TOD):
         hwpstep (float): If None, then a stepped HWP is not included.
             Otherwise, this is the step in degrees.
         hwpsteptime (float): The time in minutes between HWP steps.
-        sinc_modulation (bool): Modulate the scan rate according to
-             1/sin(az) to achieve uniform integration depth.
         All other keyword arguments are passed to the parent constructor.
 
     """


### PR DESCRIPTION
This PR adds a new ground constant elevation scan (CES) mode. With `--scan-sinc-modulate`, the user can instruct `TODGround` object to simulate CES:s that modulate the scan rate proportional to `1/sin(Azimuth)`. This modulation leads to uniform integration depth even when sweeping across wide ranges in Declination. The downside is that the modulation requires increasing the scan rate as the telescope scans towards North or South. It is typically necessary to exclude azimuths within 20-30 degrees of the North or South directions.

This PR also fixes a bug in the turnaround simulation that sped up the telescope acceleration and lead to unrealistically short turnaround times.