### PR TITLE
The detector_pointing trait must be allowed to be None

### DIFF
--- a/src/toast/ops/pointing_healpix.py
+++ b/src/toast/ops/pointing_healpix.py
@@ -57,7 +57,7 @@ class PointingHealpix(Operator):
 
     detector_pointing = Instance(
         klass=Operator,
-        allow_none=False,
+        allow_none=True,
         help="Operator that translates boresight pointing into detector frame",
     )
 
@@ -200,6 +200,9 @@ class PointingHealpix(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         env = Environment.get()
         log = Logger.get()
+
+        if self.detector_pointing is None:
+            raise RuntimeError("The detector_pointing trait must be set")
 
         if self._local_submaps is None and self.create_dist is not None:
             self._local_submaps = np.zeros(self._n_submap, dtype=np.bool)

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -81,6 +81,7 @@ def main():
         toast.ops.DefaultNoiseModel(name="default_model"),
         toast.ops.ScanHealpix(name="scan_map"),
         toast.ops.SimNoise(name="sim_noise"),
+        toast.ops.PointingDetectorSimple(name="det_pointing"),
         toast.ops.PointingHealpix(name="pointing", mode="IQU"),
         toast.ops.BinMap(name="binner", pixel_dist="pix_dist"),
         toast.ops.MapMaker(name="mapmaker"),
@@ -199,6 +200,11 @@ def main():
     # Construct a "perfect" noise model just from the focalplane parameters
 
     ops.default_model.apply(data)
+
+    # Set the pointing matrix operators to use the detector pointing
+
+    ops.pointing.detector_pointing = ops.det_pointing
+    ops.pointing_final.detector_pointing = ops.det_pointing
 
     # Simulate sky signal from a map.  We scan the sky with the "final" pointing model
     # if that is different from the solver pointing model.


### PR DESCRIPTION
This allows the pointing class to be instantiated from config files or command line.  Add detector pointing operator to satellite sim example workflow.