### PR TITLE
Improve MemoryCounter

### DIFF
--- a/src/toast/ops/madam_utils.py
+++ b/src/toast/ops/madam_utils.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import healpy as hp
 
-from ..utils import Logger, Timer, GlobalTimers, dtype_to_aligned
+from ..utils import Logger, Timer, GlobalTimers, dtype_to_aligned, memreport
 
 from ..timing import function_timer
 
@@ -43,7 +43,7 @@ def log_time_memory(
             )
             log.debug(msg)
         if full_mem:
-            memreport(msg="{} {}".format(prefix, mem_msg), comm=comm)
+            _ = memreport(msg="{} {}".format(prefix, mem_msg), comm=comm)
     if restart:
         timer.start()
 

--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -137,6 +137,7 @@ def parse_arguments():
         toast.ops.BinMap(
             name="binner_final", enabled=False, pixel_dist="pix_dist_final"
         ),
+        toast.ops.MemoryCounter(name="mem_count"),
     ]
 
     # Templates we want to configure from the command line or a parameter file.
@@ -339,11 +340,8 @@ def main():
     timer = toast.timing.Timer()
     timer.start()
 
-    # Memory use tracking
-    mem_track = toast.ops.MemoryCounter()
-
-    mem_track.prefix = "Before Simulation"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "Before Simulation"
+    job_ops.mem_count.apply(data)
 
     # Simulate the telescope pointing
     job_ops.sim_ground.telescope = telescope
@@ -352,8 +350,8 @@ def main():
     job_ops.sim_ground.apply(data)
     log.info_rank("Simulated telescope pointing in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Scan Simulation"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Scan Simulation"
+    job_ops.mem_count.apply(data)
 
     # Set up detector pointing in both Az/El and RA/DEC
     job_ops.det_pointing_azel.boresight = job_ops.sim_ground.boresight_azel
@@ -386,31 +384,31 @@ def main():
     if not job_ops.binner_final.enabled:
         job_ops.binner_final = job_ops.binner
 
-    mem_track.prefix = "After Noise and Pointing Setup"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Noise and Pointing Setup"
+    job_ops.mem_count.apply(data)
 
     # Simulate sky signal from a map.
     scan_map(args, rank, job_ops, data, log)
     log.info_rank("Simulated sky signal in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Map Scanning"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Map Scanning"
+    job_ops.mem_count.apply(data)
 
     # Simulate detector noise
     job_ops.sim_noise.noise_model = job_ops.elevation_model.out_model
     job_ops.sim_noise.apply(data)
     log.info_rank("Simulated detector noise in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Noise Simulation"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Noise Simulation"
+    job_ops.mem_count.apply(data)
 
     # Simulate atmosphere signal
     job_ops.sim_atmosphere.detector_pointing = job_ops.det_pointing_azel
     job_ops.sim_atmosphere.apply(data)
     log.info_rank("Simulated and observed atmosphere in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Atmosphere Simulation"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Atmosphere Simulation"
+    job_ops.mem_count.apply(data)
 
     # Collect signal statistics before filtering
     job_ops.raw_statistics.output_dir = args.out_dir
@@ -426,8 +424,8 @@ def main():
     job_ops.common_mode_filter.apply(data)
     log.info_rank("Finished common-mode-filtering in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Filtering"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Filtering"
+    job_ops.mem_count.apply(data)
 
     # Collect signal statistics after filtering
     job_ops.filtered_statistics.output_dir = args.out_dir
@@ -437,8 +435,8 @@ def main():
     run_mapmaker(job_ops, args, job.templates, data)
     log.info_rank("Finished map-making in", comm=world_comm, timer=timer)
 
-    mem_track.prefix = "After Map Making"
-    mem_track.apply(data)
+    job_ops.mem_count.prefix = "After Map Making"
+    job_ops.mem_count.apply(data)
 
     # end of the computations, sync and computes efficiency
     global_timer.stop_all()

--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -339,12 +339,21 @@ def main():
     timer = toast.timing.Timer()
     timer.start()
 
+    # Memory use tracking
+    mem_track = toast.ops.MemoryCounter()
+
+    mem_track.prefix = "Before Simulation"
+    mem_track.apply(data)
+
     # Simulate the telescope pointing
     job_ops.sim_ground.telescope = telescope
     job_ops.sim_ground.schedule = args.schedule
     job_ops.sim_ground.weather = telescope.site.name
     job_ops.sim_ground.apply(data)
     log.info_rank("Simulated telescope pointing in", comm=world_comm, timer=timer)
+
+    mem_track.prefix = "After Scan Simulation"
+    mem_track.apply(data)
 
     # Set up detector pointing in both Az/El and RA/DEC
     job_ops.det_pointing_azel.boresight = job_ops.sim_ground.boresight_azel
@@ -377,19 +386,31 @@ def main():
     if not job_ops.binner_final.enabled:
         job_ops.binner_final = job_ops.binner
 
+    mem_track.prefix = "After Noise and Pointing Setup"
+    mem_track.apply(data)
+
     # Simulate sky signal from a map.
     scan_map(args, rank, job_ops, data, log)
     log.info_rank("Simulated sky signal in", comm=world_comm, timer=timer)
+
+    mem_track.prefix = "After Map Scanning"
+    mem_track.apply(data)
 
     # Simulate detector noise
     job_ops.sim_noise.noise_model = job_ops.elevation_model.out_model
     job_ops.sim_noise.apply(data)
     log.info_rank("Simulated detector noise in", comm=world_comm, timer=timer)
 
+    mem_track.prefix = "After Noise Simulation"
+    mem_track.apply(data)
+
     # Simulate atmosphere signal
     job_ops.sim_atmosphere.detector_pointing = job_ops.det_pointing_azel
     job_ops.sim_atmosphere.apply(data)
     log.info_rank("Simulated and observed atmosphere in", comm=world_comm, timer=timer)
+
+    mem_track.prefix = "After Atmosphere Simulation"
+    mem_track.apply(data)
 
     # Collect signal statistics before filtering
     job_ops.raw_statistics.output_dir = args.out_dir
@@ -405,6 +426,9 @@ def main():
     job_ops.common_mode_filter.apply(data)
     log.info_rank("Finished common-mode-filtering in", comm=world_comm, timer=timer)
 
+    mem_track.prefix = "After Filtering"
+    mem_track.apply(data)
+
     # Collect signal statistics after filtering
     job_ops.filtered_statistics.output_dir = args.out_dir
     job_ops.filtered_statistics.apply(data)
@@ -412,6 +436,9 @@ def main():
     # Build up our map-making operation.
     run_mapmaker(job_ops, args, job.templates, data)
     log.info_rank("Finished map-making in", comm=world_comm, timer=timer)
+
+    mem_track.prefix = "After Map Making"
+    mem_track.apply(data)
 
     # end of the computations, sync and computes efficiency
     global_timer.stop_all()


### PR DESCRIPTION
Small changes to the memreport utility function.  Use this in the MemoryCounter operator to display total memory use in addition to just use by timestream data.  Add memory counter to the ground benchmark as a test.

I debated adding this functionality to the operator base class, in order to track memory use before / after every call to `exec()`.  However, we have potentially a deep hierarchy of operators running pipelines of other operators.  And the memreport function is collective and uses a gather.  So I think it is better to explicitly use this at the highest level.

One can disable this in the ground benchmark from the commandline with:
```
--mem_count.disable
```