### PR TITLE
Use batched FFTs for noise simulation

### DIFF
--- a/src/libtoast/include/toast/tod_filter.hpp
+++ b/src/libtoast/include/toast/tod_filter.hpp
@@ -22,8 +22,7 @@ void filter_poly2D_solve(
     int64_t nsample, int32_t ndet, int32_t ngroup, int32_t nmode,
     int32_t const * det_group, double const * templates, uint8_t const * masks,
     double const * signals, double * coeff
-);
-
+    );
 }
 
 #endif // ifndef TOAST_TOD_FILTER_HPP

--- a/src/libtoast/include/toast/tod_simnoise.hpp
+++ b/src/libtoast/include/toast/tod_simnoise.hpp
@@ -16,6 +16,11 @@ void tod_sim_noise_timestream(
     uint64_t obsindx, uint64_t detindx, double rate, int64_t firstsamp,
     int64_t samples, int64_t oversample, const double * freq,
     const double * psd, int64_t psdlen, double * noise);
+void tod_sim_noise_timestream_batch(
+    uint64_t realization, uint64_t telescope, uint64_t component,
+    uint64_t obsindx, double rate, int64_t firstsamp,
+    int64_t samples, int64_t oversample, int64_t ndet, uint64_t * detindices,
+    int64_t psdlen, const double * freq, const double * psds, double * noise);
 }
 
 #endif // ifndef TOAST_TOD_SIMNOISE_HPP

--- a/src/libtoast/src/toast_tod_filter.cpp
+++ b/src/libtoast/src/toast_tod_filter.cpp
@@ -372,7 +372,7 @@ void toast::filter_poly2D_solve(
     int64_t nsample, int32_t ndet, int32_t ngroup, int32_t nmode,
     int32_t const * det_group, double const * templates, uint8_t const * masks,
     double const * signals, double * coeff
-) {
+    ) {
     // For each sample, solve for the regression coefficients.
     // The templates are flat packed across (detectors, modes).
     // The mask is flat packed across (samples, detectors).
@@ -449,7 +449,8 @@ void toast::filter_poly2D_solve(
                         rhs[imode] += templates[tmpl_off + imode] * det_sig * det_mask;
 
                         for (int32_t jmode = imode; jmode < nmode; ++jmode) {
-                            double val = templates[tmpl_off + imode] * templates[tmpl_off + jmode] * det_mask;
+                            double val = templates[tmpl_off + imode] *
+                                         templates[tmpl_off + jmode] * det_mask;
                             A[imode * nmode + jmode] += val;
                             if (jmode > imode) {
                                 A[jmode * nmode + imode] += val;
@@ -465,7 +466,7 @@ void toast::filter_poly2D_solve(
                     &inmode, &inmode, &one, A.data(), &inmode,
                     rhs.data(), &inmode, singular_values.data(), &rcond_limit,
                     &rank, work.data(), &lwork, &info
-                );
+                    );
                 int64_t offset = isamp * (ngroup * nmode) + igroup * nmode;
                 if (info == 0) {
                     // Solve was successful

--- a/src/libtoast/src/toast_tod_simnoise.cpp
+++ b/src/libtoast/src/toast_tod_simnoise.cpp
@@ -11,6 +11,136 @@
 #include <sstream>
 
 
+void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample, int64_t n_batch, int64_t n_binned, double const * binned_freq, double const * binned_psds, int64_t & fftlen, toast::AlignedVector <double> & interp_psds) {
+
+    fftlen = 2;
+    while (fftlen <= (oversample * samples)) {
+        fftlen *= 2;
+    }
+    int64_t psdlen = (fftlen / 2) + 1;
+    double norm = rate * static_cast <double> (psdlen - 1);
+    double increment = rate / static_cast <double> (fftlen - 1);
+
+    if (binned_freq[0] > increment) {
+        auto here = TOAST_HERE();
+        auto log = toast::Logger::get();
+        std::ostringstream o;
+        o << "input PSDs have lowest frequency " << binned_freq[0]
+          << "Hz, which does not allow interpolation to " << increment
+          << "Hz";
+        log.error(o.str().c_str(), here);
+        throw std::runtime_error(o.str().c_str());
+    }
+
+    double nyquist = 0.5 * rate;
+    if (::fabs((binned_freq[n_binned - 1] - nyquist) / nyquist) > 0.01) {
+        auto here = TOAST_HERE();
+        auto log = toast::Logger::get();
+        std::ostringstream o;
+        o.precision(16);
+        o << "last frequency element does not match Nyquist "
+          << "frequency for given sample rate: "
+          << binned_freq[n_binned - 1] << " != " << nyquist;
+        log.error(o.str().c_str(), here);
+        throw std::runtime_error(o.str().c_str());
+    }
+
+    // Compute the (common) log frequency products
+
+    toast::AlignedVector <double> logfreq(n_binned);
+
+    double freqshift = increment;
+    if (toast::is_aligned(binned_freq)) {
+        #pragma omp simd
+        for (int64_t i = 0; i < n_binned; ++i) {
+            logfreq[i] = ::log10(binned_freq[i] + freqshift);
+        }
+    } else {
+        for (int64_t i = 0; i < n_binned; ++i) {
+            logfreq[i] = ::log10(binned_freq[i] + freqshift);
+        }
+    }
+
+    toast::AlignedVector <double> stepinv(n_binned);
+    for (int64_t ibin = 0; ibin < n_binned - 1; ++ibin) {
+        stepinv[ibin] = 1 / (logfreq[ibin + 1] - logfreq[ibin]);
+    }
+
+    // Resize the output
+    interp_psds.resize(n_batch * psdlen);
+
+    // Process all psds
+    #pragma omp parallel default(shared)
+    {
+        toast::AlignedVector <double> logpsd(n_binned);
+
+        #pragma omp for schedule(static)
+        for (int64_t ibatch = 0; ibatch < n_batch; ++ibatch) {
+            int64_t offset_binned = ibatch * n_binned;
+            int64_t offset_psd = ibatch * psdlen;
+
+            double psdmin = 1e30;
+            for (int64_t i = 0; i < n_binned; ++i) {
+                if (binned_psds[offset_binned + i] != 0) {
+                    if (binned_psds[offset_binned + i] < psdmin) {
+                        psdmin = binned_psds[offset_binned + i];
+                    }
+                }
+            }
+
+            if (psdmin < 0) {
+                auto here = TOAST_HERE();
+                auto log = toast::Logger::get();
+                std::string msg("input PSD values should be >= zero");
+                log.error(msg.c_str(), here);
+                throw std::runtime_error(msg.c_str());
+            }
+
+            // Perform a logarithmic interpolation.  In order to avoid zero
+            // values, we shift the PSD by a fixed amount in frequency and
+            // amplitude.
+
+            double psdshift = 0.01 * psdmin;
+
+            if (toast::is_aligned(binned_psds)) {
+                #pragma omp simd
+                for (int64_t i = 0; i < n_binned; ++i) {
+                    logpsd[i] = ::log10(::sqrt(binned_psds[offset_binned + i] * norm) + psdshift);
+                }
+            } else {
+                for (int64_t i = 0; i < n_binned; ++i) {
+                    logpsd[i] = ::log10(::sqrt(binned_psds[offset_binned + i] * norm) + psdshift);
+                }
+            }
+
+            #pragma omp simd
+            for (int64_t i = 0; i < psdlen; ++i) {
+                interp_psds[offset_psd + i] = ::log10(increment * static_cast <double> (i) + freqshift);
+            }
+
+            int64_t ibin = 0;
+
+            #pragma omp simd
+            for (int64_t i = 0; i < psdlen; ++i) {
+                double loginterp_freq = interp_psds[offset_psd + i];
+                while ((ibin < (n_binned - 2)) && (logfreq[ibin + 1] < loginterp_freq)) {
+                    ++ibin;
+                }
+                double r = (loginterp_freq - logfreq[ibin]) * stepinv[ibin];
+                interp_psds[offset_psd + i] = logpsd[ibin] + r * (logpsd[ibin + 1] - logpsd[ibin]);
+                interp_psds[offset_psd + i] = pow(10, interp_psds[offset_psd + i]);
+                interp_psds[offset_psd + i] -= psdshift;
+            }
+
+            // Zero out DC value
+            interp_psds[offset_psd + 0] = 0;
+        }
+    }
+
+    return;
+}
+
+
 void toast::tod_sim_noise_timestream(
     uint64_t realization, uint64_t telescope, uint64_t component,
     uint64_t obsindx, uint64_t detindx, double rate, int64_t firstsamp,
@@ -53,104 +183,12 @@ void toast::tod_sim_noise_timestream(
            values.
      */
 
-    int64_t fftlen = 2;
-    while (fftlen <= (oversample * samples)) fftlen *= 2;
+    int64_t fftlen;
     int64_t npsd = (fftlen / 2) + 1;
-    double norm = rate * static_cast <double> (npsd - 1);
 
-    double increment = rate / static_cast <double> (fftlen - 1);
+    toast::AlignedVector <double> interp_psd;
 
-    if (freq[0] > increment) {
-        auto here = TOAST_HERE();
-        auto log = toast::Logger::get();
-        std::ostringstream o;
-        o << "input PSD has lowest frequency " << freq[0]
-          << "Hz, which does not allow interpolation to " << increment
-          << "Hz";
-        log.error(o.str().c_str(), here);
-        throw std::runtime_error(o.str().c_str());
-    }
-
-    double psdmin = 1e30;
-    for (int64_t i = 0; i < psdlen; ++i) {
-        if (psd[i] != 0) {
-            if (psd[i] < psdmin) psdmin = psd[i];
-        }
-    }
-
-    if (psdmin < 0) {
-        auto here = TOAST_HERE();
-        auto log = toast::Logger::get();
-        std::string msg("input PSD values should be >= zero");
-        log.error(msg.c_str(), here);
-        throw std::runtime_error(msg.c_str());
-    }
-
-    double nyquist = 0.5 * rate;
-    if (::fabs((freq[psdlen - 1] - nyquist) / nyquist) > 0.01) {
-        auto here = TOAST_HERE();
-        auto log = toast::Logger::get();
-        std::ostringstream o;
-        o.precision(16);
-        o << "last frequency element does not match Nyquist "
-          << "frequency for given sample rate: "
-          << freq[psdlen - 1] << " != " << nyquist;
-        log.error(o.str().c_str(), here);
-        throw std::runtime_error(o.str().c_str());
-    }
-
-    // Perform a logarithmic interpolation.  In order to avoid zero
-    // values, we shift the PSD by a fixed amount in frequency and
-    // amplitude.
-
-    double psdshift = 0.01 * psdmin;
-    double freqshift = increment;
-
-    toast::AlignedVector <double> logfreq(psdlen);
-    toast::AlignedVector <double> logpsd(psdlen);
-
-    if (toast::is_aligned(freq) && toast::is_aligned(psd)) {
-        #pragma omp simd
-        for (int64_t i = 0; i < psdlen; ++i) {
-            logfreq[i] = ::log10(freq[i] + freqshift);
-            logpsd[i] = ::log10(::sqrt(psd[i] * norm) + psdshift);
-        }
-    } else {
-        for (int64_t i = 0; i < psdlen; ++i) {
-            logfreq[i] = ::log10(freq[i] + freqshift);
-            logpsd[i] = ::log10(::sqrt(psd[i] * norm) + psdshift);
-        }
-    }
-
-    toast::AlignedVector <double> interp_psd(npsd);
-
-    #pragma omp simd
-    for (int64_t i = 0; i < npsd; ++i) {
-        interp_psd[i] = ::log10(increment * static_cast <double> (i) +
-                                freqshift);
-    }
-
-    toast::AlignedVector <double> stepinv(psdlen);
-    for (int64_t ibin = 0; ibin < psdlen - 1; ++ibin) {
-        stepinv[ibin] = 1 / (logfreq[ibin + 1] - logfreq[ibin]);
-    }
-
-    int64_t ibin = 0;
-
-    #pragma omp simd
-    for (int64_t i = 0; i < npsd; ++i) {
-        double loginterp_freq = interp_psd[i];
-        while ((ibin < (psdlen - 2)) && (logfreq[ibin + 1] < loginterp_freq)) {
-            ++ibin;
-        }
-        double r = (loginterp_freq - logfreq[ibin]) * stepinv[ibin];
-        interp_psd[i] = logpsd[ibin] + r * (logpsd[ibin + 1] - logpsd[ibin]);
-        interp_psd[i] = pow(10, interp_psd[i]);
-        interp_psd[i] -= psdshift;
-    }
-
-    // Zero out DC value
-    interp_psd[0] = 0;
+    tod_sim_noise_psd_interp(rate, samples, oversample, 1, psdlen, freq, psd, fftlen, interp_psd);
 
     // gaussian Re/Im randoms, packed into a half-complex array
 
@@ -197,6 +235,106 @@ void toast::tod_sim_noise_timestream(
 
     for (int64_t i = 0; i < samples; ++i) {
         noise[i] -= DC;
+    }
+
+    return;
+}
+
+
+void toast::tod_sim_noise_timestream_batch(
+    uint64_t realization, uint64_t telescope, uint64_t component,
+    uint64_t obsindx, double rate, int64_t firstsamp,
+    int64_t samples, int64_t oversample, int64_t ndet, uint64_t * detindices,
+    int64_t psdlen, const double * freq, const double * psds, double * noise) {
+
+    // Generate multiple noise timestreams at once.
+    //
+    // Use the RNG parameters to generate unit-variance Gaussian samples and then modify
+    //     the Fourier domain amplitudes to match the desired PSD.
+    //
+    // The RNG (Threefry2x64 from Random123) takes a "key" and a "counter"
+    // which each consist of two unsigned 64bit integers.  These four numbers together
+    //     uniquely identify a single sample.  We construct those four numbers in the
+    //     following way:
+    //
+    // key1 = realization * 2^32 + telescope * 2^16 + component key2 = obsindx * 2^32 +
+    //     detindx counter1 = currently unused (0) counter2 = sample in stream
+    //
+    // counter2 is incremented internally by the RNG function as it calls the underlying
+    //     Random123 library for each sample.
+    //
+    // The frequency vector is common to all detectors.  The detindices are the RNG
+    // index for each detector.  The psd vector contains the flat-packed psds for
+    // all detectors.  The output noise vector contains the flat-packed timestreams
+    // for all detectors.
+
+    int64_t fftlen;
+    int64_t npsd = (fftlen / 2) + 1;
+
+    toast::AlignedVector <double> interp_psds;
+
+    tod_sim_noise_psd_interp(rate, samples, oversample, ndet, psdlen, freq, psds, fftlen, interp_psds);
+
+    // Get the plan for this batch size and length.
+
+    auto & store = toast::FFTPlanReal1DStore::get();
+    auto plan = store.backward(fftlen, ndet);
+
+    // Populate the Fourier domain buffers
+
+    #pragma omp parallel default(shared)
+    {
+        toast::AlignedVector <double> rngdata(fftlen);
+
+        #pragma omp for schedule(static)
+        for (int64_t idet = 0; idet < ndet; ++idet) {
+            int64_t offset_fft = idet * fftlen;
+            int64_t offset_psd = idet * npsd;
+
+            // Gaussian Re/Im randoms, packed into a half-complex array
+            uint64_t key1 = realization * 4294967296 + telescope * 65536 + component;
+            uint64_t key2 = obsindx * 4294967296 + detindices[idet];
+            uint64_t counter1 = 0;
+            uint64_t counter2 = static_cast <uint64_t> (firstsamp * oversample);
+
+            toast::rng_dist_normal(fftlen, key1, key2, counter1, counter2,
+                                rngdata.data());
+
+            double * pdata = plan->fdata(0) + offset_fft;
+            std::copy(rngdata.begin(), rngdata.end(), pdata);
+
+            pdata[0] *= interp_psds[offset_psd + 0];
+            for (int64_t i = 1; i < (fftlen / 2); ++i) {
+                double psdval = interp_psds[offset_psd + i];
+                pdata[i] *= psdval;
+                pdata[fftlen - i] *= psdval;
+            }
+
+            pdata[fftlen / 2] *= interp_psds[offset_psd + npsd - 1];
+        }
+    }
+
+    // Inverse FFT
+    plan->exec();
+
+    // Copy data to output
+    for (int64_t idet = 0; idet < ndet; ++idet) {
+        int64_t offset = idet * fftlen + (fftlen - samples) / 2;
+        int64_t offset_nse = idet * samples;
+        double * pdata = plan->tdata(0) + offset;
+        std::copy(pdata, (pdata + samples), &(noise[offset_nse]));
+
+        // subtract the DC level
+
+        double DC = 0;
+        for (int64_t i = 0; i < samples; ++i) {
+            DC += noise[offset_nse + i];
+        }
+        DC /= static_cast <double> (samples);
+
+        for (int64_t i = 0; i < samples; ++i) {
+            noise[offset_nse + i] -= DC;
+        }
     }
 
     return;

--- a/src/libtoast/src/toast_tod_simnoise.cpp
+++ b/src/libtoast/src/toast_tod_simnoise.cpp
@@ -11,8 +11,11 @@
 #include <sstream>
 
 
-void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample, int64_t n_batch, int64_t n_binned, double const * binned_freq, double const * binned_psds, int64_t & fftlen, toast::AlignedVector <double> & interp_psds) {
-
+void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample,
+                              int64_t n_batch, int64_t n_binned,
+                              double const * binned_freq, double const * binned_psds,
+                              int64_t & fftlen,
+                              toast::AlignedVector <double> & interp_psds) {
     fftlen = 2;
     while (fftlen <= (oversample * samples)) {
         fftlen *= 2;
@@ -105,17 +108,23 @@ void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample, 
             if (toast::is_aligned(binned_psds)) {
                 #pragma omp simd
                 for (int64_t i = 0; i < n_binned; ++i) {
-                    logpsd[i] = ::log10(::sqrt(binned_psds[offset_binned + i] * norm) + psdshift);
+                    logpsd[i] = ::log10(::sqrt(
+                                            binned_psds[offset_binned + i] * norm) +
+                                        psdshift);
                 }
             } else {
                 for (int64_t i = 0; i < n_binned; ++i) {
-                    logpsd[i] = ::log10(::sqrt(binned_psds[offset_binned + i] * norm) + psdshift);
+                    logpsd[i] = ::log10(::sqrt(
+                                            binned_psds[offset_binned + i] * norm) +
+                                        psdshift);
                 }
             }
 
             #pragma omp simd
             for (int64_t i = 0; i < psdlen; ++i) {
-                interp_psds[offset_psd + i] = ::log10(increment * static_cast <double> (i) + freqshift);
+                interp_psds[offset_psd +
+                            i] = ::log10(
+                    increment * static_cast <double> (i) + freqshift);
             }
 
             int64_t ibin = 0;
@@ -123,11 +132,13 @@ void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample, 
             #pragma omp simd
             for (int64_t i = 0; i < psdlen; ++i) {
                 double loginterp_freq = interp_psds[offset_psd + i];
-                while ((ibin < (n_binned - 2)) && (logfreq[ibin + 1] < loginterp_freq)) {
+                while ((ibin < (n_binned - 2)) &&
+                       (logfreq[ibin + 1] < loginterp_freq)) {
                     ++ibin;
                 }
                 double r = (loginterp_freq - logfreq[ibin]) * stepinv[ibin];
-                interp_psds[offset_psd + i] = logpsd[ibin] + r * (logpsd[ibin + 1] - logpsd[ibin]);
+                interp_psds[offset_psd + i] = logpsd[ibin] + r *
+                                              (logpsd[ibin + 1] - logpsd[ibin]);
                 interp_psds[offset_psd + i] = pow(10, interp_psds[offset_psd + i]);
                 interp_psds[offset_psd + i] -= psdshift;
             }
@@ -140,13 +151,11 @@ void tod_sim_noise_psd_interp(double rate, int64_t samples, int64_t oversample, 
     return;
 }
 
-
 void toast::tod_sim_noise_timestream(
     uint64_t realization, uint64_t telescope, uint64_t component,
     uint64_t obsindx, uint64_t detindx, double rate, int64_t firstsamp,
     int64_t samples, int64_t oversample, const double * freq,
     const double * psd, int64_t psdlen, double * noise) {
-
     // Generate a single noise timestream.
     //
     // Use the RNG parameters to generate unit-variance Gaussian samples and then modify
@@ -166,7 +175,8 @@ void toast::tod_sim_noise_timestream(
     int64_t fftlen;
     toast::AlignedVector <double> interp_psd;
 
-    tod_sim_noise_psd_interp(rate, samples, oversample, 1, psdlen, freq, psd, fftlen, interp_psd);
+    tod_sim_noise_psd_interp(rate, samples, oversample, 1, psdlen, freq, psd, fftlen,
+                             interp_psd);
 
     int64_t npsd = (fftlen / 2) + 1;
 
@@ -217,13 +227,11 @@ void toast::tod_sim_noise_timestream(
     return;
 }
 
-
 void toast::tod_sim_noise_timestream_batch(
     uint64_t realization, uint64_t telescope, uint64_t component,
     uint64_t obsindx, double rate, int64_t firstsamp,
     int64_t samples, int64_t oversample, int64_t ndet, uint64_t * detindices,
     int64_t psdlen, const double * freq, const double * psds, double * noise) {
-
     // Generate multiple noise timestreams at once.
     //
     // Use the RNG parameters to generate unit-variance Gaussian samples and then modify
@@ -248,7 +256,8 @@ void toast::tod_sim_noise_timestream_batch(
     int64_t fftlen;
     toast::AlignedVector <double> interp_psds;
 
-    tod_sim_noise_psd_interp(rate, samples, oversample, ndet, psdlen, freq, psds, fftlen, interp_psds);
+    tod_sim_noise_psd_interp(rate, samples, oversample, ndet, psdlen, freq, psds,
+                             fftlen, interp_psds);
 
     int64_t npsd = (fftlen / 2) + 1;
 

--- a/src/libtoast/src/toast_tod_simnoise.cpp
+++ b/src/libtoast/src/toast_tod_simnoise.cpp
@@ -269,11 +269,11 @@ void toast::tod_sim_noise_timestream_batch(
     // for all detectors.
 
     int64_t fftlen;
-    int64_t npsd = (fftlen / 2) + 1;
-
     toast::AlignedVector <double> interp_psds;
 
     tod_sim_noise_psd_interp(rate, samples, oversample, ndet, psdlen, freq, psds, fftlen, interp_psds);
+
+    int64_t npsd = (fftlen / 2) + 1;
 
     // Get the plan for this batch size and length.
 

--- a/src/toast/_libtoast/tod_filter.cpp
+++ b/src/toast/_libtoast/tod_filter.cpp
@@ -213,7 +213,8 @@ void init_tod_filter(py::module & m) {
     )");
 
     m.def("filter_poly2D",
-          [](py::buffer det_groups, py::buffer templates, py::buffer signals, py::buffer masks, py::buffer coeff) {
+          [](py::buffer det_groups, py::buffer templates, py::buffer signals,
+             py::buffer masks, py::buffer coeff) {
               pybuffer_check <uint8_t> (masks);
               pybuffer_check <int32_t> (det_groups);
               pybuffer_check <double> (templates);
@@ -224,7 +225,8 @@ void init_tod_filter(py::module & m) {
               py::buffer_info info_templates = templates.request();
               py::buffer_info info_signals = signals.request();
               py::buffer_info info_coeff = coeff.request();
-              // Check dimensions
+
+// Check dimensions
               if (info_signals.ndim != 2) {
                   auto log = toast::Logger::get();
                   std::ostringstream o;
@@ -275,7 +277,8 @@ void init_tod_filter(py::module & m) {
                   std::ostringstream o;
                   o << "Coeff array dimensions are inconsistent";
                   log.error(o.str().c_str());
-                  throw std::runtime_error(o.str().c_str());
+                  throw std::runtime_error(
+                            o.str().c_str());
               }
               int32_t ngroup = info_coeff.shape[1];
               int32_t * raw_detgroups = reinterpret_cast <int32_t *> (info_detgroups.ptr);
@@ -293,9 +296,12 @@ void init_tod_filter(py::module & m) {
               double * raw_templates = reinterpret_cast <double *> (info_templates.ptr);
               double * raw_signals = reinterpret_cast <double *> (info_signals.ptr);
               double * raw_coeff = reinterpret_cast <double *> (info_coeff.ptr);
-              toast::filter_poly2D_solve(nsample, ndet, ngroup, nmodes, raw_detgroups, raw_templates, raw_masks, raw_signals, raw_coeff);
+              toast::filter_poly2D_solve(nsample, ndet, ngroup, nmodes, raw_detgroups,
+                                         raw_templates, raw_masks, raw_signals,
+                                         raw_coeff);
               return;
-          }, py::arg("det_groups"), py::arg("templates"), py::arg("signals"), py::arg("masks"),
+          }, py::arg("det_groups"), py::arg("templates"), py::arg("signals"),
+          py::arg("masks"),
           py::arg(
               "coeff"), R"(
         Solves for 2D polynomial coefficients at each sample.

--- a/src/toast/_libtoast/tod_simnoise.cpp
+++ b/src/toast/_libtoast/tod_simnoise.cpp
@@ -81,7 +81,8 @@ void init_tod_simnoise(py::module & m) {
     m.def("tod_sim_noise_timestream_batch",
           [](uint64_t realization, uint64_t telescope, uint64_t component,
              uint64_t obsindx, double rate, int64_t firstsamp,
-             int64_t oversample, py::buffer detindices, py::buffer freq, py::buffer psds, py::buffer noise) {
+             int64_t oversample, py::buffer detindices, py::buffer freq,
+             py::buffer psds, py::buffer noise) {
               pybuffer_check_1D <uint64_t> (detindices);
               pybuffer_check_1D <double> (freq);
 
@@ -123,7 +124,11 @@ void init_tod_simnoise(py::module & m) {
               double * rawpsd = reinterpret_cast <double *> (info_psd.ptr);
               double * rawnoise = reinterpret_cast <double *> (info_noise.ptr);
 
-              toast::tod_sim_noise_timestream_batch(realization, telescope, component, obsindx, rate, firstsamp, samples, oversample, ndet, rawdetind, psdlen, rawfreq, rawpsd, rawnoise);
+              toast::tod_sim_noise_timestream_batch(realization, telescope, component,
+                                                    obsindx, rate, firstsamp, samples,
+                                                    oversample, ndet, rawdetind, psdlen,
+                                                    rawfreq,
+                                                    rawpsd, rawnoise);
               return;
           }, py::arg("realization"), py::arg("telescope"), py::arg("component"),
           py::arg("obsindx"), py::arg("rate"),

--- a/src/toast/_libtoast/tod_simnoise.cpp
+++ b/src/toast/_libtoast/tod_simnoise.cpp
@@ -78,5 +78,97 @@ void init_tod_simnoise(py::module & m) {
 
     )");
 
+    m.def("tod_sim_noise_timestream_batch",
+          [](uint64_t realization, uint64_t telescope, uint64_t component,
+             uint64_t obsindx, double rate, int64_t firstsamp,
+             int64_t oversample, py::buffer detindices, py::buffer freq, py::buffer psds, py::buffer noise) {
+              pybuffer_check_1D <uint64_t> (detindices);
+              pybuffer_check_1D <double> (freq);
+
+              pybuffer_check <double> (psds);
+              pybuffer_check <double> (noise);
+
+              py::buffer_info info_detind = detindices.request();
+              py::buffer_info info_freq = freq.request();
+              py::buffer_info info_psd = psds.request();
+              py::buffer_info info_noise = noise.request();
+
+              int64_t ndet = info_detind.size;
+              int64_t psdlen = info_freq.size;
+              if ((info_psd.ndim != 2) || (info_noise.ndim != 2)) {
+                  auto log = toast::Logger::get();
+                  std::ostringstream o;
+                  o << "psds and noise should be 2D arrays.";
+                  log.error(o.str().c_str());
+                  throw std::runtime_error(o.str().c_str());
+              }
+              if ((info_psd.shape[0] != ndet) || (info_noise.shape[0] != ndet)) {
+                  auto log = toast::Logger::get();
+                  std::ostringstream o;
+                  o << "first dimension of psds and noise should match length of detindices.";
+                  log.error(o.str().c_str());
+                  throw std::runtime_error(o.str().c_str());
+              }
+              if (info_psd.shape[1] != psdlen) {
+                  auto log = toast::Logger::get();
+                  std::ostringstream o;
+                  o << "Number of psd points does not match frequency array.";
+                  log.error(o.str().c_str());
+                  throw std::runtime_error(o.str().c_str());
+              }
+              int64_t samples = info_noise.shape[1];
+
+              uint64_t * rawdetind = reinterpret_cast <uint64_t *> (info_detind.ptr);
+              double * rawfreq = reinterpret_cast <double *> (info_freq.ptr);
+              double * rawpsd = reinterpret_cast <double *> (info_psd.ptr);
+              double * rawnoise = reinterpret_cast <double *> (info_noise.ptr);
+
+              toast::tod_sim_noise_timestream_batch(realization, telescope, component, obsindx, rate, firstsamp, samples, oversample, ndet, rawdetind, psdlen, rawfreq, rawpsd, rawnoise);
+              return;
+          }, py::arg("realization"), py::arg("telescope"), py::arg("component"),
+          py::arg("obsindx"), py::arg("rate"),
+          py::arg("firstsamp"), py::arg("oversample"), py::arg("detindices"),
+          py::arg("freq"), py::arg("psds"), py::arg(
+              "noise"), R"(
+        Generate multiple noise timestreams in parallel.
+
+        Use the RNG parameters to generate unit-variance Gaussian samples
+        and then modify the Fourier domain amplitudes to match the desired
+        PSD.
+
+        The RNG (Threefry2x64 from Random123) takes a "key" and a "counter"
+        which each consist of two unsigned 64bit integers.  These four
+        numbers together uniquely identify a single sample.  We construct
+        those four numbers in the following way:
+
+        key1 = realization * 2^32 + telescope * 2^16 + component
+        key2 = obsindx * 2^32 + detindx
+        counter1 = currently unused (0)
+        counter2 = sample in stream
+
+        counter2 is incremented internally by the RNG function as it calls
+        the underlying Random123 library for each sample.
+
+        Args:
+            realization (int): the Monte Carlo realization.
+            telescope (int): a unique index assigned to a telescope.
+            component (int): a number representing the type of timestream
+                we are generating (detector noise, common mode noise,
+                atmosphere, etc).
+            obsindx (int): the global index of this observation.
+            rate (float): the sample rate.
+            firstsamp (int): the start sample in the stream.
+            oversample (int): the factor by which to expand the FFT length
+                beyond the number of samples.
+            detindices (array): array with global index for each detector.
+            freq (array): the frequency points of all PSDs.
+            psd (array): a 2D array containing the PSD for each detector.
+            noise (array): a 2D array of the output noise timestreams.
+
+        Returns:
+            None
+
+    )");
+
     return;
 }

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -298,7 +298,7 @@ class SimNoise(Operator):
             )
 
             if self.serial:
-                # Original serial implementation
+                # Original serial implementation (for testing / comparison)
                 for key in nse.keys:
                     # Check if noise matching this PSD key is needed
                     weight = 0.0
@@ -340,22 +340,11 @@ class SimNoise(Operator):
                         ob.detdata[self.det_data][det] += weight * nsedata
 
                 # Release the work space allocated in the FFT plan store.
-                #
-                # FIXME: the fact that we are doing this begs the question of why bother
-                # using the plan store at all?  Only one plan per process, per FFT length
-                # should be created.  The memory use of these plans should be small relative
-                # to the other timestream memory use except in the case where:
-                #
-                #  1.  Each process only has a few detectors
-                #  2.  There is a broad distribution of observation lengths.
-                #
-                # If we are in this regime frequently, we should just allocate / free
-                # each plan.
                 store = FFTPlanReal1DStore.get()
                 store.clear()
             else:
                 # Build up the list of noise stream indices and verify that the
-                # frequency data for all psds are consistent.
+                # frequency data for all psds is consistent.
                 strm_names = list()
                 freq_zero = nse.freq(nse.keys[0])
                 for ikey, key in enumerate(nse.keys):
@@ -418,7 +407,7 @@ class SimNoise(Operator):
                 del freq
 
                 # Add the noise to all detectors that have nonzero weights
-                for ikey, key in enumerate(nse.keys):
+                for ikey, key in enumerate(strm_names):
                     for det in dets:
                         weight = nse.weight(det, key)
                         if weight == 0:

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -472,14 +472,10 @@ class FilterBinTest(MPITestCase):
 
             input_map = hp.read_map(input_map_file, None, nest=nest)
 
-            fname_filtered = os.path.join(
-                self.outdir, "cached_run_1_filtered_map.fits"
-            )
+            fname_filtered = os.path.join(self.outdir, "cached_run_1_filtered_map.fits")
             filtered1 = hp.read_map(fname_filtered, None, nest=nest)
 
-            fname_filtered = os.path.join(
-                self.outdir, "cached_run_2_filtered_map.fits"
-            )
+            fname_filtered = os.path.join(self.outdir, "cached_run_2_filtered_map.fits")
             filtered2 = hp.read_map(fname_filtered, None, nest=nest)
 
             test_map1 = obs_matrix1.dot(input_map.ravel()).reshape([3, -1])
@@ -526,9 +522,7 @@ class FilterBinTest(MPITestCase):
             fname = os.path.join(self.outdir, "obs_matrix_cached_test.png")
             fig.savefig(fname)
 
-            for filtered, test_map in [
-                    (filtered1, test_map1), (filtered2, test_map2)
-            ]:
+            for filtered, test_map in [(filtered1, test_map1), (filtered2, test_map2)]:
                 good = filtered[0] != 0
                 for i in range(3):
                     rms1 = np.std(filtered[i][good])


### PR DESCRIPTION
Many years ago (toast-1.x) we used our internal batched (threaded) FFTs for noise simulation.  In toast-2.x we somehow moved away from that.  For some job configurations (few processes and many threads per process), this is quite wasteful.  This work restores use of our batched FFTs for noise simulation.  The old serial implementation remains and can be enabled by a trait which is useful for testing.  The unit tests check agreement between the old and new implementations.

Running the ground benchmark (auto case) on 50 cori-KNL nodes with 4 processes per node and 16 threads per process previously took this long to simulate the noise:
```
TOAST INFO: Simulated detector noise in 2124.09 s
```
After this change, the same step runs in:
```
TOAST INFO: Simulated detector noise in 308.51 s
```
Definitely not perfect scaling with threads, but much improved.