### PR TITLE
Make rotating HWP optional

### DIFF
--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -147,7 +147,9 @@ class SimGround(Operator):
         None, allow_none=True, help="Observation detdata key for flags to initialize"
     )
 
-    hwp_angle = Unicode("hwp_angle", help="Observation shared key for HWP angle")
+    hwp_angle = Unicode(
+        None, allow_none=True, help="Observation shared key for HWP angle"
+    )
 
     azimuth = Unicode("azimuth", help="Observation shared key for Azimuth")
 
@@ -237,10 +239,56 @@ class SimGround(Operator):
                 )
         return sch
 
+    # Cross-check HWP parameters
+
+    @traitlets.validate("hwp_angle")
+    def _check_hwp_angle(self, proposal):
+        hwp_angle = proposal["value"]
+        if hwp_angle is None:
+            if self.hwp_rpm is not None or self.hwp_step is not None:
+                raise traitlets.TraitError(
+                    "Cannot simulate HWP without a shared data key"
+                )
+        else:
+            if self.hwp_rpm is None and self.hwp_step is None:
+                raise traitlets.TraitError("Cannot simulate HWP without parameters")
+        return hwp_angle
+
+    @traitlets.validate("hwp_rpm")
+    def _check_hwp_rpm(self, proposal):
+        hwp_rpm = proposal["value"]
+        if hwp_rpm is not None:
+            if self.hwp_angle is None:
+                raise traitlets.TraitError(
+                    "Cannot simulate rotating HWP without a shared data key"
+                )
+            if self.hwp_step is not None:
+                raise traitlets.TraitError("HWP cannot rotate *and* step.")
+        else:
+            if self.hwp_angle is not None and self.hwp_step is None:
+                raise traitlets.TraitError("Cannot simulate HWP without parameters")
+        return hwp_rpm
+
+    @traitlets.validate("hwp_step")
+    def _check_hwp_step(self, proposal):
+        hwp_step = proposal["value"]
+        if hwp_step is not None:
+            if self.hwp_angle is None:
+                raise traitlets.TraitError(
+                    "Cannot simulate stepped HWP without a shared data key"
+                )
+            if self.hwp_rpm is not None:
+                raise traitlets.TraitError("HWP cannot rotate *and* step.")
+        else:
+            if self.hwp_angle is not None and self.hwp_rpm is None:
+                raise traitlets.TraitError("Cannot simulate HWP without parameters")
+        return hwp_step
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
     def _exec(self, data, detectors=None, **kwargs):
+
         log = Logger.get()
         if self.schedule is None:
             raise RuntimeError(

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -216,6 +216,7 @@ def create_satellite_data(
         name="sim_sat",
         telescope=tele,
         schedule=sch,
+        hwp_angle="hwp_angle",
         hwp_rpm=10.0,
         spin_angle=5.0 * u.degree,
         prec_angle=10.0 * u.degree,
@@ -643,6 +644,7 @@ def create_ground_data(mpicomm, sample_rate=10.0 * u.Hz, temp_dir=None):
         name="sim_ground",
         telescope=tele,
         schedule=schedule,
+        hwp_angle="hwp_angle",
         hwp_rpm=1.0,
         weather="atacama",
     )

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -292,6 +292,7 @@ def create_satellite_data_big(
         name="sim_sat",
         telescope=tele,
         schedule=sch,
+        hwp_angle="hwp_angle",
         hwp_rpm=10.0,
         spin_angle=5.0 * u.degree,
         prec_angle=10.0 * u.degree,

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -101,6 +101,7 @@ class SimGroundTest(MPITestCase):
             name="sim_ground",
             telescope=tele,
             schedule=schedule,
+            hwp_angle="hwp_angle",
             hwp_rpm=1.0,
         )
         sim_ground.apply(data)
@@ -139,7 +140,7 @@ class SimGroundTest(MPITestCase):
         pointing = ops.PointingHealpix(
             nest=True,
             mode="IQU",
-            hwp_angle="hwp_angle",
+            hwp_angle=sim_ground.hwp_angle,
             create_dist="pixel_dist",
             detector_pointing=detpointing,
         )

--- a/src/toast/tests/ops_sim_satellite.py
+++ b/src/toast/tests/ops_sim_satellite.py
@@ -79,6 +79,7 @@ class SimSatelliteTest(MPITestCase):
             name="sim_sat",
             telescope=tele,
             schedule=sch,
+            hwp_angle="hwp_angle",
             hwp_rpm=1.0,
             spin_angle=30.0 * u.degree,
             prec_angle=65.0 * u.degree,
@@ -90,7 +91,7 @@ class SimSatelliteTest(MPITestCase):
         pointing = ops.PointingHealpix(
             nest=True,
             mode="IQU",
-            hwp_angle="hwp_angle",
+            hwp_angle=sim_sat.hwp_angle,
             create_dist="pixel_dist",
             detector_pointing=detpointing,
         )

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -188,7 +188,9 @@ def simulate_data(job, toast_comm, telescope, schedule):
     # Set up the pointing.  Each pointing matrix operator requires a detector pointing
     # operator, and each binning operator requires a pointing matrix operator.
     ops.pointing.detector_pointing = ops.det_pointing_radec
+    ops.pointing.hwp_angle = ops.sim_ground.hwp_angle
     ops.pointing_final.detector_pointing = ops.det_pointing_radec
+    ops.pointing_final.hwp_angle = ops.sim_ground.hwp_angle
 
     ops.binner.pointing = ops.pointing
 

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -169,7 +169,9 @@ def simulate_data(job, toast_comm, telescope, schedule):
     # Set up the pointing.  Each pointing matrix operator requires a detector pointing
     # operator, and each binning operator requires a pointing matrix operator.
     ops.pointing.detector_pointing = ops.det_pointing
+    ops.pointing.hwp_angle = ops.sim_satellite.hwp_angle
     ops.pointing_final.detector_pointing = ops.det_pointing
+    ops.pointing_final.hwp_angle = ops.sim_satellite.hwp_angle
 
     ops.binner.pointing = ops.pointing
 


### PR DESCRIPTION
sim_ground and sim_satellite now handle 'None' hwp_angle trait.  Workflows use hwp_angle trait consistently.