### PR TITLE
HDF5 maps in single precision

### DIFF
--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -807,7 +807,7 @@ class MapMaker(Operator):
                         data[prod_key],
                         fname,
                         nest=map_binning.pixel_pointing.nest,
-                        report_memory=self.report_memory,
+                        single_precision=True,
                     )
                 else:
                     # Standard FITS output


### PR DESCRIPTION
Make single precision the default for HDF5 map output, just like FITS. 

Also allow overriding precision in serial HDF5 operations.