### PR TITLE
Per detector elevation noise model

### DIFF
--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -293,6 +293,9 @@ class Focalplane(object):
             DefaultNoiseModel operator.
         "psd_alpha":  Quantity used to create a synthetic noise model with the
             DefaultNoiseModel operator.
+        "elevation_noise_a" and "elevation_noise_c":  Parameters of elevation scaling
+            noise model: PSD_{out} = PSD_{ref} * (a / sin(el) + c)^2.  Only applicable
+            to ground data.
 
     Args:
         detector_data (QTable):  Table of detector properties.

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -182,9 +182,9 @@ class ElevationNoise(Operator):
                 if self.noise_a is not None:
                     noise_a = self.noise_a
                     noise_c = self.noise_c
-                elif "A" in focalplane[det]:
-                    noise_a = focalplane[det]["A"]
-                    noise_c = focalplane[det]["C"]
+                elif "elevation_noise_a" in focalplane[det]:
+                    noise_a = focalplane[det]["elevation_noise_a"]
+                    noise_c = focalplane[det]["elevation_noise_c"]
                 else:
                     continue
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -71,13 +71,13 @@ class ElevationNoise(Operator):
     noise_a = Float(
         None,
         allow_none=True,
-        help="Parameter 'a' in (a / sin(el) + c)",
+        help="Parameter 'a' in (a / sin(el) + c).  If not set, look for one in the Focalplane.",
     )
 
     noise_c = Float(
         None,
         allow_none=True,
-        help="Parameter 'c' in (a / sin(el) + c)",
+        help="Parameter 'c' in (a / sin(el) + c).  If not set, look for one in the Focalplane.",
     )
 
     @traitlets.validate("detector_pointing")
@@ -115,6 +115,8 @@ class ElevationNoise(Operator):
             raise RuntimeError(msg)
 
         for ob in data.obs:
+            focalplane = ob.telescope.focalplane
+
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(detectors)
             if len(dets) == 0:
@@ -127,11 +129,6 @@ class ElevationNoise(Operator):
                     self.noise_model, ob.name
                 )
                 raise RuntimeError(msg)
-
-            # If both the A and B values are unset, the noise model is not modified.
-            if self.noise_a is None and self.noise_c is None:
-                ob[self.out_model] = ob[self.noise_model]
-                continue
 
             # Check that the view in the detector pointing operator covers
             # all the samples needed by this operator
@@ -181,6 +178,16 @@ class ElevationNoise(Operator):
                 view_flags.append(flags)
 
             for det in dets:
+                # If both the A and C values are unset, the noise model is not modified.
+                if self.noise_a is not None:
+                    noise_a = self.noise_a
+                    noise_c = self.noise_c
+                elif "A" in focalplane[det]:
+                    noise_a = focalplane[det]["A"]
+                    noise_c = focalplane[det]["C"]
+                else:
+                    continue
+
                 # Compute detector quaternions one detector at a time.
                 self.detector_pointing.apply(data, detectors=[det])
                 el_view = list()
@@ -199,7 +206,7 @@ class ElevationNoise(Operator):
                 el = np.median(np.concatenate(el_view))
 
                 # Scale the PSD
-                el_factor = self.noise_a / np.sin(el) + self.noise_c
+                el_factor = noise_a / np.sin(el) + noise_c
                 psd[:] *= el_factor ** 2
         return
 


### PR DESCRIPTION
If operator is not configured with an elevation noise model, look for one in the focaplane database.

@tskisner what do you think of the field names "A" and "C" in the focaplane database? Using more descriptive names like "elevation_noise_a" and "elevation_noise_c" would make the ASCII view of the database cluttered but would make things easier to understand.