### PR TITLE
Sim ground workflow tweaks

### DIFF
--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -287,7 +287,12 @@ class GroundFilter(Operator):
                 log.debug(msg)
 
             # Cache the output common flags
-            common_flags = obs.shared[self.shared_flags].data & self.shared_flag_mask
+            if self.shared_flags is not None:
+                common_flags = (
+                    obs.shared[self.shared_flags].data & self.shared_flag_mask
+                )
+            else:
+                common_flags = np.zeros(obs.n_local_samples, dtype=np.uint8)
 
             t1 = time()
             templates, legendre_trend, legendre_filter = self.build_templates(obs)
@@ -307,8 +312,11 @@ class GroundFilter(Operator):
                     )
 
                 ref = obs.detdata[self.det_data][idet]
-                def_flags = obs.detdata[self.det_flags][idet] & self.det_flag_mask
-                good = np.logical_and(common_flags == 0, def_flags == 0)
+                if self.det_flags is not None:
+                    def_flags = obs.detdata[self.det_flags][idet] & self.det_flag_mask
+                    good = np.logical_and(common_flags == 0, def_flags == 0)
+                else:
+                    good = common_flags == 0
 
                 t1 = time()
                 coeff = self.fit_templates(obs, det, templates, ref, good)

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -251,7 +251,13 @@ class MapMaker(Operator):
 
         timer.start()
 
-        if self.template_matrix is not None and len(self.template_matrix.templates) > 0:
+        n_enabled_templates = 0
+        if self.template_matrix is not None:
+            for template in self.template_matrix.templates:
+                if template.enabled:
+                    n_enabled_templates += 1
+
+        if n_enabled_templates != 0:
             # We are solving for template amplitudes
 
             self.binning.covariance = self.solver_cov_name
@@ -602,7 +608,7 @@ class MapMaker(Operator):
         pre_pipe = None
         map_binning.binned = self.map_name
 
-        if self.template_matrix is not None and len(self.template_matrix.templates) > 0:
+        if n_enabled_templates != 0:
             # We have some templates to subtract
             temp_project = "{}_temp_project".format(self.name)
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -575,11 +575,13 @@ class SimGround(Operator):
 
             # Optionally initialize detector data
 
+            dets = ob.select_local_detectors(detectors)
+
             if self.det_data is not None:
-                ob.detdata.ensure(self.det_data, dtype=np.float64, detectors=pipedets)
+                ob.detdata.ensure(self.det_data, dtype=np.float64, detectors=dets)
 
             if self.det_flags is not None:
-                ob.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=pipedets)
+                ob.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=dets)
 
             # Only the first rank of the process grid columns sets / computes these.
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -504,11 +504,12 @@ class SimGround(Operator):
                 site=site,
             )
 
+            name = f"{scan.name}_{int(scan.start.timestamp())}"
             ob = Observation(
                 telescope,
                 len(times),
-                name=f"{scan.name}_{int(scan.start.timestamp())}",
-                uid=name_UID(scan.name),
+                name=name,
+                uid=name_UID(name),
                 comm=comm.comm_group,
                 process_rows=det_ranks,
             )

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -134,7 +134,8 @@ class SimGround(Operator):
     shared_flags = Unicode("flags", help="Observation shared key for common flags")
 
     det_data = Unicode(
-        None, allow_none=True, help="Observation detdata key to initialize")
+        None, allow_none=True, help="Observation detdata key to initialize"
+    )
 
     det_flags = Unicode(
         None, allow_none=True, help="Observation detdata key for flags to initialize"

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -133,6 +133,13 @@ class SimGround(Operator):
 
     shared_flags = Unicode("flags", help="Observation shared key for common flags")
 
+    det_data = Unicode(
+        None, allow_none=True, help="Observation detdata key to initialize")
+
+    det_flags = Unicode(
+        None, allow_none=True, help="Observation detdata key for flags to initialize"
+    )
+
     hwp_angle = Unicode("hwp_angle", help="Observation shared key for HWP angle")
 
     azimuth = Unicode("azimuth", help="Observation shared key for Azimuth")
@@ -565,6 +572,14 @@ class SimGround(Operator):
                 dtype=np.float64,
                 comm=ob.comm_col,
             )
+
+            # Optionally initialize detector data
+
+            if self.det_data is not None:
+                ob.detdata.ensure(self.det_data, dtype=np.float64, detectors=pipedets)
+
+            if self.det_flags is not None:
+                ob.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=pipedets)
 
             # Only the first rank of the process grid columns sets / computes these.
 

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -273,16 +273,9 @@ class ObserveAtmosphere(Operator):
                     # Add contribution to output
                     views.detdata[self.det_data][vw][det][good] += atmdata
 
-            if comm is not None:
-                comm.Barrier()
-                ngood_tot = comm.reduce(ngood_tot)
-                nbad_tot = comm.reduce(nbad_tot)
-            if rank == 0 and nbad_tot > 0:
-                log.error(
-                    "{}: Observe atmosphere FAILED on {:.2f}% of samples".format(
-                        log_prefix, nbad_tot * 100 / ngood_tot
-                    )
-                )
+            if nbad_tot > 0:
+                frac = nbad_tot / (ngood_tot + nbad_tot) * 100
+                log.error("{log_prefix}: Observe atmosphere FAILED on {frac:.2f}% of samples")
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -275,7 +275,9 @@ class ObserveAtmosphere(Operator):
 
             if nbad_tot > 0:
                 frac = nbad_tot / (ngood_tot + nbad_tot) * 100
-                log.error("{log_prefix}: Observe atmosphere FAILED on {frac:.2f}% of samples")
+                log.error(
+                    "{log_prefix}: Observe atmosphere FAILED on {frac:.2f}% of samples"
+                )
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -1573,7 +1573,9 @@ def add_scan(
                 el_offset = np.degrees(el) - el_min
                 el_observe = np.degrees(el) + el_offset
 
-                az_offset = (az_min - azmin) * np.cos(el) / np.cos(np.radians(el_observe))
+                az_offset = (
+                    (az_min - azmin) * np.cos(el) / np.cos(np.radians(el_observe))
+                )
                 azmin += az_offset
                 azmax += az_offset
             else:

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -162,7 +162,8 @@ def simulate_data(job, toast_comm, telescope, schedule):
 
     ops.sim_ground.telescope = telescope
     ops.sim_ground.schedule = schedule
-    ops.sim_ground.weather = telescope.site.name
+    if ops.sim_ground.weather is None:
+        ops.sim_ground.weather = telescope.site.name
     ops.sim_ground.apply(data)
     log.info_rank("Simulated telescope pointing in", comm=world_comm, timer=timer)
 

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -239,6 +239,17 @@ def reduce_data(job, args, data):
     timer = toast.timing.Timer()
     timer.start()
 
+    # Apply the filter stack
+
+    ops.groundfilter.apply(data)
+    log.info_rank("Finished ground-filtering in", comm=world_comm, timer=timer)
+    ops.polyfilter1D.apply(data)
+    log.info_rank("Finished 1D-poly-filtering in", comm=world_comm, timer=timer)
+    ops.polyfilter2D.apply(data)
+    log.info_rank("Finished 2D-poly-filtering in", comm=world_comm, timer=timer)
+    ops.common_mode_filter.apply(data)
+    log.info_rank("Finished common-mode-filtering in", comm=world_comm, timer=timer)
+
     # The map maker requires the the binning operators used for the solve and final,
     # the templates, and the noise model.
 
@@ -295,6 +306,10 @@ def main():
         toast.ops.SimNoise(name="sim_noise"),
         toast.ops.SimAtmosphere(name="sim_atmosphere"),
         toast.ops.PointingHealpix(name="pointing", mode="IQU"),
+        toast.ops.GroundFilter(name="groundfilter"),
+        toast.ops.PolyFilter(name="polyfilter1D"),
+        toast.ops.PolyFilter2D(name="polyfilter2D"),
+        toast.ops.CommonModeFilter(name="common_mode_filter"),
         toast.ops.BinMap(name="binner", pixel_dist="pix_dist"),
         toast.ops.MapMaker(name="mapmaker"),
         toast.ops.PointingHealpix(name="pointing_final", enabled=False, mode="IQU"),


### PR DESCRIPTION
The PR features several tweaks:

- `SimGround` can now initialize signal and flag objects for detectors so their presence is guaranteed in the rest of the pipeline
- ground and polynomial filters will not fail if shared and/or detector flags are `None`
- `toast_sim_ground` workflow supports ground and polynomial filters
- fix a recent bug preventing running the mapmaker without any enabled templates
- fix a bug in ground observation UID that made them non-unique and prevented atmospheric caching