### PR TITLE
add crosstalk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ name:  Run Test Suite
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ name:  Run Test Suite
 
 on:
   push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,10 @@
 # *.py[cod]
 
 # Compiled extensions
-# *.so
+*.so
+
+# Python egg
+toast_cmb.egg-info
 
 /examples/job_*
 /examples/data/
@@ -23,6 +26,7 @@
 
 # generated files
 src/libtoast/src/version.cpp
+src/libtoast/version.cpp
 
 # vim
 *.swp
@@ -36,3 +40,6 @@ src/libtoast/src/version.cpp
 # Jupyter notebooks
 .ipynb_checkpoints
 __pycache__
+
+# VSCode
+.vscode/

--- a/docs/op_processing.inc
+++ b/docs/op_processing.inc
@@ -26,6 +26,12 @@ This operator applies a set of gains to the timestreams:
 .. autoclass:: toast.tod.OpApplyGain
     :members:
 
+Crosstalk
+~~~~~~~~~
+
+.. automodule:: toast.tod.crosstalk
+    :members: add_crosstalk_args, SimpleCrosstalkMatrix, OpCrosstalk
+
 Utilities
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/op_processing.inc
+++ b/docs/op_processing.inc
@@ -30,7 +30,7 @@ Crosstalk
 ~~~~~~~~~
 
 .. automodule:: toast.tod.crosstalk
-    :members: add_crosstalk_args, SimpleCrosstalkMatrix, OpCrosstalk
+    :members:
 
 Utilities
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -12,3 +12,5 @@ TOAST contains a variety of utilities for controlling the runtime environment, l
 .. include:: utils_rng.inc
 
 .. include:: utils_vmath.inc
+
+.. include:: utils_fma.inc

--- a/docs/utils_fma.inc
+++ b/docs/utils_fma.inc
@@ -1,0 +1,8 @@
+.. _utilsfma:
+
+Vector Operations
+-----------------
+
+The following function(s) is simple vector operations compiled both for speeding up and reduce memory use, comparing to their pure Python counterpart.
+
+.. autofunction:: toast.utils.inplace_weighted_sum

--- a/src/libtoast/CMakeLists.txt
+++ b/src/libtoast/CMakeLists.txt
@@ -27,6 +27,7 @@ set(toast_SOURCES
     src/toast_math_rng.cpp
     src/toast_math_qarray.cpp
     src/toast_math_fft.cpp
+    src/toast_math_fma.cpp
     src/toast_math_healpix.cpp
     src/toast_map_cov.cpp
     src/toast_fod_psd.cpp
@@ -44,6 +45,7 @@ set(toast_SOURCES
     tests/toast_test_rng.cpp
     tests/toast_test_qarray.cpp
     tests/toast_test_fft.cpp
+    tests/toast_test_fma.cpp
     tests/toast_test_healpix.cpp
     tests/toast_test_cov.cpp
     tests/toast_test_polyfilter.cpp

--- a/src/libtoast/include/toast.hpp
+++ b/src/libtoast/include/toast.hpp
@@ -13,6 +13,7 @@
 #include <toast/math_rng.hpp>
 #include <toast/math_qarray.hpp>
 #include <toast/math_fft.hpp>
+#include <toast/math_fma.hpp>
 #include <toast/math_healpix.hpp>
 #include <toast/fod_psd.hpp>
 #include <toast/map_pixels.hpp>

--- a/src/libtoast/include/toast/math_fma.hpp
+++ b/src/libtoast/include/toast/math_fma.hpp
@@ -1,0 +1,15 @@
+/*
+   Copyright (c) 2021 by the parties listed in the AUTHORS file.
+   All rights reserved.  Use of this source code is governed by
+   a BSD-style license that can be found in the LICENSE file.
+ */
+
+#ifndef TOAST_MATH_FMA_HPP
+#define TOAST_MATH_FMA_HPP
+
+
+namespace toast {
+void inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays);
+}
+
+#endif

--- a/src/libtoast/include/toast/math_fma.hpp
+++ b/src/libtoast/include/toast/math_fma.hpp
@@ -9,7 +9,13 @@
 
 
 namespace toast {
-void inplace_weighted_sum(int const n_out, int const n_weights, double * const out, double const * const weights, double const * const * const arrays);
+void inplace_weighted_sum(
+    int const n_out,
+    int const n_weights,
+    double * const out,
+    double const * const weights,
+    double const * const * const arrays
+    );
 }
 
-#endif
+#endif // ifndef TOAST_MATH_FMA_HPP

--- a/src/libtoast/include/toast/math_fma.hpp
+++ b/src/libtoast/include/toast/math_fma.hpp
@@ -9,7 +9,7 @@
 
 
 namespace toast {
-void inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays);
+void inplace_weighted_sum(int const n_out, int const n_weights, double * const out, double const * const weights, double const * const * const arrays);
 }
 
 #endif

--- a/src/libtoast/src/toast_math_fma.cpp
+++ b/src/libtoast/src/toast_math_fma.cpp
@@ -8,12 +8,18 @@
 
 
 // be careful of incorrect result if the pragma is put outside
-void toast::inplace_weighted_sum(int const n_out, int const n_weights, double * const out, double const * const weights, double const * const * const arrays) {
-    if (! toast::is_aligned(out)) {
+void toast::inplace_weighted_sum(
+    int const n_out,
+    int const n_weights,
+    double * const out,
+    double const * const weights,
+    double const * const * const arrays
+    ) {
+    if (!toast::is_aligned(out)) {
         for (int i = 0; i < n_weights; ++i) {
             double const weight = weights[i];
             double const * const array = arrays[i];
-            # pragma omp parallel for default(shared) schedule(static)
+            #pragma omp parallel for default(shared) schedule(static)
             for (int j = 0; j < n_out; ++j) {
                 out[j] += weight * array[j];
             }
@@ -23,12 +29,12 @@ void toast::inplace_weighted_sum(int const n_out, int const n_weights, double * 
             double const weight = weights[i];
             double const * const array = arrays[i];
             if (toast::is_aligned(array)) {
-                # pragma omp parallel for simd default(shared) schedule(static)
+                #pragma omp parallel for simd default(shared) schedule(static)
                 for (int j = 0; j < n_out; ++j) {
                     out[j] += weight * array[j];
                 }
             } else {
-                # pragma omp parallel for default(shared) schedule(static)
+                #pragma omp parallel for default(shared) schedule(static)
                 for (int j = 0; j < n_out; ++j) {
                     out[j] += weight * array[j];
                 }
@@ -37,10 +43,15 @@ void toast::inplace_weighted_sum(int const n_out, int const n_weights, double * 
     }
 }
 
-
 // the following produces correct results, but slower.
-// void toast::inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays) {
-//     # pragma omp parallel for simd
+// void toast::inplace_weighted_sum(
+//     int const n_out,
+//     int const n_weights,
+//     double * const out,
+//     double const * const weights,
+//     double const * const * const arrays
+//     ) {
+//     #pragma omp parallel for simd
 //     for (int j = 0; j < n_out; ++j) {
 //         for (int i = 0; i < n_weights; ++i) {
 //             out[j] += weights[i] * arrays[i][j];

--- a/src/libtoast/src/toast_math_fma.cpp
+++ b/src/libtoast/src/toast_math_fma.cpp
@@ -1,0 +1,30 @@
+
+// Copyright (c) 2021 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
+
+#include <toast/math_fma.hpp>
+
+
+// be careful of incorrect result if the pragma is put outside
+void toast::inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays) {
+    for (int i = 0; i < n_weights; ++i) {
+        double const weight = weights[i];
+        double * const array = arrays[i];
+        # pragma omp parallel for simd
+        for (int j = 0; j < n_out; ++j) {
+            out[j] += weight * array[j];
+        }
+    }
+}
+
+
+// the following produces correct results, but slower.
+// void toast::inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays) {
+//     # pragma omp parallel for simd
+//     for (int j = 0; j < n_out; ++j) {
+//         for (int i = 0; i < n_weights; ++i) {
+//             out[j] += weights[i] * arrays[i][j];
+//         }
+//     }
+// }

--- a/src/libtoast/src/toast_math_fma.cpp
+++ b/src/libtoast/src/toast_math_fma.cpp
@@ -3,17 +3,36 @@
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
+#include <toast/sys_utils.hpp>
 #include <toast/math_fma.hpp>
 
 
 // be careful of incorrect result if the pragma is put outside
-void toast::inplace_weighted_sum(int n_out, int n_weights, double * out, double const * weights, double ** arrays) {
-    for (int i = 0; i < n_weights; ++i) {
-        double const weight = weights[i];
-        double * const array = arrays[i];
-        # pragma omp parallel for simd
-        for (int j = 0; j < n_out; ++j) {
-            out[j] += weight * array[j];
+void toast::inplace_weighted_sum(int const n_out, int const n_weights, double * const out, double const * const weights, double const * const * const arrays) {
+    if (! toast::is_aligned(out)) {
+        for (int i = 0; i < n_weights; ++i) {
+            double const weight = weights[i];
+            double const * const array = arrays[i];
+            # pragma omp parallel for default(shared) schedule(static)
+            for (int j = 0; j < n_out; ++j) {
+                out[j] += weight * array[j];
+            }
+        }
+    } else {
+        for (int i = 0; i < n_weights; ++i) {
+            double const weight = weights[i];
+            double const * const array = arrays[i];
+            if (toast::is_aligned(array)) {
+                # pragma omp parallel for simd default(shared) schedule(static)
+                for (int j = 0; j < n_out; ++j) {
+                    out[j] += weight * array[j];
+                }
+            } else {
+                # pragma omp parallel for default(shared) schedule(static)
+                for (int j = 0; j < n_out; ++j) {
+                    out[j] += weight * array[j];
+                }
+            }
         }
     }
 }

--- a/src/libtoast/tests/toast_test.hpp
+++ b/src/libtoast/tests/toast_test.hpp
@@ -149,6 +149,26 @@ class TOASTfftTest : public ::testing::Test {
 };
 
 
+class TOASTfmaTest : public ::testing::Test {
+    public:
+
+        TOASTfmaTest() {}
+
+        ~TOASTfmaTest() {}
+
+        virtual void SetUp();
+
+        virtual void TearDown() {}
+
+        static const int n_out;
+        static const int n_weights;
+        toast::AlignedVector <double> weights;
+        toast::AlignedVector <double> answer;
+        toast::AlignedVector <double> arrays_flat;
+        toast::AlignedVector <double> out;
+};
+
+
 class TOASTcovTest : public ::testing::Test {
     public:
 

--- a/src/libtoast/tests/toast_test_fma.cpp
+++ b/src/libtoast/tests/toast_test_fma.cpp
@@ -18,30 +18,32 @@ void TOASTfmaTest::SetUp() {
     // create some inputs that are different for different i, j
     // and also the final result would be integer
     for (int i = 0; i < n_weights; ++i) {
-        weights[i] = (double) 12 * (i + 1);
+        weights[i] = (double)12 * (i + 1);
     }
     for (int i = 0; i < n_weights; ++i) {
         for (int j = 0; j < n_out; ++j) {
-            arrays_flat[i * n_out + j] = (double) (i + 1) * (i + j + 1) * (j + 1);
+            arrays_flat[i * n_out + j] = (double)(i + 1) * (i + j + 1) * (j + 1);
         }
     }
+
     // and calculate the analytically expected value and compare later
     const int n = n_weights;
     for (int j = 0; j < n_out; ++j) {
-        answer[j] = (double) (1 + j) * n * (1 + n) * (3 * n * (1 + n) + j * (2 + 4 * n));
+        answer[j] = (double)(1 + j) * n * (1 + n) * (3 * n * (1 + n) + j * (2 + 4 * n));
     }
     return;
 }
 
 TEST_F(TOASTfmaTest, inplace_weighted_sum) {
-    // not in SetUp: this should be done just before passing to the function below that modifies it
+    // not in SetUp: this should be done just before passing to the function below that
+    // modifies it
     out.assign(n_out, 0);
-    double** arrays = new double*[n_weights];
+    double ** arrays = new double *[n_weights];
     for (int i = 0; i < n_weights; ++i) {
         arrays[i] = &arrays_flat[i * n_out];
     }
     toast::inplace_weighted_sum(n_out, n_weights, out.data(), weights.data(), arrays);
-    delete [] arrays;
+    delete[] arrays;
 
     for (int j = 0; j < n_out; ++j) {
         EXPECT_DOUBLE_EQ(out[j], answer[j]);

--- a/src/libtoast/tests/toast_test_fma.cpp
+++ b/src/libtoast/tests/toast_test_fma.cpp
@@ -1,0 +1,49 @@
+
+// Copyright (c) 2021 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
+
+#include <toast_test.hpp>
+
+
+const int TOASTfmaTest::n_out = 128;
+const int TOASTfmaTest::n_weights = 64;
+
+
+void TOASTfmaTest::SetUp() {
+    weights.resize(n_weights);
+    answer.resize(n_out);
+    arrays_flat.resize(n_weights * n_out);
+
+    // create some inputs that are different for different i, j
+    // and also the final result would be integer
+    for (int i = 0; i < n_weights; ++i) {
+        weights[i] = (double) 12 * (i + 1);
+    }
+    for (int i = 0; i < n_weights; ++i) {
+        for (int j = 0; j < n_out; ++j) {
+            arrays_flat[i * n_out + j] = (double) (i + 1) * (i + j + 1) * (j + 1);
+        }
+    }
+    // and calculate the analytically expected value and compare later
+    const int n = n_weights;
+    for (int j = 0; j < n_out; ++j) {
+        answer[j] = (double) (1 + j) * n * (1 + n) * (3 * n * (1 + n) + j * (2 + 4 * n));
+    }
+    return;
+}
+
+TEST_F(TOASTfmaTest, inplace_weighted_sum) {
+    // not in SetUp: this should be done just before passing to the function below that modifies it
+    out.assign(n_out, 0);
+    double** arrays = new double*[n_weights];
+    for (int i = 0; i < n_weights; ++i) {
+        arrays[i] = &arrays_flat[i * n_out];
+    }
+    toast::inplace_weighted_sum(n_out, n_weights, out.data(), weights.data(), arrays);
+    delete [] arrays;
+
+    for (int j = 0; j < n_out; ++j) {
+        EXPECT_DOUBLE_EQ(out[j], answer[j]);
+    }
+}

--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -35,6 +35,7 @@ pybind11_add_module(_libtoast MODULE
     _libtoast_math_rng.cpp
     _libtoast_math_qarray.cpp
     _libtoast_math_fft.cpp
+    _libtoast_math_fma.cpp
     _libtoast_math_healpix.cpp
     _libtoast_fod_psd.cpp
     _libtoast_tod_filter.cpp

--- a/src/toast/_libtoast.cpp
+++ b/src/toast/_libtoast.cpp
@@ -32,6 +32,7 @@ PYBIND11_MODULE(_libtoast, m) {
     init_math_qarray(m);
     init_math_healpix(m);
     init_math_fft(m);
+    init_math_fma(m);
     init_fod_psd(m);
     init_tod_filter(m);
     init_tod_pointing(m);

--- a/src/toast/_libtoast.hpp
+++ b/src/toast/_libtoast.hpp
@@ -211,6 +211,7 @@ void init_math_rng(py::module & m);
 void init_math_qarray(py::module & m);
 void init_math_healpix(py::module & m);
 void init_math_fft(py::module & m);
+void init_math_fma(py::module & m);
 void init_fod_psd(py::module & m);
 void init_tod_filter(py::module & m);
 void init_tod_pointing(py::module & m);

--- a/src/toast/_libtoast_math_fma.cpp
+++ b/src/toast/_libtoast_math_fma.cpp
@@ -1,0 +1,95 @@
+
+// Copyright (c) 2021 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
+
+#include <_libtoast.hpp>
+
+
+void init_math_fma(py::module & m) {
+
+    m.def(
+        "inplace_weighted_sum",
+        [](py::buffer out, py::buffer weights, py::args a) {
+            py::buffer_info info_out = out.request();
+            py::buffer_info info_weights = weights.request();
+
+            if ((unsigned) info_weights.size != a.size()) {
+                auto log = toast::Logger::get();
+                std::ostringstream o;
+                o << "weights and args are of different sizes.";
+                log.error(o.str().c_str());
+                throw std::runtime_error(o.str().c_str());
+            }
+
+            if (info_out.format != py::format_descriptor<double>::format()) {
+                auto log = toast::Logger::get();
+                std::ostringstream o;
+                o << "Incompatible format: expecting out to be a double array!";
+                log.error(o.str().c_str());
+                throw std::runtime_error(o.str().c_str());
+            }
+            double * out_raw = reinterpret_cast <double *> (info_out.ptr);
+
+            if (info_weights.format != py::format_descriptor<double>::format()) {
+                auto log = toast::Logger::get();
+                std::ostringstream o;
+                o << "Incompatible format: expecting weights to be a double array!";
+                log.error(o.str().c_str());
+                throw std::runtime_error(o.str().c_str());
+            }
+            double * weights_raw = reinterpret_cast <double *> (info_weights.ptr);
+
+            double** arrays = new double*[a.size()];
+            for (size_t i = 0; i < a.size(); ++i) {
+                // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
+                py::handle array = PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i));
+                py::buffer array_buffer = array.cast<py::buffer>();
+                py::buffer_info info_array = array_buffer.request();
+
+                if (info_array.size != info_out.size) {
+                    auto log = toast::Logger::get();
+                    std::ostringstream o;
+                    o << "An array from args does not have the same size with out.";
+                    log.error(o.str().c_str());
+                    throw std::runtime_error(o.str().c_str());
+                }
+
+                if (info_array.format != py::format_descriptor<double>::format()) {
+                    auto log = toast::Logger::get();
+                    std::ostringstream o;
+                    o << "Incompatible format: expecting all array from args to be a double array!";
+                    log.error(o.str().c_str());
+                    throw std::runtime_error(o.str().c_str());
+                }
+                arrays[i] = reinterpret_cast <double *> (info_array.ptr);
+            }
+
+            toast::inplace_weighted_sum(info_out.size, info_weights.size, out_raw, weights_raw, arrays);
+            delete [] arrays;
+        },
+        py::arg("out"),
+        py::arg("weights"),
+        R"(
+            Compute a weighted sum of float64 values.
+
+            The results are stored in the output buffer. To guarantee SIMD
+            vectorization, the input (args) and output arrays (out) should be aligned
+            (i.e. use an AlignedF64).
+
+            Args:
+                out (array_like):  1D array of float64 values.
+                weights (array_like):  1D array of float64 values.
+                *args (array_like):  1D array of float64 values.
+
+            Returns:
+                None
+
+            Effectively equivalent to:
+
+            >>> for weight, array in zip(weights, args):
+            >>>     out += weight * array
+        )");
+
+    return;
+}

--- a/src/toast/_libtoast_math_fma.cpp
+++ b/src/toast/_libtoast_math_fma.cpp
@@ -29,7 +29,7 @@ void init_math_fma(py::module & m) {
                 log.error(o.str().c_str());
                 throw std::runtime_error(o.str().c_str());
             }
-            double * out_raw = reinterpret_cast <double *> (info_out.ptr);
+            double * const out_raw = reinterpret_cast <double *> (info_out.ptr);
 
             if (info_weights.format != py::format_descriptor<double>::format()) {
                 auto log = toast::Logger::get();
@@ -38,9 +38,9 @@ void init_math_fma(py::module & m) {
                 log.error(o.str().c_str());
                 throw std::runtime_error(o.str().c_str());
             }
-            double * weights_raw = reinterpret_cast <double *> (info_weights.ptr);
+            double const * const weights_raw = reinterpret_cast <double *> (info_weights.ptr);
 
-            double** arrays = new double*[a.size()];
+            double ** arrays = new double*[a.size()];
             for (size_t i = 0; i < a.size(); ++i) {
                 // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
                 py::handle array = PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i));

--- a/src/toast/_libtoast_math_fma.cpp
+++ b/src/toast/_libtoast_math_fma.cpp
@@ -7,14 +7,13 @@
 
 
 void init_math_fma(py::module & m) {
-
     m.def(
         "inplace_weighted_sum",
         [](py::buffer out, py::buffer weights, py::args a) {
             py::buffer_info info_out = out.request();
             py::buffer_info info_weights = weights.request();
 
-            if ((unsigned) info_weights.size != a.size()) {
+            if ((unsigned)info_weights.size != a.size()) {
                 auto log = toast::Logger::get();
                 std::ostringstream o;
                 o << "weights and args are of different sizes.";
@@ -22,7 +21,7 @@ void init_math_fma(py::module & m) {
                 throw std::runtime_error(o.str().c_str());
             }
 
-            if (info_out.format != py::format_descriptor<double>::format()) {
+            if (info_out.format != py::format_descriptor <double>::format()) {
                 auto log = toast::Logger::get();
                 std::ostringstream o;
                 o << "Incompatible format: expecting out to be a double array!";
@@ -31,20 +30,22 @@ void init_math_fma(py::module & m) {
             }
             double * const out_raw = reinterpret_cast <double *> (info_out.ptr);
 
-            if (info_weights.format != py::format_descriptor<double>::format()) {
+            if (info_weights.format != py::format_descriptor <double>::format()) {
                 auto log = toast::Logger::get();
                 std::ostringstream o;
                 o << "Incompatible format: expecting weights to be a double array!";
                 log.error(o.str().c_str());
                 throw std::runtime_error(o.str().c_str());
             }
-            double const * const weights_raw = reinterpret_cast <double *> (info_weights.ptr);
+            double const * const weights_raw =
+                reinterpret_cast <double *> (info_weights.ptr);
 
-            double ** arrays = new double*[a.size()];
+            double ** arrays = new double *[a.size()];
             for (size_t i = 0; i < a.size(); ++i) {
-                // Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
-                py::handle array = PyTuple_GET_ITEM(a.ptr(), static_cast<py::ssize_t>(i));
-                py::buffer array_buffer = array.cast<py::buffer>();
+// Use raw Python API here to avoid an extra, intermediate incref on the tuple item:
+                py::handle array =
+                    PyTuple_GET_ITEM(a.ptr(), static_cast <py::ssize_t> (i));
+                py::buffer array_buffer = array.cast <py::buffer>();
                 py::buffer_info info_array = array_buffer.request();
 
                 if (info_array.size != info_out.size) {
@@ -55,7 +56,7 @@ void init_math_fma(py::module & m) {
                     throw std::runtime_error(o.str().c_str());
                 }
 
-                if (info_array.format != py::format_descriptor<double>::format()) {
+                if (info_array.format != py::format_descriptor <double>::format()) {
                     auto log = toast::Logger::get();
                     std::ostringstream o;
                     o << "Incompatible format: expecting all array from args to be a double array!";
@@ -65,11 +66,19 @@ void init_math_fma(py::module & m) {
                 arrays[i] = reinterpret_cast <double *> (info_array.ptr);
             }
 
-            toast::inplace_weighted_sum(info_out.size, info_weights.size, out_raw, weights_raw, arrays);
-            delete [] arrays;
+            toast::inplace_weighted_sum(
+                info_out.size,
+                info_weights.size,
+                out_raw,
+                weights_raw,
+                arrays
+                );
+            delete[] arrays;
         },
         py::arg("out"),
-        py::arg("weights"),
+        py::arg(
+            "weights"
+            ),
         R"(
             Compute a weighted sum of float64 values.
 

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ install(FILES
     intervals.py
     tod_satellite.py
     ops_applygain.py
+    ops_crosstalk.py
     ops_simnoise.py
     cov.py
     ops_pmat.py

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -183,13 +183,12 @@ class OpCrosstalkTest(MPITestCase):
             self._tset_op_crosstalk_multiple_matrices(*case)
 
     def test_op_crosstalk_io(self):
-        path = self.outdir / 'simple_crosstalk_matrix.hdf5'
-
-        crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
         if rank == 0:
+            path = self.outdir / 'simple_crosstalk_matrix.hdf5'
+            crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
+
             crosstalk_matrix.dump(path)
+            crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path, debug=True)
 
-        crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path, debug=True)
-
-        np.testing.assert_array_equal(names, crosstalk_matrix_read.names)
-        np.testing.assert_array_equal(crosstalk_data, crosstalk_matrix_read.data)
+            np.testing.assert_array_equal(names, crosstalk_matrix_read.names)
+            np.testing.assert_array_equal(crosstalk_data, crosstalk_matrix_read.data)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -11,7 +11,7 @@ from ..tod import TODCache
 from ..mpi import get_world
 from ..utils import Logger
 from ..tod.crosstalk import SimpleCrosstalkMatrix, OpCrosstalk
-from .mpi import MPITestCase
+from . import mpi as mpi_test
 # from ._helpers import create_outdir, create_satellite_data
 
 if TYPE_CHECKING:
@@ -51,7 +51,7 @@ class FakeData:
     obs: List[dict]
 
 
-class OpCrosstalkTest(MPITestCase):
+class OpCrosstalkTest(mpi_test.MPITestCase):
 
     # def setUp(self):
     #     fixture_name = os.path.splitext(os.path.basename(__file__))[0]

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -1,21 +1,20 @@
 # py37+
 # from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import os
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 import numpy as np
 from numpy.random import default_rng
 
-from ..mpi import get_world
 from ..dist import Data
+from ..mpi import get_world
 from ..tod import TODCache
 from ..tod.crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
 from ..utils import Logger
-from .mpi import MPITestCase
-
 from ._helpers import create_outdir  # , create_satellite_data
+from .mpi import MPITestCase
 
 if TYPE_CHECKING:
     from typing import List

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -15,7 +15,7 @@ from ..tod.crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
 from ..utils import Logger
 from .mpi import MPITestCase
 
-from ._helpers import create_outdir  #, create_satellite_data
+from ._helpers import create_outdir  # , create_satellite_data
 
 if TYPE_CHECKING:
     from typing import List

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -182,7 +182,7 @@ class OpCrosstalkTest(MPITestCase):
         for case in cases:
             self._tset_op_crosstalk_multiple_matrices(*case)
 
-    def test_io(self):
+    def test_op_crosstalk_io(self):
         path = self.outdir / 'simple_crosstalk_matrix.hdf5'
 
         crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -201,14 +201,12 @@ class OpCrosstalkTest(MPITestCase):
     def test_op_crosstalk_multiple_matrices(self):
         for detranks in self.detranks:
             self._each_op_crosstalk_multiple_matrices(
-                (
-                    self.names,
-                    self.names_strs,
-                    self.tod,
-                    self.data,
-                    self.tod_crosstalked,
-                    detranks,
-                ),
+                self.names,
+                self.names_strs,
+                self.tod,
+                self.data,
+                self.tod_crosstalked,
+                detranks,
             )
 
     def test_op_crosstalk_io(self):

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -185,13 +185,10 @@ class OpCrosstalkTest(MPITestCase):
     def test_io(self):
         path = self.outdir / 'simple_crosstalk_matrix.hdf5'
 
-        names = np.array(['det1A', 'det1B', dtype='S'])
-        data = np.identity(2, dtype=np.float64)
-
-        crosstalk_matrix = SimpleCrosstalkMatrix(names, data)
+        crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data)
         crosstalk_matrix.dump(path)
 
         crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path)
 
         np.testing.assert_array_equal(names, crosstalk_matrix_read.names)
-        np.testing.assert_array_equal(data, crosstalk_matrix_read.data)
+        np.testing.assert_array_equal(crosstalk_data, crosstalk_matrix_read.data)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -107,11 +107,11 @@ class OpCrosstalkTest(MPITestCase):
 
         if self.world_rank == 0:
             crosstalk_matrices = [
-                SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
+                SimpleCrosstalkMatrix(names, crosstalk_data)
             ]
         else:
             crosstalk_matrices = []
-        op_crosstalk = OpCrosstalk(1, crosstalk_matrices, debug=True)
+        op_crosstalk = OpCrosstalk(1, crosstalk_matrices)
 
         tod = TODCache(self.world_comm, names_str, self.n_samples, detranks=detranks)
 
@@ -163,10 +163,10 @@ class OpCrosstalkTest(MPITestCase):
         n_crosstalk_matrices = len(names)
         idxs_per_rank = range(self.world_rank, n_crosstalk_matrices, self.world_procs)
         crosstalk_matrices = [
-            SimpleCrosstalkMatrix(names[i], crosstalk_datas[i], debug=True)
+            SimpleCrosstalkMatrix(names[i], crosstalk_datas[i])
             for i in idxs_per_rank
         ]
-        op_crosstalk = OpCrosstalk(n_crosstalk_matrices, crosstalk_matrices, debug=True)
+        op_crosstalk = OpCrosstalk(n_crosstalk_matrices, crosstalk_matrices)
 
         tod = TODCache(self.world_comm, sum(names_strs, []), self.n_samples, detranks=detranks)
 
@@ -214,10 +214,10 @@ class OpCrosstalkTest(MPITestCase):
         crosstalk_data = self.data[0]
         if self.world_rank == 0:
             path = self.outdir / "simple_crosstalk_matrix.hdf5"
-            crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
+            crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data)
 
             crosstalk_matrix.dump(path)
-            crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path, debug=True)
+            crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path)
 
             np.testing.assert_array_equal(names, crosstalk_matrix_read.names)
             np.testing.assert_array_equal(crosstalk_data, crosstalk_matrix_read.data)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.random import default_rng
 
 from ..mpi import get_world
+from ..dist import Data
 from ..tod import TODCache
 from ..tod.crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
 from ..utils import Logger
@@ -18,8 +19,6 @@ from ._helpers import create_outdir  #, create_satellite_data
 
 if TYPE_CHECKING:
     from typing import List
-
-    import toast
 
 
 mpiworld, procs, rank = get_world()
@@ -53,7 +52,7 @@ crosstalk_data_2 = np.identity(n_detectors) + np.reciprocal(np.arange(10, 10 + n
 tod_crosstalked_random = crosstalk_data_2 @ tod_array_random
 
 
-class FakeData(toast.dist.Data):
+class FakeData(Data):
 
     def __init__(
         self,

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -1,4 +1,5 @@
-from __future__ import annotations
+# py36
+# from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -48,7 +49,7 @@ tod_crosstalked_random = crosstalk_data_2 @ tod_array_random
 
 @dataclass
 class FakeData:
-    obs: List[dict]
+    obs: 'List[dict]'
 
 
 class OpCrosstalkTest(mpi_test.MPITestCase):
@@ -59,10 +60,10 @@ class OpCrosstalkTest(mpi_test.MPITestCase):
 
     @staticmethod
     def _tset_op_crosstalk(
-        tod_array: np.ndarray[np.float64],
-        crosstalk_data: np.ndarray[np.float64],
-        tod_crosstalked: np.ndarray[np.float64],
-        detranks: int,
+        tod_array: 'np.ndarray[np.float64]',
+        crosstalk_data: 'np.ndarray[np.float64]',
+        tod_crosstalked: 'np.ndarray[np.float64]',
+        detranks: 'int',
     ):
         if rank == 0:
             crosstalk_matrices = [SimpleCrosstalkMatrix(names, crosstalk_data)]
@@ -117,12 +118,12 @@ class OpCrosstalkTest(mpi_test.MPITestCase):
 
     @staticmethod
     def _tset_op_crosstalk_multiple_matrices(
-        names: List[np.ndarray['S']],
-        names_strs: List[List[str]],
-        tods_array: List[np.ndarray[np.float64]],
-        crosstalk_datas: List[np.ndarray[np.float64]],
-        tods_crosstalked: List[np.ndarray[np.float64]],
-        detranks: int,
+        names: "List[np.ndarray['S']]",
+        names_strs: 'List[List[str]]',
+        tods_array: 'List[np.ndarray[np.float64]]',
+        crosstalk_datas: 'List[np.ndarray[np.float64]]',
+        tods_crosstalked: 'List[np.ndarray[np.float64]]',
+        detranks: 'int',
     ):
         n_crosstalk_matrices = len(names)
         idxs_per_rank = range(rank, n_crosstalk_matrices, procs)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -75,10 +75,10 @@ class OpCrosstalkTest(MPITestCase):
         detranks: 'int',
     ):
         if rank == 0:
-            crosstalk_matrices = [SimpleCrosstalkMatrix(names, crosstalk_data)]
+            crosstalk_matrices = [SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)]
         else:
             crosstalk_matrices = []
-        op_crosstalk = OpCrosstalk(1, crosstalk_matrices)
+        op_crosstalk = OpCrosstalk(1, crosstalk_matrices, debug=True)
 
         tod = TODCache(mpiworld, names_str, n_samples, detranks=detranks)
 
@@ -136,8 +136,8 @@ class OpCrosstalkTest(MPITestCase):
     ):
         n_crosstalk_matrices = len(names)
         idxs_per_rank = range(rank, n_crosstalk_matrices, procs)
-        crosstalk_matrices = [SimpleCrosstalkMatrix(names[i], crosstalk_datas[i]) for i in idxs_per_rank]
-        op_crosstalk = OpCrosstalk(n_crosstalk_matrices, crosstalk_matrices)
+        crosstalk_matrices = [SimpleCrosstalkMatrix(names[i], crosstalk_datas[i], debug=True) for i in idxs_per_rank]
+        op_crosstalk = OpCrosstalk(n_crosstalk_matrices, crosstalk_matrices, debug=True)
 
         tod = TODCache(mpiworld, sum(names_strs, []), n_samples, detranks=detranks)
 
@@ -185,10 +185,10 @@ class OpCrosstalkTest(MPITestCase):
     def test_op_crosstalk_io(self):
         path = self.outdir / 'simple_crosstalk_matrix.hdf5'
 
-        crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data)
+        crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
         crosstalk_matrix.dump(path)
 
-        crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path)
+        crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path, debug=True)
 
         np.testing.assert_array_equal(names, crosstalk_matrix_read.names)
         np.testing.assert_array_equal(crosstalk_data, crosstalk_matrix_read.data)

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -26,8 +26,11 @@ log = Logger.get()
 n_detectors = 4 * procs + 3
 n_samples = 100
 signal_name = 'signal'
-# test against multiple detranks only if mpi
-detrankses = (1,) if procs == 1 else (1, 2, 4)
+detrankses = [1]
+for i in range(2, procs + 1):
+    if procs % i == 0:
+        detrankses.append(i)
+log.info(f'Testing OpCrosstalk against detranks {", ".join(map(str, detrankses))}.')
 
 names_str = [f'A{i}' for i in range(n_detectors)]
 names = np.array(names_str, dtype='S')

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -12,7 +12,7 @@ from ..tod import TODCache
 from ..mpi import get_world
 from ..utils import Logger
 from ..tod.crosstalk import SimpleCrosstalkMatrix, OpCrosstalk
-from . import mpi as mpi_test
+from .mpi import MPITestCase
 # from ._helpers import create_outdir, create_satellite_data
 
 if TYPE_CHECKING:
@@ -52,7 +52,7 @@ class FakeData:
     obs: 'List[dict]'
 
 
-class OpCrosstalkTest(mpi_test.MPITestCase):
+class OpCrosstalkTest(MPITestCase):
 
     # def setUp(self):
     #     fixture_name = os.path.splitext(os.path.basename(__file__))[0]

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -8,11 +8,12 @@ from typing import TYPE_CHECKING
 import numpy as np
 from numpy.random import default_rng
 
-from ..tod import TODCache
 from ..mpi import get_world
+from ..tod import TODCache
+from ..tod.crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
 from ..utils import Logger
-from ..tod.crosstalk import SimpleCrosstalkMatrix, OpCrosstalk
 from .mpi import MPITestCase
+
 # from ._helpers import create_outdir, create_satellite_data
 
 if TYPE_CHECKING:

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -145,12 +145,10 @@ class OpCrosstalkTest(MPITestCase):
             for detranks in self.detranks:
                 with self.subTest(msg=f'OpCrosstalk Test case {i + 1} with detranks {detranks}'):
                     self._each_op_crosstalk(
-                        (
-                            tod,
-                            data,
-                            tod_crosstalked,
-                            detranks,
-                        )
+                        tod,
+                        data,
+                        tod_crosstalked,
+                        detranks,
                     )
 
     def _each_op_crosstalk_multiple_matrices(

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -1,7 +1,6 @@
-# py36
+# py37+
 # from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 # import os
@@ -18,6 +17,8 @@ from .mpi import MPITestCase
 
 if TYPE_CHECKING:
     from typing import List
+
+    import toast
 
 
 mpiworld, procs, rank = get_world()
@@ -51,9 +52,13 @@ crosstalk_data_2 = np.identity(n_detectors) + np.reciprocal(np.arange(10, 10 + n
 tod_crosstalked_random = crosstalk_data_2 @ tod_array_random
 
 
-@dataclass
-class FakeData:
-    obs: 'List[dict]'
+class FakeData(toast.dist.Data):
+
+    def __init__(
+        self,
+        obs: 'List[dict]',
+    ):
+        self.obs = obs
 
 
 class OpCrosstalkTest(MPITestCase):

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -106,15 +106,11 @@ class OpCrosstalkTest(MPITestCase):
         # half float64 precision (float64 has 53-bit precison)
         # will not produce bit-identical output as mat-mul
         # is sensitive to the sum-ordering
-        ulp_max = 2 ** (53 / 2)
         for i, name in enumerate(names_str):
             if name in local_dets_set:
                 output = tod.cache.reference(f"{signal_name}_{name}")
-                answer = tod_crosstalked[i, start : start + length]
-                ulp = np.testing.assert_array_max_ulp(answer, output, ulp_max)
-                log.info(
-                    f"Reproducing mat-mul for detector {name} with max ULP: {ulp.max():e}"
-                )
+                answer = tod_crosstalked[i, start:start + length]
+                np.testing.assert_allclose(answer, output)
 
     def test_op_crosstalk(self):
         cases = []
@@ -175,16 +171,12 @@ class OpCrosstalkTest(MPITestCase):
         # half float64 precision (float64 has 53-bit precison)
         # will not produce bit-identical output as mat-mul
         # is sensitive to the sum-ordering
-        ulp_max = 2 ** (53 / 2)
         for names_str, tod_crosstalked in zip(names_strs, tods_crosstalked):
             for i, name in enumerate(names_str):
                 if name in local_dets_set:
                     output = tod.cache.reference(f"{signal_name}_{name}")
-                    answer = tod_crosstalked[i, start : start + length]
-                    ulp = np.testing.assert_array_max_ulp(answer, output, ulp_max)
-                    log.info(
-                        f"Reproducing mat-mul for detector {name} with max ULP: {ulp.max():e}"
-                    )
+                    answer = tod_crosstalked[i, start:start + length]
+                    np.testing.assert_allclose(answer, output)
 
     def test_op_crosstalk_multiple_matrices(self):
         cases = []

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -141,16 +141,17 @@ class OpCrosstalkTest(MPITestCase):
                 np.testing.assert_allclose(answer, output)
 
     def test_op_crosstalk(self):
-        for tod, data, tod_crosstalked in zip(self.tod, self.data, self.tod_crosstalked):
+        for i, (tod, data, tod_crosstalked) in enumerate(zip(self.tod, self.data, self.tod_crosstalked)):
             for detranks in self.detranks:
-                self._each_op_crosstalk(
-                    (
-                        tod,
-                        data,
-                        tod_crosstalked,
-                        detranks,
+                with self.subTest(msg=f'OpCrosstalk Test case {i + 1} with detranks {detranks}'):
+                    self._each_op_crosstalk(
+                        (
+                            tod,
+                            data,
+                            tod_crosstalked,
+                            detranks,
+                        )
                     )
-                )
 
     def _each_op_crosstalk_multiple_matrices(
         self,
@@ -200,14 +201,15 @@ class OpCrosstalkTest(MPITestCase):
 
     def test_op_crosstalk_multiple_matrices(self):
         for detranks in self.detranks:
-            self._each_op_crosstalk_multiple_matrices(
-                self.names,
-                self.names_strs,
-                self.tod,
-                self.data,
-                self.tod_crosstalked,
-                detranks,
-            )
+            with self.subTest(msg=f'Test OpCrosstalk with multiple matrices and detranks {detranks}'):
+                self._each_op_crosstalk_multiple_matrices(
+                    self.names,
+                    self.names_strs,
+                    self.tod,
+                    self.data,
+                    self.tod_crosstalked,
+                    detranks,
+                )
 
     def test_op_crosstalk_io(self):
         names = self.names[0]

--- a/src/toast/tests/ops_crosstalk.py
+++ b/src/toast/tests/ops_crosstalk.py
@@ -186,7 +186,8 @@ class OpCrosstalkTest(MPITestCase):
         path = self.outdir / 'simple_crosstalk_matrix.hdf5'
 
         crosstalk_matrix = SimpleCrosstalkMatrix(names, crosstalk_data, debug=True)
-        crosstalk_matrix.dump(path)
+        if rank == 0:
+            crosstalk_matrix.dump(path)
 
         crosstalk_matrix_read = SimpleCrosstalkMatrix.load(path, debug=True)
 

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -47,7 +47,7 @@ from . import ops_madam as testopsmadam
 from . import ops_mapmaker as testopsmapmaker
 from . import ops_filterbin as testopsfilterbin
 
-from . import ops_crosstalk as test_ops_crosstalk
+from . import ops_crosstalk as testopscrosstalk
 
 from . import map_satellite as testmapsatellite
 
@@ -140,7 +140,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(testopsmadam))
         suite.addTest(loader.loadTestsFromModule(testopsmapmaker))
         suite.addTest(loader.loadTestsFromModule(testopsfilterbin))
-        suite.addTest(loader.loadTestsFromModule(test_ops_crosstalk))
+        suite.addTest(loader.loadTestsFromModule(testopscrosstalk))
         suite.addTest(loader.loadTestsFromModule(testmapsatellite))
         suite.addTest(loader.loadTestsFromModule(testmapground))
         suite.addTest(loader.loadTestsFromModule(testbinned))

--- a/src/toast/tod/CMakeLists.txt
+++ b/src/toast/tod/CMakeLists.txt
@@ -4,6 +4,7 @@
 install(FILES
     __init__.py
     applygain.py
+    crosstalk.py
     gainscrambler.py
     interval.py
     memorycounter.py

--- a/src/toast/tod/__init__.py
+++ b/src/toast/tod/__init__.py
@@ -39,7 +39,6 @@ from .polyfilter import OpPolyFilter, OpPolyFilter2D
 
 from .gainscrambler import OpGainScrambler
 from .applygain import OpApplyGain, write_calibration_file
-
 from .crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
 
 from .memorycounter import OpMemoryCounter

--- a/src/toast/tod/__init__.py
+++ b/src/toast/tod/__init__.py
@@ -40,6 +40,8 @@ from .polyfilter import OpPolyFilter, OpPolyFilter2D
 from .gainscrambler import OpGainScrambler
 from .applygain import OpApplyGain, write_calibration_file
 
+from .crosstalk import OpCrosstalk, SimpleCrosstalkMatrix
+
 from .memorycounter import OpMemoryCounter
 
 from .tidas import available as tidas_available

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -9,9 +9,10 @@ import h5py
 import numpy as np
 import toast
 from numba import jit
-from toast.mpi import get_world
-from toast.op import Operator
-from toast.utils import Logger
+
+from ..mpi import get_world
+from ..op import Operator
+from ..utils import Logger
 
 if TYPE_CHECKING:
     from typing import Optional, List

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -459,16 +459,16 @@ class OpCrosstalk(Operator):
 
                 # this is easier to understand and shorter
                 # but uses allgather instead of the more efficient Allgather
-                # construct detector LUT
+                # construct detector lookup table
                 # local_dets = tod.local_dets
                 # global_dets = comm.allgather(local_dets)
                 # det_lut = {}
                 # for i, dets in enumerate(global_dets):
                 #     for det in dets:
                 #         det_lut[det] = i
-                # log.debug(f'dets LUT: {dets_lut}')
+                # log.debug(f'dets lookup table: {dets_lut}')
 
-                # construct det_lut, a LUT to know which rank holds a detector
+                # construct det_lut, a lookup table to know which rank holds a detector
                 local_has_det = tod.cache.create(
                     f"{crosstalk_name}_local_has_det_{rank}",
                     np.uint8,
@@ -499,11 +499,11 @@ class OpCrosstalk(Operator):
                 tod.cache.destroy(f"{crosstalk_name}_global_has_det_{rank}")
 
                 if debug:
-                    logger.debug(f'Rank {rank} has detectors LUT: {det_lut}')
+                    logger.debug(f'Rank {rank} has detectors lookup table: {det_lut}')
                     for name in local_crosstalk_dets_set:
                         if det_lut[name] != rank:
                             raise RuntimeError(
-                                'Error in creating a LUT '
+                                'Error in creating a lookup table '
                                 f'from detector name to rank: {det_lut}'
                             )
 

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -234,7 +234,7 @@ class SimpleCrosstalkMatrix:
 
 
 class OpCrosstalk(Operator):
-    """Operator that apply crosstalk matrix to detector ToDs.
+    """Operator that applies crosstalk matrix to detector ToDs.
 
     :param n_crosstalk_matrices: total no. of crosstalk matrices
     :param crosstalk_matrices: the crosstalk matrices.

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -68,7 +68,7 @@ from ..op import Operator
 from ..utils import Logger
 
 if TYPE_CHECKING:
-    from typing import List  # Optional
+    from typing import List, Union  # Optional
 
     import toast
 
@@ -131,22 +131,24 @@ def add_crosstalk_args(parser: 'argparse.ArgumentParser'):
 class SimpleCrosstalkMatrix:
     """A thin crosstalk matrix class.
 
+    :param names: detector names.
+    :param data: crosstalk matrix.
+        The length of `names` should match the dimension of `data`,
+        which should be a square array.
+    :param debug: emit more debug message and perform runtime validation check.
+
     This is a simple container storing the crosstalk matrix,
     but not generating it.
-
-    The length of `names` should match the dimension of `data`,
-    which should be a square array.
-    Runtime checking is done only if `debug` is set to `True`.
     """
 
     def __init__(
         self,
-        names: "np.ndarray['S']",
+        names: "Union[np.ndarray['S'], List[str]]",
         data: 'np.ndarray[np.float64]',
         *,
         debug: 'bool' = False,
     ):
-        self.names = names
+        self.names = np.asarray(names, dtype="S")
         self.data = data
         self.debug = debug
         if debug:

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -106,7 +106,7 @@ if jit is None:
     )
 else:
     # cache is False to avoid IO on HPC.
-    _fma = jit(_fma, nopython=True, nogil=True, cache=False)
+    _fma = jit(_fma, nopython=True, nogil=True, parallel=True, cache=False)
 
 
 def add_crosstalk_args(parser: 'argparse.ArgumentParser'):

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -73,10 +73,10 @@ if TYPE_CHECKING:
     import toast
 
 # py37+
-# COMM: Optional[toast.mpi.Comm]
+# world_comm: Optional[toast.mpi.Comm]
 # PROCS: int
 # RANK: int
-COMM, PROCS, RANK = get_world()
+world_comm, PROCS, RANK = get_world()
 logger = Logger.get()
 IS_SERIAL = PROCS == 1
 
@@ -284,7 +284,7 @@ class OpCrosstalk(Operator):
             lengths = np.array([names.size, names.dtype.itemsize], dtype=np.int64)
         else:
             lengths = np.empty(2, dtype=np.int64)
-        COMM.Bcast(lengths, root=rank_owner)
+        world_comm.Bcast(lengths, root=rank_owner)
         if debug:
             logger.debug(f'crosstalk: Rank {RANK} receives lengths {lengths}')
 
@@ -295,10 +295,10 @@ class OpCrosstalk(Operator):
             names_int = np.empty(n * name_len, dtype=np.uint8)
             names = names_int.view(f'S{name_len}')
             data = np.empty((n, n), dtype=np.float64)
-        COMM.Bcast(names_int, root=rank_owner)
+        world_comm.Bcast(names_int, root=rank_owner)
         if debug:
             logger.debug(f'crosstalk: Rank {RANK} receives names {names}')
-        COMM.Bcast(data, root=rank_owner)
+        world_comm.Bcast(data, root=rank_owner)
         if debug:
             logger.debug(f'crosstalk: Rank {RANK} receives data {data}')
 

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
 # PROCS: int
 # RANK: int
 COMM, PROCS, RANK = get_world()
-LOGGER = Logger.get()
+logger = Logger.get()
 IS_SERIAL = PROCS == 1
 
 
@@ -81,7 +81,7 @@ def _fma(out: 'np.ndarray[np.float64]', ws: 'np.ndarray[np.float64]', *arrays: '
 
 
 if jit is None:
-    LOGGER.warning('Numba not present. _fma in crosstalk will have more intermediate Numpy array objects created that uses more memory.')
+    logger.warning('Numba not present. _fma in crosstalk will have more intermediate Numpy array objects created that uses more memory.')
 else:
     # cache is False to avoid IO on HPC.
     _fma = jit(_fma, nopython=True, nogil=True, cache=False)
@@ -216,7 +216,7 @@ class OpCrosstalk(Operator):
         else:
             lengths = np.empty(2, dtype=np.int64)
         COMM.Bcast(lengths, root=rank_owner)
-        LOGGER.debug(f'crosstalk: Rank {RANK} receives lengths {lengths}')
+        logger.debug(f'crosstalk: Rank {RANK} receives lengths {lengths}')
 
         # broadcast arrays
         if RANK != rank_owner:
@@ -226,9 +226,9 @@ class OpCrosstalk(Operator):
             names = names_int.view(f'S{name_len}')
             data = np.empty((n, n), dtype=np.float64)
         COMM.Bcast(names_int, root=rank_owner)
-        LOGGER.debug(f'crosstalk: Rank {RANK} receives names {names}')
+        logger.debug(f'crosstalk: Rank {RANK} receives names {names}')
         COMM.Bcast(data, root=rank_owner)
-        LOGGER.debug(f'crosstalk: Rank {RANK} receives data {data}')
+        logger.debug(f'crosstalk: Rank {RANK} receives data {data}')
 
         if RANK == rank_owner:
             return crosstalk_matrix
@@ -282,7 +282,7 @@ class OpCrosstalk(Operator):
                 # TODO: should we only check this only `if debug`?
                 detectors_set = set(tod.detectors)
                 if not (names_set & detectors_set):
-                    LOGGER.info(f"Crosstalk: skipping tod {tod} as it does not include detectors from crosstalk matrix with these detectors: {names}.")
+                    logger.info(f"Crosstalk: skipping tod {tod} as it does not include detectors from crosstalk matrix with these detectors: {names}.")
                     continue
                 elif not (names_set <= detectors_set):
                     raise ValueError(f"Crosstalk: tod {tod} only include some detectors from the crosstalk matrix with these detectors: {names}.")
@@ -332,7 +332,7 @@ class OpCrosstalk(Operator):
                 # all ranks need to check this as they need to perform the same action
                 detectors_set = set(tod.detectors)
                 if not (names_set & detectors_set):
-                    LOGGER.info(f"Crosstalk: skipping tod {tod} as it does not include detectors from crosstalk matrix with these detectors: {names}.")
+                    logger.info(f"Crosstalk: skipping tod {tod} as it does not include detectors from crosstalk matrix with these detectors: {names}.")
                     continue
                 elif not (names_set <= detectors_set):
                     raise ValueError(f"Crosstalk: tod {tod} only include some detectors from the crosstalk matrix with these detectors: {names}.")
@@ -375,7 +375,7 @@ class OpCrosstalk(Operator):
                 del global_has_det, i, j
                 tod.cache.destroy(f"{crosstalk_name}_global_has_det_{rank}")
 
-                LOGGER.debug(f'Rank {rank} has detectors LUT: {det_lut}')
+                logger.debug(f'Rank {rank} has detectors LUT: {det_lut}')
 
                 if debug:
                     for name in local_crosstalk_dets_set:

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -68,9 +68,9 @@ from ..op import Operator
 from ..utils import Logger
 
 if TYPE_CHECKING:
-    from typing import List, Union  # Optional
+    from typing import List, Union, Optional
 
-    # from .mpi import Comm
+    from .mpi import Comm
     from .dist import Data
 
 
@@ -259,10 +259,9 @@ class OpCrosstalk(Operator):
         self.name = name
         self.debug = debug
 
-        # py37+
-        # self.world_comm: Optional[Comm]
-        # self.world_procs: int
-        # self.world_rank: int
+        self.world_comm: 'Optional[Comm]'
+        self.world_procs: 'int'
+        self.world_rank: 'int'
         self.world_comm, self.world_procs, self.world_rank = get_world()
 
     @property

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -3,16 +3,23 @@
 
 """Simulate crosstalk between detectors in ToD.
 
-A typical use of this is that in your pipeline script, add
+A typical use of this is that in your pipeline script,
 
-1. `add_crosstalk_args(parser)` to your argparse parser to add cli args,
-2. Read & create `op_crosstalk`:
+1. Add `add_crosstalk_args(parser)` to your argparse parser to add cli args,
+2. Read & create `op_crosstalk` by adding
+
+
+    .. highlight:: python
+    .. code-block:: python
 
         if args.crosstalk_matrix is not None:
             op_crosstalk = OpCrosstalk.read(args)
 
-3. Apply the crosstalk matrix to your data after the ToD is prepared (e.g. signal & noise):
+3. Apply the crosstalk matrix to your data after the ToD is prepared (e.g. signal & noise) by adding
 
+
+    .. highlight:: python
+    .. code-block:: python
 
         if args.crosstalk_matrix is not None:
             if comm.comm_world is not None:
@@ -22,7 +29,9 @@ A typical use of this is that in your pipeline script, add
                 comm.comm_world.barrier()
 
 Note that you need to create your crosstalk matri(x|ces)
-in HDF5 container(s) beforehand. With the simple conventions that
+in HDF5 container(s) beforehand. A simple class `SimpleCrosstalkMatrix`
+can assist you to write such file,
+with the simple conventions that
 it has the following datasets:
 
 1. names: ASCII names of your detectors, say of length ``n``
@@ -32,9 +41,12 @@ it has the following datasets:
 
     (Assuming row-major as is standard in Python.)
 
-Note that each crosstalk matrix has no assumption (i.e. they are dense),
+Note that each crosstalk matrix is dense,
 and when multiple matrices are supplied, they are effectively block-diagonal
-(where each dense matrix given in the form of a HDF5 file forms a block.)
+(where each given dense matrix is a block.)
+I.e. in order to provide a block-diagonal crosstalk matrix,
+each block (together with the names of the detectors in that block)
+should write to a seperate HDF5 file to avoid unnessary computation.
 """
 
 import argparse
@@ -203,11 +215,9 @@ class SimpleCrosstalkMatrix:
 class OpCrosstalk(Operator):
     """Operator that apply crosstalk matrix to detector ToDs.
 
-    : param n_crosstalk_matrices: total no. of crosstalk matrices
-    : param crosstalk_matrices: the crosstalk matrices.
-        In MPI case, this holds only those matrices owned by a rank
-        dictate by the condition `i % PROCS == RANK`
-    : param name: this name is used to save data in tod.cache, so better be unique from other cache
+    :param n_crosstalk_matrices: total no. of crosstalk matrices
+    :param crosstalk_matrices: the crosstalk matrices. In MPI case, this holds only those matrices owned by a rank dictate by the condition `i % PROCS == RANK`
+    :param name: this name is used to save data in tod.cache, so better be unique from other cache
 
     In a typical scenario, the classmethod `read` is used to create an object instead of initiating directly.
     """

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -52,6 +52,7 @@ else:
 
 
 def add_crosstalk_args(parser: 'argparse.ArgumentParser'):
+    """Add crosstalk args to argparse.ArgumentParser object."""
     parser.add_argument(
         "--crosstalk-matrix",
         type=Path,

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -86,7 +86,7 @@ def _fma(
     weights: 'np.ndarray[np.float64]',
     *arrays: 'np.ndarray[np.float64]',
 ):
-    """Simple FMA, compiled to avoid Python memory implications.
+    """Simple fused multiply–add, compiled to avoid Python memory implications.
 
     :param out: must be zero array in the same shape of each in `arrays`
 

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -312,7 +312,7 @@ class OpCrosstalk(Operator):
 
         """
         gt = GlobalTimers.get()
-        gt.start(f"OpCrosstalk_read")
+        gt.start("OpCrosstalk_read")
 
         _, world_procs, world_rank = get_world()
 
@@ -325,7 +325,7 @@ class OpCrosstalk(Operator):
             for i in range(world_rank, N, world_procs)
         ]
 
-        gt.stop(f"OpCrosstalk_read")
+        gt.stop("OpCrosstalk_read")
 
         return cls(N, crosstalk_matrices, name=name)
 
@@ -583,10 +583,10 @@ class OpCrosstalk(Operator):
 
         """
         gt = GlobalTimers.get()
-        gt.start(f"OpCrosstalk_exec")
+        gt.start("OpCrosstalk_exec")
         (
             self._exec_serial(data, signal_name)
         ) if self.is_serial else (
             self._exec_mpi(data, signal_name)
         )
-        gt.stop(f"OpCrosstalk_exec")
+        gt.stop("OpCrosstalk_exec")

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -113,7 +113,6 @@ def add_crosstalk_args(parser: 'argparse.ArgumentParser'):
     )
     parser.add_argument(
         "--crosstalk-matrix-debug",
-        type=bool,
         action='store_true',
         required=False,
         help="if specified, perform more checks and emit more messages. "

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -70,10 +70,11 @@ from ..utils import Logger
 if TYPE_CHECKING:
     from typing import List, Union  # Optional
 
-    import toast
+    from .mpi import Comm
+    from .dist import Data
 
 # py37+
-# world_comm: Optional[toast.mpi.Comm]
+# world_comm: Optional[Comm]
 # PROCS: int
 # RANK: int
 world_comm, PROCS, RANK = get_world()
@@ -358,7 +359,7 @@ class OpCrosstalk(Operator):
 
     def _exec_serial(
         self,
-        data: 'toast.dist.Data',
+        data: 'Data',
         signal_name: 'str',
     ):
         """Apply crosstalk matrix on ToD in data serially."""
@@ -417,7 +418,7 @@ class OpCrosstalk(Operator):
 
     def _exec_mpi(
         self,
-        data: 'toast.dist.Data',
+        data: 'Data',
         signal_name: 'str',
     ):
         """Apply crosstalk matrix on ToD in data with MPI."""
@@ -574,7 +575,7 @@ class OpCrosstalk(Operator):
 
     def exec(
         self,
-        data: 'toast.dist.Data',
+        data: 'Data',
         signal_name: 'str',
     ):
         """Apply crosstalk matrix on ToD in data.

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -73,8 +73,6 @@ if TYPE_CHECKING:
     # from .mpi import Comm
     from .dist import Data
 
-logger = Logger.get()
-
 
 def _fma(
     out: 'np.ndarray[np.float64]',
@@ -94,7 +92,7 @@ def _fma(
 
 
 if jit is None:
-    logger.warning(
+    Logger.get().warning(
         'Numba not present. '
         '_fma in crosstalk will have more intermediate Numpy array objects '
         'created that uses more memory.'
@@ -275,6 +273,7 @@ class OpCrosstalk(Operator):
         """Get the i-th crosstalk matrix, used this with MPI only.
         """
         debug = self.debug
+        logger = Logger.get()
 
         rank_owner = i % self.world_procs
         # index of the i-th matrix in the local rank
@@ -354,6 +353,7 @@ class OpCrosstalk(Operator):
     ):
         """Apply crosstalk matrix on ToD in data serially."""
         crosstalk_name = self.name
+        logger = Logger.get()
 
         # loop over crosstalk matrices
         for crosstalk_matrix in self.crosstalk_matrices:
@@ -414,6 +414,7 @@ class OpCrosstalk(Operator):
         """Apply crosstalk matrix on ToD in data with MPI."""
         debug = self.debug
         crosstalk_name = self.name
+        logger = Logger.get()
 
         # loop over crosstalk matrices
         for idx_crosstalk_matrix in range(self.n_crosstalk_matrices):

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -233,12 +233,19 @@ class OpCrosstalk(Operator):
 
     :param n_crosstalk_matrices: total no. of crosstalk matrices
     :param crosstalk_matrices: the crosstalk matrices.
-        In MPI case, this holds only those matrices owned by a rank dictate
+        In MPI case, this should holds only those matrices owned by a rank dictate
         by the condition `i % world_procs == world_rank`
     :param name: this name is used to save data in tod.cache, so better be unique from other cache
 
     In a typical scenario, the classmethod `read` is used to create an object
-    instead of initiating directly.
+    instead of initiating directly. This classmethod guarantees the condition above holds.
+
+    Note that in the MPI case, the matrices are distributed in the world communicator, while the
+    `exec` method will uses the grid commuicator specified per ToD. This is because at the time
+    of initiating, we have no knowledge on how the data is going to be distributed yet,
+    nor how that is "partitioned" in relation with multiple crosstalk matrix files given.
+    These 2 processes (of finding the crosstalk matrix, and finding the ToD) are orthogonal though
+    so the operator is completely general.
     """
 
     def __init__(

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -279,7 +279,7 @@ class OpCrosstalk(Operator):
             crosstalk_data = crosstalk_matrix.data
             for obs in data.obs:
                 tod = obs["tod"]
-                # TODO: should we only check this only `if debug`?
+
                 detectors_set = set(tod.detectors)
                 if not (names_set & detectors_set):
                     logger.info(f"Crosstalk: skipping tod {tod} as it does not include detectors from crosstalk matrix with these detectors: {names}.")
@@ -328,7 +328,6 @@ class OpCrosstalk(Operator):
                 procs = tod.grid_size[0]
                 rank = tod.grid_ranks[0]
 
-                # TODO: should we only check this only `if debug`?
                 # all ranks need to check this as they need to perform the same action
                 detectors_set = set(tod.detectors)
                 if not (names_set & detectors_set):

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -69,10 +69,10 @@ from ..timing import GlobalTimers
 from ..utils import Logger
 
 if TYPE_CHECKING:
-    from typing import List, Union, Optional
+    from typing import List, Optional, Union
 
-    from .mpi import Comm
     from .dist import Data
+    from .mpi import Comm
 
 
 def _fma(

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -36,6 +36,7 @@ with the simple conventions that
 it has the following datasets:
 
 1. names: ASCII names of your detectors, say of length ``n``
+
 2. data: ``n`` by ``n`` float64 array of your crosstalk matrix ``m``,
 where you expect
 
@@ -71,7 +72,14 @@ if TYPE_CHECKING:
 
 
 def add_crosstalk_args(parser: 'argparse.ArgumentParser'):
-    """Add crosstalk args to argparse.ArgumentParser object."""
+    """Add crosstalk args to argparse.ArgumentParser object.
+
+    Args:
+      parser: 'argparse.ArgumentParser': argparse' argument parser
+
+    Returns:
+        None
+    """
     parser.add_argument(
         "--crosstalk-matrix",
         type=Path,
@@ -84,10 +92,11 @@ def add_crosstalk_args(parser: 'argparse.ArgumentParser'):
 class SimpleCrosstalkMatrix:
     """A thin crosstalk matrix class.
 
-    :param names: detector names.
-    :param data: crosstalk matrix.
-        The length of `names` should match the dimension of `data`,
-        which should be a square array.
+    Args:
+      names: detector names.
+      data: crosstalk matrix.
+    The length of `names` should match the dimension of `data`,
+    which should be a square array.
 
     This is a simple container storing the crosstalk matrix,
     but not generating it.
@@ -126,8 +135,15 @@ class SimpleCrosstalkMatrix:
         return [name.decode() for name in self.names]
 
     @classmethod
-    def load(cls, path: 'Path'):
-        """Load from an HDF5 file."""
+    def load(cls, path: 'Path') -> 'SimpleCrosstalkMatrix':
+        """Load from an HDF5 file.
+
+        Args:
+          path: 'Path': path to an HDF5 file containing the data and names.
+
+        Returns:
+            SimpleCrosstalkMatrix
+        """
         with h5py.File(path, 'r') as f:
             names = f["names"][:]
             data = f["data"][:]
@@ -151,6 +167,12 @@ class SimpleCrosstalkMatrix:
         `libver` will be passed to h5py.File,
         and the rest keyword arguments will be passed to `h5py.File.create_dataset`
         with sensible defaults.
+
+        Args:
+          path: 'Path': output file path.
+
+        Returns:
+            None
         """
         with h5py.File(path, 'w', libver=libver) as f:
             f.create_dataset(
@@ -178,11 +200,12 @@ class SimpleCrosstalkMatrix:
 class OpCrosstalk(Operator):
     """Operator that applies crosstalk matrix to detector ToDs.
 
-    :param n_crosstalk_matrices: total no. of crosstalk matrices
-    :param crosstalk_matrices: the crosstalk matrices.
+    Args:
+      n_crosstalk_matrices: total no. of crosstalk matrices
+      crosstalk_matrices: the crosstalk matrices.
         In MPI case, this should holds only those matrices owned by a rank dictate
         by the condition `i % world_procs == world_rank`
-    :param name: this name is used to save data in tod.cache, so better be unique from other cache
+      name: this name is used to save data in tod.cache, so better be unique from other cache
 
     In a typical scenario, the classmethod `read` is used to create an object
     instead of initiating directly. This classmethod guarantees the condition above holds.
@@ -217,6 +240,12 @@ class OpCrosstalk(Operator):
 
     def _get_crosstalk_matrix(self, i: 'int') -> 'SimpleCrosstalkMatrix':
         """Get the i-th crosstalk matrix, used this with MPI only.
+
+        Args:
+          i: 'int': the i-th crosstalk matrix.
+
+        Returns:
+            SimpleCrosstalkMatrix
         """
         logger = Logger.get()
 
@@ -273,6 +302,14 @@ class OpCrosstalk(Operator):
 
         This holds only those matrices owned by a rank
         dictate by the condition `i % world_procs == world_rank`.
+
+        Args:
+          args: 'argparse.Namespace': namespace object from argparse' parser
+          name: 'str':  (Default value = "crosstalk"): this name is used to
+            save data in tod.cache, so better be unique from other cache
+
+        Returns:
+
         """
         gt = GlobalTimers.get()
         gt.start(f"OpCrosstalk_read")
@@ -536,7 +573,15 @@ class OpCrosstalk(Operator):
     ):
         """Apply crosstalk matrix on ToD in data.
 
-        It is dispatched depending if MPI is used."""
+        It is dispatched depending if MPI is used.
+
+        Args:
+          data: 'Data': the data to be exec on.
+          signal_name: 'str': the name of the signal.
+
+        Returns:
+
+        """
         gt = GlobalTimers.get()
         gt.start(f"OpCrosstalk_exec")
         (

--- a/src/toast/tod/crosstalk.py
+++ b/src/toast/tod/crosstalk.py
@@ -274,6 +274,9 @@ class OpCrosstalk(Operator):
         This holds only those matrices owned by a rank
         dictate by the condition `i % world_procs == world_rank`.
         """
+        gt = GlobalTimers.get()
+        gt.start(f"OpCrosstalk_read")
+
         _, world_procs, world_rank = get_world()
 
         paths = args.crosstalk_matrix
@@ -284,6 +287,8 @@ class OpCrosstalk(Operator):
             SimpleCrosstalkMatrix.load(paths[i])
             for i in range(world_rank, N, world_procs)
         ]
+
+        gt.stop(f"OpCrosstalk_read")
 
         return cls(N, crosstalk_matrices, name=name)
 
@@ -532,8 +537,11 @@ class OpCrosstalk(Operator):
         """Apply crosstalk matrix on ToD in data.
 
         It is dispatched depending if MPI is used."""
+        gt = GlobalTimers.get()
+        gt.start(f"OpCrosstalk_exec")
         (
             self._exec_serial(data, signal_name)
         ) if self.is_serial else (
             self._exec_mpi(data, signal_name)
         )
+        gt.stop(f"OpCrosstalk_exec")

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -36,6 +36,8 @@ from ._libtoast import (
     vfast_erfinv,
 )
 
+from ._libtoast import inplace_weighted_sum
+
 from .mpi import MPI, use_mpi
 
 


### PR DESCRIPTION
@keskitalo, @tskisner, ~~it is still a Work In Progress but welcome any comments to the below both for corrections and additions:~~ It is now ready for 2nd round review, see summary below, and [the diff since 1st round review here](https://github.com/hpc4cmb/toast/pull/380/files/5b3e12e24030bac3cf2835cb3829baf321067133..bbcf03b28e350895bc42e706981e79b86b163073).

# Progress

Commit e742c6e

- Generalized to arbitrary no. of crosstalk matrices (effectively any block diagonal crosstalk matrix where the input matrices are the blocks)
- Add a thin SimpleCrosstalkMatrix class
- Implement the serial case

Commit 5831130

- remove the assumption that `detranks == procs`

Commit cce57c4

- add global timer that reveals performance implication of uncompiled `_fma`

Commit a38d1d6dbcc97001a1ad1c315bb08cf1eecc74c7

- replace _fma by a compiled C++ function `inplace_weighted_sum`

    This not only eliminates Numba as an optional dependency, but also makes it faster:

    - In a test with `n_weights = 68; n_out = 19 * 60 * 60 * 24`, the function is faster by ~30%
    - In a real world test when using the crosstalk operator, this speeds up the matmul by ~10% (which includes MPI communications)

    (performance gain likely due to guaranteed memory alignment in our C++ code)

    Note that we probably need to discuss the naming here. Currently, the module is named `math_fma`, and the function is named `inplace_weighted_sum` to better convey what it is doing. And the doc called it "Vector operation". How should we organize and name these? e.g. it is not vector math like those trigonometric functions. (Previously, `_fma` is private to op_crosstalk so we never thought about that before.)

Commit 483c82e

- remove debug options

Commit dc8938b

- convert to Google style docstring

Commit 48d9091 & 7bf6086

- Following "Developer Guidelines" including formatting and check `is_aligned`. On my local computer, removing the `is_aligned` logic and `simd` altogether does not result in any slow down. I suspect the compiler can automatically apply simd here. The way it is written here is just following the guideline and other examples in the codebase.

# TODO

- [x] tests:
    - [x] tap into the test framework used by TOAST (currently using pytest framework and is passing in my "staging" repo: https://github.com/ickc/python-coscon/actions)
    - [x] investigate why CI is failing (import error). Test is passing locally.
    - [x] add tests to the read method as well? Currently only exec is tested.
    - [x] remove global vars
- [x] resolve some compatibility issues
    - [x] support older versions of Python by turning the type annotations to string: remove `from __future__ import annotations`
    - [x] write a fake numba.jit such that numba is not mandatory (see the `fma` function to see why this is advantageous to avoid "explosion" of intermediate python objects.): handle `from numba import jit`
    - [x] remove the use of Numba
        - Performance implication:
            - command: `mpirun -n 10 ../lb_toast_sim_crosstalk.py	--bands M1-140	--obs-num 1	--obs-time-h 24	--madam	--sample-rate 19	--spin-period-min 20	--prec-angle-deg 45	--spin-angle-deg 50	--prec-period-min 192.348	--nside 256	--coord G	--hwp-rpm 39	--MC-start 0	--MC-count 1	--group-size 10	--input-map $SCRATCH/lb/crosstalk/planck2018_256.fits	--hardware $SCRATCH/lb/crosstalk/order-angle/hardware/AlternateQU.toml.gz	--outdir $SCRATCH/lb/crosstalk/benchmark/AlternateQU/out_crosstalk	--crosstalk-matrix $SCRATCH/lb/crosstalk/order-angle/hardware/AlternateQU_SQUID1.hdf5 $SCRATCH/lb/crosstalk/order-angle/hardware/AlternateQU_SQUID2.hdf5`
            - memory use with or without Numba-jit actually is negligible
            - no crosstalk: 0:27.85s
            - with crosstalk w/ Numba-jit: 0:35.95s
            - with crosstalk w/o Numba-jit: 0:40.30s
            - i.e. removing Numba-jit is a 50% increase in mat-mul in crosstalk
    - [x] remove dataclasses that is supported only in py37+, or consider [dataclasses backport for py36](https://pypi.org/project/dataclasses/)
    - [x] debug handling:
        - [x] add a `--crosstalk-debug` option to control the `exec(..., debug=...)` option?
        - [x] one TODO marked in the code: `TODO: should we only check this only `if debug`?`
        - [x] check LOGGER levels if they are appropriate
        - [x] simplify/remove `--crostalk-matrix-debug`
            - [x] improve `if debug: logger.debug...`. See #411.
            - [x] There's some assert statements only run if debug. Maybe just remove this so that we can remove `--crostalk-matrix-debug` as well.
            - [x] always run `self.__post_init__()`
- [x] docs
    - [x] expand docstrings and adapt the style used in TOAST (currently written in Sphinx style)
    - [x] add some descriptions/into in docs?
    - [x] convert to Google style docstring (watch out for comments within function definition)

            pyment src/toast/tod/crosstalk.py -o google --write --convert
- [x] code style
    - [x] define COMM, ..., LOGGER as global variables
- [x] undo temporary commit on GitHub Actions: 38a8abb
- [ ] refactor
    - [ ] refactor detector LUT construction to toast.Comm? This may help replacing the _serial and _mpi methods into 1. This should be discussed for a future refactoring but not a blocking item of this PR.
    - [x] global var to local, including logger
- [x] simplify/remove global timer introduced in cce57c4. Please comment if changes is necessary on how the global timer is used, added after the 1st review.
