### PR TITLE
Small tweaks to the benchmarks

### DIFF
--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -26,6 +26,7 @@ from toast.scripts.benchmarking_utilities import (
     run_mapmaker,
     compute_science_metric,
     estimate_memory_overhead,
+    python_startup_time,
 )
 
 
@@ -436,5 +437,6 @@ def main():
 
 if __name__ == "__main__":
     world, procs, rank = toast.mpi.get_world()
+    python_startup_time(rank)
     with toast.mpi.exception_guard(comm=world):
         main()

--- a/src/toast/scripts/toast_benchmark_satellite
+++ b/src/toast/scripts/toast_benchmark_satellite
@@ -28,6 +28,7 @@ from toast.scripts.benchmarking_utilities import (
     run_mapmaker,
     compute_science_metric,
     estimate_memory_overhead,
+    python_startup_time,
 )
 
 
@@ -306,5 +307,6 @@ def main():
 
 if __name__ == "__main__":
     world, procs, rank = toast.mpi.get_world()
+    python_startup_time(rank)
     with toast.mpi.exception_guard(comm=world):
         main()


### PR DESCRIPTION
Add a check for python startup time to benchmarks.  Require a minimum number of detectors per process in the benchmarks.  When running the benchmark, a message is logged with instructions for timing the interpreter startup.  Basically you can just prefix the call to the script with an environment variable containing the time command was run:
```
TOAST_PYTHON_START=$(date '+%Y%m%d-%H%M%S') mpirun -np 4 toast_benchmark_ground --case tiny --scan_map.disable

TOAST INFO: Python interpreter startup took 0.17 minutes
TOAST INFO: TOAST version = 2.3.12.dev182
...
```