### PR TITLE
Add an option to explicitly disable MKL checks.  

### DIFF
--- a/cmake/FindLAPACKnames.cmake
+++ b/cmake/FindLAPACKnames.cmake
@@ -23,8 +23,8 @@ foreach(MANGLING IN LISTS MANGLING_OPTIONS)
               COMPILE_DEFINITIONS "-DLAPACK_${MANGLING}"
               LINK_LIBRARIES "${LAPACK_LIBRARIES}" "${BLAS_LIBRARIES}"
               OUTPUT_VARIABLE OUTPUT_MANGLING)
-  # message("Test output for LAPACK_${MANGLING}:")
-  # message(${OUTPUT_MANGLING})
+  #message("Test output for LAPACK_${MANGLING}:")
+  #message(${OUTPUT_MANGLING})
   if(TRY_MANGLING)
     set(LAPACK_NAMES "${MANGLING}")
     break()

--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -12,9 +12,15 @@
 #   MKL_INCLUDE_DIRS           ... MKL include directory paths
 #
 # The following variables will be checked by the function
+#   MKL_DISABLED               ... if true, skip all checks for MKL.
 #   MKL_DIR                    ... if set, look for MKL in this directory.
 #   environment $MKLROOT       ... if set, look for MKL in this directory.
 #
+
+set(MKL_FOUND FALSE)
+if(MKL_DISABLED)
+    message(NOTICE "-- MKL disabled, skipping checks")
+else(MKL_DISABLED)
 
 # Set default value of MKL_DIR.
 
@@ -96,4 +102,6 @@ mark_as_advanced(
     MKL_INCLUDE_DIRS
     MKL_LIBRARIES
 )
+
+endif(MKL_DISABLED)
 

--- a/platforms/cori-gcc.sh
+++ b/platforms/cori-gcc.sh
@@ -3,14 +3,15 @@
 opts="$@"
 
 cmake \
-    -DCMAKE_C_COMPILER="${CRAYPE_DIR}/bin/cc" \
-    -DCMAKE_CXX_COMPILER="${CRAYPE_DIR}/bin/CC" \
+    -DCMAKE_C_COMPILER="gcc" \
+    -DCMAKE_CXX_COMPILER="g++" \
     -DCMAKE_C_FLAGS="-O3 -g -fPIC -pthread" \
     -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -pthread" \
     -DPYTHON_EXECUTABLE:FILEPATH=$(which python3) \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
-    -DBLAS_LIBRARIES=$CMBENV_AUX_ROOT/lib/libopenblas.a \
-    -DLAPACK_LIBRARIES=$CMBENV_AUX_ROOT/lib/libopenblas.a \
+    -DMKL_DISABLED=TRUE	\
+    -DBLAS_LIBRARIES=$CMBENV_AUX_ROOT/lib/libopenblas.so \
+    -DLAPACK_LIBRARIES=$CMBENV_AUX_ROOT/lib/libopenblas.so \
     -DFFTW_ROOT=$CMBENV_AUX_ROOT \
     -DSUITESPARSE_INCLUDE_DIR_HINTS="${CMBENV_AUX_ROOT}/include" \
     -DSUITESPARSE_LIBRARY_DIR_HINTS="${CMBENV_AUX_ROOT}/lib" \

--- a/platforms/cori-intel.sh
+++ b/platforms/cori-intel.sh
@@ -3,14 +3,11 @@
 opts="$@"
 
 cmake \
-    -DCMAKE_C_COMPILER="${CRAYPE_DIR}/bin/cc" \
-    -DCMAKE_CXX_COMPILER="${CRAYPE_DIR}/bin/CC" \
+    -DCMAKE_C_COMPILER="icc" \
+    -DCMAKE_CXX_COMPILER="icpc" \
     -DCMAKE_C_FLAGS="-O3 -g -fPIC -xcore-avx2 -axmic-avx512 -pthread" \
     -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -xcore-avx2 -axmic-avx512 -pthread" \
     -DPYTHON_EXECUTABLE:FILEPATH=$(which python3) \
-    -DBLAS_LIBRARIES=$MKLROOT/lib/intel64/libmkl_rt.so \
-    -DLAPACK_LIBRARIES=$MKLROOT/lib/intel64/libmkl_rt.so \
-    -DFFTW_ROOT=$CMBENV_AUX_ROOT \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     -DSUITESPARSE_INCLUDE_DIR_HINTS="${CMBENV_AUX_ROOT}/include" \
     -DSUITESPARSE_LIBRARY_DIR_HINTS="${CMBENV_AUX_ROOT}/lib" \

--- a/platforms/linux-gcc.sh
+++ b/platforms/linux-gcc.sh
@@ -10,6 +10,7 @@ cmake \
     -DCMAKE_CXX_COMPILER="g++" \
     -DCMAKE_C_FLAGS="-O3 -g -fPIC -pthread" \
     -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -pthread" \
+    -DMKL_DISABLED=TRUE \
     -DPYTHON_EXECUTABLE:FILEPATH=$(which python3) \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     ${opts} \

--- a/platforms/linux-intel.sh
+++ b/platforms/linux-intel.sh
@@ -10,8 +10,6 @@ cmake \
     -DCMAKE_CXX_COMPILER="icpc" \
     -DCMAKE_C_FLAGS="-O3 -g -fPIC -pthread" \
     -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -pthread" \
-    -DBLAS_LIBRARIES=${MKLROOT}/lib/intel64/libmkl_rt.so \
-    -DLAPACK_LIBRARIES=${MKLROOT}/lib/intel64/libmkl_rt.so \
     -DPYTHON_EXECUTABLE:FILEPATH=$(which python3) \
     -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
     ${opts} \


### PR DESCRIPTION
Needed on systems where MKL exists but we do not want to use it.  Update platform examples to reflect new MKL check.  This is a trivial fix and cannot be tested with our CI.  I tested on cori.nersc.gov with GNU and Intel stacks.