### PR TITLE
Fix memory handling in serial noise simulation

### DIFF
--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -182,7 +182,9 @@ class GainDrifter(Operator):
                         psd=psd,
                         py=False,
                     )
-                    thermal_fluct.append(gain)
+                    thermal_fluct.append(np.array(gain))
+                    gain.clear()
+                    del gain
                 thermal_fluct = np.array(thermal_fluct)
 
                 for det in dets:
@@ -246,21 +248,22 @@ class GainDrifter(Operator):
                 else:
                     gain_common = []
                     for iw, w in enumerate(det_group):
-                        gain_common.append(
-                            sim_noise_timestream(
-                                realization=self.realization,
-                                telescope=ob.telescope.uid,
-                                component=self.component,
-                                obsindx=ob.uid,
-                                detindx=iw,  # drift common to all detectors
-                                rate=fsampl,
-                                firstsamp=ob.local_index_offset,
-                                samples=ob.n_local_samples,
-                                freq=freq,
-                                psd=psd,
-                                py=False,
-                            )
+                        gain = sim_noise_timestream(
+                            realization=self.realization,
+                            telescope=ob.telescope.uid,
+                            component=self.component,
+                            obsindx=ob.uid,
+                            detindx=iw,  # drift common to all detectors
+                            rate=fsampl,
+                            firstsamp=ob.local_index_offset,
+                            samples=ob.n_local_samples,
+                            freq=freq,
+                            psd=psd,
+                            py=False,
                         )
+                        gain_common.append(np.array(gain))
+                        gain.clear()
+                        del gain
                 gain_common = np.array(gain_common)
 
                 for det in dets:
@@ -287,9 +290,11 @@ class GainDrifter(Operator):
                     # assign the thermal fluct. simulated for that det. group
                     ob.detdata[self.det_data][det] *= (
                         1
-                        + (self.detector_mismatch * gain)
+                        + (self.detector_mismatch * gain.array())
                         + (1 - self.detector_mismatch) * gain_common[mask][0]
                     )
+                    gain.clear()
+                    del gain
 
         return
 

--- a/src/toast/tests/ops_sim_tod_noise.py
+++ b/src/toast/tests/ops_sim_tod_noise.py
@@ -201,8 +201,9 @@ class SimNoiseTest(MPITestCase):
                     py=True,
                 )
                 np.testing.assert_array_almost_equal(
-                    pytod, ob.detdata[sim_noise.det_data][det], decimal=2
+                    pytod.array(), ob.detdata[sim_noise.det_data][det], decimal=2
                 )
+                pytod.clear()
 
             if wrank == 0:
                 # One process dumps out interpolated PSD for debugging
@@ -328,6 +329,8 @@ class SimNoiseTest(MPITestCase):
                     psd=nse.psd(det).to_value(u.K ** 2 * u.second),
                     py=True,
                 )
+                pytod.clear()
+
                 # Factor of 2 comes from the negative frequency values.
                 psd_norm[det] = 2.0 * np.sum(psds[det] * dfreq)
 


### PR DESCRIPTION
This makes serial noise handling the default, since there is a large temporary memory overhead associated with the batched (threaded) case.  This also explicitly frees the memory after each timestream simulated.