### PR TITLE
Add trait to SimAtmosphere operator that just caches the simulation

### DIFF
--- a/src/toast/scripts/toast_benchmark_ground_setup
+++ b/src/toast/scripts/toast_benchmark_ground_setup
@@ -308,6 +308,7 @@ def main():
         world_comm.barrier()
     job_ops.sim_atmosphere.detector_pointing = job_ops.det_pointing_azel
     job_ops.sim_atmosphere.cache_dir = cache_dir
+    job_ops.sim_atmosphere.cache_only = True
     job_ops.sim_atmosphere.apply(data)
     log.info_rank("Simulated atmosphere in", comm=world_comm, timer=timer)
 


### PR DESCRIPTION
Add several "short circuit" points in the atmosphere simulation to speed up caching the atmosphere.  Eventually, we should split the code to have separate caching and observing operators.  However, this would require extra work to ensure that the files on disk are compatible.  For example, recording the scan range, field of view, etc in the metadata and checking it.