### PR TITLE
Overhaul data distribution

### DIFF
--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -595,6 +595,9 @@ def fake_hexagon_focalplane(
             Column(name="psd_net", length=n_det, unit=(u.K * np.sqrt(1.0 * u.second))),
             Column(name="bandcenter", length=n_det, unit=u.GHz),
             Column(name="bandwidth", length=n_det, unit=u.GHz),
+            Column(
+                name="pixel", data=[x.rstrip("A").rstrip("B") for x in det_data.keys()]
+            ),
         ]
     )
 

--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -123,8 +123,12 @@ class Interval(object):
 class IntervalList(Sequence):
     """An list of Intervals which supports logical operations.
 
+    The timestamps define the valid local range of intervals.  When constructing
+    from intervals, timespans, or samplespans, the inputs are truncated to the
+    allowed range given by the timestamps.
+
     Args:
-        timestamps (array):  Array of sample times, required.
+        timestamps (array):  Array of local sample times, required.
         intervals (list):  A list of Interval objects.
         timespans (list):  A list of tuples containing start and stop times.
         samplespans (list):  A list of tuples containing first and last (inclusive)
@@ -134,13 +138,23 @@ class IntervalList(Sequence):
 
     def __init__(self, timestamps, intervals=None, timespans=None, samplespans=None):
         self.timestamps = timestamps
-        self._internal = None
+        self._internal = list()
         if intervals is not None:
             if timespans is not None or samplespans is not None:
                 raise RuntimeError(
                     "If constructing from intervals, other spans should be None"
                 )
-            self._internal = list(intervals)
+            timespans = [(x.start, x.stop) for x in intervals]
+            indices = self._find_indices(timespans)
+            self._internal = [
+                Interval(
+                    start=self.timestamps[x[0]],
+                    stop=self.timestamps[x[1]],
+                    first=x[0],
+                    last=x[1],
+                )
+                for x in indices
+            ]
         else:
             if timespans is not None:
                 if samplespans is not None:
@@ -151,21 +165,15 @@ class IntervalList(Sequence):
                     self._internal = list()
                 else:
                     # Construct intervals from time ranges
-                    start_indx = np.searchsorted(
-                        timestamps, [x[0] for x in timespans], side="left"
-                    )
-                    stop_indx = np.searchsorted(
-                        timestamps, [x[1] for x in timespans], side="right"
-                    )
-                    stop_indx -= 1
+                    indices = self._find_indices(timespans)
                     self._internal = [
                         Interval(
-                            start=timestamps[x[0]],
-                            stop=timestamps[x[1]],
+                            start=self.timestamps[x[0]],
+                            stop=self.timestamps[x[1]],
                             first=x[0],
                             last=x[1],
                         )
-                        for x in zip(start_indx, stop_indx)
+                        for x in indices
                     ]
             else:
                 if samplespans is None:
@@ -176,15 +184,37 @@ class IntervalList(Sequence):
                     self._internal = list()
                 else:
                     # Construct intervals from sample ranges
-                    self._internal = [
-                        Interval(
-                            start=timestamps[x[0]],
-                            stop=timestamps[x[1]],
-                            first=x[0],
-                            last=x[1],
+                    self._internal = list()
+                    for first, last in samplespans:
+                        if last < 0 or first >= len(self.timestamps):
+                            continue
+                        if first < 0:
+                            first = 0
+                        if last >= len(self.timestamps):
+                            last = len(self.timestamps) - 1
+                        self._internal.append(
+                            Interval(
+                                start=timestamps[first],
+                                stop=timestamps[last],
+                                first=first,
+                                last=last,
+                            )
                         )
-                        for x in samplespans
-                    ]
+
+    def _find_indices(self, timespans):
+        start_indx = np.searchsorted(
+            self.timestamps, [x[0] for x in timespans], side="left"
+        )
+        stop_indx = np.searchsorted(
+            self.timestamps, [x[1] for x in timespans], side="right"
+        )
+        stop_indx -= 1
+        out = list()
+        for start, stop in zip(start_indx, stop_indx):
+            if stop < 0 or start >= len(self.timestamps):
+                continue
+            out.append((start, stop))
+        return out
 
     def __getitem__(self, key):
         return self._internal[key]

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -373,7 +373,7 @@ class DetectorData(object):
         return not self.__eq__(other)
 
 
-class DetDataMgr(MutableMapping):
+class DetDataManager(MutableMapping):
     """Class used to manage DetectorData objects in an Observation.
 
     New objects can be created several ways.  The "create()" method:
@@ -683,7 +683,7 @@ class DetDataMgr(MutableMapping):
             self._internal[k].clear()
 
     def __repr__(self):
-        val = "<DetDataMgr {} local detectors, {} samples".format(
+        val = "<DetDataManager {} local detectors, {} samples".format(
             len(self.detectors), self.samples
         )
         for k in self._internal.keys():
@@ -714,7 +714,7 @@ class DetDataMgr(MutableMapping):
         return not self.__eq__(other)
 
 
-class SharedDataMgr(MutableMapping):
+class SharedDataManager(MutableMapping):
     """Class used to manage shared data objects in an Observation.
 
     New objects can be created with the "create()" method:
@@ -1000,7 +1000,7 @@ class SharedDataMgr(MutableMapping):
         return bytes
 
     def __repr__(self):
-        val = "<SharedDataMgr"
+        val = "<SharedDataManager"
         for k in self._internal.keys():
             val += "\n    {}: shape = {}, dtype = {}".format(
                 k, self._internal[k].shape, self._internal[k].dtype
@@ -1009,7 +1009,7 @@ class SharedDataMgr(MutableMapping):
         return val
 
 
-class IntervalMgr(MutableMapping):
+class IntervalsManager(MutableMapping):
     """Class for creating and storing interval lists in an observation.
 
     Named lists of intervals are accessed by dictionary style syntax ([] brackets).
@@ -1135,7 +1135,7 @@ class IntervalMgr(MutableMapping):
             self.clear()
 
     def __repr__(self):
-        val = "<IntervalMgr {} lists".format(len(self._internal))
+        val = "<IntervalsManager {} lists".format(len(self._internal))
         for k in self._internal.keys():
             val += "\n  {}: {} intervals".format(k, len(self._internal[k]))
         val += ">"

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -12,13 +12,15 @@ import numpy as np
 
 from pshmem.utils import mpi_data_type
 
-from .mpi import MPI
+from .mpi import MPI, comm_equal, comm_equivalent
 
 from .dist import distribute_samples
 
 from .utils import (
     Logger,
     name_UID,
+    dtype_to_aligned,
+    AlignedI32,
 )
 
 from .observation_data import DetectorData, DetDataMgr, SharedDataMgr, IntervalMgr
@@ -33,8 +35,10 @@ class DistDetSamp(object):
 
     Args:
         samples (int):  The total number of samples.
-        detectors (list):  The list of detector names.
-        detector_sets (list):  (Optional) List of lists containing detector names.
+        detectors (list):  The full list of detector names.  Note that detector_sets
+            may be used to prune this full list to only include a subset of detectors.
+        detector_sets (list or dict):  (Optional) List of lists containing detector
+            names or dictionary of lists with detector names (the keys are irrelevant).
             These discrete detector sets are used to distribute detectors- a detector
             set will always be within a single row of the process grid.  If None,
             every detector is a set of one.
@@ -73,6 +77,9 @@ class DistDetSamp(object):
         if self.comm is not None:
             self.comm_size = self.comm.size
             self.comm_rank = self.comm.rank
+            # Duplicate the input communicator, to ensure that we keep a copy if the
+            # the input is freed.
+            self.comm = MPI.Comm.Dup(self.comm)
 
         if self.process_rows is None:
             if self.comm is None:
@@ -109,35 +116,57 @@ class DistDetSamp(object):
             # Split the main communicator into process row and column
             # communicators.
 
-            if self.process_cols > 1:
+            if self.process_cols == 1:
+                self.comm_row = MPI.Comm.Dup(MPI.COMM_SELF)
+            else:
                 self.comm_row = self.comm.Split(self.comm_col_rank, self.comm_row_rank)
                 self.comm_row_size = self.comm_row.size
 
-            if self.process_rows > 1:
+            if self.process_rows == 1:
+                self.comm_col = MPI.Comm.Dup(MPI.COMM_SELF)
+            else:
                 self.comm_col = self.comm.Split(self.comm_row_rank, self.comm_col_rank)
                 self.comm_col_size = self.comm_col.size
 
         # If detector_sets is specified, check consistency.
 
         if self.detector_sets is not None:
-            test = 0
-            for ds in self.detector_sets:
-                test += len(ds)
-                for d in ds:
-                    if d not in self.detectors:
-                        msg = (
-                            "Detector {} in detector_sets but not in detectors".format(
-                                d
+            # We have some detector sets.  Verify that every det set contains detectors
+            # in the full list.  Make a new list of detectors including only those in
+            # the det sets.
+            new_dets = list()
+            detsets = list()
+            if isinstance(self.detector_sets, list):
+                # We have a list of lists
+                for ds in self.detector_sets:
+                    for d in ds:
+                        if d not in self.detectors:
+                            raise RuntimeError(
+                                f"detector {d} in a detset but not in detector list"
                             )
-                        )
-                        log.error(msg)
-                        raise RuntimeError(msg)
-            if test != len(detectors):
-                msg = "{} detectors given, but detector_sets has {}".format(
-                    len(detectors), test
-                )
-                log.error(msg)
-                raise RuntimeError(msg)
+                        new_dets.append(d)
+                    detsets.append(list(ds))
+            elif isinstance(self.detector_sets, dict):
+                # We have a detector group dictionary
+                for k, ds in self.detector_sets.items():
+                    for d in ds:
+                        if d not in self.detectors:
+                            raise RuntimeError(
+                                f"detector {d} in a detset but not in detector list"
+                            )
+                        new_dets.append(d)
+                    detsets.append(list(ds))
+            else:
+                raise RuntimeError("detector_sets should be a list or dict")
+
+            # Replace original detector list with only those found in detsets.
+            # Replace detector_sets with the structure needed by the low level
+            # distribution code.
+            self.detectors = new_dets
+            self.detector_sets = detsets
+
+        # Detector name to index
+        self.det_index = {y: x for x, y in enumerate(self.detectors)}
 
         # If sample_sets is specified, it must be consistent with
         # the total number of samples.
@@ -164,170 +193,285 @@ class DistDetSamp(object):
             sampsets=self.sample_sets,
         )
 
+        self.det_indices = list()
+        for ds in self.dets:
+            dfirst = self.det_index[ds[0]]
+            dlast = self.det_index[ds[-1]]
+            self.det_indices.append((dfirst, dlast - dfirst + 1))
 
-def compute_1d_offsets(off, n, new_dist):
+        if self.comm_rank == 0:
+            # check that all processes have some data, otherwise print warning
+            for i, d in enumerate(self.dets):
+                if d[1] == 0:
+                    msg = f"Process {i} has no detectors assigned."
+                    log.warning(msg)
+            for i, d in enumerate(self.samps):
+                if d[1] == 0:
+                    msg = f"Process {i} has no samples assigned."
+                    log.warning(msg)
+
+    def close(self):
+        # Explicitly free communicators if needed
+        if hasattr(self, "comm_row") and (self.comm_row is not None):
+            self.comm_row.Free()
+            self.comm_row = None
+        if hasattr(self, "comm_col") and (self.comm_col is not None):
+            self.comm_col.Free()
+            self.comm_col = None
+        if hasattr(self, "comm") and (self.comm is not None):
+            self.comm.Free()
+            self.comm = None
+        return
+
+    def __del__(self):
+        self.close()
+
+    def __eq__(self, other):
+        log = Logger.get()
+        fail = 0
+        if self.process_rows != other.process_rows:
+            fail = 1
+            log.verbose(f"  process_rows {self.process_rows} != {other.process_rows}")
+        if not comm_equivalent(self.comm, other.comm):
+            fail = 1
+            log.verbose(f"  obs comm not equivalent")
+        if not comm_equivalent(self.comm_row, other.comm_row):
+            fail = 1
+            log.verbose(f"  obs comm_row not equivalent")
+        if not comm_equivalent(self.comm_col, other.comm_col):
+            fail = 1
+            log.verbose(f"  obs comm_col not equivalent")
+        # Test the resulting distribution quantities, rather than the
+        # inputs passed to the constructor, in case those are slightly
+        # different types.
+        if self.dets != other.dets:
+            fail = 1
+            log.verbose(f"  dist dets {self.dets} != {other.dets}")
+        if self.det_sets != other.det_sets:
+            fail = 1
+            log.verbose(f"  dist detsets {self.det_sets} != {other.det_sets}")
+        if self.samps != other.samps:
+            fail = 1
+            log.verbose(f"  dist samps {self.samps} != {other.samps}")
+        if self.samp_sets != other.samp_sets:
+            fail = 1
+            log.verbose(f"  dist samp_sets {self.samp_sets} != {other.samp_sets}")
+        if self.comm is not None:
+            fail = self.comm.allreduce(fail, op=MPI.SUM)
+        return fail == 0
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+def compute_1d_offsets(off, n, target_dist):
     """Helper function to compute slices along one dimension.
 
     Args:
-        off (int):  The local offset.
+        off (int):  The offset of the local data.
         n (int):  The local number of elements.
-        new_dist (list):  A list of tuples, one per process, with the local offset and
-            number of elements for that process.
+        target_dist (list):  A list of tuples, one per process, with the offset
+            and number of elements for that process in the new distribution.
 
     Returns:
-        (list):  A list of tuples (one per process) containing information about which
-            local samples map to each target process in new_dist.  Each tuple contains:
-            (target process, local_offset, global_offset, num_elements).
+        (list):  A list of slices (one per process) with the slice of local data
+            that overlaps the data on the target process.  If there is no overlap
+            a None value is returned.
 
     """
-    pnew = list()
-    for ip, p in enumerate(new_dist):
-        poff = p[0]
-        pend = p[0] + p[1]
-        if poff >= off + n:
+    out = list()
+    for ip, p in enumerate(target_dist):
+        toff = p[0]
+        tend = p[0] + p[1]
+        if toff >= off + n:
+            out.append(None)
             continue
-        if pend <= off:
+        if tend <= off:
+            out.append(None)
             continue
-        new_off = off
-        if poff > off:
-            new_off = poff
-        new_n = off + n - new_off
-        if pend < off + n:
-            new_n = pend - new_off
-        pnew.append((ip, new_off - off, new_off, new_n))
-    return pnew
+        local_off = 0
+        target_off = 0
+        if toff >= off:
+            local_off = toff - off
+        else:
+            target_off = off - toff
+        tnum = n - local_off
+        if tend < off + n:
+            tnum = tend - local_off
+        out.append(slice(local_off, local_off + tnum, 1))
+    return out
 
 
-def compute_det_sample_offsets(all_dets, old_dist, new_dist):
-    """ """
-    det_order = {y: x for x, y in enumerate(all_dets)}
+def redistribute_buffer(
+    comm,
+    buffer_class,
+    mpi_type,
+    input,
+    output,
+    send_info,
+    recv_info,
+):
+    """Low-level Alltoallv redistribution of multidimensional buffers.
 
-    old_dets = list()
-    for pdet in old_dist.dets:
-        dfirst = det_order[pdet[0]]
-        dlast = det_order[pdet[-1]]
-        old_dets.append((dfirst, dlast - dfirst + 1))
-
-    new_dets = list()
-    for pdet in new_dist.dets:
-        dfirst = det_order[pdet[0]]
-        dlast = det_order[pdet[-1]]
-        new_dets.append((dfirst, dlast - dfirst + 1))
-
-    # Every process figures out its send and receive information
-
-    send_row = compute_1d(self.local_index_offset, self.n_local_samples, newdist.samps)
-    det_first = det_order[self.local_detectors[0]]
-    det_last = det_order[self.local_detectors[-1]]
-    send_col = compute_1d(det_first, det_last - det_first + 1, newdets)
-    send_info = list()
-    for sc in send_col:
-        for sr in send_row:
-            psend = sc[0] * newdist.comm_row_size + sr[0]
-            send_info.append((psend, sc[1], sc[2], sc[3], sr[1], sr[2], sr[3]))
-
-    msg = "Proc {} det send:  {}".format(self.comm_rank, send_info)
-    print(msg, flush=True)
-
-    recv_row = compute_1d(
-        newdist.samps[newdist.comm_row_rank][0],
-        newdist.samps[newdist.comm_row_rank][1],
-        self.dist.samps,
-    )
-    det_first = det_order[newdist.dets[newdist.comm_col_rank][0]]
-    det_last = det_order[newdist.dets[newdist.comm_col_rank][-1]]
-    recv_col = compute_1d(det_first, det_last - det_first + 1, olddets)
-    recv_info = list()
-    for rc in recv_col:
-        for rr in recv_row:
-            precv = rc[0] * self.dist.comm_row_size + rr[0]
-            recv_info.append((precv, rc[1], rc[2], rc[3], rr[1], rr[2], rr[3]))
-
-    msg = "Proc {} det recv:  {}".format(self.comm_rank, recv_info)
-    print(msg, flush=True)
-
-
-def redistribute(self, process_rows, times=None):
-    """Take the currently allocated observation and redistribute in place.
-
-    This changes the data distribution within the observation.  After
-    re-assigning all detectors and samples, the currently allocated shared data
-    objects and detector data objects are redistributed using the observation
-    communicator.
+    The send and receive slices for each process are used to construct flat-packed
+    buffers and copy data into and out of them.
 
     Args:
-        process_rows (int):  The size of the new process grid in the detector
-            direction.  This number must evenly divide into the size of the
-            observation communicator.
-        times (str):  The shared data field representing the timestamps.  This
-            is used to recompute the intervals after redistribution.
+        comm (mpi4py.Comm):  The communicator
+        buffer_class (object):  The AlignedXX class used for the send and receive
+            buffers.
+        mpi_type (MPI.Type):  The MPI data type.
+        input (array-like):  The multidimensional local piece of the input.
+        output (array-like):  The multidimensional local piece of the output.
+        send_info (list):  A list of tuples, one per process, with the send slices.
+        recv_info (list):  A list of tuples, one per process, with the receive slices.
 
     Returns:
         None
 
     """
-    log = Logger.get()
-    if process_rows == self.dist.process_rows:
-        # Nothing to do!
-        return
+    # Per-process send and receive information in terms of the flat
+    # packed buffers.
+    send_counts = AlignedI32(comm.size)
+    recv_counts = AlignedI32(comm.size)
+    send_displ = AlignedI32(comm.size)
+    recv_displ = AlignedI32(comm.size)
 
-    # Construct the new distribution
-    newdist = DistDetSamp(
-        self._samples,
-        self._telescope.focalplane.detectors,
-        self._sample_sets,
-        self._detector_sets,
-        self._comm,
-        process_rows,
+    off = 0
+    send_shape = list()
+    for iproc, send_slc in enumerate(send_info):
+        send_displ[iproc] = off
+        n_elem = 0
+        if send_slc is not None:
+            n_elem = 1
+            ss = list()
+            for slc in send_slc:
+                slen = slc.stop - slc.start
+                n_elem *= slen
+                ss.append(slen)
+            send_shape.append(tuple(ss))
+        else:
+            send_shape.append(None)
+        send_counts[iproc] = n_elem
+        off += n_elem
+    send_n_elem = off
+
+    off = 0
+    recv_shape = list()
+    for iproc, recv_slc in enumerate(recv_info):
+        recv_displ[iproc] = off
+        n_elem = 0
+        if recv_slc is not None:
+            n_elem = 1
+            rs = list()
+            for slc in recv_slc:
+                rlen = slc.stop - slc.start
+                n_elem *= rlen
+                rs.append(rlen)
+            recv_shape.append(tuple(rs))
+        else:
+            recv_shape.append(None)
+        recv_counts[iproc] = n_elem
+        off += n_elem
+    recv_n_elem = off
+
+    # Set up the send / receive buffers
+    send_buf = buffer_class(send_n_elem)
+    recv_buf = buffer_class(recv_n_elem)
+
+    # Copy data into the send buffer
+    for iproc, send_slc in enumerate(send_info):
+        off = send_displ[iproc]
+        n_elem = send_counts[iproc]
+        if n_elem > 0:
+            send_buf[off : off + n_elem] = input[send_slc].flatten()
+
+    # Communicate data
+    comm.Alltoallv(
+        [
+            send_buf,
+            send_counts,
+            send_displ,
+            mpi_type,
+        ],
+        [
+            recv_buf,
+            recv_counts,
+            recv_displ,
+            mpi_type,
+        ],
     )
 
-    det_order = {y: x for x, y in enumerate(self.all_detectors)}
+    # Copy data to output
+    for iproc, recv_slc in enumerate(recv_info):
+        off = recv_displ[iproc]
+        n_elem = recv_counts[iproc]
+        if n_elem > 0:
+            output[recv_slc] = (
+                recv_buf[off : off + n_elem].array().reshape(recv_shape[iproc])
+            )
 
-    if newdist.comm_rank == 0:
-        # check that all processes have some data, otherwise print warning
-        for d in range(newdist.process_rows):
-            if len(newdist.dets[d]) == 0:
-                msg = "WARNING: process row rank {} has no detectors"
-                " assigned in new distribution.".format(d)
-                log.warning(msg)
-        for r in range(newdist.process_cols):
-            if newdist.samps[r][1] <= 0:
-                msg = "WARNING: process column rank {} has no data assigned "
-                "in new distribution.".format(r)
-                log.warning(msg)
+    # Delete buffers
+    send_buf.clear()
+    del send_buf
+    recv_buf.clear()
+    del recv_buf
+    send_counts.clear()
+    del send_counts
+    send_displ.clear()
+    del send_displ
+    recv_counts.clear()
+    del recv_counts
+    recv_displ.clear()
+    del recv_displ
 
-    # Clear all views, since they depend on the intervals we are about to
-    # delete.  Views are re-created on demand.
 
-    print("clearing views", flush=True)
-    self.view.clear()
+def redistribute_data(old_dist, new_dist, shr_mgr, det_mgr, ivl_mgr, times=None):
+    """Helper function to redistribute data in an observation.
+
+    Given the old and new data distributions, redistribute all objects in the
+    shared, detdata, and intervals manager objects.  The input managers are cleared
+    upon return.  If times is None and there exist some intervals, a warning
+    will be given and the intervals will be deleted.
+
+    Args:
+        old_dist (DistDetSamp):  The existing data distribution.
+        new_dist (DistDetSamp):  The new data distribution.
+        mgr (SharedDataMgr):  The manager instance.
+        time (str):  The name of the shared object containing the timestamps.
+
+    Returns:
+        (tuple):  The new (SharedDataMgr, DetDataMgr, IntervalsMgr) instances.
+
+    """
+    log = Logger.get()
 
     # After an IntervalList is added, only the local intervals on each process are
-    # kept.  We need to construct the original timespans that were used and save,
+    # kept.  We need to reconstruct the original timespans that were used and save,
     # so that we can rebuild them after the timestamps have been redistributed.
+    # After reconstructing the time ranges, the input interval list is cleared.
 
-    if times is None:
-        if self.comm_rank == 0:
-            msg = "Time stamps not specified when redistributing observation {}."
+    if times is None and len(ivl_mgr.keys()) > 0:
+        if old_dist.comm_rank == 0:
+            msg = "Time stamps not specified when redistributing observation."
             msg += "  Intervals will be deleted and not redistributed."
             log.warning(msg)
 
-    global_intervals = None
-    if self.comm_rank == 0:
-        global_intervals = dict()
+    global_intervals = dict()
 
-    for iname in list(self.intervals.keys()):
-        print("gathering interval {}".format(iname), flush=True)
-        ilist = self.intervals[iname]
+    for iname in list(ivl_mgr.keys()):
+        ilist = [(x.start, x.stop, x.first, x.last) for x in ivl_mgr[iname]]
         all_ilist = None
-        if self.comm_row is None:
-            all_ilist = [(ilist, self.n_local_samples)]
+        if old_dist.comm_row is None:
+            all_ilist = [(ilist, old_dist.samps[old_dist.comm_row_rank][1])]
         else:
             # Gather across the process row
-            if self.comm_col_rank == 0:
-                all_ilist = self.comm_row.gather((ilist, self.n_local_samples), root=0)
+            if old_dist.comm_col_rank == 0:
+                all_ilist = old_dist.comm_row.gather(
+                    (ilist, old_dist.samps[old_dist.comm_row_rank][1]), root=0
+                )
         del ilist
-        if self.comm_rank == 0:
+        if old_dist.comm_rank == 0:
             # Only one process builds the list of start / stop times.
             glist = list()
             last_continue = False
@@ -336,21 +480,20 @@ def redistribute(self, process_rows, times=None):
             for pdata, pn in all_ilist:
                 if len(pdata) == 0:
                     continue
-
-                for intvl in pdata:
+                for start, stop, first, last in pdata:
                     if last_continue:
-                        if invl.first == 0:
-                            last_stop = intvl.stop
+                        if first == 0:
+                            last_stop = stop
                         else:
                             glist.append((last_start, last_stop))
                             last_continue = False
-                            last_start = intvl.start
-                            last_stop = intvl.stop
+                            last_start = start
+                            last_stop = stop
                     else:
-                        last_start = intvl.start
-                        last_stop = intvl.stop
+                        last_start = start
+                        last_stop = stop
 
-                    if intvl.last == pn - 1:
+                    if last == pn - 1:
                         last_continue = True
                     else:
                         glist.append((last_start, last_stop))
@@ -358,106 +501,280 @@ def redistribute(self, process_rows, times=None):
             if last_continue:
                 # add final range
                 glist.append((last_start, last_stop))
-        global_intervals[iname] = glist
-        print("purging interval {}".format(iname), flush=True)
-        del self.intervals[iname]
+            global_intervals[iname] = glist
 
-    # Create the new detdata manager
-
-    newdetdata = DetDataMgr(
-        newdist.dets[newdist.comm_col_rank],
-        newdist.samps[newdist.comm_row_rank][1],
-    )
+    ivl_mgr.clear()
 
     # Redistribute detector data.  For purposes of redistribution, we require
-    # that all DetectorData objects span the full set of local detectors.  This
-    # allows all detectors to determine (without further communication) the new
-    # and old distribution of all the data.
-    #
+    # that all DetectorData objects span the full set of local detectors.
     # In practice, smaller DetectorData objects are only used for intermediate data
     # products.  Data redistribution is something that will happen infrequently at
     # fixed points in a larger workflow.  If this ever becomes too much of a
     # limitation, we could add more logic to handle the case of detdata fields with
     # subsets of local detectors.
 
-    send_counts = np.zeros(self.comm_size, dtype=np.int32)
-    recv_counts = np.zeros(self.comm_size, dtype=np.int32)
-    send_displ = np.zeros(self.comm_size, dtype=np.int32)
-    recv_displ = np.zeros(self.comm_size, dtype=np.int32)
+    new_det_mgr = DetDataMgr(
+        new_dist.dets[new_dist.comm_rank], new_dist.samps[new_dist.comm_rank][1]
+    )
 
-    for field in list(self.detdata.keys()):
-        field_dets = self.detdata[field].detectors
-        if field_dets != self.local_detectors:
+    # Compute the detector and sample ranges we are sending and receiving.  These are
+    # common for all detdata objects.
+
+    old_det_off = old_dist.det_indices[old_dist.comm_rank][0]
+    old_det_n = old_dist.det_indices[old_dist.comm_rank][1]
+    det_send_info = compute_1d_offsets(old_det_off, old_det_n, new_dist.det_indices)
+    old_samp_off = old_dist.samps[old_dist.comm_rank][0]
+    old_samp_n = old_dist.samps[old_dist.comm_rank][1]
+    samp_send_info = compute_1d_offsets(old_samp_off, old_samp_n, new_dist.samps)
+
+    new_det_off = new_dist.det_indices[new_dist.comm_rank][0]
+    new_det_n = new_dist.det_indices[new_dist.comm_rank][1]
+    det_recv_info = compute_1d_offsets(new_det_off, new_det_n, old_dist.det_indices)
+    new_samp_off = new_dist.samps[new_dist.comm_rank][0]
+    new_samp_n = new_dist.samps[new_dist.comm_rank][1]
+    samp_recv_info = compute_1d_offsets(new_samp_off, new_samp_n, old_dist.samps)
+
+    # Process every detdata object
+
+    for field in list(det_mgr.keys()):
+        field_dets = det_mgr[field].detectors
+        local_dets = old_dist.detectors[old_det_off : old_det_off + old_det_n]
+        if not all([x == y for x, y in zip(field_dets, local_dets)]):
             msg = "Redistribution only supports detdata with all local detectors."
             msg += " Field {} has {} dets instead of {}".format(
-                field, len(field_dets), len(self.local_detectors)
+                field, len(field_dets), len(local_dets)
             )
+            log.error(msg)
             raise NotImplementedError(msg)
+
+        # Buffer class to use
+        buffer_class, _ = dtype_to_aligned(det_mgr[field].dtype)
 
         # Get MPI data type.  Note that in the case of no MPI, this function would
         # have returned at the very start.  So we know that we have a real
         # communicator at this point.
-        mpibytesize, mpitype = mpi_data_type(self.comm, self.detdata[field].dtype)
+        mpibytesize, mpitype = mpi_data_type(old_dist.comm, det_mgr[field].dtype)
 
         # Allocate new data
         sample_shape = None
-        if len(self.detdata[field].detector_shape) == 1:
-            # One number per sample
-            sample_shape = (1,)
-        else:
-            sample_shape = self.detdata[field].detector_shape[1:]
+        n_per_sample = 1
+        if len(det_mgr[field].detector_shape) > 1:
+            sample_shape = det_mgr[field].detector_shape[1:]
+            for dim in sample_shape:
+                n_per_sample *= dim
 
-        newdetdata.create(
+        new_det_mgr.create(
             field,
             sample_shape=sample_shape,
-            dtype=self.detdata[field].dtype,
-            detectors=None,
+            dtype=det_mgr[field].dtype,
         )
 
-        # Set up the send / receive counts and displacements
+        # Redistribution send / recv slices
+        samp_slices = None
+        if sample_shape is not None:
+            samp_slices = [slice(0, x, 1) for x in sample_shape]
+        send_info = list()
+        for dinfo, sinfo in zip(det_send_info, samp_send_info):
+            proc_slices = None
+            if dinfo is not None and sinfo is not None:
+                proc_slices = [dinfo, sinfo]
+                if samp_slices is not None:
+                    proc_slices.extend(samp_slices)
+                proc_slices = tuple(proc_slices)
+            send_info.append(proc_slices)
 
-        send_counts[:] = 0
-        send_displ[:] = 0
-        for (
-            p,
-            loc_det_off,
-            glob_det_off,
-            n_det,
-            loc_samp_off,
-            glob_samp_off,
-            n_samp,
-        ) in send_info:
-            pass
+        recv_info = list()
+        for dinfo, sinfo in zip(det_recv_info, samp_recv_info):
+            proc_slices = None
+            if dinfo is not None and sinfo is not None:
+                proc_slices = [dinfo, sinfo]
+                if samp_slices is not None:
+                    proc_slices.extend(samp_slices)
+                proc_slices = tuple(proc_slices)
+            recv_info.append(proc_slices)
 
-        # Communicate data
-
-        self._dist.comm.Alltoallv(
-            [
-                self.detdata[field].flatdata,
-                self._send_counts,
-                self._send_displ,
-                mpitype,
-            ],
-            [
-                newdetdata[field].flatdata,
-                self._recv_counts,
-                self._recv_displ,
-                mpitype,
-            ],
+        # Redistribute
+        redistribute_buffer(
+            old_dist.comm,
+            buffer_class,
+            mpitype,
+            det_mgr[field].data,
+            new_det_mgr[field].data,
+            send_info,
+            recv_info,
         )
 
-        del self.detdata[field]
+    # Shared data.  If the data is shared across the observation (group) communicator,
+    # then no action is needed.  If it is shared across a row or column communicator,
+    # then only the rank zero processes in those communicators need to do anything.
 
-    # # Redistribute shared data
-    #
-    # newshared = SharedDataMgr(
-    #     self._comm,
-    #     newdist.comm_row,
-    #     newdist.comm_col,
-    # )
-    #
-    # # Redistribute intervals
-    #
-    # newintervals = IntervalMgr(self._comm, newdist.comm_row, newdist.comm_col)
+    # In order to determine how to split up and recombine shared objects, we require
+    # that the leading dimension of the object corresponds to either the number of
+    # local detectors (for row-shared objects) or the number of local samples (for
+    # column-shared objects).
 
-    # Swap new data objects into place
+    # Create the new shared manager.
+    new_shr_mgr = SharedDataMgr(
+        len(new_dist.dets[new_dist.comm_rank]),
+        new_dist.samps[new_dist.comm_rank][1],
+        new_dist.comm,
+        new_dist.comm_row,
+        new_dist.comm_col,
+    )
+
+    for field in shr_mgr.keys():
+        shobj = shr_mgr[field]
+        if comm_equal(shobj.comm, old_dist.comm):
+            # Using full group communicator, just copy to the new data manager.
+            new_shr_mgr[field] = shobj
+        else:
+            # Full shape of the object
+            shp = shobj.shape
+
+            # Buffer type
+            buffer_class, _ = dtype_to_aligned(shobj.dtype)
+            mpibytesize, mpitype = mpi_data_type(shobj.comm, shobj.dtype)
+
+            # Shape of the non-leading dimensions
+            other_shape = None
+            n_per_leading = 1
+            if len(shp) > 1:
+                other_shape = shp[1:]
+                for dim in other_shape:
+                    n_per_leading *= dim
+
+            # slices for non-leading dimensions
+            dim_slices = None
+            if other_shape is not None:
+                dim_slices = [slice(0, x, 1) for x in other_shape]
+
+            if comm_equal(shobj.comm, old_dist.comm_row):
+                # Shared in the sample direction.
+                if shp[0] != old_det_n:
+                    msg = f"Shared object {field} uses the row communicator, "
+                    msg += f"but has leading dimension {shp[0]} rather than the "
+                    msg += f"number of local detectors ({old_det_n}).  "
+                    msg += f"Cannot redistribute."
+                    raise RuntimeError(msg)
+
+                # Redistribution send / recv slices
+                send_info = [None for x in range(shobj.comm.size)]
+                recv_info = [None for x in range(shobj.comm.size)]
+
+                if old_dist.comm_row_rank == 0:
+                    # We are sending something
+                    send_info = list()
+                    for rproc, sinfo in enumerate(det_send_info):
+                        proc_slices = None
+                        if sinfo is not None and rproc % new_dist.comm_row_size == 0:
+                            proc_slices = [sinfo]
+                            if dim_slices is not None:
+                                proc_slices.extend(dim_slices)
+                            proc_slices = tuple(proc_slices)
+                        send_info.append(proc_slices)
+                if new_dist.comm_row_rank == 0:
+                    # We are receiving something
+                    recv_info = list()
+                    for sproc, rinfo in enumerate(det_recv_info):
+                        proc_slices = None
+                        if rinfo is not None and sproc % old_dist.comm_row_size == 0:
+                            proc_slices = [rinfo]
+                            if dim_slices is not None:
+                                proc_slices.extend(dim_slices)
+                            proc_slices = tuple(proc_slices)
+                        recv_info.append(proc_slices)
+
+                # Create the new object
+                new_shp = [new_det_n]
+                if other_shape is not None:
+                    new_shp.extend(other_shape)
+
+                new_shr_mgr.create(
+                    field, new_shp, dtype=shobj.dtype, comm=new_dist.comm_row
+                )
+
+                # Redistribute
+                redistribute_buffer(
+                    old_dist.comm,
+                    buffer_class,
+                    mpitype,
+                    shobj.data,
+                    new_shr_mgr[field].data,
+                    send_info,
+                    recv_info,
+                )
+            elif comm_equal(shobj.comm, old_dist.comm_col):
+                # Shared in the detector direction
+                shp = shobj.shape
+                if shp[0] != old_samp_n:
+                    msg = f"Shared object {field} uses the column communicator, "
+                    msg += f"but has leading dimension {shp[0]} rather than the "
+                    msg += f"number of local samples {old_samp_n}.  "
+                    msg += f"Cannot redistribute."
+                    raise RuntimeError(msg)
+
+                # Redistribution send / recv slices
+                send_info = [None for x in range(shobj.comm.size)]
+                recv_info = [None for x in range(shobj.comm.size)]
+                if old_dist.comm_col_rank == 0:
+                    # We are sending something
+                    send_info = list()
+                    for rproc, sinfo in enumerate(samp_send_info):
+                        proc_slices = None
+                        if sinfo is not None and rproc % new_dist.comm_col_size == 0:
+                            proc_slices = [sinfo]
+                            if dim_slices is not None:
+                                proc_slices.extend(dim_slices)
+                            proc_slices = tuple(proc_slices)
+                        send_info.append(proc_slices)
+                if new_dist.comm_col_rank == 0:
+                    # We are receiving something
+                    recv_info = list()
+                    for sproc, rinfo in enumerate(samp_recv_info):
+                        proc_slices = None
+                        if rinfo is not None and sproc % old_dist.comm_col_size == 0:
+                            proc_slices = [rinfo]
+                            if dim_slices is not None:
+                                proc_slices.extend(dim_slices)
+                            proc_slices = tuple(proc_slices)
+                        recv_info.append(proc_slices)
+
+                # Create the new object
+                new_shp = [new_samp_n]
+                if other_shape is not None:
+                    new_shp.extend(other_shape)
+                new_shr_mgr.create(
+                    field, new_shp, dtype=shobj.dtype, comm=new_dist.comm_col
+                )
+
+                # Redistribute
+                redistribute_buffer(
+                    old_dist.comm,
+                    buffer_class,
+                    mpitype,
+                    shobj.data,
+                    new_shr_mgr[field].data,
+                    send_info,
+                    recv_info,
+                )
+            else:
+                msg = "Only shared objects using the group, row, and column "
+                msg += "communicators can be redistributed"
+                log.error(msg)
+                raise RuntimeError(msg)
+
+    # Re-create the intervals in the new data distribution.
+    new_ivl_mgr = IntervalMgr(new_dist.comm, new_dist.comm_row, new_dist.comm_col)
+
+    # Communicate the field list
+    ivl_fields = old_dist.comm.bcast(list(global_intervals.keys()), root=0)
+
+    for field in ivl_fields:
+        glb = None
+        if old_dist.comm_rank == 0:
+            glb = global_intervals[field]
+        new_ivl_mgr.create(field, glb, new_shr_mgr[times], fromrank=0)
+        # If there were intervals breaks due only to data distribution, join them now.
+        new_ivl_mgr[field].simplify()
+
+    return new_shr_mgr, new_det_mgr, new_ivl_mgr

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -71,15 +71,15 @@ class DistDetSamp(object):
             log.error(msg)
             raise RuntimeError(msg)
 
-        self.comm = comm
+        self.comm = None
         self.comm_size = 1
         self.comm_rank = 0
-        if self.comm is not None:
-            self.comm_size = self.comm.size
-            self.comm_rank = self.comm.rank
+        if comm is not None:
             # Duplicate the input communicator, to ensure that we keep a copy if the
             # the input is freed.
-            self.comm = MPI.Comm.Dup(self.comm)
+            self.comm = MPI.Comm.Dup(comm)
+            self.comm_size = self.comm.size
+            self.comm_rank = self.comm.rank
 
         if self.process_rows is None:
             if self.comm is None:
@@ -201,12 +201,12 @@ class DistDetSamp(object):
 
         if self.comm_rank == 0:
             # check that all processes have some data, otherwise print warning
-            for i, d in enumerate(self.dets):
-                if d[1] == 0:
+            for i, ds in enumerate(self.dets):
+                if len(ds) == 0:
                     msg = f"Process {i} has no detectors assigned."
                     log.warning(msg)
-            for i, d in enumerate(self.samps):
-                if d[1] == 0:
+            for i, ss in enumerate(self.samps):
+                if ss[1] == 0:
                     msg = f"Process {i} has no samples assigned."
                     log.warning(msg)
 

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -12,7 +12,7 @@ import numpy as np
 
 
 class DetDataView(MutableMapping):
-    """Class that applies views to a DetDataMgr instance."""
+    """Class that applies views to a DetDataManager instance."""
 
     def __init__(self, obj, slices):
         self.obj = obj
@@ -55,7 +55,7 @@ class DetDataView(MutableMapping):
 
 
 class SharedView(MutableMapping):
-    """Class that applies views to a SharedDataMgr instance."""
+    """Class that applies views to a SharedDataManager instance."""
 
     def __init__(self, obj, slices):
         self.obj = obj
@@ -133,7 +133,7 @@ class View(Sequence):
         return s
 
 
-class ViewMgr(MutableMapping):
+class ViewManager(MutableMapping):
     """Internal class to manage views into observation data objects."""
 
     def __init__(self, obj):
@@ -201,7 +201,7 @@ class ViewInterface(object):
             return self
         else:
             if not hasattr(obj, "_viewmgr"):
-                obj._viewmgr = ViewMgr(obj)
+                obj._viewmgr = ViewManager(obj)
             return obj._viewmgr
 
     def __set__(self, obj, value):

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -135,6 +135,12 @@ class SimGround(Operator):
         help="Distribute observation data along the time axis rather than detector axis",
     )
 
+    detset_key = Unicode(
+        None,
+        allow_none=True,
+        help="If specified, use this column of the focalplane detector_data to group detectors",
+    )
+
     times = Unicode("times", help="Observation shared key for timestamps")
 
     shared_flags = Unicode("flags", help="Observation shared key for common flags")
@@ -251,6 +257,13 @@ class SimGround(Operator):
         rate = focalplane.sample_rate.to_value(u.Hz)
         comm = data.comm
 
+        # Data distribution in the detector and sample directions
+        det_ranks = comm.group_size
+        samp_ranks = 1
+        if self.distribute_time:
+            det_ranks = 1
+            samp_ranks = comm.group_size
+
         # List of detectors in this pipeline
         pipedets = None
         if detectors is None:
@@ -260,6 +273,37 @@ class SimGround(Operator):
             for det in focalplane.detectors:
                 if det in detectors:
                     pipedets.append(det)
+
+        # Group by detector sets and prune to include only the detectors we
+        # are using.
+        detsets = None
+        if self.detset_key is not None:
+            detsets = dict()
+            dsets = focalplane.detector_groups(self.detset_key)
+            for k, v in dsets.items():
+                detsets[k] = list()
+                for d in v:
+                    if d in pipedets:
+                        detsets[k].append(d)
+
+        # Verify that we have enough detector data for all of our processes.  If we are
+        # distributing by time, we check the sample sets on a per-observation basis
+        # later.  If we are distributing by detector, we must have at least one
+        # detector set for each process.
+
+        if not self.distribute_time:
+            # distributing by detector...
+            n_detset = None
+            if detsets is None:
+                # Every detector is independently distributed
+                n_detset = len(pipedets)
+            else:
+                n_detset = len(detsets)
+            if det_ranks > n_detset:
+                if comm.group_rank == 0:
+                    msg = f"Group {comm.group} with {comm.group_size} processes cannot distribute {n_detset} detector sets."
+                    log.error(msg)
+                    raise RuntimeError(msg)
 
         # Check valid combinations of options
 
@@ -305,10 +349,6 @@ class SimGround(Operator):
         # weight it by the duration in samples.
 
         groupdist = distribute_discrete(scan_samples, comm.ngroups)
-
-        det_ranks = comm.group_size
-        if self.distribute_time:
-            det_ranks = 1
 
         # Every process group creates its observations
 
@@ -360,6 +400,12 @@ class SimGround(Operator):
                 elnod_el = np.array([x.to_value(u.radian) for x in self.elnods])
                 elnod_az = np.zeros_like(elnod_el) + scan.az_min.to_value(u.radian)
 
+            # Sample sets.  Although Observations support data distribution in any
+            # shape process grid, this operator only supports 2 cases:  distributing
+            # by detector and distributing by time.  We want to ensure that
+
+            sample_sets = list()
+
             # Do starting El nod.  We do this before the start of the scheduled scan.
             if self.elnod_start:
                 (
@@ -389,6 +435,7 @@ class SimGround(Operator):
                 if len(elnod_times) > 0:
                     # Shift these elnod times so that they end one sample before the
                     # start of the scan.
+                    sample_sets.append([len(elnod_times)])
                     t_elnod = elnod_times[-1] - elnod_times[0]
                     elnod_times -= t_elnod + incr
                     times.append(elnod_times)
@@ -447,6 +494,16 @@ class SimGround(Operator):
                     self.el_mod_step.to_value(u.radian),
                 )
 
+            # When distributing data, ensure that each process has a whole number of
+            # complete scans.
+            scan_indices = np.searchsorted(
+                scan_times, [x[0] for x in ival_scan_leftright], side="left"
+            )
+            sample_sets.extend([[x] for x in scan_indices[1:] - scan_indices[:-1]])
+            remainder = len(scan_times) - scan_indices[-1]
+            if remainder > 0:
+                sample_sets.append([remainder])
+
             times.append(scan_times)
             az.append(scan_az_data)
             el.append(scan_el_data)
@@ -481,6 +538,7 @@ class SimGround(Operator):
                     scan_max_el,
                 )
                 if len(elnod_times) > 0:
+                    sample_sets.append([len(elnod_times)])
                     times.append(elnod_times)
                     az.append(elnod_az_data)
                     el.append(elnod_el_data)
@@ -489,6 +547,15 @@ class SimGround(Operator):
             times = np.hstack(times)
             az = np.hstack(az)
             el = np.hstack(el)
+
+            # If we are distributing by time, ensure we have enough sample sets for the
+            # number of processes.
+            if self.distribute_time:
+                if samp_ranks > len(sample_sets):
+                    if comm.group_rank == 0:
+                        msg = f"Group {comm.group} with {comm.group_size} processes cannot distribute {len(sample_sets)} sample sets."
+                        log.error(msg)
+                        raise RuntimeError(msg)
 
             # Create the observation, now that we know the total number of samples.
             # We copy the original site information and add weather information for
@@ -525,7 +592,9 @@ class SimGround(Operator):
                 name=name,
                 uid=name_UID(name),
                 comm=comm.comm_group,
+                detector_sets=detsets,
                 process_rows=det_ranks,
+                sample_sets=sample_sets,
             )
 
             # Scan limits

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -614,37 +614,6 @@ def simulate_ces_scan(
             # interval is truncated
             ival[-1] = (last[0], times[-1])
 
-    # if self._el_mod_rate != 0:
-    #     new_min_el, new_max_el = oscillate_el(times, az_sample, el_sample)
-    # if self._el_mod_step != 0:
-    #     new_min_el, new_max_el = step_el(times, az_sample, el_sample)
-
-    # offset = self._times.size
-    # self._times = np.hstack([self._times, times])
-    # self._az = np.hstack([self._az, az_sample])
-    # self._el = np.hstack([self._el, el_sample])
-    # ind = np.searchsorted(tvec - tmin, (times - tmin) % tdelta)
-    # ind[ind == tvec.size] = tvec.size - 1
-    # self._commonflags = np.hstack([self._commonflags, flags[ind]]).astype(np.uint8)
-    #
-    # # Subscan start indices
-    #
-    # turnflags = flags[ind] & self.TURNAROUND
-    # self._stable_starts = (
-    #     np.argwhere(np.logical_and(turnflags[:-1] != 0, turnflags[1:] == 0)).ravel() + 1
-    # )
-    # if turnflags[0] == 0:
-    #     self._stable_starts = np.hstack([[0], self._stable_starts])
-    # self._stable_stops = (
-    #     np.argwhere(np.logical_and(turnflags[:-1] == 0, turnflags[1:] != 0)).ravel() + 2
-    # )
-    # if turnflags[-1] == 0:
-    #     self._stable_stops = np.hstack([self._stable_stops, [samples]])
-    # self._stable_starts += offset
-    # self._stable_stops += offset
-    #
-    # self._CES_stop = self._times[-1]
-
     return (
         times,
         az_sample,

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -246,6 +246,12 @@ class SimSatellite(Operator):
         help="Distribute observation data along the time axis rather than detector axis",
     )
 
+    detset_key = Unicode(
+        None,
+        allow_none=True,
+        help="If specified, use this column of the focalplane detector_data to group detectors",
+    )
+
     times = Unicode("times", help="Observation shared key for timestamps")
 
     shared_flags = Unicode("flags", help="Observation shared key for common flags")
@@ -309,10 +315,40 @@ class SimSatellite(Operator):
                 if det in detectors:
                     pipedets.append(det)
 
-        if comm.group_size > len(pipedets):
-            if comm.world_rank == 0:
-                log.error("process group is too large for the number of detectors")
-                comm.comm_world.Abort()
+        # Group by detector sets and prune to include only the detectors we
+        # are using.
+        detsets = None
+        if self.detset_key is not None:
+            dsets = focalplane.detector_groups(self.detset_key)
+            for k, v in dsets.items():
+                detsets[k] = list()
+                for d in v:
+                    if d in pipedets:
+                        detsets[k].append(d)
+
+        # Data distribution in the detector direction
+        det_ranks = comm.group_size
+        if self.distribute_time:
+            det_ranks = 1
+
+        # Verify that we have enough data for all of our processes.  If we are
+        # distributing by time, we have no sample sets, so can accomodate any
+        # number of processes.  If we are distributing by detector, we must have
+        # at least one detector set for each process.
+
+        if not self.distribute_time:
+            # distributing by detector...
+            n_detset = None
+            if detsets is None:
+                # Every detector is independently distributed
+                n_detset = len(pipedets)
+            else:
+                n_detset = len(detsets)
+            if det_ranks > n_detset:
+                if comm.group_rank == 0:
+                    msg = f"Group {comm.group} has {comm.group_size} processes but {n_detset} detector sets."
+                    log.error(msg)
+                    raise RuntimeError(msg)
 
         # The global start is the beginning of the first scan
 
@@ -348,10 +384,6 @@ class SimSatellite(Operator):
 
         groupdist = distribute_discrete(scan_samples, comm.ngroups)
 
-        det_ranks = comm.group_size
-        if self.distribute_time:
-            det_ranks = 1
-
         # Every process group creates its observations
 
         group_firstobs = groupdist[comm.group][0]
@@ -366,6 +398,7 @@ class SimSatellite(Operator):
                 name=f"{scan.name}_{int(scan.start.timestamp())}",
                 uid=name_UID(scan.name),
                 comm=comm.comm_group,
+                detector_sets=detsets,
                 process_rows=det_ranks,
             )
 

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -319,6 +319,7 @@ class SimSatellite(Operator):
         # are using.
         detsets = None
         if self.detset_key is not None:
+            detsets = dict()
             dsets = focalplane.detector_groups(self.detset_key)
             for k, v in dsets.items():
                 detsets[k] = list()

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -101,7 +101,7 @@ def create_space_telescope(group_size, sample_rate=10.0 * u.Hz, pixel_per_proces
     """Create a fake satellite telescope with at least one pixel per process."""
     npix = 1
     ring = 1
-    while npix < group_size * pixel_per_process:
+    while 2 * npix <= group_size * pixel_per_process:
         npix += 6 * ring
         ring += 1
     fp = fake_hexagon_focalplane(

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -120,7 +120,7 @@ def create_ground_telescope(group_size, sample_rate=10.0 * u.Hz, pixel_per_proce
     """Create a fake ground telescope with at least one detector per process."""
     npix = 1
     ring = 1
-    while 2 * npix < group_size * pixel_per_process:
+    while 2 * npix <= group_size * pixel_per_process:
         npix += 6 * ring
         ring += 1
     fp = fake_hexagon_focalplane(
@@ -219,6 +219,7 @@ def create_satellite_data(
         hwp_rpm=10.0,
         spin_angle=5.0 * u.degree,
         prec_angle=10.0 * u.degree,
+        detset_key="pixel",
     )
     sim_sat.apply(data)
 
@@ -294,6 +295,7 @@ def create_satellite_data_big(
         hwp_rpm=10.0,
         spin_angle=5.0 * u.degree,
         prec_angle=10.0 * u.degree,
+        detset_key="pixel",
     )
     sim_sat.apply(data)
 
@@ -645,6 +647,7 @@ def create_ground_data(mpicomm, sample_rate=10.0 * u.Hz, temp_dir=None):
         schedule=schedule,
         hwp_rpm=1.0,
         weather="atacama",
+        detset_key="pixel",
     )
     sim_ground.apply(data)
 

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -506,6 +506,9 @@ class ObservationTest(MPITestCase):
         for ob in data.obs:
             original.append(ob.duplicate(times="times"))
             ob.redistribute(1, times="times")
+            self.assertTrue(ob.comm_col_size == 1)
+            self.assertTrue(ob.comm_row_size == data.comm.group_size)
+            self.assertTrue(ob.local_detectors == ob.all_detectors)
 
         # Verify that the observations are no longer equal- only if we actually
         # have more than one process per observation.

--- a/src/toast/tests/ops_sim_satellite.py
+++ b/src/toast/tests/ops_sim_satellite.py
@@ -45,7 +45,7 @@ class SimSatelliteTest(MPITestCase):
 
         npix = 1
         ring = 1
-        while 2 * npix < self.toastcomm.group_size:
+        while 2 * npix <= self.toastcomm.group_size:
             npix += 6 * ring
             ring += 1
         self.npix = npix


### PR DESCRIPTION
- Use detector sets and sample sets in their intended way when
  simulating observations.

- Fix the distribute_samples function to actually return the documented
  structure containing the distribution for all processes.

- Add method to the Focalplane class to return groupings of detectors
  by column value.  Simulated focalplane now includes pixel column.

- Add support for equality tests between Observation objects and all
  their associated data classes.

- Improve encapsulation of observation distribution properties, to ease
  the process of redistribution.

- Add more checks to ensure shared objects have allowed communicators
  within the observation.

- Add working redistribute method to Observation class.