### PR TITLE
Attempt serialize the data caching and loading done by PySM

### DIFF
--- a/src/toast/pipeline_tools/dist.py
+++ b/src/toast/pipeline_tools/dist.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..mpi import get_world, Comm
 from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
+from ..utils import Logger, Environment, numba_threading_layer
 
 
 def add_dist_args(parser):
@@ -68,7 +68,8 @@ def get_comm():
     env = Environment.get()
     mpiworld, procs, rank = get_world()
     if rank == 0:
-        print(env)
+        print(env, flush=True)
+        log.info("Numba threading layer set to '{}'".format(numba_threading_layer))
     if mpiworld is None:
         log.info("Running serially with one process at {}".format(str(datetime.now())))
     else:

--- a/src/toast/pipeline_tools/sky_signal.py
+++ b/src/toast/pipeline_tools/sky_signal.py
@@ -348,7 +348,7 @@ def simulate_sky_signal(
     # Convolve a signal TOD from PySM
     op_sim_pysm = OpSimPySM(
         data,
-        comm=getattr(comm, "comm_" + args.pysm_mpi_comm),
+        comm_name=args.pysm_mpi_comm,
         out=cache_prefix,
         pysm_model=args.pysm_model.split(","),
         pysm_precomputed_cmb_K_CMB=fn_cmb,
@@ -357,10 +357,14 @@ def simulate_sky_signal(
         coord=args.coord,
         pixels=pixels,
     )
+    if comm.comm_world is not None:
+        comm.comm_world.barrier()
+    if comm.world_rank == 0:
+        timer.report_clear("Construct PySM operator (load model)")
     op_sim_pysm.exec(data)
     if comm.comm_world is not None:
         comm.comm_world.barrier()
     if comm.world_rank == 0 and verbose:
-        timer.report_clear("PySM")
+        timer.report_clear("Execute PySM")
 
     return cache_prefix

--- a/src/toast/tests/ops_sim_pysm.py
+++ b/src/toast/tests/ops_sim_pysm.py
@@ -83,11 +83,12 @@ class OpSimPySMTest(MPITestCase):
             "2b": (np.linspace(19, 24, 10), np.ones(10)),
         }
         op = PySMSky(
+            comm=self.data.comm,
+            mpi_comm_name="group",
             pixel_indices=local_pixels,
             nside=self.nside,
             pysm_sky_config=pysm_sky_config,
             units="uK_RJ",
-            comm=self.comm,
         )
         local_map = {}  # it should be Cache in production
         op.exec(local_map, out="sky", bandpasses=bandpasses)
@@ -125,10 +126,11 @@ class OpSimPySMTest(MPITestCase):
             "2b": (np.linspace(19, 24, 10), np.ones(10)),
         }
         op = PySMSky(
+            comm=self.data.comm,
+            mpi_comm_name="group",
             nside=self.nside,
             pysm_sky_config=pysm_sky_config,
             units="uK_RJ",
-            comm=self.comm,
         )
         local_map = {}  # it should be Cache in production
         op.exec(local_map, out="sky", bandpasses=bandpasses)
@@ -173,7 +175,7 @@ class OpSimPySMTest(MPITestCase):
         }
         op_sim_pysm = OpSimPySM(
             self.data,
-            comm=self.comm,
+            comm_name="rank",
             out="signal",
             pysm_model=["a1", "f1", "s1"],
             focalplanes=[focalplane],
@@ -222,7 +224,7 @@ class OpSimPySMTestSmooth(MPITestCase):
         }  # fwhm is in arcmin
         op_sim_pysm = OpSimPySM(
             self.data,
-            comm=self.comm,
+            comm_name="rank",
             out="signal",
             pysm_model=["a1", "f1", "s1"],
             focalplanes=[focalplane],


### PR DESCRIPTION
`astropy.utils.data` is super convenient, but seems fragile on distributed systems.  See #330.  This branch attempts to "pre-initialize" the sky model on a single process, which should download the files.  Then it instantiates each Sky object one at a time, to avoid multiple processes reading the files at the same time.  Unfortunately this technique does not yet work.