### PR TITLE
Add support for atmospheric polarization

### DIFF
--- a/src/toast/ops/pointing_healpix.py
+++ b/src/toast/ops/pointing_healpix.py
@@ -69,7 +69,7 @@ class PointingHealpix(Operator):
 
     nside_submap = Int(16, help="The NSIDE of the submap resolution")
 
-    nest = Bool(False, help="If True, used NESTED ordering instead of RING")
+    nest = Bool(False, help="If True, use NESTED ordering instead of RING")
 
     mode = Unicode("I", help="The Stokes weights to generate (I or IQU)")
 

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -127,6 +127,7 @@ class SimAtmTest(MPITestCase):
 
             mapfile = os.path.join(self.outdir, f"{mapmaker.name}_hits.fits")
             mdata = hp.read_map(mapfile, nest=False)
+            mdata[mdata == 0] = hp.UNSEEN
 
             outfile = "{}.png".format(mapfile)
             hp.gnomview(mdata, xsize=1600, rot=(42.0, -42.0), reso=0.5, nest=False)
@@ -134,9 +135,193 @@ class SimAtmTest(MPITestCase):
             plt.close()
 
             mapfile = os.path.join(self.outdir, f"{mapmaker.name}_map.fits")
+            mdata = hp.read_map(mapfile, None, nest=False)
+            mdata[mdata == 0] = hp.UNSEEN
+
+            outfile = "{}.png".format(mapfile)
+            fig = plt.figure(figsize=[8 * 3, 12])
+            hp.gnomview(
+                mdata[0],
+                xsize=1600,
+                sub=[1, 3, 1],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            hp.gnomview(
+                mdata[1],
+                xsize=1600,
+                sub=[1, 3, 2],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            hp.gnomview(
+                mdata[2],
+                xsize=1600,
+                sub=[1, 3, 3],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            plt.savefig(outfile)
+            plt.close()
+
+            good = mdata[0] != hp.UNSEEN
+            p = np.sqrt(mdata[1] ** 2 + mdata[2] ** 2)
+            pfrac = np.median(p[good] / mdata[0][good])
+            if pfrac > 0.01:
+                raise RuntimeError("Simulated atmosphere is polarized")
+
+    def test_sim_pol(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+        detpointing_radec = ops.PointingDetectorSimple(
+            boresight="boresight_radec", quats="quats_radec"
+        )
+
+        # Detector weights
+        detweights_azel = ops.PointingHealpix(
+            nside=64,
+            mode="IQU",
+            hwp_angle="hwp_angle",
+            detector_pointing=detpointing_azel,
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model="noise_model",
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(noise_model=el_model.out_model)
+        sim_noise.apply(data)
+
+        if rank == 0:
+            set_matplotlib_backend()
+            import matplotlib.pyplot as plt
+
+            ob = data.obs[0]
+            det = ob.local_detectors[0]
+            times = np.array(ob.shared["times"])
+
+            fig = plt.figure(figsize=(12, 8), dpi=72)
+            ax = fig.add_subplot(1, 1, 1, aspect="auto")
+            ax.plot(times, ob.detdata["signal"][det])
+            ax.set_title(f"Detector {det} Noise TOD")
+            outfile = os.path.join(self.outdir, f"{det}_noise_tod.pdf")
+            plt.savefig(outfile)
+            plt.close()
+
+        # Simulate atmosphere signal and accumulate
+        sim_atm = ops.SimAtmosphere(
+            detector_pointing=detpointing_azel,
+            detector_weights=detweights_azel,
+            polarization_fraction=0.2,
+        )
+        sim_atm.apply(data)
+
+        if rank == 0:
+            import matplotlib.pyplot as plt
+
+            ob = data.obs[0]
+            det = ob.local_detectors[0]
+            times = np.array(ob.shared["times"])
+
+            fig = plt.figure(figsize=(12, 8), dpi=72)
+            ax = fig.add_subplot(1, 1, 1, aspect="auto")
+            ax.plot(times, ob.detdata["signal"][det])
+            ax.set_title(f"Detector {det} Atmosphere + Noise TOD")
+            outfile = os.path.join(self.outdir, f"{det}_atm-noise_tod.pdf")
+            plt.savefig(outfile)
+            plt.close()
+
+        # Pointing matrix
+        pointing = ops.PointingHealpix(
+            nside=self.nside,
+            nest=False,
+            mode="IQU",
+            detector_pointing=detpointing_radec,
+        )
+
+        # Make a binned map
+
+        binner = ops.BinMap(
+            pointing=pointing,
+            noise_model=el_model.out_model,
+        )
+
+        mapmaker = ops.MapMaker(
+            name="test_atm_pol",
+            binning=binner,
+            output_dir=self.outdir,
+        )
+        mapmaker.apply(data)
+
+        if rank == 0:
+            import matplotlib.pyplot as plt
+
+            mapfile = os.path.join(self.outdir, f"{mapmaker.name}_hits.fits")
             mdata = hp.read_map(mapfile, nest=False)
+            mdata[mdata == 0] = hp.UNSEEN
 
             outfile = "{}.png".format(mapfile)
             hp.gnomview(mdata, xsize=1600, rot=(42.0, -42.0), reso=0.5, nest=False)
             plt.savefig(outfile)
             plt.close()
+
+            mapfile = os.path.join(self.outdir, f"{mapmaker.name}_map.fits")
+            mdata = hp.read_map(mapfile, None, nest=False)
+            mdata[mdata == 0] = hp.UNSEEN
+
+            outfile = "{}.png".format(mapfile)
+            fig = plt.figure(figsize=[8 * 3, 12])
+            hp.gnomview(
+                mdata[0],
+                xsize=1600,
+                sub=[1, 3, 1],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            hp.gnomview(
+                mdata[1],
+                xsize=1600,
+                sub=[1, 3, 2],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            hp.gnomview(
+                mdata[2],
+                xsize=1600,
+                sub=[1, 3, 3],
+                rot=(42.0, -42.0),
+                reso=0.5,
+                nest=False,
+            )
+            plt.savefig(outfile)
+            plt.close()
+
+            good = mdata[0] != hp.UNSEEN
+            p = np.sqrt(mdata[1] ** 2 + mdata[2] ** 2)
+            i = np.abs(mdata[0])
+            pfrac = np.median(p[good] / i[good])
+            if pfrac < 0.01:
+                raise RuntimeError("Simulated atmosphere is not polarized")

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -177,6 +177,9 @@ def simulate_data(job, toast_comm, telescope, schedule):
     ops.det_pointing_azel.boresight = ops.sim_ground.boresight_azel
     ops.det_pointing_radec.boresight = ops.sim_ground.boresight_radec
 
+    ops.det_weights_azel.detector_pointing = ops.det_pointing_azel
+    ops.det_weights_azel.hwp_angle = ops.sim_ground.hwp_angle
+
     # Create the Elevation modulated noise model
 
     ops.elevation_model.noise_model = ops.default_model.noise_model
@@ -222,6 +225,8 @@ def simulate_data(job, toast_comm, telescope, schedule):
     # Simulate atmosphere
 
     ops.sim_atmosphere.detector_pointing = ops.det_pointing_azel
+    if ops.sim_atmosphere.polarization_fraction != 0:
+        ops.sim_atmosphere.detector_weights = ops.det_weights_azel
     ops.sim_atmosphere.apply(data)
     log.info_rank("Simulated and observed atmosphere in", comm=world_comm, timer=timer)
 
@@ -309,6 +314,9 @@ def main():
             out_model="el_noise_model",
         ),
         toast.ops.PointingDetectorSimple(name="det_pointing_azel", quats="quats_azel"),
+        # In the future, `det_weights_azel` may be a dedicated operator that does not
+        # expand pixel numbers but just Stokes weights
+        toast.ops.PointingHealpix(name="det_weights_azel", mode="IQU"),
         toast.ops.PointingDetectorSimple(
             name="det_pointing_radec", quats="quats_radec"
         ),

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -316,7 +316,9 @@ def main():
         toast.ops.PointingDetectorSimple(name="det_pointing_azel", quats="quats_azel"),
         # In the future, `det_weights_azel` may be a dedicated operator that does not
         # expand pixel numbers but just Stokes weights
-        toast.ops.PointingHealpix(name="det_weights_azel", mode="IQU"),
+        toast.ops.PointingHealpix(
+            name="det_weights_azel", weights="weights_azel", mode="IQU"
+        ),
         toast.ops.PointingDetectorSimple(
             name="det_pointing_radec", quats="quats_radec"
         ),


### PR DESCRIPTION
This PR adds `polarization_fraction` as a trait to the atmospheric simulation. It is a constant fraction that generates Q-polarization from the pure intensity simulation.