### PR TITLE
Updates to CI Tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,39 +33,6 @@ jobs:
       - name: Upload to PyPI
         run: |
           python -m twine upload dist/toast*.tar.gz
-  wheels-36:
-    name: Python 3.6 wheels for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    env:
-      CIBW_BUILD: cp36-macosx_x86_64 cp36-manylinux_x86_64
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-      CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-      CIBW_BUILD_VERBOSITY: 3
-      CIBW_ENVIRONMENT_LINUX: "PATH=/usr/lib64/mpich-3.2/bin:${PATH} TOAST_BUILD_BLAS_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_LAPACK_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_CMAKE_VERBOSE_MAKEFILE=ON"
-      CIBW_ENVIRONMENT_MACOS:
-      CIBW_BEFORE_BUILD_LINUX: ./wheels/install_deps_linux.sh
-      CIBW_BEFORE_BUILD_MACOS: ./wheels/install_deps_osx.sh
-      CIBW_BEFORE_TEST: pip3 install numpy && pip3 install mpi4py
-      CIBW_TEST_COMMAND: export OMP_NUM_THREADS=2; python -c 'import toast.tests; toast.tests.run()'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install twine cibuildwheel==1.6.3
-      - name: Build wheel
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-      - name: Upload to PyPI
-        run: |
-          python -m twine upload wheelhouse/toast*.whl
   wheels-37:
     name: Python 3.7 wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -132,3 +99,36 @@ jobs:
       - name: Upload to PyPI
         run: |
           python -m twine upload wheelhouse/toast*.whl
+  # wheels-39:
+  #   name: Python 3.9 wheels for ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #   env:
+  #     CIBW_BUILD: cp39-macosx_x86_64 cp39-manylinux_x86_64
+  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2010
+  #     CIBW_BUILD_VERBOSITY: 3
+  #     CIBW_ENVIRONMENT_LINUX: "PATH=/usr/lib64/mpich-3.2/bin:${PATH} TOAST_BUILD_BLAS_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_LAPACK_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_CMAKE_VERBOSE_MAKEFILE=ON"
+  #     CIBW_ENVIRONMENT_MACOS:
+  #     CIBW_BEFORE_BUILD_LINUX: ./wheels/install_deps_linux.sh
+  #     CIBW_BEFORE_BUILD_MACOS: ./wheels/install_deps_osx.sh
+  #     CIBW_BEFORE_TEST: pip3 install numpy && pip3 install mpi4py
+  #     CIBW_TEST_COMMAND: export OMP_NUM_THREADS=2; python -c 'import toast.tests; toast.tests.run()'
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.7'
+  #     - name: Install cibuildwheel
+  #       run: |
+  #         python -m pip install twine cibuildwheel==1.6.3
+  #     - name: Build wheel
+  #       run: |
+  #         python -m cibuildwheel --output-dir wheelhouse
+  #     - name: Upload to PyPI
+  #       run: |
+  #         python -m twine upload wheelhouse/toast*.whl

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,31 +4,14 @@ name:  Run Test Suite
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - toast3
 
 jobs:
-  py36:
-    name: Python 3.6
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.4.0
-        with:
-          access_token: ${{ github.token }}
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Pull Dependency Image
-        run: docker pull hpc4cmb/toast-deps-py36:latest
-      - name: Compile
-        run: docker run -v "$(pwd)":/home/toast --name="test_py36" hpc4cmb/toast-deps-py36:latest /home/toast/platforms/install_test_runner.sh && docker commit -m "test runner" test_py36 test_runner:py36
-      - name: Test Documentation Build
-        run: docker run -v "$(pwd)":/home/toast test_runner:py36 /home/toast/docs/build_docs.sh
-      - name: Run Serial Tests
-        run: docker run -e MPI_DISABLE=1 test_runner:py36 python -c 'import toast.tests; toast.tests.run()'
-      - name: Run MPI Tests
-        run: docker run test_runner:py36 mpirun -np 2 python -c 'import toast.tests; toast.tests.run()'
   py37:
     name: Python 3.7
     runs-on: ubuntu-latest
@@ -43,8 +26,8 @@ jobs:
         run: docker pull hpc4cmb/toast-deps-py37:latest
       - name: Compile
         run: docker run -v "$(pwd)":/home/toast --name="test_py37" hpc4cmb/toast-deps-py37:latest /home/toast/platforms/install_test_runner.sh && docker commit -m "test runner" test_py37 test_runner:py37
-      - name: Test Documentation Build
-        run: docker run -v "$(pwd)":/home/toast test_runner:py37 /home/toast/docs/build_docs.sh
+      # - name: Test Documentation Build
+      #   run: docker run -v "$(pwd)":/home/toast test_runner:py37 /home/toast/docs/build_docs.sh
       - name: Run Serial Tests
         run: docker run -e MPI_DISABLE=1 test_runner:py37 python -c 'import toast.tests; toast.tests.run()'
       - name: Run MPI Tests
@@ -63,9 +46,29 @@ jobs:
         run: docker pull hpc4cmb/toast-deps-py38:latest
       - name: Compile
         run: docker run -v "$(pwd)":/home/toast --name="test_py38" hpc4cmb/toast-deps-py38:latest /home/toast/platforms/install_test_runner.sh && docker commit -m "test runner" test_py38 test_runner:py38
-      - name: Test Documentation Build
-        run: docker run -v "$(pwd)":/home/toast test_runner:py38 /home/toast/docs/build_docs.sh
+      # - name: Test Documentation Build
+      #   run: docker run -v "$(pwd)":/home/toast test_runner:py38 /home/toast/docs/build_docs.sh
       - name: Run Serial Tests
         run: docker run -e MPI_DISABLE=1 test_runner:py38 python -c 'import toast.tests; toast.tests.run()'
       - name: Run MPI Tests
         run: docker run test_runner:py38 mpirun -np 2 python -c 'import toast.tests; toast.tests.run()'
+  # py39:
+  #   name: Python 3.9
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Cancel Previous Runs
+  #       uses: styfle/cancel-workflow-action@0.4.0
+  #       with:
+  #         access_token: ${{ github.token }}
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - name: Pull Dependency Image
+  #       run: docker pull hpc4cmb/toast-deps-py39:latest
+  #     - name: Compile
+  #       run: docker run -v "$(pwd)":/home/toast --name="test_py39" hpc4cmb/toast-deps-py39:latest /home/toast/platforms/install_test_runner.sh && docker commit -m "test runner" test_py39 test_runner:py39
+  #     - name: Test Documentation Build
+  #       run: docker run -v "$(pwd)":/home/toast test_runner:py39 /home/toast/docs/build_docs.sh
+  #     - name: Run Serial Tests
+  #       run: docker run -e MPI_DISABLE=1 test_runner:py39 python -c 'import toast.tests; toast.tests.run()'
+  #     - name: Run MPI Tests
+  #       run: docker run test_runner:py39 mpirun -np 2 python -c 'import toast.tests; toast.tests.run()'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,40 +30,6 @@ jobs:
         with:
           name: sdist
           path: ./dist/toast*.gz
-  wheels-py36:
-    name: Python 3.6 wheels for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    env:
-      CIBW_BUILD: cp36-macosx_x86_64 cp36-manylinux_x86_64
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
-      CIBW_MANYLINUX_I686_IMAGE: manylinux2010
-      CIBW_BUILD_VERBOSITY: 3
-      CIBW_ENVIRONMENT_LINUX: "PATH=/usr/lib64/mpich-3.2/bin:${PATH} TOAST_BUILD_BLAS_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_LAPACK_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_CMAKE_VERBOSE_MAKEFILE=ON"
-      CIBW_ENVIRONMENT_MACOS:
-      CIBW_BEFORE_BUILD_LINUX: ./wheels/install_deps_linux.sh
-      CIBW_BEFORE_BUILD_MACOS: ./wheels/install_deps_osx.sh
-      CIBW_BEFORE_TEST: pip3 install numpy && pip3 install mpi4py
-      CIBW_TEST_COMMAND: export OMP_NUM_THREADS=2; python -c 'import toast.tests; toast.tests.run()'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.7'
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==1.6.3
-      - name: Build wheel
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse/toast*.whl
   wheels-py37:
     name: Python 3.7 wheels for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -132,3 +98,37 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse/toast*.whl
+  # wheels-py39:
+  #   name: Python 3.9 wheels for ${{ matrix.os }}
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, macos-latest]
+  #   env:
+  #     CIBW_BUILD: cp39-macosx_x86_64 cp39-manylinux_x86_64
+  #     CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+  #     CIBW_MANYLINUX_I686_IMAGE: manylinux2010
+  #     CIBW_BUILD_VERBOSITY: 3
+  #     CIBW_ENVIRONMENT_LINUX: "PATH=/usr/lib64/mpich-3.2/bin:${PATH} TOAST_BUILD_BLAS_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_LAPACK_LIBRARIES='-lopenblas -fopenmp -lm -lgfortran' TOAST_BUILD_CMAKE_VERBOSE_MAKEFILE=ON"
+  #     CIBW_ENVIRONMENT_MACOS:
+  #     CIBW_BEFORE_BUILD_LINUX: ./wheels/install_deps_linux.sh
+  #     CIBW_BEFORE_BUILD_MACOS: ./wheels/install_deps_osx.sh
+  #     CIBW_BEFORE_TEST: pip3 install numpy && pip3 install mpi4py
+  #     CIBW_TEST_COMMAND: export OMP_NUM_THREADS=2; python -c 'import toast.tests; toast.tests.run()'
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
+  #     - uses: actions/setup-python@v2
+  #       name: Install Python
+  #       with:
+  #         python-version: '3.7'
+  #     - name: Install cibuildwheel
+  #       run: |
+  #         python -m pip install cibuildwheel==1.6.3
+  #     - name: Build wheel
+  #       run: |
+  #         python -m cibuildwheel --output-dir wheelhouse
+  #     - uses: actions/upload-artifact@v2
+  #       with:
+  #         name: wheels
+  #         path: ./wheelhouse/toast*.whl

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,10 +1,11 @@
 cmake>=3.12.0
+tomlkit
 numpy
 scipy
-healpy
+healpy>=1.14.0
 astropy
 h5py
+psutil
 ephem
-tomlkit
 traitlets>=5.0
 pshmem

--- a/platforms/install_test_runner.sh
+++ b/platforms/install_test_runner.sh
@@ -10,6 +10,11 @@ pushd $(dirname $(dirname $0)) >/dev/null 2>&1
 toastdir=$(pwd -P)
 popd >/dev/null 2>&1
 
+# FIXME:  remove this after the next release of cmbenv which includes
+# these packages.
+python3 -m pip install pshmem tomlkit pyyaml
+python3 -m pip install --upgrade traitlets>=5.0
+
 mkdir build
 pushd build >/dev/null 2>&1
 

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,10 @@ conf["install_requires"] = [
     "healpy",
     "ephem",
 ]
-conf["extras_require"] = {"mpi": ["mpi4py>=3.0"]}
+conf["extras_require"] = {
+    "mpi": ["mpi4py>=3.0"],
+    "totalconvolve": ["ducc0"],
+}
 conf["packages"] = find_packages("src")
 conf["package_dir"] = {"": "src"}
 conf["ext_modules"] = ext_modules
@@ -264,9 +267,9 @@ conf["classifiers"] = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -428,13 +428,24 @@ def create_fake_beam_alm(
         beam_map_I = np.vstack([beam_map, empty, empty])
         beam_map_Q = np.vstack([empty, beam_map, empty])
         beam_map_U = np.vstack([empty, empty, beam_map])
-        a_lm = [
-            hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False),
-            hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False),
-            hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False),
-        ]
+        try:
+            a_lm = [
+                hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False),
+                hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False),
+                hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False),
+            ]
+        except TypeError:
+            # older healpy which does not have verbose keyword
+            a_lm = [
+                hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax),
+                hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax),
+                hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax),
+            ]
     else:
         if pol:
             beam_map = np.vstack([beam_map, beam_map, empty])
-        a_lm = hp.map2alm(beam_map, lmax=lmax, mmax=mmax, verbose=False)
+        try:
+            a_lm = hp.map2alm(beam_map, lmax=lmax, mmax=mmax, verbose=False)
+        except TypeError:
+            a_lm = hp.map2alm(beam_map, lmax=lmax, mmax=mmax)
     return a_lm


### PR DESCRIPTION
Some code now requires healpy-1.14.0.  Run unit tests on toast3 branch for now as well as master, since we are actively using PRs against that branch.  Remove python-3.6 tests since we now require 3.7.  We can enable 3.9 tests as soon as upstream cmbenv docker container is built.