### PR TITLE
Support passing None for HWP angles to pointing matrix calculation.

### DIFF
--- a/src/libtoast/src/toast_tod_pointing.cpp
+++ b/src/libtoast/src/toast_tod_pointing.cpp
@@ -92,7 +92,11 @@ void toast::pointing_matrix_healpix(toast::HealpixPixels const & hpix,
         // FIXME:  Switch back to fast version after unit tests improved.
         toast::vatan2(n, by, bx, detang.data());
 
-        if (hwpang != NULL) {
+        if (hwpang == NULL) {
+            for (size_t i = 0; i < n; ++i) {
+                detang[i] *= 2.0;
+            }
+        } else {
             for (size_t i = 0; i < n; ++i) {
                 detang[i] += 2.0 * hwpang[i];
                 detang[i] *= 2.0;

--- a/src/toast/_libtoast_tod_pointing.cpp
+++ b/src/toast/_libtoast_tod_pointing.cpp
@@ -41,6 +41,13 @@ void init_tod_pointing(py::module & m) {
                   auto hwpbuf = py::cast <py::buffer> (hwpang);
                   pybuffer_check_1D <double> (hwpbuf);
                   py::buffer_info info_hwpang = hwpbuf.request();
+                  if (info_hwpang.size != n) {
+                      auto log = toast::Logger::get();
+                      std::ostringstream o;
+                      o << "HWP buffer size is not consistent.";
+                      log.error(o.str().c_str());
+                      throw std::runtime_error(o.str().c_str());
+                  }
                   rawhwpang = reinterpret_cast <double *> (info_hwpang.ptr);
               }
               toast::pointing_matrix_healpix(hpix, nest, eps, cal, mode, n,

--- a/src/toast/_libtoast_tod_pointing.cpp
+++ b/src/toast/_libtoast_tod_pointing.cpp
@@ -9,15 +9,13 @@
 void init_tod_pointing(py::module & m) {
     m.def("pointing_matrix_healpix",
           [](toast::HealpixPixels const & hpix, bool nest, double eps, double cal,
-             std::string const & mode, py::buffer pdata, py::buffer hwpang,
+             std::string const & mode, py::buffer pdata, py::object hwpang,
              py::buffer flags, py::buffer pixels, py::buffer weights) {
               pybuffer_check_1D <double> (pdata);
-              pybuffer_check_1D <double> (hwpang);
               pybuffer_check_1D <uint8_t> (flags);
               pybuffer_check_1D <double> (weights);
               pybuffer_check_1D <int64_t> (pixels);
               py::buffer_info info_pdata = pdata.request();
-              py::buffer_info info_hwpang = hwpang.request();
               py::buffer_info info_flags = flags.request();
               py::buffer_info info_pixels = pixels.request();
               py::buffer_info info_weights = weights.request();
@@ -26,8 +24,7 @@ void init_tod_pointing(py::module & m) {
               if (mode.compare("IQU") == 0) {
                   nw = (size_t)(info_weights.size / 3);
               }
-              if ((info_hwpang.size != n) ||
-                  (info_flags.size != n) ||
+              if ((info_flags.size != n) ||
                   (info_pixels.size != n) || (nw != n)) {
                   auto log = toast::Logger::get();
                   std::ostringstream o;
@@ -36,16 +33,23 @@ void init_tod_pointing(py::module & m) {
                   throw std::runtime_error(o.str().c_str());
               }
               double * rawpdata = reinterpret_cast <double *> (info_pdata.ptr);
-              double * rawhwpang = reinterpret_cast <double *> (info_hwpang.ptr);
               uint8_t * rawflags = reinterpret_cast <uint8_t *> (info_flags.ptr);
               double * rawweights = reinterpret_cast <double *> (info_weights.ptr);
               int64_t * rawpixels = reinterpret_cast <int64_t *> (info_pixels.ptr);
+              double * rawhwpang = NULL;
+              if (!hwpang.is_none()) {
+                  auto hwpbuf = py::cast <py::buffer> (hwpang);
+                  pybuffer_check_1D <double> (hwpbuf);
+                  py::buffer_info info_hwpang = hwpbuf.request();
+                  rawhwpang = reinterpret_cast <double *> (info_hwpang.ptr);
+              }
               toast::pointing_matrix_healpix(hpix, nest, eps, cal, mode, n,
                                              rawpdata, rawhwpang, rawflags, rawpixels,
                                              rawweights);
               return;
           }, py::arg("hpix"), py::arg("nest"), py::arg("eps"), py::arg("cal"),
-          py::arg("mode"), py::arg("pdata"), py::arg("hwpang"), py::arg("flags"),
+          py::arg("mode"), py::arg("pdata"), py::arg("hwpang").none(true),
+          py::arg("flags"),
           py::arg("pixels"), py::arg(
               "weights"), R"(
         Compute the healpix pixel indices and weights for one detector.

--- a/src/toast/todmap/pointing.py
+++ b/src/toast/todmap/pointing.py
@@ -164,7 +164,7 @@ class OpPointingHpix(Operator):
             try:
                 hwpang = tod.local_hwp_angle()
             except:
-                pass
+                hwpang = None
 
             # read the common flags and apply bitmask
 

--- a/src/toast/todmap/pointing.py
+++ b/src/toast/todmap/pointing.py
@@ -33,7 +33,7 @@ class OpPointingHpix(Operator):
     the total response is:
 
     .. math::
-        d = cal \\left[\\frac{(1+eps)}{2} I + \\frac{(1-eps)}{2} \\left[Q \\cos{4(a+w)} + U \\sin{4(a+w)}\\right]\\right]
+        d = cal \\left[\\frac{(1+eps)}{2} I + \\frac{(1-eps)}{2} \\left[Q \\cos{2a+4w} + U \\sin{2a+4w}\\right]\\right]
 
     Args:
         pixels (str): write pixels to the cache with name <pixels>_<detector>.
@@ -165,8 +165,6 @@ class OpPointingHpix(Operator):
                 hwpang = tod.local_hwp_angle()
             except:
                 pass
-            if hwpang is None:
-                hwpang = np.zeros(nsamp, dtype=np.float64)
 
             # read the common flags and apply bitmask
 
@@ -227,7 +225,9 @@ class OpPointingHpix(Operator):
                         # Use cached version
                         detp = pdata[bslice, :]
 
-                    hslice = hwpang[bslice].reshape(-1)
+                    hslice = None
+                    if hwpang is not None:
+                        hslice = hwpang[bslice].reshape(-1)
                     fslice = common[bslice].reshape(-1)
 
                     pointing_matrix_healpix(


### PR DESCRIPTION
Rather than always passing an array of zeros if there is no HWP,
support passing None value to the underlying C++ code.  Fix an
error in the docstring.  Add a unit test to verify that no HWP
and HWP angles of all zero give matching results.

We should rebase this after #343 is merged.