### PR TITLE
Improve interfaces for working with subsets of data

### DIFF
--- a/docs/dev_operators.rst
+++ b/docs/dev_operators.rst
@@ -1,0 +1,119 @@
+.. _dev_ops:
+
+Developing Operators
+=======================
+
+The ``Operator`` class is the building block for assembling workflows that simulate, reduce, or otherwise manipulate ``Data`` objects.
+
+Overall Structure
+-----------------------
+
+Operators are classes which must have several required methods.  Operators must also be configured using class "traits" from the ``traitlets`` package.  Traits can be set at construction time or afterwards.  The constructor should take no additional parameters- everything should be a trait.  Using traits allows us to automate several things:
+
+- Class docstring generated automatically from trait help strings.
+- Class traits can be set from configuration files and / or commandline arguments.
+- Class instances can be modified after construction by setting traits and there are mechanisms to validate trait values when the user sets them.
+
+In addition to using traits for all configuration, each operator must define an ``_exec()`` method which accepts a ``Data`` instance (with one or more observations) and optionally a selection of detectors.  The operator can process the data however it likes (see below for guidelines of common patterns).  The operator must support the ``_exec()`` method being called multiple times, for example with different ``Data`` instances or different sets of detectors.
+
+Each operator should also define a ``_finalize()`` method which will be called at the end of a sequence of calls to ``_exec()``.  This finalize method should perform any closing calculations needed.  If a call to ``_exec()`` is made **after** ``_finalize()``, the operator should reinitialize its state and prepare to start working again on new sets of data.
+
+The Operator base class apply a helper method ``apply()``, which is a shortcut for running ``exec()`` and ``finalize()`` in a sequence.  It is useful when you only intend to make a single call to the exec method.
+
+Operator classes typically require some input data fields in each observation and may create new output data as well.  The inputs in each observations should be returned by the ``_requires()`` method of the operator.  The outputs are returned by ``_provides()`` method.  Both of these return dictionaries of the required or provided names of metadata, shared, detdata and intervals data.
+
+Over time, the traits used by an operator may change.  If an old configuration file is used to construct a "newer" version of the operator, the operator can simply raise an exception or it can attempt to translate this configuration.  Each configuration dumped from operator traits includes an "API" trait.  Each operator has this integer trait and can increment it whenever incompatible changes are made to its traits.  To support older versions of the API, the operator can define a ``translate()`` method that takes an older version of the configuration and translates it to the latest version of the configuration.
+
+Data Processing Patterns
+--------------------------------
+
+Different data processing operations require passing through the data in different ways.  Additionally, there are cases when an operator will use other operators on subsets of data as part of the higher-level operation.  Here we go through some common patterns.
+
+One Observation at a Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This pattern is used when there is an expensive (in terms of either calculation or memory use) operation that occurs within an observation and which can then be used by multiple detectors.  Some example operations like this might be simulating atmosphere that is common to all detectors or calculating planet locations for the timespan covered by an observation.
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        for ob in data.obs:
+            # (Some expensive operation here which is needed by all detectors.)
+            # Get the detectors we are using for this observation
+            dets = ob.select_local_detectors(detectors)
+            if len(dets) == 0:
+                # Nothing to do for this observation
+                continue
+            for det in dets:
+                # (Do something for this detector)
+
+This works fine for simple operators but what if we want use other, lower-level operators within our operator?  We can do this by calling the other operator's ``exec()`` and ``finalize()`` methods (or the shortcut ``apply()`` method) at the appropriate places.  First, imagine we want to run one operator before our code and another afterwards, for each observation:
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        op_A = OperatorA()
+        op_B = OperatorB()
+        for iobs, ob in enumerate(data.obs):
+            # Temporary data object with just this observation
+            temp_data = data.select(obs_index=iobs)
+
+            # Run op_A on all detectors for this observation
+            op_A.apply(temp_data, detectors=detectors)
+
+            # Now do our work on this observation.
+            dets = ob.select_local_detectors(detectors)
+            if len(dets) == 0:
+                # Nothing to do for this observation
+                continue
+            for det in dets:
+                # (Do something for this detector)
+
+            # Run op_B on all detectors for this observation
+            op_B.apply(temp_data, detectors=detectors)
+
+There are also times when we need to run an operator inside the "loop over detectors".  For example, if we are doing a small operation like computing the detector quaternion rotations from the boresight.  That scenario looks like this:
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        op_A = OperatorA()
+        op_B = OperatorB()
+        for iobs, ob in enumerate(data.obs):
+            # Temporary data object with just this observation
+            temp_data = data.select(obs_index=iobs)
+
+            dets = ob.select_local_detectors(detectors)
+            if len(dets) == 0:
+                # Nothing to do for this observation
+                continue
+            for det in dets:
+                # Run op_A on this single observation and detector
+                op_A.apply(temp_data, detectors=[det])
+
+                # (Do something for this detector)
+
+                # Run op_B on this single observation and detector
+                op_B.apply(temp_data, detectors=[det])
+
+
+
+
+One Detector at a Time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This pattern is used when there is an expensive operation that occurs for each detector, and we want to make use of that result for all observations before moving on to the next detector.  An example would be simulating detector band-pass or beam convolution.
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        # Get the superset of local detectors across all observations
+        all_dets = data.all_local_detectors(selection=detectors)
+
+        for det in all_dets:
+            # Loop over all local detectors
+            #
+            # (Some expensive operation for this detector).
+            #
+            for ob in data.obs:
+                # Loop over observations
+                if det not in ob.local_detectors:
+                    # This observation does not have this detector
+                    continue
+                # (Do something for this observation)

--- a/docs/dev_operators.rst
+++ b/docs/dev_operators.rst
@@ -94,8 +94,6 @@ There are also times when we need to run an operator inside the "loop over detec
                 op_B.apply(temp_data, detectors=[det])
 
 
-
-
 One Detector at a Time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -107,13 +105,67 @@ This pattern is used when there is an expensive operation that occurs for each d
         all_dets = data.all_local_detectors(selection=detectors)
 
         for det in all_dets:
-            # Loop over all local detectors
-            #
             # (Some expensive operation for this detector).
-            #
             for ob in data.obs:
-                # Loop over observations
                 if det not in ob.local_detectors:
                     # This observation does not have this detector
                     continue
                 # (Do something for this observation)
+
+And if we are running sub-operators for each detector and all observations we can do that as well:
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        op_A = OperatorA()
+        op_B = OperatorB()
+
+        # Get the superset of local detectors across all observations
+        all_dets = data.all_local_detectors(selection=detectors)
+
+        for det in all_dets:
+            # Run op_A on all observations for this detector
+            op_A.apply(data, detectors=[det])
+
+            # (Some expensive operation for this detector).
+            for ob in data.obs:
+                if det not in ob.local_detectors:
+                    # This observation does not have this detector
+                    continue
+                # (Do something for this observation)
+
+            # Run op_B on all observations for this detector
+            op_B.apply(data, detectors=[det])
+
+And we can also run other operators on single observations for each detector:
+
+.. code-block:: python
+    def _exec(self, data, detectors=None, **kwargs):
+        op_A = OperatorA()
+        op_B = OperatorB()
+
+        # Get the superset of local detectors across all observations
+        all_dets = data.all_local_detectors(selection=detectors)
+
+        for det in all_dets:
+            # (Some expensive operation for this detector).
+            for iobs, ob in data.obs:
+                if det not in ob.local_detectors:
+                    # This observation does not have this detector
+                    continue
+                # Temporary data object with just this observation
+                temp_data = data.select(obs_index=iobs)
+
+                # Run op_A on one observation for this detector
+                op_A.apply(temp_data, detectors=[det])
+
+                # (Do something for this observation)
+
+                # Run op_B on one observation for this detector
+                op_B.apply(temp_data, detectors=[det])
+
+
+Using the Pipeline Operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the previous examples we were interspersing our new code with the use of other operators.
+

--- a/docs/dev_operators.rst
+++ b/docs/dev_operators.rst
@@ -136,7 +136,7 @@ And if we are running sub-operators for each detector and all observations we ca
             # Run op_B on all observations for this detector
             op_B.apply(data, detectors=[det])
 
-And we can also run other operators on single observations for each detector:
+We can also run other operators on single observations for each detector:
 
 .. code-block:: python
     def _exec(self, data, detectors=None, **kwargs):
@@ -167,5 +167,7 @@ And we can also run other operators on single observations for each detector:
 Using the Pipeline Operator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the previous examples we were interspersing our new code with the use of other operators.
+In the previous examples we were interspersing our new code with the use of other operators...
+
+.. todo::  Discuss benefits of Pipelining code, automatic GPU memory staging, etc.
 

--- a/src/toast/data.py
+++ b/src/toast/data.py
@@ -6,9 +6,13 @@ from collections.abc import MutableMapping
 
 from collections import OrderedDict
 
+import re
+
 import numpy as np
 
 from .mpi import Comm
+
+from .utils import Logger
 
 
 class Data(MutableMapping):
@@ -18,12 +22,14 @@ class Data(MutableMapping):
     each process group in the Comm.
 
     Args:
-        comm (:class:`toast.Comm`): the toast Comm class for distributing the data.
+        comm (:class:`toast.Comm`):  The toast Comm class for distributing the data.
+        view (bool):  If True, do not explicitly clear observation data on deletion.
 
     """
 
-    def __init__(self, comm=Comm()):
+    def __init__(self, comm=Comm(), view=False):
         self._comm = comm
+        self._view = view
         self.obs = []
         """The list of observations.
         """
@@ -64,10 +70,29 @@ class Data(MutableMapping):
 
     def clear(self):
         """Clear the list of observations."""
-        for ob in self.obs:
-            ob.clear()
+        if not self._view:
+            for ob in self.obs:
+                ob.clear()
         self.obs.clear()
         return
+
+    def all_local_detectors(self, selection=None):
+        """Get the superset of local detectors in all observations.
+
+        This builds up the result from calling `select_local_detectors()` on
+        all observations.
+
+        Returns:
+            (list):  The list of all local detectors across all observations.
+
+        """
+        all_dets = OrderedDict()
+        for ob in self.obs:
+            dets = ob.select_local_detectors(selection=selection)
+            for d in dets:
+                if d not in all_dets:
+                    all_dets[d] = None
+        return list(all_dets.keys())
 
     def info(self, handle=None):
         """Print information about the distributed data.
@@ -141,86 +166,167 @@ class Data(MutableMapping):
                 wcomm.barrier()
         return
 
-    def select_observations(self, key, require=False):
-        """Given an observation key, return lists of observations with unique values.
-
-        In the returned dictionary, the order of observations for a given value is
-        preserved relative to the original list.  For a given observation, the value
-        across all processes in the group must match.
-
-        Args:
-            key (str):  The observation key
-            require (bool):  If True, the key must exist in every observation.
-
-        Returns:
-            (OrderedDict):  For each key value, the list of observations.
-
-        """
-        group_rank = self.comm.group_rank
-        group_comm = self.comm.comm_group
-
-        selected = OrderedDict()
-
-        for ob in self.obs:
-            # The value on this process
-            proc_val = None
-            if key in ob:
-                proc_val = ob[key]
-
-            # Get the values from all processes in the group
-            group_vals = None
-            if group_comm is None:
-                group_vals = [proc_val]
-            else:
-                group_vals = group_comm.allgather(proc_val)
-
-            # Check for consistency
-            if group_vals.count(group_vals[0]) == len(group_vals):
-                # All entries equal
-                if proc_val is None:
-                    if require:
-                        msg = "Observation '{}' does not have key '{}'".format(
-                            ob.name, key
-                        )
-                        if group_rank == 0:
-                            log.error(msg)
-                        raise RuntimeError(msg)
-                    continue
-                if proc_val not in selected:
-                    selected[proc_val] = list()
-                selected[proc_val].append(ob)
-            else:
-                # Mismatch
-                msg = "Observation '{}', key '{}' has different values across the group".format(
-                    ob.name, key
-                )
-                if group_rank == 0:
-                    log.error(msg)
-                raise RuntimeError(msg)
-        return selected
-
-    def split(self, key, require=False):
+    def split(
+        self,
+        obs_index=False,
+        obs_name=False,
+        obs_uid=False,
+        obs_key=None,
+        require_full=False,
+    ):
         """Split the Data object.
 
-        Split the Data object based on the value of `key` in the observation dictionary.
+        Create new Data objects that have views into unique subsets of the observations
+        (the observations are not copied).  Only one "criteria" may be used to perform
+        this splitting operation.  The observations may be split by index in the
+        original list, by name, by UID, or by the value of a specified key.
+
+        The new Data objects are returned in a dictionary whose keys are the value of
+        the selection criteria (index, name, uid, or value of the key).  Any observation
+        that cannot be place (because it is missing a name, uid or key) will be ignored
+        and not added to any of the returned Data objects.  If the `require_full`
+        parameter is set to True, such situations will raise an exception.
 
         Args:
-            key (str):  Observation key to use.
-            require (bool):  If True, require that all observations have the key.
+            obs_index (bool):  If True, split by index in original list of observations.
+            obs_name (bool):  If True, split by observation name.
+            obs_uid (bool):  If True, split by observation UID.
+            obs_key (str):  Split by values of this observation key.
 
         Returns:
-            (OrderedDict):  For each key value, a new Data object.
+            (OrderedDict):  The dictionary of new Data objects.
 
         """
-        selected = self.select_observations(key, require=require)
+        log = Logger.get()
+        check = int(obs_index) + int(obs_name) + int(obs_uid) + int(obs_key is not None)
+        if check == 0 or check > 1:
+            raise RuntimeError("You must specify exactly one split criteria")
 
         datasplit = OrderedDict()
 
-        for value, obslist in selected.items():
-            new_data = Data(comm=self._comm)
-            new_data._internal = self._internal
-            for ob in obslist:
-                new_data.obs.append(ob)
-            datasplit[value] = new_data
+        group_rank = self.comm.group_rank
+        group_comm = self.comm.comm_group
 
+        if obs_index:
+            # Splitting by index
+            for iob, ob in enumerate(self.obs):
+                newdat = Data(comm=self._comm, view=True)
+                newdat._internal = self._internal
+                newdat.obs.append(ob)
+                datasplit[iob] = newdat
+        elif obs_name:
+            # Splitting by name
+            for iob, ob in enumerate(self.obs):
+                if ob.name is None:
+                    if require_full:
+                        msg = f"require_full is True, but observation {iob} has no name"
+                        log.error_rank(msg, comm=group_comm)
+                        raise RuntimeError(msg)
+                else:
+                    newdat = Data(comm=self._comm, view=True)
+                    newdat._internal = self._internal
+                    newdat.obs.append(ob)
+                    datasplit[ob.name] = newdat
+        elif obs_uid:
+            # Splitting by UID
+            for iob, ob in enumerate(self.obs):
+                if ob.uid is None:
+                    if require_full:
+                        msg = f"require_full is True, but observation {iob} has no UID"
+                        log.error_rank(msg, comm=group_comm)
+                        raise RuntimeError(msg)
+                else:
+                    newdat = Data(comm=self._comm, view=True)
+                    newdat._internal = self._internal
+                    newdat.obs.append(ob)
+                    datasplit[ob.uid] = newdat
+        elif obs_key is not None:
+            # Splitting by arbitrary key.  Unlike name / uid which are built it to the
+            # observation class, arbitrary keys might be modified in different ways
+            # across all processes in a group.  For this reason, we do an additional
+            # check for consistent values across the process group.
+            for iob, ob in enumerate(self.obs):
+                if obs_key not in ob:
+                    if require_full:
+                        msg = f"require_full is True, but observation {iob} has no key '{obs_key}'"
+                        log.error_rank(msg, comm=group_comm)
+                        raise RuntimeError(msg)
+                else:
+                    obs_val = ob[obs_key]
+                    # Get the values from all processes in the group
+                    group_vals = None
+                    if group_comm is None:
+                        group_vals = [obs_val]
+                    else:
+                        group_vals = group_comm.allgather(obs_val)
+                    if group_vals.count(group_vals[0]) != len(group_vals):
+                        msg = f"observation {iob}, key '{obs_key}' has inconsistent values across processes"
+                        log.error_rank(msg, comm=group_comm)
+                        raise RuntimeError(msg)
+                    if obs_val not in datasplit:
+                        newdat = Data(comm=self._comm, view=True)
+                        newdat._internal = self._internal
+                        datasplit[obs_val] = newdat
+                    datasplit[obs_val].obs.append(ob)
         return datasplit
+
+    def select(
+        self, obs_index=None, obs_name=None, obs_uid=None, obs_key=None, obs_val=None
+    ):
+        """Create a new Data object with a subset of observations.
+
+        The returned Data object just has a view of the original observations (they
+        are not copied).
+
+        The list of observations in the new Data object is a logical OR of the
+        criteria passed in:
+            * Index location in the original list of observations
+            * Name of the observation
+            * UID of the observation
+            * Existence of the specified dictionary key
+            * Required value of the specified dictionary key
+
+        Args:
+            obs_index (int):  Observation location in the original list.
+            obs_name (str):  The observation name or a compiled regular expression
+                object to use for matching.
+            obs_uid (int):  The observation UID to select.
+            obs_key (str):  The observation dictionary key to examine.
+            obs_val (str):  The required value of the observation dictionary key or a
+                compiled regular expression object to use for matching.
+
+        Returns:
+            (Data):  A new Data object with references to the orginal metadata and
+                a subset of observations.
+
+        """
+        if obs_val is not None and obs_key is None:
+            raise RuntimeError("If you specify obs_val, you must also specify obs_key")
+
+        new_data = Data(comm=self._comm, view=True)
+
+        # Use a reference to the original metadata
+        new_data._internal = self._internal
+
+        for iob, ob in enumerate(self.obs):
+            if obs_index is not None and obs_index == iob:
+                new_data.obs.append(ob)
+            if obs_name is not None and ob.name is not None:
+                if isinstance(obs_name, re.Pattern):
+                    if obs_name.match(ob.name) is not None:
+                        new_data.obs.append(ob)
+                elif obs_name == ob.name:
+                    new_data.obs.append(ob)
+            if obs_uid is not None and ob.uid is not None and obs_uid == ob.uid:
+                new_data.obs.append(ob)
+            if obs_key is not None and obs_key in ob:
+                if obs_val is None:
+                    # We have the key, and are accepting any value
+                    new_data.obs.append(ob)
+                elif isinstance(obs_val, re.Pattern):
+                    if obs_val.match(ob[obs_key]) is not None:
+                        # Matches our regex
+                        new_data.obs.append(ob)
+                elif obs_val == ob[obs_key]:
+                    new_data.obs.append(ob)
+        return new_data

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -24,8 +24,6 @@ from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
 
 from .operator import Operator
 
-from .pipeline import Pipeline
-
 from ..utils import Environment, Logger, Timer
 
 from .._libtoast import bin_templates, add_templates, legendre

--- a/src/toast/ops/mapmaker_templates.py
+++ b/src/toast/ops/mapmaker_templates.py
@@ -161,17 +161,7 @@ class TemplateMatrix(Operator):
         # We loop over detectors.  Internally, each template loops over observations
         # and ignores observations where the detector does not exist.
 
-        all_dets = None
-        if detectors is None:
-            # We don't have an explicit list of detectors- build our superset.
-            all_dets = OrderedDict()
-            for ob in data.obs:
-                for d in ob.local_detectors:
-                    if d not in all_dets:
-                        all_dets[d] = None
-            all_dets = list(all_dets.keys())
-        else:
-            all_dets = detectors
+        all_dets = data.all_local_detectors(selection=detectors)
 
         if self.transpose:
             if self.amplitudes not in data:
@@ -196,7 +186,7 @@ class TemplateMatrix(Operator):
             # Ensure that our output detector data exists in each observation
             for ob in data.obs:
                 # Get the detectors we are using for this observation
-                dets = ob.select_local_detectors(detectors)
+                dets = ob.select_local_detectors(selection=detectors)
                 if len(dets) == 0:
                     # Nothing to do for this observation
                     continue

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -145,7 +145,7 @@ class BuildHitMap(Operator):
 
         for ob in data.obs:
             # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors)
+            dets = ob.select_local_detectors(selection=detectors)
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
@@ -347,7 +347,7 @@ class BuildInverseCovariance(Operator):
 
         for ob in data.obs:
             # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors)
+            dets = ob.select_local_detectors(selection=detectors)
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
@@ -584,7 +584,7 @@ class BuildNoiseWeighted(Operator):
 
         for ob in data.obs:
             # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors)
+            dets = ob.select_local_detectors(selection=detectors)
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue


### PR DESCRIPTION
* Add method to the Data class for constructing shallow views of
  subsets of observations based on observation index, name, uid,
  and key / values.

* Improve the existing split() method to allow splitting on other
  observation properties.

* Add method to Data for getting superset of detectors across
  all observations.

* Remove "data hack" from existing atmosphere simulation operator.

* Clean up Pipeline class to use the various new functions above and remove the data slicing code (which is now handled directly by the Data class).

* Begin stub of developer docs on creation of Operators and use
  of sub-operators.  Still work to do on this.

I'm going to add a few more notes in the draft documentation, including a discussion of the future benefits of using the `Pipeline` class.  However, the code changes are in place.  We can discuss / iterate on these changes, and once happy with them we can modify the code in #446 and #451 to use the new `Data.select()` method. 