### PR TITLE
Boresight offset

### DIFF
--- a/pipelines/toast_ground_schedule.py
+++ b/pipelines/toast_ground_schedule.py
@@ -1375,9 +1375,9 @@ def add_scan(
             to_MJD(t1),
             to_MJD(t2),
             patch.name,
-            azmin,
-            azmax,
-            el / degree,
+            (azmin + args.boresight_offset_az_deg) % 360,
+            (azmax + args.boresight_offset_az_deg) % 360,
+            (el / degree + args.boresight_offset_el_deg),
             rising_string,
             sun_el1,
             sun_az1,
@@ -2088,6 +2088,20 @@ def parse_args():
     )
     parser.add_argument(
         "--out", required=False, default="schedule.txt", help="Output filename"
+    )
+    parser.add_argument(
+        "--boresight-offset-el-deg",
+        required=False,
+        default=0,
+        type=np.float,
+        help="Optional offset added to every observing elevation",
+    )
+    parser.add_argument(
+        "--boresight-offset-az-deg",
+        required=False,
+        default=0,
+        type=np.float,
+        help="Optional offset added to every observing azimuth",
     )
 
     try:

--- a/src/toast/_libtoast_pixels.cpp
+++ b/src/toast/_libtoast_pixels.cpp
@@ -60,6 +60,6 @@ void init_pixels(py::module & m) {
             (tuple):  The (local submap, pixel within submap) for each global pixel.
 
     )");
-    m.def("global_to_local", &global_to_local <int32_t> );
-    m.def("global_to_local", &global_to_local <int16_t> );
+    m.def("global_to_local", &global_to_local <int32_t>);
+    m.def("global_to_local", &global_to_local <int16_t>);
 }

--- a/src/toast/tod/polyfilter.py
+++ b/src/toast/tod/polyfilter.py
@@ -82,6 +82,9 @@ class OpPolyFilter(Operator):
             else:
                 intervals = None
             local_intervals = tod.local_intervals(intervals)
+            if len(local_intervals) == 0:
+                # No intervals to filter
+                continue
             common_ref = tod.local_common_flags(self._common_flag_name)
 
             pat = re.compile(self._pattern)

--- a/src/toast/tod/tod.py
+++ b/src/toast/tod/tod.py
@@ -164,7 +164,7 @@ class TOD(object):
     """Default cache name for common flags."""
 
     VELOCITY_NAME = "velocity"
-    """Default cache name for velociyt."""
+    """Default cache name for velocity."""
 
     POSITION_NAME = "position"
     """Default cache name for position."""


### PR DESCRIPTION
This PR adds a feature in the scheduler to add an offset to the scheduled scan. An application of this is that one may create observing schedules for an individual tube of the focal plane. It is often necessary for beam campaigns.