### PR TITLE
Toast3 simplify

### DIFF
--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -2,6 +2,8 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import os
+
 import traitlets
 
 import numpy as np
@@ -230,7 +232,7 @@ class MapMaker(Operator):
 
         # Check map binning
         map_binning = self.map_binning
-        if self.map_binning is None:
+        if self.map_binning is None or not self.map_binning.enabled:
             # Use the same binning used in the solver.
             map_binning = self.binning
 
@@ -653,7 +655,7 @@ class MapMaker(Operator):
             for prod in ["map", "hits", "cov", "rcond"]:
                 dkey = "{}_{}".format(self.name, prod)
                 file = os.path.join(self.output_dir, "{}.fits".format(dkey))
-                write_healpix_fits(data[dkey], file, nest=self.pointing.nest)
+                write_healpix_fits(data[dkey], file, nest=map_binning.pointing.nest)
 
         self._log_info(comm, rank, "  finished output write in", timer=timer)
 

--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -39,7 +39,13 @@ class Operator(TraitConfig):
             None
 
         """
-        self._exec(data, detectors=detectors, **kwargs)
+        log = Logger.get()
+        if self.enabled:
+            self._exec(data, detectors=detectors, **kwargs)
+        else:
+            if data.comm.world_rank == 0:
+                msg = f"Operator {self.name} is disabled, skipping call to exec()"
+                log.debug(msg)
 
     def _finalize(self, data, **kwargs):
         raise NotImplementedError("Fell through to Operator base class")
@@ -59,7 +65,13 @@ class Operator(TraitConfig):
             (value):  None or an Operator-dependent result.
 
         """
-        return self._finalize(data, **kwargs)
+        log = Logger.get()
+        if self.enabled:
+            return self._finalize(data, **kwargs)
+        else:
+            if data.comm.world_rank == 0:
+                msg = f"Operator {self.name} is disabled, skipping call to finalize()"
+                log.debug(msg)
 
     @function_timer_stackskip
     def apply(self, data, detectors=None, **kwargs):

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -20,6 +20,8 @@ from .operator import Operator
 
 from .scan_map import ScanMap
 
+from .pointing import BuildPixelDistribution
+
 from .pipeline import Pipeline
 
 

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -60,6 +60,11 @@ class ScanHealpix(Operator):
 
     save_map = Bool(False, help="If True, do not delete map during finalize")
 
+    save_pointing = Bool(
+        False,
+        help="If True, do not clear detector pointing matrices if we generate the pixel distribution",
+    )
+
     @traitlets.validate("pointing")
     def _check_pointing(self, proposal):
         pntg = proposal["value"]
@@ -84,6 +89,16 @@ class ScanHealpix(Operator):
         # Check that the file is set
         if self.file is None:
             raise RuntimeError("You must set the file trait before calling exec()")
+
+        # Construct the pointing distribution if it does not already exist
+
+        if self.pixel_dist not in data:
+            pix_dist = BuildPixelDistribution(
+                pixel_dist=self.pixel_dist,
+                pointing=self.pointing,
+                save_pointing=self.save_pointing,
+            )
+            pix_dist.apply(data)
 
         dist = data[self.pixel_dist]
         if not isinstance(dist, PixelDistribution):

--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -201,16 +201,26 @@ def main():
     ops.pointing.detector_pointing = ops.det_pointing
     ops.pointing_final.detector_pointing = ops.det_pointing
 
+    # If we are not using a different pointing matrix for our final binning, then
+    # use the same one as the solve.
+    ops.binner.pointing = ops.pointing
+    if not ops.pointing_final.enabled:
+        ops.pointing_final = ops.pointing
+    
+    # If we are not using a different binner for our final binning, use the same one
+    # as the solve.
+    ops.binner_final.pointing = ops.pointing_final
+    if not ops.binner_final.enabled:
+        ops.binner_final = ops.binner
+
     # Simulate sky signal from a map.
     scan_map(args, rank, ops, data, log)
 
     # Simulate detector noise
-    if ops.sim_noise.enabled:
-        ops.sim_noise.apply(data)
+    ops.sim_noise.apply(data)
 
     # Build up our map-making operation.
-    if ops.mapmaker.enabled:
-        run_mapmaker(ops, args, job.templates, data)
+    run_mapmaker(ops, args, job.templates, data)
 
     # end of the computations, sync and computes efficiency
     global_timer.stop_all()

--- a/src/toast/scripts/toast_benchmark_satellite
+++ b/src/toast/scripts/toast_benchmark_satellite
@@ -185,16 +185,26 @@ def main():
     ops.pointing.detector_pointing = ops.det_pointing
     ops.pointing_final.detector_pointing = ops.det_pointing
 
+    # If we are not using a different pointing matrix for our final binning, then
+    # use the same one as the solve.
+    ops.binner.pointing = ops.pointing
+    if not ops.pointing_final.enabled:
+        ops.pointing_final = ops.pointing
+    
+    # If we are not using a different binner for our final binning, use the same one
+    # as the solve.
+    ops.binner_final.pointing = ops.pointing_final
+    if not ops.binner_final.enabled:
+        ops.binner_final = ops.binner
+
     # Simulate sky signal from a map.
     scan_map(args, rank, ops, data, log)
 
     # Simulate detector noise
-    if ops.sim_noise.enabled:
-        ops.sim_noise.apply(data)
+    ops.sim_noise.apply(data)
 
     # Build up our map-making operation.
-    if ops.mapmaker.enabled:
-        run_mapmaker(ops, args, job.templates, data)
+    run_mapmaker(ops, args, job.templates, data)
 
     # end of the computations, sync and computes efficiency
     global_timer.stop_all()

--- a/workflows/CMakeLists.txt
+++ b/workflows/CMakeLists.txt
@@ -4,5 +4,7 @@
 install(PROGRAMS
     toast_sim_satellite.py
     toast_sim_ground.py
+    toast_sim_satellite_simple.py
+    toast_sim_ground_simple.py
     DESTINATION bin
 )

--- a/workflows/toast_sim_ground_simple.py
+++ b/workflows/toast_sim_ground_simple.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""
+This script runs a simple ground simulation and makes a map.
+
+This script is an example of fully specifying all operators and options within
+the script (rather than from config files and command line options).  This is a
+useful starting point for interactively hacking on a specific use case or test.
+
+"""
+
+import os
+import sys
+import traceback
+import argparse
+
+import numpy as np
+
+from astropy import units as u
+
+import toast
+
+from toast.mpi import MPI
+
+
+def main():
+    env = toast.utils.Environment.get()
+    log = toast.utils.Logger.get()
+
+    # Get optional MPI parameters
+    comm, procs, rank = toast.get_world()
+
+    # Get just our focalplane and schedule from the command line
+    parser = argparse.ArgumentParser(description="Simple Ground Simulation Example.")
+
+    parser.add_argument(
+        "--focalplane", required=True, default=None, help="Input fake focalplane"
+    )
+
+    parser.add_argument(
+        "--schedule", required=True, default=None, help="Input observing schedule"
+    )
+
+    args = parser.parse_args()
+
+    # Create our output directory
+    out_dir = "toast_sim_ground_simple"
+    if comm is None or comm.rank == 0:
+        if not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
+
+    # Load a generic focalplane file.
+    focalplane = toast.instrument.Focalplane(file=args.focalplane, comm=comm)
+
+    # Load the schedule file
+    schedule = toast.schedule.GroundSchedule()
+    schedule.read(args.schedule, comm=comm)
+
+    # Create a telescope for the simulation.  Again, for a specific experiment we
+    # would use custom classes for the site.
+    site = toast.instrument.GroundSite(
+        schedule.site_name,
+        schedule.site_lat,
+        schedule.site_lon,
+        schedule.site_alt,
+        weather=None,
+    )
+    telescope = toast.instrument.Telescope(
+        schedule.telescope_name, focalplane=focalplane, site=site
+    )
+
+    # Create the toast communicator.  Use the default of one group.
+    toast_comm = toast.Comm(world=comm)
+
+    # Create the (initially empty) data
+    data = toast.Data(comm=toast_comm)
+
+    # Set up some operators that we are going to use later in both
+    # Simulation and Reduction.
+    #---------------------------------------------------------------
+
+    # Construct a "perfect" noise model just from the focalplane parameters
+    default_model = toast.ops.DefaultNoiseModel()
+
+    # Set up detector pointing.  This just uses the focalplane offsets.
+    det_pointing = toast.ops.PointingDetectorSimple()
+
+    # Elevation-modulated noise model.
+    elevation_model = toast.ops.ElevationNoise(
+        noise_model=default_model.noise_model,
+        out_model="el_weighted_model",
+        detector_pointing=det_pointing,
+        view=det_pointing.view
+    )
+
+    # Set up the pointing matrix.  We will use the same pointing matrix for the
+    # template solve and the final binning.
+    pointing = toast.ops.PointingHealpix(
+        nside=2048, 
+        mode="IQU",
+        detector_pointing=det_pointing
+    )
+
+    # Simulate data
+    #---------------------------------------------------------------
+
+    # Simulate the telescope pointing
+    sim_ground = toast.ops.SimGround(
+        telescope=telescope,
+        schedule=schedule
+    )
+    sim_ground.apply(data)
+
+    # Create a default noise model from focalplane parameters
+    default_model.apply(data)
+
+    # Modulate the noise model by the elevation
+    elevation_model.apply(data)
+
+    # Simulate sky signal from a map and accumulate.
+    # scan_map = toast.ops.ScanHealpix(
+    #     pointing=pointing,
+    #     file="input.fits"
+    # )
+    # scan_map.apply(data)
+
+    # FIXME:  Add atmosphere, ground pickup, etc here.
+
+    # Simulate detector noise and accumulate.
+    sim_noise = toast.ops.SimNoise()
+    sim_noise.apply(data)
+
+    # Reduce data
+    #---------------------------------------------------------------
+
+    # Set up the binning operator.  We will use the same binning for the template solve
+    # and the final map.
+    binner = toast.ops.BinMap(
+        pointing=pointing,
+        noise_model=elevation_model.out_model
+    )
+
+    # FIXME:  Apply filtering here, and optionally pass an empty template
+    # list to disable the template solve and just make a binned map.
+
+    # Set up the template matrix for the solve
+    template_matrix = toast.ops.TemplateMatrix(
+        templates=[
+            toast.templates.Offset(),
+        ]
+    )
+
+    # Map making
+    mapmaker = toast.ops.MapMaker(
+        det_data=sim_noise.det_data,
+        binning=binner,
+        template_matrix=template_matrix,
+        output_dir=out_dir,
+    )
+    mapmaker.apply(data)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # We have an unhandled exception on at least one process.  Print a stack
+        # trace for this process and then abort so that all processes terminate.
+        mpiworld, procs, rank = toast.get_world()
+        if procs == 1:
+            raise
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+        lines = ["Proc {}: {}".format(rank, x) for x in lines]
+        print("".join(lines), flush=True)
+        if mpiworld is not None:
+            mpiworld.Abort()

--- a/workflows/toast_sim_satellite_simple.py
+++ b/workflows/toast_sim_satellite_simple.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""
+This script runs a simple satellite simulation and makes a map.
+
+This script is an example of fully specifying all operators and options within
+the script (rather than from config files and command line options).  This is a
+useful starting point for interactively hacking on a specific use case or test.
+
+"""
+
+import os
+import sys
+import traceback
+import argparse
+
+import numpy as np
+
+from astropy import units as u
+
+import toast
+
+from toast.mpi import MPI
+
+
+def main():
+    env = toast.utils.Environment.get()
+    log = toast.utils.Logger.get()
+
+    # Get optional MPI parameters
+    comm, procs, rank = toast.get_world()
+
+    # Get just our focalplane and schedule from the command line
+    parser = argparse.ArgumentParser(description="Simple Satellite Simulation Example.")
+
+    parser.add_argument(
+        "--focalplane", required=True, default=None, help="Input fake focalplane"
+    )
+
+    parser.add_argument(
+        "--schedule", required=True, default=None, help="Input observing schedule"
+    )
+
+    args = parser.parse_args()
+
+    # Create our output directory
+    out_dir = "toast_sim_satellite_simple"
+    if comm is None or comm.rank == 0:
+        if not os.path.isdir(out_dir):
+            os.makedirs(out_dir)
+
+    # Load a generic focalplane file.
+    focalplane = toast.instrument.Focalplane(file=args.focalplane, comm=comm)
+
+    # Load the schedule file
+    schedule = toast.schedule.SatelliteSchedule()
+    schedule.read(args.schedule, comm=comm)
+
+    # Create a telescope for the simulation.  Again, for a specific experiment we
+    # would use custom classes for the site.
+    site = toast.instrument.SpaceSite(schedule.site_name)
+    telescope = toast.instrument.Telescope(
+        schedule.telescope_name, focalplane=focalplane, site=site
+    )
+
+    # Create the toast communicator.  Use the default of one group.
+    toast_comm = toast.Comm(world=comm)
+
+    # Create the (initially empty) data
+    data = toast.Data(comm=toast_comm)
+
+    # Set up some operators that we are going to use later in both
+    # Simulation and Reduction.
+    #---------------------------------------------------------------
+
+    # Construct a "perfect" noise model just from the focalplane parameters
+    default_model = toast.ops.DefaultNoiseModel()
+
+    # Set up detector pointing.  This just uses the focalplane offsets.
+    det_pointing = toast.ops.PointingDetectorSimple()
+
+    # Set up the pointing matrix.  We will use the same pointing matrix for the
+    # template solve and the final binning.
+    pointing = toast.ops.PointingHealpix(
+        nside=512, 
+        mode="IQU",
+        detector_pointing=det_pointing
+    )
+
+    # Simulate data
+    #---------------------------------------------------------------
+
+    # Simulate the telescope pointing
+    sim_satellite = toast.ops.SimSatellite(
+        telescope=telescope,
+        schedule=schedule
+    )
+    sim_satellite.apply(data)
+
+    # Create a default noise model from focalplane parameters
+    default_model.apply(data)
+
+    # Simulate sky signal from a map and accumulate.
+    # scan_map = toast.ops.ScanHealpix(
+    #     pointing=pointing,
+    #     file="input.fits"
+    # )
+    # scan_map.apply(data)
+
+    # Simulate detector noise and accumulate.
+    sim_noise = toast.ops.SimNoise()
+    sim_noise.apply(data)
+
+    # Reduce data
+    #---------------------------------------------------------------
+
+    # Set up the binning operator.  We will use the same binning for the template solve
+    # and the final map.
+    binner = toast.ops.BinMap(
+        pointing=pointing,
+        noise_model=default_model.noise_model
+    )
+
+    # Set up the template matrix for the solve
+    template_matrix = toast.ops.TemplateMatrix(
+        templates=[
+            toast.templates.Offset(),
+        ]
+    )
+
+    # Map making
+    mapmaker = toast.ops.MapMaker(
+        det_data=sim_noise.det_data,
+        binning=binner,
+        template_matrix=template_matrix,
+        output_dir=out_dir,
+    )
+    mapmaker.apply(data)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        # We have an unhandled exception on at least one process.  Print a stack
+        # trace for this process and then abort so that all processes terminate.
+        mpiworld, procs, rank = toast.get_world()
+        if procs == 1:
+            raise
+        exc_type, exc_value, exc_traceback = sys.exc_info()
+        lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+        lines = ["Proc {}: {}".format(rank, x) for x in lines]
+        print("".join(lines), flush=True)
+        if mpiworld is not None:
+            mpiworld.Abort()


### PR DESCRIPTION
This PR attempts to remove boilerplate from workflow code by moving some logic into the operators.  It also breaks up the `main()` function in the workflows for easier reading.

The existing workflow "style" copied the paradigm from toast2 which used a small number of very flexible workflows that could simulate any supported component and apply nearly all the possible reduction operations.  This kind of script is useful for production use with generic simulations.  For learning and interactive hacking it can be easier to just have a simple script with options directly in the script.  This allows a user to just copy the script and start changing it.  I have now added a satellite and ground workflow that follows this technique.

I will rebase this after #404 is merged, since it touches the same source file.