### PR TITLE
Fix a several MPI issues and some typos

### DIFF
--- a/src/toast/job.py
+++ b/src/toast/job.py
@@ -184,7 +184,7 @@ def job_group_size(
             )
         log.info(
             "Job observation lengths = {} minutes / {} minutes (min / max)".format(
-                int(obs_mem[-1] / 60), int(obs_mem[0] / 60)
+                int(obs_len[-1] / 60), int(obs_len[0] / 60)
             )
         )
 

--- a/src/toast/ops/mapmaker_binning.py
+++ b/src/toast/ops/mapmaker_binning.py
@@ -161,7 +161,7 @@ class BinMap(Operator):
                 )
                 log.error(msg)
                 raise RuntimeError(msg)
-            data[self.binned].raw[:] = 0.0
+            data[self.binned].raw[:] = 0
 
         # Noise weighted map.  We output this to the final binned map location,
         # since we will multiply by the covariance in-place.

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -120,8 +120,6 @@ class BuildHitMap(Operator):
                 "Building hit map with pixel_distribution {}".format(self.pixel_dist)
             )
 
-        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
-
         hits = None
         if self.hits in data:
             # We have an existing map from a previous call.  Verify
@@ -554,8 +552,6 @@ class BuildNoiseWeighted(Operator):
 
         zmap = None
         weight_nnz = None
-
-        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
 
         # This operator requires that all detectors in all observations have the same
         # number of non-zeros in the pointing matrix.

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -120,6 +120,8 @@ class BuildHitMap(Operator):
                 "Building hit map with pixel_distribution {}".format(self.pixel_dist)
             )
 
+        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
+
         hits = None
         if self.hits in data:
             # We have an existing map from a previous call.  Verify
@@ -313,6 +315,36 @@ class BuildInverseCovariance(Operator):
         weight_nnz = None
         cov_nnz = None
 
+        # We will store the lower triangle of the covariance.  This operator requires
+        # that all detectors in all observations have the same number of non-zeros
+        # in the pointing matrix.
+
+        if self.inverse_covariance in data:
+            # We have an existing map from a previous call.  Verify
+            # the distribution.
+            if data[self.inverse_covariance].distribution != dist:
+                msg = "Existing inv cov '{}' has different data distribution".format(
+                    self.inverse_covariance
+                )
+                log.error(msg)
+                raise RuntimeError(msg)
+            invcov = data[self.inverse_covariance]
+            cov_nnz = invcov.n_value
+            weight_nnz = int((np.sqrt(1 + 8 * cov_nnz) - 1) // 2)
+        else:
+            # The first global process checks its data shape and broadcasts
+            if data.comm.world_rank == 0:
+                first_detwt = data.obs[0].detdata[self.weights][0]
+                if len(first_detwt.shape) == 1:
+                    weight_nnz = 1
+                else:
+                    weight_nnz = first_detwt.shape[1]
+            if data.comm.comm_world is not None:
+                weight_nnz = data.comm.comm_world.bcast(weight_nnz, root=0)
+            cov_nnz = int(weight_nnz * (weight_nnz + 1) // 2)
+            data[self.inverse_covariance] = PixelData(dist, np.float64, n_value=cov_nnz)
+            invcov = data[self.inverse_covariance]
+
         for ob in data.obs:
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(detectors)
@@ -341,49 +373,18 @@ class BuildInverseCovariance(Operator):
                 for det in dets:
                     # We require that the pointing matrix has the same number of
                     # non-zero elements for every detector and every observation.
-                    # We check that here, and if this is the first observation and
-                    # detector we have worked with we create the PixelData object.
-                    if invcov is None:
-                        # We will store the lower triangle of the covariance.
-                        if len(wview.detector_shape) == 1:
-                            weight_nnz = 1
-                        else:
-                            weight_nnz = wview.detector_shape[1]
-                        cov_nnz = weight_nnz * (weight_nnz + 1) // 2
-                        if self.inverse_covariance in data:
-                            # We have an existing map from a previous call.  Verify
-                            # the distribution and nnz.
-                            if data[self.inverse_covariance].distribution != dist:
-                                msg = "Existing inv cov '{}' has different data distribution".format(
-                                    self.inverse_covariance
-                                )
-                                log.error(msg)
-                                raise RuntimeError(msg)
-                            if data[self.inverse_covariance].n_value != cov_nnz:
-                                msg = "Existing inv cov '{}' has {} nnz, but pointing implies {}".format(
-                                    self.inverse_covariance,
-                                    data[self.inverse_covariance].n_value,
-                                    cov_nnz,
-                                )
-                                log.error(msg)
-                                raise RuntimeError(msg)
-                            invcov = data[self.inverse_covariance]
-                        else:
-                            data[self.inverse_covariance] = PixelData(
-                                dist, np.float64, n_value=cov_nnz
-                            )
-                            invcov = data[self.inverse_covariance]
+                    # We check that here.
+
+                    check_nnz = None
+                    if len(wview.detector_shape) == 1:
+                        check_nnz = 1
                     else:
-                        check_nnz = None
-                        if len(wview.detector_shape) == 1:
-                            check_nnz = 1
-                        else:
-                            check_nnz = wview.detector_shape[1]
-                        if check_nnz != weight_nnz:
-                            msg = "observation '{}', detector '{}', pointing weights '{}' has {} nnz, not {}".format(
-                                ob.name, det, self.weights, check_nnz, weight_nnz
-                            )
-                            raise RuntimeError(msg)
+                        check_nnz = wview.detector_shape[1]
+                    if check_nnz != weight_nnz:
+                        msg = "observation '{}', detector '{}', pointing weights '{}' has {} nnz, not {}".format(
+                            ob.name, det, self.weights, check_nnz, weight_nnz
+                        )
+                        raise RuntimeError(msg)
 
                     # Get local submap and pixels
                     local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
@@ -554,6 +555,35 @@ class BuildNoiseWeighted(Operator):
         zmap = None
         weight_nnz = None
 
+        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
+
+        # This operator requires that all detectors in all observations have the same
+        # number of non-zeros in the pointing matrix.
+
+        if self.zmap in data:
+            # We have an existing map from a previous call.  Verify
+            # the distribution.
+            if data[self.zmap].distribution != dist:
+                msg = "Existing zmap '{}' has different data distribution".format(
+                    self.zmap
+                )
+                log.error(msg)
+                raise RuntimeError(msg)
+            zmap = data[self.zmap]
+            weight_nnz = zmap.n_value
+        else:
+            # The first global process checks its data shape and broadcasts
+            if data.comm.world_rank == 0:
+                first_detwt = data.obs[0].detdata[self.weights][0]
+                if len(first_detwt.shape) == 1:
+                    weight_nnz = 1
+                else:
+                    weight_nnz = first_detwt.shape[1]
+            if data.comm.comm_world is not None:
+                weight_nnz = data.comm.comm_world.bcast(weight_nnz, root=0)
+            data[self.zmap] = PixelData(dist, np.float64, n_value=weight_nnz)
+            zmap = data[self.zmap]
+
         for ob in data.obs:
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(detectors)
@@ -586,46 +616,18 @@ class BuildNoiseWeighted(Operator):
 
                     # We require that the pointing matrix has the same number of
                     # non-zero elements for every detector and every observation.
-                    # We check that here, and if this is the first observation and
-                    # detector we have worked with we create the PixelData object
-                    # if needed.
-                    if zmap is None:
-                        if len(wview.detector_shape) == 1:
-                            weight_nnz = 1
-                        else:
-                            weight_nnz = wview.detector_shape[1]
-                        if self.zmap in data:
-                            # We have an existing map from a previous call.  Verify
-                            # the distribution and nnz.
-                            if data[self.zmap].distribution != dist:
-                                msg = "Existing ZMap '{}' has different data distribution".format(
-                                    self.zmap
-                                )
-                                log.error(msg)
-                                raise RuntimeError(msg)
-                            if data[self.zmap].n_value != weight_nnz:
-                                msg = "Existing ZMap '{}' has {} nnz, but pointing has {}".format(
-                                    self.zmap, data[self.zmap].n_value, weight_nnz
-                                )
-                                log.error(msg)
-                                raise RuntimeError(msg)
-                            zmap = data[self.zmap]
-                        else:
-                            data[self.zmap] = PixelData(
-                                dist, np.float64, n_value=weight_nnz
-                            )
-                            zmap = data[self.zmap]
+                    # We check that here.
+
+                    check_nnz = None
+                    if len(wview.detector_shape) == 1:
+                        check_nnz = 1
                     else:
-                        check_nnz = None
-                        if len(wview.detector_shape) == 1:
-                            check_nnz = 1
-                        else:
-                            check_nnz = wview.detector_shape[1]
-                        if check_nnz != weight_nnz:
-                            msg = "observation {}, detector {}, pointing weights {} has inconsistent number of values".format(
-                                ob.name, det, self.weights
-                            )
-                            raise RuntimeError(msg)
+                        check_nnz = wview.detector_shape[1]
+                    if check_nnz != weight_nnz:
+                        msg = "observation {}, detector {}, pointing weights {} has inconsistent number of values".format(
+                            ob.name, det, self.weights
+                        )
+                        raise RuntimeError(msg)
 
                     # Get local submap and pixels
                     local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
@@ -654,7 +656,6 @@ class BuildNoiseWeighted(Operator):
                         ddata,
                         zmap.raw,
                     )
-                    zm = zmap.raw.array()
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/pipeline.py
+++ b/src/toast/ops/pipeline.py
@@ -97,6 +97,8 @@ class Pipeline(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
 
+        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
+
         acc = self.accelerators()
 
         if "CUDA" in acc:
@@ -161,8 +163,8 @@ class Pipeline(Operator):
 
                     # Run the operators with this full list
                     for op in self.operators:
-                        msg = "Pipeline calling operator '{}' exec() with ALL dets".format(
-                            op.name
+                        msg = "{} Pipeline calling operator '{}' exec() with ALL dets".format(
+                            pstr, op.name
                         )
                         log.verbose(msg)
                         op.exec(ds, detectors=selected_dets)
@@ -190,11 +192,11 @@ class Pipeline(Operator):
                                 selected_dets.append(det)
 
                     for det in selected_dets:
-                        msg = "Pipeline SINGLE detector {}".format(det)
+                        msg = "{} Pipeline SINGLE detector {}".format(pstr, det)
                         log.verbose(msg)
                         for op in self.operators:
-                            msg = "Pipeline   calling operator '{}' exec()".format(
-                                op.name
+                            msg = "{} Pipeline   calling operator '{}' exec()".format(
+                                pstr, op.name
                             )
                             log.verbose(msg)
                             op.exec(ds, detectors=[det])
@@ -207,10 +209,12 @@ class Pipeline(Operator):
                         for det in det_set:
                             if det in detectors:
                                 selected_set.append(det)
-                    msg = "Pipeline detector set {}".format(selected_set)
+                    msg = "{} Pipeline detector set {}".format(pstr, selected_set)
                     log.verbose(msg)
                     for op in self.operators:
-                        msg = "Pipeline   calling operator '{}' exec()".format(op.name)
+                        msg = "{} Pipeline   calling operator '{}' exec()".format(
+                            pstr, op.name
+                        )
                         log.verbose(msg)
                         op.exec(ds, detectors=selected_set)
 
@@ -221,9 +225,10 @@ class Pipeline(Operator):
     def _finalize(self, data, **kwargs):
         log = Logger.get()
         result = list()
+        pstr = f"Proc ({data.comm.world_rank}, {data.comm.group_rank})"
         if self.operators is not None:
             for op in self.operators:
-                msg = "Pipeline calling operator '{}' finalize()".format(op.name)
+                msg = f"{pstr} Pipeline calling operator '{op.name}' finalize()"
                 log.verbose(msg)
                 result.append(op.finalize(data))
         return result

--- a/src/toast/ops/pointing_detector.py
+++ b/src/toast/ops/pointing_detector.py
@@ -169,7 +169,7 @@ class PointingDetectorSimple(Operator):
                     # In such cases, the detector quaternion can depend on
                     # time and the observing direction and a custom detector
                     # pointing operator needs to be implemented.
-                    detquat = focalplane[det]["quat"]
+                    detquat = np.array(focalplane[det]["quat"], dtype=np.float64)
 
                     # Timestream of detector quaternions
                     quats = qa.mult(boresight, detquat)

--- a/src/toast/ops/pointing_healpix.py
+++ b/src/toast/ops/pointing_healpix.py
@@ -208,10 +208,10 @@ class PointingHealpix(Operator):
             self._local_submaps = np.zeros(self._n_submap, dtype=np.bool)
 
         # Expand detector pointing
-        if self.quats:
+        if self.quats is not None:
             quats_name = self.quats
         else:
-            if self.detector_pointing.quats:
+            if self.detector_pointing.quats is not None:
                 quats_name = self.detector_pointing.quats
             else:
                 quats_name = "quats"

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -96,8 +96,6 @@ class PixelDistribution(object):
             comp = MPI.Comm.Compare(self._comm, other._comm)
             if comp not in (MPI.IDENT, MPI.CONGRUENT):
                 local_eq = False
-        if self._comm is not None:
-            local_eq = self._comm.allreduce(local_eq, op=MPI.LAND)
         return local_eq
 
     def __ne__(self, other):

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -76,6 +76,8 @@ def main():
     #
     # We can also set some default values here for the traits.
 
+    madam_available = toast.ops.madam.available()
+
     operators = [
         toast.ops.SimSatellite(name="sim_satellite"),
         toast.ops.DefaultNoiseModel(name="default_model"),
@@ -89,8 +91,9 @@ def main():
         toast.ops.BinMap(
             name="binner_final", enabled=False, pixel_dist="pix_dist_final"
         ),
-        toast.ops.Madam(name="madam", enabled=False),
     ]
+    if madam_available:
+        operators.append(toast.ops.Madam(name="madam", enabled=False))
 
     # Templates we want to configure from the command line or a parameter file.
 
@@ -161,7 +164,7 @@ def main():
     # requires full pointing) is enabled.
 
     full_pointing = False
-    if ops.madam.enabled:
+    if madam_available and ops.madam.enabled:
         full_pointing = True
     if ops.binner.full_pointing:
         full_pointing = True
@@ -222,7 +225,7 @@ def main():
             pix_dist.pointing = ops.pointing
             pix_dist.shared_flags = ops.binner.shared_flags
             pix_dist.shared_flag_mask = ops.binner.shared_flag_mask
-            pix_dist.save_pointing = ops.binner.full_pointing
+            pix_dist.save_pointing = full_pointing
         pix_dist.apply(data)
 
         ops.scan_map.pixel_dist = pix_dist.pixel_dist
@@ -273,7 +276,7 @@ def main():
             toast.pixels_io.write_healpix_fits(data[dkey], file, nest=ops.pointing.nest)
 
     # Run Madam
-    if ops.madam.enabled:
+    if madam_available and ops.madam.enabled:
         ops.madam.apply(data)
 
 


### PR DESCRIPTION
- Removing stale debugging barrier() inside the Pipeline operator

- In the mapmaker utils, do the check of existing map domain objects
  before looping over observations, so that processes with different
  numbers of detectors still participate in communication

- In equality test of a PixelDistribution, do not use blocking
  communication.

- In the satellite workflow, do not attempt to use madam unless it
  is available.