### PR TITLE
Fix benchmark script to work with recent changes

### DIFF
--- a/pipelines/toast_benchmark.py
+++ b/pipelines/toast_benchmark.py
@@ -332,6 +332,8 @@ def job_config(mpicomm, cases):
         apply_gainscrambler = False
         gain_sigma = 0.01
         # Map maker
+        destripe = True
+        no_mapmaker = False
         mapmaker_prefix = "toast"
         mapmaker_mask = None
         mapmaker_weightmap = None


### PR DESCRIPTION
The recent merge of the observation matrix work made an update to the mapmaker pipeline_tools package.  The benchmark script pre-creates the args namespace with hardcoded options, and some args members were missing that are now required.  This small PR gets the benchmark script running again.

@nestordemeure can you test that this change fixes your runs at NERSC?