### PR TITLE
Atmospheric loading and bandpass

### DIFF
--- a/src/libtoast/src/toast_atm_utils.cpp
+++ b/src/libtoast/src/toast_atm_utils.cpp
@@ -149,7 +149,7 @@ double toast::atm_get_atmospheric_loading(double altitude,
     atm::SkyStatus ss = get_sky_status(altitude, temperature, pressure, freq);
     ss.setUserWH2O(pwv, "mm");
 
-    return ss.getTebbSky().get();
+    return ss.getTrjSky().get();
 }
 
 int toast::atm_get_atmospheric_loading_vec(double altitude,
@@ -172,7 +172,7 @@ int toast::atm_get_atmospheric_loading_vec(double altitude,
                                            freqmin, freqmax, nfreq);
     ss.setUserWH2O(pwv, "mm");
     for (size_t i = 0; i < nfreq; ++i) {
-        loading[i] = ss.getTebbSky(i).get();
+        loading[i] = ss.getTrjSky(i).get();
     }
 
     return 0;

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -286,10 +286,11 @@ class Bandpass(object):
 
     def __init__(self, bandcenters, bandwidths, nstep=1001):
         """All units in GHz
+
         Args :
-        bandcenters(dict) : Dictionary of bandpass centers
-        bandwidths(dict) : Dictionary of bandpass widths
-        nstep(int) : Number of interplation steps to use in `convolve()`
+            bandcenters(dict) : Dictionary of bandpass centers
+            bandwidths(dict) : Dictionary of bandpass widths
+            nstep(int) : Number of interplation steps to use in `convolve()`
         """
         self.nstep = nstep
         self.dets = []
@@ -327,6 +328,9 @@ class Bandpass(object):
             spectrum(array of floats):  Spectral bin values
             rj(bool):  Input spectrum is in Rayleigh-Jeans units and
                 should be converted into thermal units for convolution
+
+        Returns:
+            (array):  The bandpass-convolved spectrum
         """
         if det not in self.bandpass:
             # Normalize and interpolate the bandpass

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -18,7 +18,7 @@ from astropy.table import QTable, Column
 from scipy.constants import h, k
 try:
     from scipy.integrate import simpson
-except ModuleNotFoundError:
+except ImportError:
     from scipy.integrate import simps as simpson
 
 import tomlkit

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -16,6 +16,7 @@ import astropy.coordinates as coord
 from astropy.table import QTable, Column
 
 from scipy.constants import h, k
+
 try:
     from scipy.integrate import simpson
 except ImportError:

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -16,7 +16,10 @@ import astropy.coordinates as coord
 from astropy.table import QTable, Column
 
 from scipy.constants import h, k
-from scipy.integrate import simpson
+try:
+    from scipy.integrate import simpson
+except ModuleNotFoundError:
+    from scipy.integrate import simps as simpson
 
 import tomlkit
 

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -16,7 +16,7 @@ import astropy.coordinates as coord
 from astropy.table import QTable, Column
 
 from scipy.constants import h, k
-import scipy.integrate
+from scipy.integrate import simpson
 
 import tomlkit
 
@@ -337,7 +337,7 @@ class Bandpass(object):
             except AttributeError:
                 self.bandpass[det] = np.ones(self.nstep)
 
-            norm = scipy.integrate.simpson(self.bandpass[det], x=self.freqs[det])
+            norm = simpson(self.bandpass[det], x=self.freqs[det])
             if norm == 0:
                 raise RuntimeError("Bandpass cannot be normalized")
             self.bandpass[det] /= norm
@@ -355,7 +355,7 @@ class Bandpass(object):
             spectrum_det *= rj2cmb
 
         # Average across the bandpass
-        convolved = scipy.integrate.simpson(spectrum_det * bandpass_det, x=freqs_det)
+        convolved = simpson(spectrum_det * bandpass_det, x=freqs_det)
 
         return convolved
 

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -46,36 +46,9 @@ class DefaultNoiseModel(Operator):
         comm = data.comm
 
         for ob in data.obs:
-            # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors)
-            if len(dets) == 0:
-                # Nothing to do for this observation
-                continue
-
-            # The focalplane for this observation
-            focalplane = ob.telescope.focalplane
-
-            # Every process has a copy of the focalplane, and every process may want
-            # the noise model for all detectors (not just our local detectors).
-            # So we simply have every process generate the same noise model locally.
-
-            fmin = {}
-            fknee = {}
-            alpha = {}
-            NET = {}
-            rates = {}
-            for d in dets:
-                rates[d] = focalplane.sample_rate
-                fmin[d] = focalplane[d]["psd_fmin"]
-                fknee[d] = focalplane[d]["psd_fknee"]
-                alpha[d] = focalplane[d]["psd_alpha"]
-                NET[d] = focalplane[d]["psd_net"]
-
-            noise = AnalyticNoise(
-                rate=rates, fmin=fmin, detectors=dets, fknee=fknee, alpha=alpha, NET=NET
-            )
-
-            ob[self.noise_model] = noise
+            if ob.telescope.focalplane.noise is None:
+                raise RuntimeError("Focalplane does not have a noise model")
+            ob[self.noise_model] = ob.telescope.focalplane.noise
 
         return
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -96,7 +96,7 @@ class SimGround(Operator):
     )
 
     scan_rate_el = Quantity(
-        None, allow_none=True, help="The sky elevation scanning rate"
+        1.0 * u.degree / u.second, allow_none=True, help="The sky elevation scanning rate"
     )
 
     scan_accel_az = Quantity(
@@ -105,7 +105,7 @@ class SimGround(Operator):
     )
 
     scan_accel_el = Quantity(
-        None, allow_none=True, help="Mount elevation rate acceleration."
+        1.0 * u.degree / u.second ** 2, allow_none=True, help="Mount elevation rate acceleration."
     )
 
     scan_cosecant_modulation = Bool(
@@ -445,7 +445,9 @@ class SimGround(Operator):
             elnod_el = None
             elnod_az = None
             if len(self.elnods) > 0:
-                elnod_el = np.array([x.to_value(u.radian) for x in self.elnods])
+                elnod_el = np.array(
+                    [(scan.el + x).to_value(u.radian) for x in self.elnods]
+                )
                 elnod_az = np.zeros_like(elnod_el) + scan.az_min.to_value(u.radian)
 
             # Sample sets.  Although Observations support data distribution in any
@@ -465,7 +467,7 @@ class SimGround(Operator):
                     scan_min_el,
                     scan_max_el,
                 ) = simulate_elnod(
-                    scan.start,
+                    scan.start.timestamp(),
                     rate,
                     scan.az_min.to_value(u.radian),
                     scan.el.to_value(u.radian),

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -96,7 +96,9 @@ class SimGround(Operator):
     )
 
     scan_rate_el = Quantity(
-        1.0 * u.degree / u.second, allow_none=True, help="The sky elevation scanning rate"
+        1.0 * u.degree / u.second,
+        allow_none=True,
+        help="The sky elevation scanning rate",
     )
 
     scan_accel_az = Quantity(
@@ -105,7 +107,9 @@ class SimGround(Operator):
     )
 
     scan_accel_el = Quantity(
-        1.0 * u.degree / u.second ** 2, allow_none=True, help="Mount elevation rate acceleration."
+        1.0 * u.degree / u.second ** 2,
+        allow_none=True,
+        help="Mount elevation rate acceleration.",
     )
 
     scan_cosecant_modulation = Bool(

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -100,7 +100,7 @@ def scan_between(
     az_accel,
     el_rate,
     el_accel,
-    scanstep=10000,
+    nstep=10000,
 ):
     """Simulate motion between two coordinates.
 
@@ -113,12 +113,12 @@ def scan_between(
         (tuple):  The (times, az, el) arrays.
 
     """
-    az_time = self.scan_time(az1, az2, az_rate, az_accel)
-    el_time = self.scan_time(el1, el2, el_rate, el_accel)
+    az_time = scan_time(az1, az2, az_rate, az_accel)
+    el_time = scan_time(el1, el2, el_rate, el_accel)
     time_tot = max(az_time, el_time)
     times = np.linspace(0, time_tot, nstep)
-    az = self.scan_profile(az1, az2, az_rate, az_accel, times, nstep=scanstep)
-    el = self.scan_profile(el1, el2, el_rate, el_accel, times, nstep=scanstep)
+    az = scan_profile(az1, az2, az_rate, az_accel, times, nstep=nstep)
+    el = scan_profile(el1, el2, el_rate, el_accel, times, nstep=nstep)
     return times + time_start, az, el
 
 

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -322,10 +322,6 @@ class SimAtmosphere(Operator):
 
             key1, key2, counter1, counter2 = self._get_rng_keys(ob)
 
-            absorption, loading = self._get_absorption_and_loading(ob)
-
-            observe_atm.absorption = absorption
-
             cachedir = self._get_cache_dir(ob, comm)
 
             ob[atm_sim_key] = list()
@@ -506,37 +502,6 @@ class SimAtmosphere(Operator):
         counter2 = 0
 
         return key1, key2, counter1, counter2
-
-    @function_timer
-    def _get_absorption_and_loading(self, obs):
-        altitude = obs.telescope.site.earthloc.height.to_value(u.meter)
-        weather = obs.telescope.site.weather
-        absorption = None
-        loading = None
-        if self.freq is not None:
-            if not available_utils:
-                msg = (
-                    "TOAST not compiled with libaatm support- absorption and "
-                    "loading unavailable"
-                )
-                raise RuntimeError(msg)
-            from ..atm import atm_absorption_coefficient, atm_atmospheric_loading
-
-            absorption = atm_absorption_coefficient(
-                altitude,
-                weather.air_temperature.to_value(u.kelvin),
-                weather.surface_pressure,
-                weather.pwv,
-                self.freq.to_value(u.GHz),
-            )
-            loading = atm_atmospheric_loading(
-                altitude,
-                weather.air_temperature.to_value(u.kelvin),
-                weather.surface_pressure,
-                weather.pwv,
-                self.freq.to_value(u.GHz),
-            )
-        return absorption, loading
 
     def _get_cache_dir(self, obs, comm):
         obsid = obs.uid

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -536,14 +536,18 @@ class SimAtmosphere(Operator):
         # Read the extent of the AZ/EL boresight pointing, and use that
         # to compute the range of angles needed for simulating the slab.
 
-        # FIXME:  This is quite arbitrary and assumes that the boresight
-        # pointing has been created by the SimGround operator.  We should
-        # define the observation keys to use in some standard place and
-        # compute these limits from the data if they do not exist.
-        min_az_bore = obs["scan_min_az"].to_value(u.radian)
-        max_az_bore = obs["scan_max_az"].to_value(u.radian)
-        min_el_bore = obs["scan_min_el"].to_value(u.radian)
-        max_el_bore = obs["scan_max_el"].to_value(u.radian)
+        quats = obs.shared[self.detector_pointing.boresight]
+        theta, phi = qa.to_position(quats)
+        az = 2 * np.pi - phi
+        el = np.pi / 2 - theta
+        if self.shared_flags is not None:
+            good = (self.shared[self.shared_flags] & self.shared_flag_mask) == 0
+            az = az[good]
+            el = el[good]
+        min_az_bore = np.amin(az)
+        max_az_bore = np.amax(az)
+        min_el_bore = np.amin(el)
+        max_el_bore = np.amax(el)
 
         # Use a fixed focal plane radius so that changing the actual
         # set of detectors will not affect the simulated atmosphere.

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -352,7 +352,7 @@ class ObserveAtmosphere(Operator):
         loading_det = {}
         for det in dets:
             absorption_det[det] = bandpass.convolve(det, freqs, absorption, rj=True)
-            loading_det[det] = bandpass.convolve(det, freqs, absorption, rj=True)
+            loading_det[det] = bandpass.convolve(det, freqs, loading, rj=True)
 
         return absorption_det, loading_det
 

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -580,7 +580,13 @@ def fake_flags(data, shared_name="flags", shared_val=1, det_name="flags", det_va
             ob.detdata[det_name][det, :half] |= det_val
 
 
-def create_ground_data(mpicomm, sample_rate=10.0 * u.Hz, temp_dir=None):
+def create_ground_data(
+        mpicomm,
+        sample_rate=10.0 * u.Hz,
+        temp_dir=None,
+        el_nod=False,
+        el_nods=[-1 * u.degree, 1 * u.degree],
+):
     """Create a data object with a simple ground sim.
 
     Use the specified MPI communicator to attempt to create 2 process groups.  Create
@@ -651,6 +657,8 @@ def create_ground_data(mpicomm, sample_rate=10.0 * u.Hz, temp_dir=None):
         hwp_rpm=1.0,
         weather="atacama",
         detset_key="pixel",
+        elnod_start=el_nod,
+        elnods=el_nods,
     )
     sim_ground.apply(data)
 

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -581,11 +581,11 @@ def fake_flags(data, shared_name="flags", shared_val=1, det_name="flags", det_va
 
 
 def create_ground_data(
-        mpicomm,
-        sample_rate=10.0 * u.Hz,
-        temp_dir=None,
-        el_nod=False,
-        el_nods=[-1 * u.degree, 1 * u.degree],
+    mpicomm,
+    sample_rate=10.0 * u.Hz,
+    temp_dir=None,
+    el_nod=False,
+    el_nods=[-1 * u.degree, 1 * u.degree],
 ):
     """Create a data object with a simple ground sim.
 

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -347,14 +347,6 @@ class SimAtmTest(MPITestCase):
         default_model = ops.DefaultNoiseModel()
         default_model.apply(data)
 
-        # Make an elevation-dependent noise model
-        el_model = ops.ElevationNoise(
-            noise_model="noise_model",
-            out_model="el_weighted",
-            detector_pointing=detpointing_azel,
-        )
-        el_model.apply(data)
-
         # Simulate atmosphere signal
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
@@ -372,7 +364,7 @@ class SimAtmTest(MPITestCase):
             fig = plt.figure(figsize=(12, 8), dpi=72)
             ax = fig.add_subplot(1, 1, 1, aspect="auto")
             ax.plot(times, ob.detdata["signal"][det])
-            ax.set_title(f"Detector {det} Atmospheric loadingg TOD")
+            ax.set_title(f"Detector {det} Atmospheric loading TOD")
             outfile = os.path.join(self.outdir, f"{det}_atm_loading_tod.pdf")
             plt.savefig(outfile)
             plt.close()
@@ -385,5 +377,67 @@ class SimAtmTest(MPITestCase):
             for det in obs.local_detectors:
                 sig = obs.detdata["signal"][det]
                 assert np.std(sig) != 0
+
+        return
+
+    def test_bandpass(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        # Override the simulated bandpass
+        for obs in data.obs:
+            fp = obs.telescope.focalplane
+            fp.detector_data["bandcenter"] = 100 * u.GHz
+            fp.detector_data["bandwidth"] = 10 * u.GHz
+            fp._get_bandpass()
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+        detpointing_radec = ops.PointingDetectorSimple(
+            boresight="boresight_radec", quats="quats_radec"
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        cache_dir = os.path.join(self.outdir, "atm_cache")
+
+        # Simulate atmosphere signal
+        sim_atm = ops.SimAtmosphere(
+            detector_pointing=detpointing_azel,
+            cache_dir=cache_dir,
+        )
+        sim_atm.apply(data)
+
+        old_rms = {}
+        for obs in data.obs:
+            old_rms[obs.name] = {}
+            for det in obs.local_detectors:
+                sig = obs.detdata["signal"][det]
+                old_rms[obs.name][det] = np.std(sig)
+                sig[:] = 0
+
+        # Override the simulated bandpass again
+        for obs in data.obs:
+            fp = obs.telescope.focalplane
+            fp.detector_data["bandcenter"] = 150 * u.GHz
+            fp.detector_data["bandwidth"] = 15 * u.GHz
+            fp._get_bandpass()
+
+        # Simulate atmosphere signal again
+        sim_atm.apply(data)
+
+        # Check that the atmospheric fluctuations are stronger at higher frequency
+        for obs in data.obs:
+            for det in obs.local_detectors:
+                new_rms = np.std(obs.detdata["signal"][det])
+                assert new_rms > 1.1 * old_rms[obs.name][det]
 
         return

--- a/src/toast/weather.py
+++ b/src/toast/weather.py
@@ -232,11 +232,11 @@ class SimWeather(Weather):
         # Use a separate RNG index for each data type
         self._varindex = {y: x for x, y in enumerate(self._data[0]["data"].keys())}
 
-        self._sim_ice_water = self._draw("TQI")
-        self._sim_liquid_water = self._draw("TQL")
-        self._sim_pwv = self._draw("TQV")
-        self._sim_humidity = self._draw("QV10M")
-        self._sim_surface_pressure = self._draw("PS")
+        self._sim_ice_water = self._draw("TQI") * u.mm
+        self._sim_liquid_water = self._draw("TQL") * u.mm
+        self._sim_pwv = self._draw("TQV") * u.mm
+        self._sim_humidity = self._draw("QV10M") * u.mm
+        self._sim_surface_pressure = self._draw("PS") * u.Pa
         self._sim_surface_temperature = self._draw("TS") * u.Kelvin
         self._sim_air_temperature = self._draw("T10M") * u.Kelvin
         self._sim_west_wind = self._draw("U10M") * (u.meter / u.second)


### PR DESCRIPTION
- Scale the atmospheric fluctuations according to bandpass
- Add atmospheric background loading, also according to bandpass

Both are applied in `ObserveAtmosphere` but we could also separate the background loading into a separate operator.

This PR adds to named members to the `Focalplane` class:
- `noise`
- `bandpass`
If the detector data allows, they are created upon initialization. This renders the `DefaultNoiseModel` almost trivial: it only links the `focalplane.noise` to the appropriate observation key. It may still make sense to retain this operator so that noise simulation operators always look for an observation key instead of a focalplane member.
