### PR TITLE
Fix 2D polynomial filter

### DIFF
--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -116,7 +116,7 @@ class PolyFilterTest(MPITestCase):
             os.makedirs(testdir)
 
         # Create a fake satellite data set for testing
-        data = create_satellite_data(self.comm, pixel_per_process=2)
+        data = create_satellite_data(self.comm, pixel_per_process=4)
 
         # Add wafer IDs for filtering
         for obs in data.obs:
@@ -159,7 +159,7 @@ class PolyFilterTest(MPITestCase):
                 x, y, z = qa.rotate(det_quat, ZAXIS)
                 theta, phi = np.arcsin([x, y])
                 signal = obs.detdata["signal"][det]
-                signal[:] = 0
+                # signal[:] = 0
                 icoeff = 0
                 for xorder in range(norder):
                     for yorder in range(norder):
@@ -194,7 +194,9 @@ class PolyFilterTest(MPITestCase):
                 good = flags == 0
                 signal = ob.detdata["signal"][det]
                 x = np.arange(signal.size)
-                ax.plot(x[good], signal[good], "-", label=f"{det} unfiltered")
+                ax.plot(x, signal, "-", label=f"{det} unfiltered")
+                ax.plot(x, good, "-", label=f"{det} input good samples")
+            ax.legend(loc="best")
 
         # Filter
 
@@ -220,8 +222,9 @@ class PolyFilterTest(MPITestCase):
                 good = flags == 0
                 signal = ob.detdata["signal"][det]
                 x = np.arange(signal.size)
-                ax.plot(x[good], signal[good], ".", label=f"{det} filtered")
-            plt.legend(loc="best")
+                ax.plot(x, signal, ".", label=f"{det} filtered")
+                ax.plot(x, good, "-", label=f"{det} new good samples")
+            ax.legend(loc="best")
             outfile = os.path.join(testdir, "2Dfiltered_tod.png")
             fig.savefig(outfile)
 


### PR DESCRIPTION
The 2D polynomial filter was using `MPI.Comm.allreduce()` (lower case) which returns the result (it is not in place).  The return value was being ignored.  This converts the code to using the "upper case" version and doing an in-place allreduce.  Other small tweaks to the unit tests include not zero-ing out the sky signal when accumulating the input test polynomial, and plotting the unflagged samples for reference.

This issue is only seen if the group size is larger than one process (otherwise the allreduce is not called), which only occurs in the unit tests if running on 4 or more processes (since the unit tests create 2 groups).

The original plot of the input / output is:
![2Dfiltered_tod](https://user-images.githubusercontent.com/84221/130501106-141475c6-6354-40cb-94b3-6ceb9bef6707.png)

After this fix, the output is more reasonable:
![2Dfiltered_tod_new](https://user-images.githubusercontent.com/84221/130501404-188b7822-7a3e-40a7-89cd-84810364df25.png)

