### PR TITLE
tweak weather

### DIFF
--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -227,6 +227,10 @@ class SimGround(Operator):
 
     sun_close_distance = Quantity(45.0 * u.degree, help="'Sun close' flagging distance")
 
+    max_pwv = Quantity(
+        None, allow_none=True, help="Maximum PWV for the simulated weather."
+    )
+
     @traitlets.validate("telescope")
     def _check_telescope(self, proposal):
         tele = proposal["value"]
@@ -624,10 +628,20 @@ class SimGround(Operator):
                 # realization.
                 mid_time = scan.start + (scan.stop - scan.start) / 2
                 try:
-                    weather = SimWeather(time=mid_time, name=self.weather)
+                    weather = SimWeather(
+                        time=mid_time,
+                        name=self.weather,
+                        site_uid=site.uid,
+                        max_pwv=self.max_pwv,
+                    )
                 except RuntimeError:
                     # must be a file
-                    weather = SimWeather(time=mid_time, file=self.weather)
+                    weather = SimWeather(
+                        time=mid_time,
+                        file=self.weather,
+                        site_uid=site.uid,
+                        max_pwv=self.max_pwv,
+                    )
                 site = copy.deepcopy(self.telescope.site)
                 site.weather = weather
 

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -103,6 +103,7 @@ class SimGroundTest(MPITestCase):
             schedule=schedule,
             hwp_angle="hwp_angle",
             hwp_rpm=1.0,
+            max_pwv=5 * u.mm,
         )
         sim_ground.apply(data)
 


### PR DESCRIPTION
Modify the SimWeather class:
- changing the `time`, `realization` and `site_uid` after initialization with `set()`
- calling `set()` triggers drawing new randomized weather values
- add parameter to cap the randomized PWV values

The `set()` method can be used in workflows that implement a Monte Carlo loop or allow setting the realization index.