### PR TITLE
Use native mapmaker

### DIFF
--- a/pipelines/toast_ground_sim.py
+++ b/pipelines/toast_ground_sim.py
@@ -581,7 +581,6 @@ def main():
                         data,
                         outpath,
                         totalname_freq,
-                        freq=freq,
                         time_comms=time_comms,
                         telescope_data=telescope_data,
                         first_call=False,

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -417,16 +417,16 @@ def main():
             args, comm, data, mc, "tot_signal", overwrite=True
         )
         if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Simulate noise {:04d}".format(mc))
+            comm.comm_world.barrier()
+        if comm.world_rank == 0:
+            tmr.report_clear("    Simulate noise {:04d}".format(mc))
 
         # add sky signal
         pipeline_tools.add_signal(args, comm, data, "tot_signal", signalname)
         if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Add sky signal {:04d}".format(mc))
+            comm.comm_world.barrier()
+        if comm.world_rank == 0:
+            tmr.report_clear("    Add sky signal {:04d}".format(mc))
 
         if gain is not None:
             op_apply_gain = OpApplyGain(gain, name="tot_signal")
@@ -434,7 +434,7 @@ def main():
             if comm.comm_world is not None:
                 comm.comm_world.barrier()
             if comm.world_rank == 0:
-	        tmr.report_clear("    Apply gains {:04d}".format(mc))
+                tmr.report_clear("    Apply gains {:04d}".format(mc))
 
         if mc == firstmc:
             # For the first realization, optionally export the

--- a/pipelines/toast_satellite_sim.py
+++ b/pipelines/toast_satellite_sim.py
@@ -69,6 +69,7 @@ def parse_arguments(comm, procs):
     )
 
     pipeline_tools.add_madam_args(parser)
+    pipeline_tools.add_mapmaker_args(parser)
     pipeline_tools.add_binner_args(parser)
 
     parser.add_argument(
@@ -377,132 +378,95 @@ def main():
         if comm.world_rank == 0:
             tmr.report_clear("Dumping data distribution")
 
-    # Mapmaking.
-
-    if not args.use_madam:
+    # in debug mode, print out data distribution information
+    if args.debug:
+        handle = None
         if comm.world_rank == 0:
-            log.info("Not using Madam, will only make a binned map")
-
-        npp, zmap = pipeline_tools.init_binner(args, comm, data, detweights)
+            handle = open(os.path.join(args.outdir, "distdata.txt"), "w")
+        data.info(handle)
+        if comm.world_rank == 0:
+            handle.close()
         if comm.comm_world is not None:
             comm.comm_world.barrier()
         if comm.world_rank == 0:
-            tmr.report_clear("Initialize binned map-making")
+            tmr.report_clear("Dumping data distribution")
 
-        # Loop over Monte Carlos
+    # Mapmaking.
 
-        firstmc = args.MC_start
-        nmc = args.MC_count
-
-        for mc in range(firstmc, firstmc + nmc):
-            mctmr = Timer()
-            mctmr.start()
-
-            outpath = os.path.join(args.outdir, "mc_{:03d}".format(mc))
-
-            pipeline_tools.simulate_noise(
-                args, comm, data, mc, "tot_signal", overwrite=True
-            )
-            if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Simulate noise {:04d}".format(mc))
-
-            # add sky signal
-            pipeline_tools.add_signal(args, comm, data, "tot_signal", signalname)
-            if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Add sky signal {:04d}".format(mc))
-
-            if gain is not None:
-                op_apply_gain = OpApplyGain(gain, name="tot_signal")
-                op_apply_gain.exec(data)
-                if comm.comm_world is not None:
-                    comm.comm_world.barrier()
-                if comm.world_rank == 0:
-                    tmr.report_clear("    Apply gains {:04d}".format(mc))
-
-            if mc == firstmc:
-                # For the first realization, optionally export the
-                # timestream data.  If we had observation intervals defined,
-                # we could pass "use_interval=True" to the export operators,
-                # which would ensure breaks in the exported data at
-                # acceptable places.
-                pipeline_tools.output_tidas(args, comm, data, "tot_signal")
-                pipeline_tools.output_spt3g(args, comm, data, "tot_signal")
-                if comm.comm_world is not None:
-                    comm.comm_world.barrier()
-                if comm.world_rank == 0:
-                    tmr.report_clear("    Write TOD snapshot {:04d}".format(mc))
-
-            pipeline_tools.apply_binner(
-                args, comm, data, npp, zmap, detweights, outpath, "tot_signal"
-            )
-            if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Apply binner {:04d}".format(mc))
-
-            if comm.world_rank == 0:
-                mctmr.report_clear("  Map-making {:04d}".format(mc))
-    else:
-
+    if args.use_madam:
         # Initialize madam parameters
-
         madampars = pipeline_tools.setup_madam(args)
         if comm.comm_world is not None:
             comm.comm_world.barrier()
         if comm.world_rank == 0:
             tmr.report_clear("Initialize madam map-making")
 
-        # Loop over Monte Carlos
+    # Loop over Monte Carlos
 
-        firstmc = args.MC_start
-        nmc = args.MC_count
+    firstmc = args.MC_start
+    nmc = args.MC_count
 
-        for mc in range(firstmc, firstmc + nmc):
-            mctmr = Timer()
-            mctmr.start()
+    for mc in range(firstmc, firstmc + nmc):
+        mctmr = Timer()
+        mctmr.start()
 
-            # create output directory for this realization
-            outpath = os.path.join(args.outdir, "mc_{:03d}".format(mc))
+        # create output directory for this realization
+        outpath = os.path.join(args.outdir, "mc_{:03d}".format(mc))
 
-            pipeline_tools.simulate_noise(
-                args, comm, data, mc, "tot_signal", overwrite=True
-            )
-            if comm.comm_world is not None:
+        pipeline_tools.simulate_noise(
+            args, comm, data, mc, "tot_signal", overwrite=True
+        )
+        if comm.comm_world is not None:
                 comm.comm_world.barrier()
             if comm.world_rank == 0:
                 tmr.report_clear("    Simulate noise {:04d}".format(mc))
 
-            # add sky signal
-            pipeline_tools.add_signal(args, comm, data, "tot_signal", signalname)
-            if comm.comm_world is not None:
+        # add sky signal
+        pipeline_tools.add_signal(args, comm, data, "tot_signal", signalname)
+        if comm.comm_world is not None:
                 comm.comm_world.barrier()
             if comm.world_rank == 0:
                 tmr.report_clear("    Add sky signal {:04d}".format(mc))
 
-            if gain is not None:
-                op_apply_gain = OpApplyGain(gain, name="tot_signal")
-                op_apply_gain.exec(data)
-                if comm.comm_world is not None:
-                    comm.comm_world.barrier()
-                if comm.world_rank == 0:
-                    tmr.report_clear("    Apply gains {:04d}".format(mc))
+        if gain is not None:
+            op_apply_gain = OpApplyGain(gain, name="tot_signal")
+            op_apply_gain.exec(data)
+            if comm.comm_world is not None:
+                comm.comm_world.barrier()
+            if comm.world_rank == 0:
+	        tmr.report_clear("    Apply gains {:04d}".format(mc))
 
+        if mc == firstmc:
+            # For the first realization, optionally export the
+            # timestream data.  If we had observation intervals defined,
+            # we could pass "use_interval=True" to the export operators,
+            # which would ensure breaks in the exported data at
+            # acceptable places.
+            pipeline_tools.output_tidas(args, comm, data, "tot_signal")
+            pipeline_tools.output_spt3g(args, comm, data, "tot_signal")
+            if comm.comm_world is not None:
+                comm.comm_world.barrier()
+            if comm.world_rank == 0:
+                tmr.report_clear("    Write TOD snapshot {:04d}".format(mc))
+
+        if args.use_madam:
             pipeline_tools.apply_madam(
                 args, comm, data, madampars, outpath, detweights, "tot_signal"
             )
-            if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                tmr.report_clear("    Apply madam {:04d}".format(mc))
+        else:
+            pipeline_tools.apply_mapmaker(
+                args, comm, data, outpath, "tot_signal"
+            )
 
-            if comm.comm_world is not None:
-                comm.comm_world.barrier()
-            if comm.world_rank == 0:
-                mctmr.report_clear("  Map-making {:04d}".format(mc))
+        if comm.comm_world is not None:
+            comm.comm_world.barrier()
+        if comm.world_rank == 0:
+            tmr.report_clear("  Map-making {:04d}".format(mc))
+
+        if comm.comm_world is not None:
+            comm.comm_world.barrier()
+        if comm.world_rank == 0:
+            mctmr.report_clear("  Monte Carlo loop {:04d}".format(mc))
 
     gt.stop_all()
     if comm.comm_world is not None:

--- a/src/libtoast/src/toast_atm.cpp
+++ b/src/libtoast/src/toast_atm.cpp
@@ -3,9 +3,9 @@
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
-//#if !defined(NO_ATM_CHECKS)
-//# define NO_ATM_CHECKS
-//#endif // if !defined(NO_ATM_CHECKS)
+// #if !defined(NO_ATM_CHECKS)
+// # define NO_ATM_CHECKS
+// #endif // if !defined(NO_ATM_CHECKS)
 
 #include <toast/sys_utils.hpp>
 #include <toast/sys_environment.hpp>
@@ -1660,10 +1660,10 @@ cholmod_sparse * toast::atm_sim::build_sparse_covariance(long ind_start,
                 if (fabs(colcoord[2] - rowcoord[2]) > rcorr) continue;
 
                 double val = cov_eval(colcoord, rowcoord);
-		if (icol == irow) {
-		  // Regularize the matrix by promoting the diagonal
-		  val *= 1.01;
-		}
+                if (icol == irow) {
+                    // Regularize the matrix by promoting the diagonal
+                    val *= 1.01;
+                }
 
                 // If the covariance exceeds the threshold, add it to the
                 // sparse matrix

--- a/src/libtoast/src/toast_tod_filter.cpp
+++ b/src/libtoast/src/toast_tod_filter.cpp
@@ -202,7 +202,7 @@ void toast::bin_templates(double * signal, double * templates,
         #ifdef _OPENMP
         nthread = omp_get_num_threads();
         id_thread = omp_get_thread_num();
-        #endif
+        #endif // ifdef _OPENMP
 
         int worker = -1;
         for (size_t row = 0; row < ntemplate; row++) {

--- a/src/libtoast/src/toast_tod_filter.cpp
+++ b/src/libtoast/src/toast_tod_filter.cpp
@@ -226,21 +226,24 @@ void toast::bin_templates(double * signal, double * templates,
 
 void toast::chebyshev(double * x, double * templates, size_t start_order,
                       size_t stop_order, size_t nsample) {
+
     // order == 0
-    if (start_order == 0) {
+    if (start_order == 0 && stop_order > 0) {
         for (size_t i = 0; i < nsample; ++i) templates[i] = 1;
     }
 
     // order == 1
-    if (start_order <= 1) {
+    if (start_order <= 1 && stop_order > 1) {
         memcpy(templates + (1 - start_order) * nsample, x, nsample * sizeof(double));
     }
 
+    // Calculate the hierarchy of polynomials, one buffer length
+    // at a time
     const size_t buflen = 1000;
     size_t nbuf = nsample / buflen + 1;
 
-#pragma omp parallel for \
-    schedule(static) default(none) shared(x, templates, start_order, stop_order, nsample, nbuf)
+#pragma omp parallel for schedule(static) default(none) \
+    shared(x, templates, start_order, stop_order, nsample, nbuf)
     for (size_t ibuf = 0; ibuf < nbuf; ++ibuf) {
         size_t istart = ibuf * buflen;
         size_t istop = istart + buflen;
@@ -257,8 +260,9 @@ void toast::chebyshev(double * x, double * templates, size_t start_order,
 
         for (size_t order = 2; order < stop_order; ++order) {
             // Evaluate current order and store in val
-            for (size_t i = 0; i < n;
-                 ++i) next[i] = 2 * x[istart + i] * val[i] - prev[i];
+            for (size_t i = 0; i < n; ++i) {
+                next[i] = 2 * x[istart + i] * val[i] - prev[i];
+            }
             memcpy(prev.data(), val.data(), nbyte);
             memcpy(val.data(), next.data(), nbyte);
             if (order >= start_order) {

--- a/src/libtoast_mpi/src/toast_mpi_atm.cpp
+++ b/src/libtoast_mpi/src/toast_mpi_atm.cpp
@@ -3,9 +3,9 @@
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
-//#if !defined(NO_ATM_CHECKS)
-//# define NO_ATM_CHECKS
-//#endif // if !defined(NO_ATM_CHECKS)
+// #if !defined(NO_ATM_CHECKS)
+// # define NO_ATM_CHECKS
+// #endif // if !defined(NO_ATM_CHECKS)
 
 #include <toast_mpi_internal.hpp>
 
@@ -1805,10 +1805,10 @@ cholmod_sparse * toast::mpi_atm_sim::build_sparse_covariance(long ind_start,
                 if (fabs(colcoord[2] - rowcoord[2]) > rcorr) continue;
 
                 double val = cov_eval(colcoord, rowcoord);
-		if (icol == irow) {
-		  // Regularize the matrix by promoting the diagonal
-		  val *= 1.01;
-		}
+                if (icol == irow) {
+                    // Regularize the matrix by promoting the diagonal
+                    val *= 1.01;
+                }
 
                 // If the covariance exceeds the threshold, add it to the
                 // sparse matrix

--- a/src/toast/pipeline_tools/madam.py
+++ b/src/toast/pipeline_tools/madam.py
@@ -80,6 +80,12 @@ def add_madam_args(parser):
     parser.add_argument(
         "--madam-parfile", required=False, default=None, help="Madam parameter file"
     )
+    parser.add_argument(
+        "--madam-mask",
+        required=False,
+        help="Destriping mask",
+        dest="mapmaker_mask",
+    )
 
     parser.add_argument(
         "--madam-allreduce",
@@ -304,6 +310,8 @@ def setup_madam(args):
         # only enough memory to communicate with one process at a time.
         pars["concatenate_messages"] = False
         pars["allreduce"] = False
+    if args.mapmaker_mask:
+        pars["file_inmask"] = args.mapmaker_mask
     pars["reassign_submaps"] = True
     pars["pixlim_cross"] = 1e-3
     pars["pixmode_cross"] = 2
@@ -484,7 +492,7 @@ def apply_madam(
         for tele_name, tele_data in telescope_data:
             if len(time_name.split("-")) == 3:
                 # Special rules for daily maps
-                if args.do_daymaps:
+                if not args.do_daymaps:
                     continue
                 if len(telescope_data) > 1 and tele_name == "all":
                     # Skip daily maps over multiple telescopes

--- a/src/toast/pipeline_tools/madam.py
+++ b/src/toast/pipeline_tools/madam.py
@@ -81,10 +81,7 @@ def add_madam_args(parser):
         "--madam-parfile", required=False, default=None, help="Madam parameter file"
     )
     parser.add_argument(
-        "--madam-mask",
-        required=False,
-        help="Destriping mask",
-        dest="mapmaker_mask",
+        "--madam-mask", required=False, help="Destriping mask", dest="mapmaker_mask",
     )
 
     parser.add_argument(

--- a/src/toast/pipeline_tools/mapmaker.py
+++ b/src/toast/pipeline_tools/mapmaker.py
@@ -278,6 +278,10 @@ def apply_mapmaker(
 
             mapmaker.exec(tele_data, time_comm)
 
+            # User needs to set TOAST_FUNCTIME to see timing results
+            if "TOAST_FUNCTIME" in os.environ and os.environ["TOAST_FUNCTIME"]:
+                mapmaker.report_timing()
+
     if comm.world_rank == 0 and verbose:
         timer.report_clear("  OpMapMaker")
 

--- a/src/toast/pipeline_tools/mapmaker.py
+++ b/src/toast/pipeline_tools/mapmaker.py
@@ -246,11 +246,10 @@ def apply_mapmaker(
                 write_destriped = False
 
             timer.start()
-            madam.params["file_root"] = "{}_telescope_{}_time_{}".format(
-                file_root, tele_name, time_name
-            )
-            
-            prefix = "{}_telescope_{}_time_{}".format(
+
+            if len(file_root) > 0 and not file_root.endswith("_"):
+                file_root += "_"
+            prefix = "{}telescope_{}_time_{}_".format(
                 file_root, tele_name, time_name
             )
 
@@ -268,7 +267,7 @@ def apply_mapmaker(
                 write_destriped=write_destriped,
                 write_rcond=True,
                 rcond_limit=1e-3,
-                baseline_length=baseline_length
+                baseline_length=baseline_length,
                 maskfile=args.mapmaker_mask,
                 weightmapfile=args.mapmaker_weightmap,
                 common_flag_mask=args.common_flag_mask,

--- a/src/toast/pipeline_tools/mapmaker.py
+++ b/src/toast/pipeline_tools/mapmaker.py
@@ -26,10 +26,7 @@ def add_mapmaker_args(parser):
         dest="mapmaker_prefix",
     )
     parser.add_argument(
-        "--mapmaker-mask",
-        required=False,
-        help="Destriping mask",
-        dest="mapmaker_mask",
+        "--mapmaker-mask", required=False, help="Destriping mask", dest="mapmaker_mask",
     )
     parser.add_argument(
         "--mapmaker-weightmap",
@@ -232,7 +229,7 @@ def apply_mapmaker(
                 baseline_length = args.mapmaker_baseline_length
                 write_binned = args.write_binmap
                 write_destriped = True
-            
+
             if len(time_name.split("-")) == 3:
                 # Special rules for daily maps
                 if not args.do_daymaps:
@@ -249,9 +246,7 @@ def apply_mapmaker(
 
             if len(file_root) > 0 and not file_root.endswith("_"):
                 file_root += "_"
-            prefix = "{}telescope_{}_time_{}_".format(
-                file_root, tele_name, time_name
-            )
+            prefix = "{}telescope_{}_time_{}_".format(file_root, tele_name, time_name)
 
             mapmaker = OpMapMaker(
                 nside=args.nside,

--- a/src/toast/todmap/groundfilter.py
+++ b/src/toast/todmap/groundfilter.py
@@ -135,10 +135,6 @@ class OpGroundFilter(Operator):
             del common_ref
             cheby_filter = np.vstack(cheby_filter)
 
-        # templates = []
-        # for temp in cheby_trend, cheby_filter:
-        #    for template in temp:
-        #        templates.append(template)
         templates = np.vstack([cheby_trend, cheby_filter])
 
         return templates, cheby_trend, cheby_filter

--- a/src/toast/todmap/mapmaker.py
+++ b/src/toast/todmap/mapmaker.py
@@ -1488,12 +1488,15 @@ class OpMapMaker(Operator):
         return
 
     @function_timer
-    def exec(self, data):
+    def exec(self, data, comm=None):
         log = Logger.get()
         timer = Timer()
 
         # Initialize objects
-        self.comm = data.comm.comm_world
+        if comm is None:
+            self.comm = data.comm.comm_world
+        else:
+            self.comm = comm
         if self.comm is None:
             self.rank = 0
         else:


### PR DESCRIPTION
Make the `TOAST` native mapmaker the default in `toast_satellite_sim.py` and `toast_ground_sim.py`.  `madam` can still be invoked with `--madam` but now the pipelines will run even without it. The `TOAST` mapmaker is still significantly slower in a head-to-head comparison but it is built to be more generic and will support templates that are not limited to `1/f` noise models.