### PR TITLE
Consolodate creation of MPI communicators

### DIFF
--- a/platforms/install_test_runner.sh
+++ b/platforms/install_test_runner.sh
@@ -5,6 +5,10 @@
 
 set -e
 
+# Temporary workaround- update pshmem pip package until upstream container
+# has new release.
+python3 -m pip install --upgrade pshmem
+
 # Get the absolute path to the source tree
 pushd $(dirname $(dirname $0)) >/dev/null 2>&1
 toastdir=$(pwd -P)

--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,7 @@ conf["install_requires"] = [
     "matplotlib",
     "psutil",
     "h5py",
-    "pshmem",
+    "pshmem>=0.2.9",
     "astropy",
     "healpy",
     "ephem",

--- a/src/toast/data.py
+++ b/src/toast/data.py
@@ -115,7 +115,7 @@ class Data(MutableMapping):
 
         gcomm = self._comm.comm_group
         wcomm = self._comm.comm_world
-        rcomm = self._comm.comm_rank
+        rcomm = self._comm.comm_group_rank
 
         if wcomm is None:
             msg = "Data distributed over a single process (no MPI)"

--- a/src/toast/job.py
+++ b/src/toast/job.py
@@ -41,7 +41,6 @@ def job_size(world_comm):
 
     procs_per_node = 1
     node_rank = 0
-    node_comm = None
     rank = 0
     procs = 1
 
@@ -55,6 +54,8 @@ def job_size(world_comm):
         max_per_node = world_comm.allreduce(procs_per_node, op=MPI.MAX)
         if min_per_node != max_per_node:
             raise RuntimeError("Nodes have inconsistent numbers of MPI ranks")
+        node_comm.Free()
+        del node_comm
 
     n_node = procs // procs_per_node
 

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -254,18 +254,20 @@ class Comm(object):
         # Go through the cache of row / column grid communicators and free
         if hasattr(self, "_rowcolcomm"):
             for process_rows, comms in self._rowcolcomm.items():
-                comms["row"].Free()
-                del comms["row"]
-                comms["row_node"].Free()
-                del comms["row_node"]
-                comms["row_rank_node"].Free()
-                del comms["row_rank_node"]
-                comms["col"].Free()
-                del comms["col"]
-                comms["col_node"].Free()
-                del comms["col_node"]
-                comms["col_rank_node"].Free()
-                del comms["col_rank_node"]
+                if comms["row"] is not None:
+                    comms["row_node"].Free()
+                    del comms["row_node"]
+                    comms["row_rank_node"].Free()
+                    del comms["row_rank_node"]
+                    comms["row"].Free()
+                    del comms["row"]
+                if comms["col"] is not None:
+                    comms["col_node"].Free()
+                    del comms["col_node"]
+                    comms["col_rank_node"].Free()
+                    del comms["col_rank_node"]
+                    comms["col"].Free()
+                    del comms["col"]
         return
 
     def __del__(self):

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -87,12 +87,23 @@ class Comm(object):
     "group".  If group_size does not divide evenly into the size of the given
     communicator, then those processes remain idle.
 
-    A Comm object stores three MPI communicators:  The "world" communicator
+    A Comm object stores several MPI communicators:  The "world" communicator
     given here, which contains all processes to consider, a "group"
     communicator (one per group), and a "rank" communicator which contains the
     processes with the same group-rank across all groups.
 
-    If MPI is not enabled, then all communicators are set to None.
+    This object also stores a "node" communicator containing all processes with
+    access to the same shared memory, and a "node rank" communicator for
+    processes with the same rank on a node.  There is a node rank communicator
+    for all nodes and also one for within the group.
+
+    Additionally, there is a mechanism for creating and caching row / column
+    communicators for process grids within a group.
+
+    If MPI is not enabled, then all communicators are set to None.  Additionally,
+    there may be cases where MPI is enabled in the environment, but the user wishes
+    to disable it when creating a Comm object.  This can be done by passing
+    MPI.COMM_SELF as the world communicator.
 
     Args:
         world (mpi4py.MPI.Comm): the MPI communicator containing all processes.
@@ -134,9 +145,16 @@ class Comm(object):
         self._wcomm = world
         self._wrank = 0
         self._wsize = 1
+        self._nodecomm = None
+        self._noderankcomm = None
+        self._nodeprocs = 1
         if self._wcomm is not None:
             self._wrank = self._wcomm.rank
             self._wsize = self._wcomm.size
+            self._nodecomm = self._wcomm.Split_type(MPI.COMM_TYPE_SHARED, 0)
+            self._nodeprocs = self._nodecomm.size
+            myworldnode = self._wrank // self._nodeprocs
+            self._noderankcomm = self._wcomm.Split(self._nodecomm.rank, myworldnode)
 
         self._gsize = groupsize
 
@@ -162,13 +180,21 @@ class Comm(object):
             log.error(msg)
             raise RuntimeError(msg)
 
+        if self._gsize > self._nodeprocs and self._gsize % self._nodeprocs != 0:
+            msg = f"Group size of {self._gsize} is not a whole number of "
+            msg += f"nodes (there are {self._nodeprocs} processes per node)"
+            log.error(msg)
+            raise RuntimeError(msg)
+
         self._group = self._wrank // self._gsize
         self._grank = self._wrank % self._gsize
-        self._cleanup_split_comm = False
+        self._cleanup_group_comm = False
 
+        self._gnoderankcomm = None
         if self._ngroups == 1:
             # We just have one group with all processes.
             self._gcomm = self._wcomm
+            self._gnoderankcomm = self._noderankcomm
             if use_mpi:
                 self._rcomm = MPI.COMM_SELF
             else:
@@ -178,7 +204,9 @@ class Comm(object):
             # unless MPI is enabled and we have multiple groups.
             self._gcomm = self._wcomm.Split(self._group, self._grank)
             self._rcomm = self._wcomm.Split(self._grank, self._group)
-            self._cleanup_split_comm = True
+            mygroupnode = self._grank // self._nodeprocs
+            self._gnoderankcomm = self._wcomm.Split(self._nodecomm.rank, mygroupnode)
+            self._cleanup_group_comm = True
 
         # See if we are using CUDA and if so, determine which device each process will
         # be using.
@@ -188,27 +216,41 @@ class Comm(object):
                 # We are not using MPI, so we will just use the first device
                 self._cuda = AcceleratorCuda(0)
             else:
-                # How many processes are on this node?
-                nodecomm = self._wcomm.Split_type(MPI.COMM_TYPE_SHARED, 0)
-                nodeprocs = nodecomm.size
-                noderank = nodecomm.rank
                 # Assign this process to one of the GPUs.
                 # FIXME:  Is it better for ranks to be spread across the devices
                 # or for contiguous ranks to be assigned to same device?
-                rank_dev = noderank % cuda_devices
+                rank_dev = self._nodecomm.rank % cuda_devices
                 self._cuda = AcceleratorCuda(rank_dev)
-                nodecomm.Free()
-                del nodecomm
+
+        # Create a cache of row / column communicators for each group.  These can
+        # then be re-used for observations with the same grid shapes.
+        self._rowcolcomm = dict()
 
     def close(self):
-        # Explicitly free communicators if needed
-        if hasattr(self, "_cleanup_split_comm") and self._cleanup_split_comm:
+        # Explicitly free communicators if needed.
+        # We always need to clean up the node and world node-rank communicators
+        # if they exist
+        if hasattr(self, "_nodecomm") and self._nodecomm is not None:
+            self._nodecomm.Free()
+            del self._nodecomm
+        if hasattr(self, "_noderankcomm") and self._noderankcomm is not None:
+            self._noderankcomm.Free()
+            del self._noderankcomm
+        # Optionally delete the group communicators if they were created.
+        if hasattr(self, "_cleanup_split_comm") and self._cleanup_group_comm:
             self._gcomm.Free()
             self._rcomm.Free()
-            # Delete these members completely, so that an error will be
-            # triggered if we try to do something after calling close().
+            self._gnoderankcomm.Free()
             del self._gcomm
             del self._rcomm
+            del self._gnoderankcomm
+        # Go through the cache of row / column grid communicators and free
+        if hasattr(self, "_rowcolcomm"):
+            for process_rows, comms in self._rowcolcomm.items():
+                comms["row"].Free()
+                del comms["row"]
+                comms["col"].Free()
+                del comms["col"]
         return
 
     def __del__(self):
@@ -250,14 +292,80 @@ class Comm(object):
         return self._wcomm
 
     @property
+    def comm_node(self):
+        """The communicator shared by processes on the same node."""
+        return self._nodecomm
+
+    @property
+    def comm_node_rank(self):
+        """The communicator shared by processes with the same node rank across all nodes."""
+        return self._nodecomm
+
+    @property
     def comm_group(self):
         """The communicator shared by processes within this group."""
         return self._gcomm
 
     @property
-    def comm_rank(self):
+    def comm_group_rank(self):
         """The communicator shared by processes with the same group_rank."""
         return self._rcomm
+
+    @property
+    def comm_group_node_rank(self):
+        """The communicator shared by processes with the same node rank on nodes within the group."""
+        return self._rcomm
+
+    def comm_row_col(self, process_rows):
+        """Return the row and column communicators for this group and grid shape.
+
+        Args:
+            process_rows (int):  The number of rows in the process grid.
+
+        Returns:
+            (tuple):  The (row MPI.Comm, column MPI.Comm) for the group using the
+                specified number of process rows.
+
+        """
+        if process_rows not in self._rowcolcomm:
+            # Does not exist yet, create it.
+            if self._gcomm is None:
+                if process_rows != 1:
+                    msg = "MPI not in use, so only process_rows == 1 is allowed"
+                    log.error(msg)
+                    raise ValueError(msg)
+                self._rowcolcomm[process_rows] = {
+                    "row": None,
+                    "col": None,
+                }
+            else:
+                if self._gcomm.size % process_rows != 0:
+                    msg = f"The number of process_rows ({process_rows}) "
+                    msg += f"does not divide evenly into the communicator "
+                    msg += f"size ({self._gcomm.size})"
+                    log.error(msg)
+                    raise RuntimeError(msg)
+                process_cols = self._gcomm.size // process_rows
+                col_rank = self._gcomm.rank // process_cols
+                row_rank = self._gcomm.rank % process_cols
+
+                self._rowcolcomm[process_rows] = dict()
+                if process_cols == 1:
+                    self._rowcolcomm[process_rows]["row"] = MPI.Comm.Dup(MPI.COMM_SELF)
+                else:
+                    self._rowcolcomm[process_rows]["row"] = self._gcomm.Split(
+                        col_rank, row_rank
+                    )
+                if process_rows == 1:
+                    self._rowcolcomm[process_rows]["col"] = MPI.Comm.Dup(MPI.COMM_SELF)
+                else:
+                    self._rowcolcomm[process_rows]["col"] = self._gcomm.Split(
+                        row_rank, col_rank
+                    )
+        return (
+            self._rowcolcomm[process_rows]["row"],
+            self._rowcolcomm[process_rows]["col"],
+        )
 
     @property
     def cuda(self):

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -805,9 +805,7 @@ class SharedDataManager(MutableMapping):
     def __init__(self, dist):
         self.n_detectors = len(dist.dets[dist.comm.group_rank])
         self.n_samples = dist.samps[dist.comm.group_rank].n_elem
-        self.comm = dist.comm
-        self.comm_row = dist.comm_row
-        self.comm_col = dist.comm_col
+        self.dist = dist
         self._internal = dict()
 
     def create(self, name, shape, dtype=None, comm=None):
@@ -837,15 +835,20 @@ class SharedDataManager(MutableMapping):
             raise RuntimeError(msg)
 
         shared_comm = comm
+        shared_comm_node = None
+        shared_comm_rank_node = None
         if shared_comm is None:
             # Use the observation group communicator.
-            shared_comm = self.comm.comm_group
+            shared_comm = self.dist.comm.comm_group
+            shared_comm_node = self.dist.comm.comm_group_node
+            shared_comm_rank_node = self.dist.comm.comm_group_node_rank
 
-        if comm_equal(self.comm.comm_group, shared_comm):
+        if comm_equal(self.dist.comm.comm_group, shared_comm):
             # This is shared over the whole observation communicator, so it
             # may have any shape.
-            pass
-        elif comm_equal(self.comm_row, shared_comm):
+            shared_comm_node = self.dist.comm.comm_group_node
+            shared_comm_rank_node = self.dist.comm.comm_group_node_rank
+        elif comm_equal(self.dist.comm_row, shared_comm):
             # This is shared over the row communicator, so the leading
             # dimension must be the number of local detectors.
             if shape[0] != self.n_detectors:
@@ -854,7 +857,9 @@ class SharedDataManager(MutableMapping):
                 msg += f"detectors ({self.n_detectors}).  Shape given = {shape}."
                 log.error(msg)
                 raise RuntimeError(msg)
-        elif comm_equal(self.comm_col, shared_comm):
+            shared_comm_node = self.dist.comm_row_node
+            shared_comm_rank_node = self.dist.comm_row_rank_node
+        elif comm_equal(self.dist.comm_col, shared_comm):
             # This is shared over the column communicator, so the leading
             # dimension must be the number of local samples.
             if shape[0] != self.n_samples:
@@ -863,6 +868,8 @@ class SharedDataManager(MutableMapping):
                 msg += f"samples ({self.n_samples}).  Shape given = {shape}"
                 log.error(msg)
                 raise RuntimeError(msg)
+            shared_comm_node = self.dist.comm_col_node
+            shared_comm_rank_node = self.dist.comm_col_rank_node
         else:
             msg = f"When creating shared data '{name}', you must use either the "
             msg += "observation communicator or the row or column communicators."
@@ -876,7 +883,13 @@ class SharedDataManager(MutableMapping):
             shared_dtype = np.float64
 
         # Create the data object
-        self._internal[name] = MPIShared(shape, shared_dtype, shared_comm)
+        self._internal[name] = MPIShared(
+            shape,
+            shared_dtype,
+            shared_comm,
+            comm_node=shared_comm_node,
+            comm_node_rank=shared_comm_rank_node,
+        )
 
         return
 
@@ -896,7 +909,10 @@ class SharedDataManager(MutableMapping):
             # This is an existing shared object.
             if key not in self._internal:
                 self.create(
-                    key, shape=value.shape, dtype=value.dtype, comm=self.comm.comm_group
+                    key,
+                    shape=value.shape,
+                    dtype=value.dtype,
+                    comm=self.dist.comm.comm_group,
                 )
             else:
                 # Verify that communicators and dimensions match
@@ -925,7 +941,7 @@ class SharedDataManager(MutableMapping):
                 # We need to create it.  In that case we use the default communicator
                 # (the full observation comm).  We also need to get the array
                 # properties to all processes in order to create the object.
-                if self.comm.comm_group is None:
+                if self.dist.comm.comm_group is None:
                     # No MPI
                     self.create(key, shape=value.shape, dtype=value.dtype)
                     offset = tuple([0 for x in self._internal[key].shape])
@@ -933,13 +949,17 @@ class SharedDataManager(MutableMapping):
                 else:
                     shp = None
                     dt = None
-                    check_rank = np.zeros((self.comm.group_size,), dtype=np.int32)
-                    check_result = np.zeros((self.comm.group_size,), dtype=np.int32)
+                    check_rank = np.zeros((self.dist.comm.group_size,), dtype=np.int32)
+                    check_result = np.zeros(
+                        (self.dist.comm.group_size,), dtype=np.int32
+                    )
                     if value is not None:
                         shp = value.shape
                         dt = value.dtype
-                        check_rank[self.comm.group_rank] = 1
-                    self.comm.comm_group.Allreduce(check_rank, check_result, op=MPI.SUM)
+                        check_rank[self.dist.comm.group_rank] = 1
+                    self.dist.comm.comm_group.Allreduce(
+                        check_rank, check_result, op=MPI.SUM
+                    )
                     tot = np.sum(check_result)
                     if tot > 1:
                         msg = "When creating shared data with [] notation, only "
@@ -948,11 +968,11 @@ class SharedDataManager(MutableMapping):
                         raise RuntimeError(msg)
 
                     from_rank = np.where(check_result == 1)[0][0]
-                    shp = self.comm.comm_group.bcast(shp, root=from_rank)
-                    dt = self.comm.comm_group.bcast(dt, root=from_rank)
+                    shp = self.dist.comm.comm_group.bcast(shp, root=from_rank)
+                    dt = self.dist.comm.comm_group.bcast(dt, root=from_rank)
                     self.create(key, shape=shp, dtype=dt)
                     offset = None
-                    if self.comm.group_rank == from_rank:
+                    if self.dist.comm.group_rank == from_rank:
                         offset = tuple([0 for x in self._internal[key].shape])
                     self._internal[key].set(value, offset=offset, fromrank=from_rank)
             else:
@@ -988,13 +1008,13 @@ class SharedDataManager(MutableMapping):
         if self.n_samples != other.n_samples:
             log.verbose(f"  n_detectors {self.n_samples} != {other.n_samples}")
             return False
-        if not comm_equivalent(self.comm.comm_group, other.comm.comm_group):
+        if not comm_equivalent(self.dist.comm.comm_group, other.dist.comm.comm_group):
             log.verbose(f"  comm_group not equivalent")
             return False
-        if not comm_equivalent(self.comm_row, other.comm_row):
+        if not comm_equivalent(self.dist.comm_row, other.dist.comm_row):
             log.verbose(f"  comm_row not equivalent")
             return False
-        if not comm_equivalent(self.comm_col, other.comm_col):
+        if not comm_equivalent(self.dist.comm_col, other.dist.comm_col):
             log.verbose(f"  comm_col not equivalent")
             return False
         if set(self._internal.keys()) != set(other._internal.keys()):

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -53,7 +53,7 @@ class DistDetSamp(object):
             None, any distribution break in the sample direction will happen at an
             arbitrary place.  The sum of all chunks must equal the total number of
             samples.
-        comm (mpi4py.MPI.Comm):  (Optional) The MPI communicator to use.
+        comm (toast.Comm):  The communicator to use.
         process_rows (int):  (Optional) The size of the rectangular process grid
             in the detector direction.  This number must evenly divide into the size of
             comm.  If not specified, defaults to the size of the communicator.
@@ -76,60 +76,29 @@ class DistDetSamp(object):
             log.error(msg)
             raise RuntimeError(msg)
 
-        self.comm = None
-        self.comm_size = 1
-        self.comm_rank = 0
-        if comm is not None:
-            self.comm = comm
-            self.comm_size = self.comm.size
-            self.comm_rank = self.comm.rank
+        self.comm = comm
 
         if self.process_rows is None:
-            if self.comm is None:
+            if self.comm.comm_group is None:
                 # No MPI, default to 1
                 self.process_rows = 1
             else:
-                # We have MPI, default to the size of the communicator
-                self.process_rows = self.comm.size
+                # We have MPI, default to the size of the group
+                self.process_rows = self.comm.group_size
 
-        self.process_cols = 1
+        # Get the row / column communicators for this grid shape
+
+        self.comm_row, self.comm_col = self.comm.comm_row_col(self.process_rows)
         self.comm_row_size = 1
         self.comm_row_rank = 0
+        if self.comm_row is not None:
+            self.comm_row_size = self.comm_row.size
+            self.comm_row_rank = self.comm_row.rank
         self.comm_col_size = 1
         self.comm_col_rank = 0
-        self.comm_row = None
-        self.comm_col = None
-
-        if self.comm is None:
-            if self.process_rows != 1:
-                msg = "MPI is disabled, so process_rows must equal 1"
-                log.error(msg)
-                raise RuntimeError(msg)
-        else:
-            if comm.size % self.process_rows != 0:
-                msg = "The number of process_rows ({}) does not divide evenly into the communicator size ({})".format(
-                    self.process_rows, comm.size
-                )
-                log.error(msg)
-                raise RuntimeError(msg)
-            self.process_cols = comm.size // self.process_rows
-            self.comm_col_rank = comm.rank // self.process_cols
-            self.comm_row_rank = comm.rank % self.process_cols
-
-            # Split the main communicator into process row and column
-            # communicators.
-
-            if self.process_cols == 1:
-                self.comm_row = MPI.Comm.Dup(MPI.COMM_SELF)
-            else:
-                self.comm_row = self.comm.Split(self.comm_col_rank, self.comm_row_rank)
-                self.comm_row_size = self.comm_row.size
-
-            if self.process_rows == 1:
-                self.comm_col = MPI.Comm.Dup(MPI.COMM_SELF)
-            else:
-                self.comm_col = self.comm.Split(self.comm_row_rank, self.comm_col_rank)
-                self.comm_col_size = self.comm_col.size
+        if self.comm_col is not None:
+            self.comm_col_size = self.comm_col.size
+            self.comm_col_rank = self.comm_col.rank
 
         # If detector_sets is specified, check consistency.
 
@@ -188,7 +157,7 @@ class DistDetSamp(object):
                 raise RuntimeError(msg)
 
         (self.dets, self.det_sets, self.samps, self.samp_sets) = distribute_samples(
-            self.comm,
+            self.comm.comm_group,
             self.detectors,
             self.samples,
             detranks=self.process_rows,
@@ -202,7 +171,7 @@ class DistDetSamp(object):
             dlast = self.det_index[ds[-1]]
             self.det_indices.append(DistRange(dfirst, dlast - dfirst + 1))
 
-        if self.comm_rank == 0:
+        if self.comm.group_rank == 0:
             # check that all processes have some data, otherwise print warning
             for i, ds in enumerate(self.dets):
                 if len(ds) == 0:
@@ -213,34 +182,19 @@ class DistDetSamp(object):
                     msg = f"Process {i} has no samples assigned."
                     log.warning(msg)
 
-    def close(self):
-        # Explicitly free communicators if needed
-        if hasattr(self, "comm_row") and (self.comm_row is not None):
-            self.comm_row.Free()
-            self.comm_row = None
-        if hasattr(self, "comm_col") and (self.comm_col is not None):
-            self.comm_col.Free()
-            self.comm_col = None
-        return
-
-    def __del__(self):
-        self.close()
-
     def __eq__(self, other):
         log = Logger.get()
         fail = 0
         if self.process_rows != other.process_rows:
             fail = 1
             log.verbose(f"  process_rows {self.process_rows} != {other.process_rows}")
-        if not comm_equivalent(self.comm, other.comm):
+        if not comm_equivalent(self.comm.comm_group, other.comm.comm_group):
             fail = 1
-            log.verbose(f"  obs comm not equivalent")
-        if not comm_equivalent(self.comm_row, other.comm_row):
-            fail = 1
-            log.verbose(f"  obs comm_row not equivalent")
-        if not comm_equivalent(self.comm_col, other.comm_col):
-            fail = 1
-            log.verbose(f"  obs comm_col not equivalent")
+            log.verbose(f"  obs group comm not equivalent")
+        # If the group comms are equivalent, then we know that the row / col
+        # comms are equivalent, since they come from the same cache for a given
+        # value of process_rows.
+        #
         # Test the resulting distribution quantities, rather than the
         # inputs passed to the constructor, in case those are slightly
         # different types.
@@ -256,8 +210,8 @@ class DistDetSamp(object):
         if self.samp_sets != other.samp_sets:
             fail = 1
             log.verbose(f"  dist samp_sets {self.samp_sets} != {other.samp_sets}")
-        if self.comm is not None:
-            fail = self.comm.allreduce(fail, op=MPI.SUM)
+        if self.comm.comm_group is not None:
+            fail = self.comm.comm_group.allreduce(fail, op=MPI.SUM)
         return fail == 0
 
     def __ne__(self, other):
@@ -445,7 +399,7 @@ def extract_global_intervals(old_dist, intervals_manager):
     log = Logger.get()
 
     global_intervals = None
-    if old_dist.comm_rank == 0:
+    if old_dist.comm.group_rank == 0:
         global_intervals = dict()
 
     for iname in list(intervals_manager.keys()):
@@ -460,7 +414,7 @@ def extract_global_intervals(old_dist, intervals_manager):
                     (ilist, old_dist.samps[old_dist.comm_row_rank].n_elem), root=0
                 )
         del ilist
-        if old_dist.comm_rank == 0:
+        if old_dist.comm.group_rank == 0:
             # Only one process builds the list of start / stop times.  By definition,
             # the rank zero process of the observation is also the process with rank
             # zero along both the rows and columns.
@@ -545,7 +499,7 @@ def redistribute_detector_data(
             msg = "Redistribution only supports detdata with all local detectors."
             msg += f" Field {field} has {len(field_dets)} dets instead of "
             msg += f"{len(old_local_dets)}.  Deleting."
-            log.warning_rank(msg, comm=old_dist.comm)
+            log.warning_rank(msg, comm=old_dist.comm.comm_group)
             del detdata_manager[field]
             continue
 
@@ -556,7 +510,7 @@ def redistribute_detector_data(
         # have returned at the very start.  So we know that we have a real
         # communicator at this point.
         mpibytesize, mpitype = mpi_data_type(
-            old_dist.comm, detdata_manager[field].dtype
+            old_dist.comm.comm_group, detdata_manager[field].dtype
         )
 
         # Allocate new data
@@ -599,7 +553,7 @@ def redistribute_detector_data(
 
         # Redistribute
         redistribute_buffer(
-            old_dist.comm,
+            old_dist.comm.comm_group,
             buffer_class,
             mpitype,
             detdata_manager[field].data,
@@ -659,7 +613,7 @@ def redistribute_shared_data(
 
     for field in shared_manager.keys():
         shobj = shared_manager[field]
-        if comm_equal(shobj.comm, old_dist.comm):
+        if comm_equal(shobj.comm, old_dist.comm.comm_group):
             # Using full group communicator, just copy to the new data manager.
             new_shared_manager[field] = shobj
         else:
@@ -730,7 +684,7 @@ def redistribute_shared_data(
 
                 # Redistribute
                 redistribute_buffer(
-                    old_dist.comm,
+                    old_dist.comm.comm_group,
                     buffer_class,
                     mpitype,
                     shobj.data,
@@ -784,7 +738,7 @@ def redistribute_shared_data(
 
                 # Redistribute
                 redistribute_buffer(
-                    old_dist.comm,
+                    old_dist.comm.comm_group,
                     buffer_class,
                     mpitype,
                     shobj.data,
@@ -829,7 +783,7 @@ def redistribute_data(
 
     global_intervals = dict()
     if times is None and len(intervals_manager.keys()) > 0:
-        if old_dist.comm_rank == 0:
+        if old_dist.comm.group_rank == 0:
             msg = "Time stamps not specified when redistributing observation."
             msg += "  Intervals will be deleted and not redistributed."
             log.warning(msg)
@@ -841,21 +795,21 @@ def redistribute_data(
     # Compute the detector and sample ranges we are sending and receiving.  These are
     # common for all detdata objects.
 
-    old_det_off = old_dist.det_indices[old_dist.comm_rank].offset
-    old_det_n = old_dist.det_indices[old_dist.comm_rank].n_elem
+    old_det_off = old_dist.det_indices[old_dist.comm.group_rank].offset
+    old_det_n = old_dist.det_indices[old_dist.comm.group_rank].n_elem
     old_local_dets = old_dist.detectors[old_det_off : old_det_off + old_det_n]
     det_send_info = compute_1d_offsets(old_det_off, old_det_n, new_dist.det_indices)
 
-    old_samp_off = old_dist.samps[old_dist.comm_rank].offset
-    old_samp_n = old_dist.samps[old_dist.comm_rank].n_elem
+    old_samp_off = old_dist.samps[old_dist.comm.group_rank].offset
+    old_samp_n = old_dist.samps[old_dist.comm.group_rank].n_elem
     samp_send_info = compute_1d_offsets(old_samp_off, old_samp_n, new_dist.samps)
 
-    new_det_off = new_dist.det_indices[new_dist.comm_rank].offset
-    new_det_n = new_dist.det_indices[new_dist.comm_rank].n_elem
+    new_det_off = new_dist.det_indices[new_dist.comm.group_rank].offset
+    new_det_n = new_dist.det_indices[new_dist.comm.group_rank].n_elem
     det_recv_info = compute_1d_offsets(new_det_off, new_det_n, old_dist.det_indices)
 
-    new_samp_off = new_dist.samps[new_dist.comm_rank].offset
-    new_samp_n = new_dist.samps[new_dist.comm_rank].n_elem
+    new_samp_off = new_dist.samps[new_dist.comm.group_rank].offset
+    new_samp_n = new_dist.samps[new_dist.comm.group_rank].n_elem
     samp_recv_info = compute_1d_offsets(new_samp_off, new_samp_n, old_dist.samps)
 
     # Redistribute detector data.
@@ -892,13 +846,13 @@ def redistribute_data(
 
     # Communicate the field list
     gkeys = None
-    if old_dist.comm_rank == 0:
+    if old_dist.comm.group_rank == 0:
         gkeys = list(global_intervals.keys())
-    ivl_fields = old_dist.comm.bcast(gkeys, root=0)
+    ivl_fields = old_dist.comm.comm_group.bcast(gkeys, root=0)
 
     for field in ivl_fields:
         glb = None
-        if old_dist.comm_rank == 0:
+        if old_dist.comm.group_rank == 0:
             glb = global_intervals[field]
         new_intervals_manager.create(field, glb, new_shared_manager[times], fromrank=0)
 

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -88,7 +88,14 @@ class DistDetSamp(object):
 
         # Get the row / column communicators for this grid shape
 
-        self.comm_row, self.comm_col = self.comm.comm_row_col(self.process_rows)
+        rowcolcomm = self.comm.comm_row_col(self.process_rows)
+        self.comm_row = rowcolcomm["row"]
+        self.comm_col = rowcolcomm["col"]
+        self.comm_row_node = rowcolcomm["row_node"]
+        self.comm_col_node = rowcolcomm["col_node"]
+        self.comm_row_rank_node = rowcolcomm["row_rank_node"]
+        self.comm_col_rank_node = rowcolcomm["col_rank_node"]
+
         self.comm_row_size = 1
         self.comm_row_rank = 0
         if self.comm_row is not None:

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -200,11 +200,11 @@ class Demodulate(Operator):
 
             demod_name = f"demod_{obs.name}"
             demod_obs = Observation(
+                obs.comm,
                 demod_telescope,
                 demod_times.size,
                 name=demod_name,
                 uid=name_UID(demod_name),
-                comm=obs.comm,
                 detector_sets=demod_detsets,
                 process_rows=demod_process_rows,
                 sample_sets=demod_sample_sets,

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -818,19 +818,13 @@ class FilterBin(Operator):
 
     @function_timer
     def _initialize_comm(self, data):
+        """Create convenience aliases to the communicators and properties."""
         self.comm = data.comm.comm_world
-        if self.comm is None:
-            self.rank = 0
-            self.ntask = 1
-        else:
-            self.rank = self.comm.rank
-            self.ntask = self.comm.size
+        self.rank = data.comm.world_rank
+        self.ntask = data.comm.world_size
         self.gcomm = data.comm.comm_group
         self.group = data.comm.group
-        if self.gcomm is None:
-            self.grank = 0
-        else:
-            self.grank = self.gcomm.rank
+        self.grank = data.comm.group_rank
         return
 
     @function_timer

--- a/src/toast/ops/gainscrambler.py
+++ b/src/toast/ops/gainscrambler.py
@@ -68,8 +68,8 @@ class GainScrambler(Operator):
                 # Nothing to do for this observation
                 continue
 
-            comm = obs.comm
-            rank = obs.comm_rank
+            comm = obs.comm.comm_group
+            rank = obs.comm.group_rank
 
             obsindx = obs.uid
             telescope = obs.telescope.uid

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -281,7 +281,7 @@ class GroundFilter(Operator):
             # Prefix for logging
             log_prefix = f"{data.comm.group} : {obs.name} :"
 
-            if gcomm is None or gcomm.rank == 0:
+            if data.comm.group_rank == 0:
                 msg = (
                     f"{log_prefix} OpGroundFilter: "
                     f"Processing observation {iobs + 1} / {nobs}"
@@ -298,7 +298,7 @@ class GroundFilter(Operator):
 
             t1 = time()
             templates, legendre_trend, legendre_filter = self.build_templates(obs)
-            if gcomm is None or gcomm.rank == 0:
+            if data.comm.group_rank == 0:
                 msg = (
                     f"{log_prefix} OpGroundFilter: "
                     f"Built templates in {time() - t1:.1f}s"
@@ -307,7 +307,7 @@ class GroundFilter(Operator):
 
             ndet = len(obs.local_detectors)
             for idet, det in enumerate(obs.local_detectors):
-                if gcomm is None or gcomm.rank == 0:
+                if data.comm.group_rank == 0:
                     msg = (
                         f"{log_prefix} OpGroundFilter: "
                         f"Processing detector # {idet + 1} / {ndet}"
@@ -322,7 +322,7 @@ class GroundFilter(Operator):
 
                 t1 = time()
                 coeff = self.fit_templates(obs, det, templates, ref, good)
-                if gcomm is None or gcomm.rank == 0:
+                if data.comm.group_rank == 0:
                     msg = (
                         f"{log_prefix} OpGroundFilter: "
                         f"Fit templates in {time() - t1:.1f}s"
@@ -336,7 +336,7 @@ class GroundFilter(Operator):
                 self.subtract_templates(
                     ref, good, coeff, legendre_trend, legendre_filter
                 )
-                if gcomm is None or gcomm.rank == 0:
+                if data.comm.group_rank == 0:
                     msg = (
                         f"{log_prefix} OpGroundFilter: "
                         f"Subtract templates in {time() - t1:.1f}s"

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -633,9 +633,7 @@ class Madam(Operator):
         log = Logger.get()
         timer = Timer()
 
-        nodecomm = data.comm.comm_world.Split_type(
-            MPI.COMM_TYPE_SHARED, data.comm.world_rank
-        )
+        nodecomm = data.comm.comm_node
 
         # Determine how many processes per node should copy at once.
         n_copy_groups = 1
@@ -903,7 +901,6 @@ class Madam(Operator):
                 prefix=self._logprefix,
             )
         timer.stop()
-        del nodecomm
 
         return psdinfo, signal_dtype
 
@@ -929,9 +926,7 @@ class Madam(Operator):
         log = Logger.get()
         timer = Timer()
 
-        nodecomm = data.comm.comm_world.Split_type(
-            MPI.COMM_TYPE_SHARED, data.comm.world_rank
-        )
+        nodecomm = data.comm.comm_node
 
         # Determine how many processes per node should copy at once.
         n_copy_groups = 1
@@ -1008,8 +1003,6 @@ class Madam(Operator):
             del self._madam_pixels_raw
             del self._madam_pixweights
             del self._madam_pixweights_raw
-
-        del nodecomm
         return
 
     @function_timer

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -329,8 +329,6 @@ class Madam(Operator):
                 msg = f"You must set the '{trait}' trait before calling exec()"
                 raise RuntimeError(msg)
 
-        #
-
         # Combine parameters from an external file and other parameters passed in
 
         params = dict()
@@ -633,7 +631,7 @@ class Madam(Operator):
         log = Logger.get()
         timer = Timer()
 
-        nodecomm = data.comm.comm_node
+        nodecomm = data.comm.comm_group_node
 
         # Determine how many processes per node should copy at once.
         n_copy_groups = 1
@@ -926,7 +924,7 @@ class Madam(Operator):
         log = Logger.get()
         timer = Timer()
 
-        nodecomm = data.comm.comm_node
+        nodecomm = data.comm.comm_group_node
 
         # Determine how many processes per node should copy at once.
         n_copy_groups = 1

--- a/src/toast/ops/madam_utils.py
+++ b/src/toast/ops/madam_utils.py
@@ -40,7 +40,9 @@ def log_time_memory(
             )
             log.debug(msg)
         if full_mem:
-            _ = memreport(msg="{} {}".format(prefix, mem_msg), comm=comm)
+            _ = memreport(
+                msg="{} {}".format(prefix, mem_msg), comm=data.comm.comm_world
+            )
     if restart:
         timer.start()
 

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -241,9 +241,7 @@ class MapMaker(Operator):
 
         # The global communicator we are using (or None)
         comm = data.comm.comm_world
-        rank = 0
-        if comm is not None:
-            rank = comm.rank
+        rank = data.comm.world_rank
 
         # Check map binning
         map_binning = self.map_binning

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -143,9 +143,7 @@ class SolverRHS(Operator):
 
         # The global communicator we are using (or None)
         comm = data.comm.comm_world
-        rank = 0
-        if comm is not None:
-            rank = comm.rank
+        rank = data.comm.world_rank
 
         # Check that the inputs are set
         if self.det_data is None:
@@ -401,9 +399,7 @@ class SolverLHS(Operator):
 
         # The global communicator we are using (or None)
         comm = data.comm.comm_world
-        rank = 0
-        if comm is not None:
-            rank = comm.rank
+        rank = data.comm.world_rank
 
         # Check that input traits are set
         if self.binning is None:
@@ -576,9 +572,7 @@ def solve(
 
     # The global communicator we are using (or None)
     comm = data.comm.comm_world
-    rank = 0
-    if comm is not None:
-        rank = comm.rank
+    rank = data.comm.world_rank
 
     if rhs_key not in data:
         msg = "rhs_key '{}' does not exist in data".format(rhs_key)

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -43,8 +43,6 @@ class DefaultNoiseModel(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
 
-        comm = data.comm
-
         for ob in data.obs:
             if ob.telescope.focalplane.noise is None:
                 raise RuntimeError("Focalplane does not have a noise model")

--- a/src/toast/ops/save_spt3g.py
+++ b/src/toast/ops/save_spt3g.py
@@ -101,7 +101,7 @@ class SaveSpt3g(Operator):
             frames = self.obs_export(ob)
 
             # One process writes frame files
-            if ob.comm_rank == ex_rank:
+            if ob.comm.group_rank == ex_rank:
                 # Make observation directory.  This should NOT already exist.
                 ob_dir = os.path.join(self.directory, ob.name)
                 os.makedirs(ob_dir)
@@ -117,8 +117,8 @@ class SaveSpt3g(Operator):
                 )
                 save_pipe.Run()
 
-            if ob.comm is not None:
-                ob.comm.barrier()
+            if ob.comm.comm_group is not None:
+                ob.comm.comm_group.barrier()
 
         return
 

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -139,8 +139,8 @@ class InjectCosmicRays(Operator):
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
-            comm = ob.comm
-            rank = ob.comm_rank
+            comm = ob.comm.comm_group
+            rank = ob.comm.group_rank
             # Make sure detector data output exists
             ob.detdata.ensure(self.det_data, detectors=dets)
             obsindx = ob.uid

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -125,8 +125,8 @@ class GainDrifter(Operator):
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
-            comm = ob.comm
-            rank = ob.comm_rank
+            comm = ob.comm.comm_group
+            rank = ob.comm.group_rank
             # Make sure detector data output exists
             ob.detdata.ensure(self.det_data, detectors=dets)
             obsindx = ob.uid

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -666,11 +666,11 @@ class SimGround(Operator):
 
             name = f"{scan.name}_{int(scan.start.timestamp())}"
             ob = Observation(
+                comm,
                 telescope,
                 len(times),
                 name=name,
                 uid=name_UID(name),
-                comm=comm.comm_group,
                 detector_sets=detsets,
                 process_rows=det_ranks,
                 sample_sets=sample_sets,

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -444,11 +444,11 @@ class SimSatellite(Operator):
             scan = self.schedule.scans[obindx]
 
             ob = Observation(
+                comm,
                 self.telescope,
                 scan_samples[obindx],
                 name=f"{scan.name}_{int(scan.start.timestamp())}",
                 uid=name_UID(scan.name),
-                comm=comm.comm_group,
                 detector_sets=detsets,
                 process_rows=det_ranks,
             )

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -252,6 +252,8 @@ class SimAtmosphere(Operator):
         comm = data.comm.comm_group
         group = data.comm.group
         rank = data.comm.group_rank
+        comm_node = data.comm.comm_group_node
+        comm_node_rank = data.comm.comm_group_node_rank
 
         view = self.view
         if view is None:
@@ -424,6 +426,8 @@ class SimAtmosphere(Operator):
                         tmin,
                         tmax,
                         comm,
+                        comm_node,
+                        comm_node_rank,
                         key1,
                         key2,
                         counter1,
@@ -735,6 +739,8 @@ class SimAtmosphere(Operator):
         tmin,
         tmax,
         comm,
+        comm_node,
+        comm_node_rank,
         key1,
         key2,
         counter1,
@@ -799,6 +805,8 @@ class SimAtmosphere(Operator):
             rmin * u.meter,
             rmax * u.meter,
             write_debug=self.debug_spectrum,
+            node_comm=comm_node,
+            node_rank_comm=comm_node_rank,
         )
 
         if comm is not None:

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -562,9 +562,10 @@ class SimAtmosphere(Operator):
         freq_min, freq_max = bandpass.get_range()
         n_freq = self.n_bandpass_freqs
         freqs = np.linspace(freq_min, freq_max, n_freq)
-        ntask = 1
-        my_rank = 0
-        if comm is not None:
+        if comm is None:
+            ntask = 1
+            my_rank = 0
+        else:
             ntask = comm.size
             my_rank = comm.rank
         n_freq_task = int(np.ceil(n_freq / ntask))

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -558,10 +558,9 @@ class SimAtmosphere(Operator):
         freq_min, freq_max = bandpass.get_range()
         n_freq = self.n_bandpass_freqs
         freqs = np.linspace(freq_min, freq_max, n_freq)
-        if comm is None:
-            ntask = 1
-            my_rank = 0
-        else:
+        ntask = 1
+        my_rank = 0
+        if comm is not None:
             ntask = comm.size
             my_rank = comm.rank
         n_freq_task = int(np.ceil(n_freq / ntask))

--- a/src/toast/ops/statistics.py
+++ b/src/toast/ops/statistics.py
@@ -130,9 +130,9 @@ class Statistics(Operator):
                     # Mean
                     means[idet] += np.sum(good_signal)
 
-            if obs.comm is not None:
-                hits = obs.comm.allreduce(hits, op=MPI.SUM)
-                means = obs.comm.allreduce(means, op=MPI.SUM)
+            if obs.comm.comm_group is not None:
+                hits = obs.comm.comm_group.allreduce(hits, op=MPI.SUM)
+                means = obs.comm.comm_group.allreduce(means, op=MPI.SUM)
 
             good = hits != 0
             means[good] /= hits[good]
@@ -171,10 +171,10 @@ class Statistics(Operator):
                     # Kurtosis
                     stats[2, idet] += np.sum(good_signal ** 4)
 
-            if obs.comm is not None:
-                stats = obs.comm.reduce(stats, op=MPI.SUM)
+            if obs.comm.comm_group is not None:
+                stats = obs.comm.comm_group.reduce(stats, op=MPI.SUM)
 
-            if obs.comm is None or obs.comm.rank == 0:
+            if obs.comm.group_rank == 0:
                 # Central moments
                 m2 = stats[0]
                 m3 = stats[1]

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -159,9 +159,7 @@ def create_satellite_empty(mpicomm, obs_per_group=1, samples=10):
         tele = create_space_telescope(toastcomm.group_size)
         # FIXME: for full testing we should set detranks as approximately the sqrt
         # of the grid size so that we test the row / col communicators.
-        ob = Observation(
-            tele, n_samples=samples, name=oname, uid=oid, comm=toastcomm.comm_group
-        )
+        ob = Observation(toastcomm, tele, n_samples=samples, name=oname, uid=oid)
         data.obs.append(ob)
     return data
 
@@ -340,9 +338,7 @@ def create_healpix_ring_satellite(mpicomm, obs_per_group=1, nside=64):
 
         # FIXME: for full testing we should set detranks as approximately the sqrt
         # of the grid size so that we test the row / col communicators.
-        ob = Observation(
-            tele, n_samples=nsamp, name=oname, uid=oid, comm=toastcomm.comm_group
-        )
+        ob = Observation(toastcomm, tele, n_samples=nsamp, name=oname, uid=oid)
         # Create shared objects for timestamps, common flags, boresight, position,
         # and velocity.
         ob.shared.create(

--- a/src/toast/tests/dist.py
+++ b/src/toast/tests/dist.py
@@ -190,19 +190,13 @@ class DataTest(MPITestCase):
         get_uid = None
         for season in range(3):
             data.obs.append(
-                Observation(
-                    tele, 10, name=f"atacama-{season:02d}", comm=toastcomm.comm_group
-                )
+                Observation(toastcomm, tele, 10, name=f"atacama-{season:02d}")
             )
             data.obs[-1]["site"] = "Atacama"
             data.obs[-1]["season"] = season
             get_uid = data.obs[-1].uid
         for season in range(3):
-            data.obs.append(
-                Observation(
-                    tele, 10, name=f"pole-{season:02d}", comm=toastcomm.comm_group
-                )
-            )
+            data.obs.append(Observation(toastcomm, tele, 10, name=f"pole-{season:02d}"))
             data.obs[-1]["site"] = "Pole"
             data.obs[-1]["season"] = season
 
@@ -231,18 +225,12 @@ class DataTest(MPITestCase):
         data = Data(toastcomm)
         for season in range(3):
             data.obs.append(
-                Observation(
-                    tele, 10, name=f"atacama-{season:02d}", comm=toastcomm.comm_group
-                )
+                Observation(toastcomm, tele, 10, name=f"atacama-{season:02d}")
             )
             data.obs[-1]["site"] = "Atacama"
             data.obs[-1]["season"] = season
         for season in range(3):
-            data.obs.append(
-                Observation(
-                    tele, 10, name=f"pole-{season:02d}", comm=toastcomm.comm_group
-                )
-            )
+            data.obs.append(Observation(toastcomm, tele, 10, name=f"pole-{season:02d}"))
             data.obs[-1]["site"] = "Pole"
             data.obs[-1]["season"] = season
 

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -125,9 +125,9 @@ class ObservationTest(MPITestCase):
                 "all_A",
                 shape=all_common.shape,
                 dtype=all_common.dtype,
-                comm=obs.comm,
+                comm=obs.comm.comm_group,
             )
-            if obs.comm_rank == 0:
+            if obs.comm.group_rank == 0:
                 obs.shared["all_A"][:, :, :] = all_common
             else:
                 obs.shared["all_A"][None] = None
@@ -166,15 +166,15 @@ class ObservationTest(MPITestCase):
                 sh[None] = None
             obs.shared["det_B"] = sh
 
-            sh = MPIShared(all_common.shape, all_common.dtype, obs.comm)
-            if obs.comm_rank == 0:
+            sh = MPIShared(all_common.shape, all_common.dtype, obs.comm.comm_group)
+            if obs.comm.group_rank == 0:
                 sh[:, :, :] = all_common
             else:
                 sh[None] = None
             obs.shared["all_B"] = sh
 
-            # this style of assignment only works for the default obs.comm
-            if obs.comm_rank == 0:
+            # this style of assignment only works for the default obs.comm.comm_group
+            if obs.comm.group_rank == 0:
                 obs.shared["all_C"] = all_common
             else:
                 obs.shared["all_C"] = None
@@ -268,7 +268,7 @@ class ObservationTest(MPITestCase):
 
             # Create some shared objects over the whole comm
             local_array = None
-            if obs.comm_rank == 0:
+            if obs.comm.group_rank == 0:
                 local_array = np.arange(100, dtype=np.int16)
             obs.shared["everywhere"] = local_array
 
@@ -383,7 +383,7 @@ class ObservationTest(MPITestCase):
             # Make some intervals
 
             bad = None
-            if ob.comm_rank == 0:
+            if ob.comm.group_rank == 0:
                 all_time = np.arange(ob.n_all_samples, dtype=np.float64)
                 incr = ob.n_all_samples // 2
                 bad = [(float(x * incr), float(x * incr + 2)) for x in range(2)]
@@ -459,7 +459,7 @@ class ObservationTest(MPITestCase):
 
             # Create some shared objects over the whole comm
             local_array = None
-            if obs.comm_rank == 0:
+            if obs.comm.group_rank == 0:
                 local_array = np.arange(100, dtype=np.int16)
             obs.shared["everywhere"] = local_array
 
@@ -536,7 +536,7 @@ class ObservationTest(MPITestCase):
 
         # Redistribute back and verify
         for ob, orig in zip(data.obs, original):
-            ob.redistribute(orig.comm_size, times="times")
+            ob.redistribute(orig.comm.group_size, times="times")
             self.assertTrue(ob == orig)
 
     # The code below is here for reference, but we cannot actually test this

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -189,22 +189,22 @@ class PolyFilterTest(MPITestCase):
 
         # Plot unfiltered TOD
 
-        if data.comm.world_rank == 0:
-            set_matplotlib_backend()
-            import matplotlib.pyplot as plt
+        # if data.comm.world_rank == 0:
+        #     set_matplotlib_backend()
+        #     import matplotlib.pyplot as plt
 
-            fig = plt.figure(figsize=[18, 12])
-            ax = fig.add_subplot(1, 2, 1)
-            ob = data.obs[0]
-            for idet, det in enumerate(ob.local_detectors):
-                flags = np.array(ob.shared["flags"])
-                flags |= ob.detdata["flags"][det]
-                good = flags == 0
-                signal = ob.detdata["signal"][det]
-                x = np.arange(signal.size)
-                ax.plot(x, signal, "-", label=f"{det} unfiltered")
-                ax.plot(x, good, "-", label=f"{det} input good samples")
-            ax.legend(loc="best")
+        #     fig = plt.figure(figsize=[18, 12])
+        #     ax = fig.add_subplot(1, 3, 1)
+        #     ob = data.obs[0]
+        #     for idet, det in enumerate(ob.local_detectors):
+        #         flags = np.array(ob.shared["flags"])
+        #         flags |= ob.detdata["flags"][det]
+        #         good = flags == 0
+        #         signal = ob.detdata["signal"][det]
+        #         x = np.arange(signal.size)
+        #         ax.plot(x, signal, "-", label=f"{det} unfiltered")
+        #         ax.plot(x, good, "-", label=f"{det} input good samples")
+        #     ax.legend(loc="best")
 
         # Filter with python implementation.  Make a copy first
 
@@ -225,19 +225,17 @@ class PolyFilterTest(MPITestCase):
 
         # Plot filtered TOD
 
-        if data.comm.world_rank == 0:
-            ax = fig.add_subplot(1, 2, 2)
-            for idet, det in enumerate(ob.local_detectors):
-                flags = np.array(ob.shared["flags"])
-                flags |= ob.detdata["flags"][det]
-                good = flags == 0
-                signal = ob.detdata["pyfilter"][det]
-                x = np.arange(signal.size)
-                ax.plot(x, signal, ".", label=f"{det} filtered")
-                ax.plot(x, good, "-", label=f"{det} new good samples")
-            ax.legend(loc="best")
-            outfile = os.path.join(testdir, "2Dfiltered_tod_python.png")
-            fig.savefig(outfile)
+        # if data.comm.world_rank == 0:
+        #     ax = fig.add_subplot(1, 3, 2)
+        #     for idet, det in enumerate(ob.local_detectors):
+        #         flags = np.array(ob.shared["flags"])
+        #         flags |= ob.detdata["flags"][det]
+        #         good = flags == 0
+        #         signal = ob.detdata["pyfilter"][det]
+        #         x = np.arange(signal.size)
+        #         ax.plot(x, signal, ".", label=f"{det} filtered")
+        #         ax.plot(x, good, "-", label=f"{det} new good samples")
+        #     ax.legend(loc="best")
 
         # Do the same with C++ implementation
 
@@ -245,19 +243,19 @@ class PolyFilterTest(MPITestCase):
         polyfilter.use_python = False
         polyfilter.apply(data)
 
-        if data.comm.world_rank == 0:
-            ax = fig.add_subplot(1, 2, 2)
-            for idet, det in enumerate(ob.local_detectors):
-                flags = np.array(ob.shared["flags"])
-                flags |= ob.detdata["flags"][det]
-                good = flags == 0
-                signal = ob.detdata["signal"][det]
-                x = np.arange(signal.size)
-                ax.plot(x, signal, ".", label=f"{det} filtered")
-                ax.plot(x, good, "-", label=f"{det} new good samples")
-            ax.legend(loc="best")
-            outfile = os.path.join(testdir, "2Dfiltered_tod.png")
-            fig.savefig(outfile)
+        # if data.comm.world_rank == 0:
+        #     ax = fig.add_subplot(1, 3, 3)
+        #     for idet, det in enumerate(ob.local_detectors):
+        #         flags = np.array(ob.shared["flags"])
+        #         flags |= ob.detdata["flags"][det]
+        #         good = flags == 0
+        #         signal = ob.detdata["signal"][det]
+        #         x = np.arange(signal.size)
+        #         ax.plot(x, signal, ".", label=f"{det} filtered")
+        #         ax.plot(x, good, "-", label=f"{det} new good samples")
+        #     ax.legend(loc="best")
+        #     outfile = os.path.join(testdir, "2Dfiltered_tod.png")
+        #     fig.savefig(outfile)
 
         # Check for consistency
         for ob in data.obs:

--- a/src/toast/tests/ops_time_constant.py
+++ b/src/toast/tests/ops_time_constant.py
@@ -73,12 +73,12 @@ class TimeConstantTest(MPITestCase):
 
         # Verify that the signal is restored
         for obs in data.obs:
-            if obs.comm_rank == 0:
+            if obs.comm.group_rank == 0:
                 import matplotlib.pyplot as plt
             for det in obs.local_detectors:
                 signal0 = obs.detdata["signal0"][det]
                 signal = obs.detdata["signal"][det]
-                if obs.comm_rank == 0:
+                if obs.comm.group_rank == 0:
                     fig = plt.figure(figsize=(12, 8), dpi=72)
                     ax = fig.add_subplot(2, 1, 1, aspect="auto")
                     ax.plot(


### PR DESCRIPTION
* All split communicators are stored within the toast.Comm class,
  including the world, group, rank, node, world node-rank, group
  node-rank, and a store of row / column communicators that are
  created as needed for different values of process_rows.

* These communicators are re-used within each observation, including
  passing the node and group node-rank communicators to the
  pshmem.MPIShared constructor.

* Overall cleanup across the code of the use of these communicators.