### PR TITLE
No defaults to SSO flagging

### DIFF
--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -64,14 +64,14 @@ class FlagSSO(Operator):
     det_flag_mask = Int(1, help="Bit mask to raise flags with")
 
     sso_names = List(
-        default_value=["Sun", "Moon"],
+        #default_value=["Sun", "Moon"],
         trait=Unicode,
         allow_none=True,
         help="Names of the SSOs, must be recognized by pyEphem",
     )
 
     sso_radii = List(
-        default_value=[45.0 * u.deg, 5.0 * u.deg],
+        #default_value=[45.0 * u.deg, 5.0 * u.deg],
         trait=Quantity,
         allow_none=True,
         help="Radii around the sources to flag",
@@ -114,6 +114,11 @@ class FlagSSO(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         env = Environment.get()
         log = Logger.get()
+
+        for trait in "sso_names", "sso_radii":
+            if getattr(self, trait) is None:
+                msg = f"You must set the '{trait}' trait before calling exec()"
+                raise RuntimeError(msg)
 
         if len(self.sso_names) != len(self.sso_radii):
             raise RuntimeError("Each SSO must have a radius")


### PR DESCRIPTION
Removing the defaults fixes a recent issue in parsing FlagSSO traits. sso_names and sso_radii can still be set in a config file.