### PR TITLE
Function timing improvements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,8 @@ conf["entry_points"] = {
         "toast_fake_focalplane = toast.scripts.toast_fake_focalplane:main",
         "toast_ground_schedule = toast.scripts.toast_ground_schedule:main",
         "toast_satellite_schedule = toast.scripts.toast_satellite_schedule:main",
-        "toast_benchmark = toast.scripts.toast_benchmark:main",
+        "toast_benchmark_satellite = toast.scripts.toast_benchmark_satellite:main",
+        "toast_timing_plot = toast.scripts.toast_timing_plot:main",
     ]
 }
 conf["cmdclass"] = {"build_ext": CMakeBuild}

--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -3,6 +3,7 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 
+from toast.timing import function_timer_stackskip
 from ..utils import Logger
 
 from ..traits import TraitConfig
@@ -22,6 +23,7 @@ class Operator(TraitConfig):
     def _exec(self, data, detectors=None, **kwargs):
         raise NotImplementedError("Fell through to Operator base class")
 
+    @function_timer_stackskip
     def exec(self, data, detectors=None, **kwargs):
         """Perform operations on a Data object.
 
@@ -42,6 +44,7 @@ class Operator(TraitConfig):
     def _finalize(self, data, **kwargs):
         raise NotImplementedError("Fell through to Operator base class")
 
+    @function_timer_stackskip
     def finalize(self, data, **kwargs):
         """Perform any final operations / communication.
 
@@ -58,6 +61,7 @@ class Operator(TraitConfig):
         """
         return self._finalize(data, **kwargs)
 
+    @function_timer_stackskip
     def apply(self, data, detectors=None, **kwargs):
         """Run exec() and finalize().
 

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -647,9 +647,9 @@ class PixelData(object):
                         loc = dist.global_submap_to_local[glob]
                         sendview[c, :, :] = self.data[loc, :, :]
 
-                gt.start("REAL Allreduce")
+                gt.start("PixelData.sync_allreduce MPI Allreduce")
                 dist.comm.Allreduce(self._all_send, self._all_recv, op=MPI.SUM)
-                gt.stop("REAL Allreduce")
+                gt.stop("PixelData.sync_allreduce MPI Allreduce")
 
                 for c in range(ncomm):
                     glob = submap_off + c
@@ -755,6 +755,7 @@ class PixelData(object):
             None.
 
         """
+        gt = GlobalTimers.get()
         self.setup_alltoallv()
 
         if self._dist.comm is None:
@@ -762,10 +763,12 @@ class PixelData(object):
             return
 
         # Gather owned submaps locally
+        gt.start("PixelData.forward_alltoallv MPI Alltoallv")
         self._dist.comm.Alltoallv(
             [self.raw, self._send_counts, self._send_displ, self.mpitype],
             [self.receive, self._recv_counts, self._recv_displ, self.mpitype],
         )
+        gt.stop("PixelData.forward_alltoallv MPI Alltoallv")
         return
 
     @function_timer
@@ -776,6 +779,7 @@ class PixelData(object):
             None.
 
         """
+        gt = GlobalTimers.get()
         if self._dist.comm is None:
             # No communication needed
             return
@@ -785,10 +789,12 @@ class PixelData(object):
             )
 
         # Scatter result back
+        gt.start("PixelData.reverse_alltoallv MPI Alltoallv")
         self._dist.comm.Alltoallv(
             [self.receive, self._recv_counts, self._recv_displ, self.mpitype],
             [self.raw, self._send_counts, self._send_displ, self.mpitype],
         )
+        gt.stop("PixelData.reverse_alltoallv MPI Alltoallv")
         return
 
     @function_timer

--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -7,5 +7,6 @@ install(PROGRAMS
     toast_ground_schedule
     toast_satellite_schedule
     toast_benchmark_satellite
+    toast_timing_plot
     DESTINATION bin
 )

--- a/src/toast/scripts/toast_benchmark_satellite
+++ b/src/toast/scripts/toast_benchmark_satellite
@@ -29,6 +29,7 @@ from toast.timing import gather_timers, dump
 from toast.instrument_sim import fake_hexagon_focalplane
 from toast.schedule_sim_satellite import create_satellite_schedule
 
+
 def parse_arguments():
     """
     Defines and parses the arguments for the script.
@@ -494,14 +495,16 @@ def main():
     compute_science_metric(args, global_timer, n_nodes, rank, log)
 
     # dumps all the timing information
-    timer = toast.timing.GlobalTimers.get()
-    timer.start("toast_benchmark_satellite (gathering and dumping timing info)")
+    timer = toast.timing.Timer()
+    timer.start()
     alltimers = gather_timers(comm=world_comm)
     if comm.world_rank == 0:
         out = os.path.join(args.out_dir, "timing")
         dump(alltimers, out)
-        timer.stop("toast_benchmark_satellite (gathering and dumping timing info)")
-        timer.report()
+        timer.stop()
+        timer.report("toast_benchmark_satellite (gathering and dumping timing info)")
+    else:
+        timer.stop()
 
 if __name__ == "__main__":
     try:

--- a/src/toast/scripts/toast_timing_plot
+++ b/src/toast/scripts/toast_timing_plot
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""Plot global timing results
+"""
+
+from pprint import PrettyPrinter
+import sys
+import argparse
+import re
+
+import csv
+
+import numpy as np
+
+import pandas as pd
+
+import plotly.express as px
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Plot a timing dump.")
+
+    parser.add_argument(
+        "--file",
+        required=True,
+        help="Name of input CSV file",
+    )
+
+    parser.add_argument(
+        "--out",
+        required=False,
+        default="timing.pdf",
+        help="Name of output file",
+    )
+
+    args = parser.parse_args()
+
+    print(f"Reading input timing from {args.file}")
+
+    raw = list()
+    values = list()
+
+    n_column = 0
+    n_rows = 0
+
+    with open(args.file, "r") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            name = row[0]
+            mat = re.match(r"\(function\) (.*)", name)
+            if mat is not None:
+                # this is a function timer
+                trace = mat.group(1)
+                med = float(row[7])
+                levels = trace.split("|")
+                raw.append(levels)
+                values.append(med)
+                n_column = max(n_column, len(levels))
+                n_rows += 1
+
+    lnames = [f"level{x}" for x in range(n_column)]
+    data = list()
+
+    for row, val in zip(raw, values):
+        n_cols = len(row)
+        rlist = list()
+        for i in range(n_cols):
+            rlist.append(row[i])
+        if n_cols < n_column:
+            rlist.append("Other")
+            for i in range(n_cols + 1, n_column):
+                rlist.append(None)
+        rlist.append(val)
+        data.append(rlist)
+
+    cnames = list(lnames)
+    cnames.append("value")
+    df = pd.DataFrame(data=data, columns=cnames)
+
+    fig = px.sunburst(
+        data_frame=df,
+        path=lnames,
+        values="value",
+        title="TOAST Timing",
+        height=700,
+        template="plotly",
+        branchvalues="total",
+    )
+    fig.write_image(args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/toast/templates/template.py
+++ b/src/toast/templates/template.py
@@ -6,6 +6,8 @@ import numpy as np
 
 import traitlets
 
+from toast.timing import function_timer_stackskip
+
 from ..utils import Logger
 
 from ..traits import TraitConfig, Instance, Unicode, Int
@@ -113,6 +115,7 @@ class Template(TraitConfig):
     def _add_to_signal(self, detector, amplitudes):
         raise NotImplementedError("Derived class must implement _add_to_signal()")
 
+    @function_timer_stackskip
     def add_to_signal(self, detector, amplitudes):
         """Accumulate the projected amplitudes to a timestream.
 
@@ -138,6 +141,7 @@ class Template(TraitConfig):
     def _project_signal(self, detector, amplitudes):
         raise NotImplementedError("Derived class must implement _project_signal()")
 
+    @function_timer_stackskip
     def project_signal(self, detector, amplitudes):
         """Project a timestream into template amplitudes.
 
@@ -164,6 +168,7 @@ class Template(TraitConfig):
         # Not all Templates implement the prior
         return
 
+    @function_timer_stackskip
     def add_prior(self, amplitudes_in, amplitudes_out):
         """Apply the inverse amplitude covariance as a prior.
 
@@ -187,6 +192,7 @@ class Template(TraitConfig):
     def _apply_precond(self, amplitudes_in, amplitudes_out):
         raise NotImplementedError("Derived class must implement _apply_precond()")
 
+    @function_timer_stackskip
     def apply_precond(self, amplitudes_in, amplitudes_out):
         """Apply the template preconditioner.
 

--- a/src/toast/timing.py
+++ b/src/toast/timing.py
@@ -22,26 +22,25 @@ from .utils import Environment
 
 stack_toast_file_pat = re.compile(r".*(toast.*)\.py")
 
-stack_toast_skip = [
+# Global list of functions to ignore in our simplified timing stacktrace.
+# This can be updated by decorating functions with the function_timer_stackskip
+# below.
+
+stack_toast_skip = {
     "df",
     "<module>",
-    "apply",
-    "exec",
-    "add_to_signal",
-    "project_signal",
-    "add_prior",
-    "apply_precond",
-]
+}
 
 
 def function_timer(f):
     env = Environment.get()
     ft = env.function_timers()
     if ft:
-        nm = f"{f.__qualname__}"
+        fname = f"{f.__qualname__}"
 
         @wraps(f)
         def df(*args, **kwargs):
+            global stack_toast_skip
             gt = GlobalTimers.get()
             # Build a name from the current function and the call trace.
             tnm = "(function) "
@@ -51,15 +50,22 @@ def function_timer(f):
                 mat = stack_toast_file_pat.match(frm.f_code.co_filename)
                 if mat is not None:
                     # This is a stack frame that we care about
-                    if frm.f_code.co_name not in stack_toast_skip:
-                        funcname = None
-                        if "self" in frm.f_locals:
-                            # this is inside a class instance
-                            funcname = f"{frm.f_locals['self'].__class__.__name__}.{frm.f_code.co_name}"
-                        else:
-                            # this is just a function call
-                            funcname = frm.f_code.co_name
-                        fnmlist.append(funcname)
+                    if "self" in frm.f_locals:
+                        # this is inside a class instance
+                        funcname = f"{frm.f_locals['self'].__class__.__name__}.{frm.f_code.co_name}"
+                        if funcname not in stack_toast_skip:
+                            found = False
+                            for base in frm.f_locals["self"].__class__.__bases__:
+                                basename = f"{base.__name__}.{frm.f_code.co_name}"
+                                if basename in stack_toast_skip:
+                                    found = True
+                                    break
+                            if not found:
+                                fnmlist.append(funcname)
+                    else:
+                        # this is just a function call
+                        if frm.f_code.co_name not in stack_toast_skip:
+                            fnmlist.append(frm.f_code.co_name)
                 frm = frm.f_back
 
             if len(fnmlist) > 0:
@@ -68,11 +74,37 @@ def function_timer(f):
 
             # Make sure the final frame handle is released
             del frm
-            tnm += nm
+            tnm += fname
             gt.start(tnm)
             result = f(*args, **kwargs)
             gt.stop(tnm)
             return result
+
+    else:
+
+        @wraps(f)
+        def df(*args, **kwargs):
+            return f(*args, **kwargs)
+
+    return df
+
+
+def function_timer_stackskip(f):
+    env = Environment.get()
+    ft = env.function_timers()
+    if ft:
+
+        @wraps(f)
+        def df(*args, **kwargs):
+            global stack_toast_skip
+            funcname = None
+            if inspect.ismethod(f):
+                funcname = f.__self__.__name__
+            else:
+                funcname = f.__qualname__
+            if funcname not in stack_toast_skip:
+                stack_toast_skip.add(funcname)
+            return f(*args, **kwargs)
 
     else:
 

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -279,6 +279,11 @@ def main():
     if madam_available and ops.madam.enabled:
         ops.madam.apply(data)
 
+    alltimers = toast.timing.gather_timers(comm=comm.comm_world)
+    if comm.world_rank == 0:
+        out = os.path.join(args.out_dir, "timing")
+        toast.timing.dump(alltimers, out)
+
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
The timers used in toast are designed to provide a built-in, "mid-level" view of the overall runtime of different pieces of the code.  They are used around functions and blocks of code which do a non-trivial amount of work, since starting and stopping these timers introduces a small amount of overhead.  The idea is to quickly give a global picture of a workflow's performance in order to know where to focus performance tuning effort using dedicated profiling tools.

Our current function_timer decorator simply gets the wrapped function's name and uses that for the global timer name.  However, this does not distinguish between the same function being called through a different call trace.  A full call trace is too verbose for the intended purpose of these timers, but it would be useful to group calls to a low-level function based on the call trace.

This work adds a "simplified" call trace to the timer name that:
- Cuts any stack frames not in the toast package
- Cuts out base-class wrapper functions (e.g. Operator.exec(), Template.add_prior(), etc)
- Includes just the function or class.method names (no source file or line numbers)

There is also a simple plotting script that can read a dumped CSV file and make a sunburst plot.

Some notes:
- Apparently enabling function timers with `Environment.enable_function_timers()` does not work.  We can figure that out at some point.  For now, they can be enabled with (for example) `TOAST_FUNCTIME=1 toast_benchmark_satellite --case tiny`.
- The plotting script uses pandas and plotly, but I don't think we want to make those package dependencies for all of toast.  We can add them to the cmbenv stack, but for people running on their local machines they can pip / conda install them if they want to use the script.

Here are some examples from running the tiny benchmark case on my laptop:
```
$>  cat toast_benchmark_satellite_out/timing.csv 
Timer,Processes,Minimum Calls,Maximum Calls,Minimum Time,Maximum Time,Mean Time,Median Time
(function) BuildPixelDistribution._exec,1,1,1,0.128526919,0.128526919,0.128526919,0.128526919
(function) BuildPixelDistribution._exec|Pipeline._exec|PointingHealpix._exec,1,2,2,0.120071915,0.120071915,0.120071915,0.120071915
(function) BuildPixelDistribution._exec|Pipeline._exec|PointingHealpix._exec|PointingDetectorSimple._exec,1,2,2,0.011679545999999999,0
.011679545999999999,0.011679545999999999,0.011679545999999999
(function) MapMaker._exec,1,1,1,16.514301034,16.514301034,16.514301034,16.514301034
(function) MapMaker._exec|BinMap._exec,1,1,1,1.285735414,1.285735414,1.285735414,1.285735414
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|BuildNoiseWeighted._exec,1,2,2,0.126040968,0.126040968,0.126040968,0.126040968
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|BuildNoiseWeighted._exec|PixelDistribution.global_pixel_to_submap,1,2,2,0.006473
804,0.006473804,0.006473804,0.006473804
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|Pipeline._exec|TemplateMatrix._exec,1,2,2,0.001856417,0.001856417,0.001856417,0.
001856417
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|Pipeline._exec|TemplateMatrix._exec|Offset._add_to_signal,1,2,2,0.00054239,0.000
54239,0.00054239,0.00054239
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|PointingHealpix._exec,1,2,2,0.137313905,0.137313905,0.137313905,0.137313905
(function) MapMaker._exec|BinMap._exec|Pipeline._exec|PointingHealpix._exec|PointingDetectorSimple._exec,1,2,2,0.013350357,0.013350357
,0.013350357,0.013350357
...
```

```
$>  toast_timing_plot --file toast_benchmark_satellite_out/timing.csv 
Reading input timing from toast_benchmark_satellite_out/timing.csv
(output saved to timing.pdf, see attached plot)
```
[timing.pdf](https://github.com/hpc4cmb/toast/files/6480270/timing.pdf)
![timing](https://user-images.githubusercontent.com/84221/118307027-fef16f00-b49e-11eb-825b-63b39fe3f716.jpg)
