### PR TITLE
Explicitly track the communicator used for observation shared data

### DIFF
--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -538,9 +538,7 @@ class Observation(MutableMapping):
         for name, data in self.shared.items():
             if shared is None or name in shared:
                 # Create the object on the corresponding communicator in the new obs
-                new_obs.shared._assign_mpishared(
-                    name, data, self.shared.comm_type(name)
-                )
+                new_obs.shared.assign_mpishared(name, data, self.shared.comm_type(name))
         for name, data in self.intervals.items():
             if intervals is None or name in intervals:
                 timespans = [(x.start, x.stop) for x in data]

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -538,23 +538,9 @@ class Observation(MutableMapping):
         for name, data in self.shared.items():
             if shared is None or name in shared:
                 # Create the object on the corresponding communicator in the new obs
-                new_comm = None
-                if comm_equal(data.comm, self.dist.comm_row):
-                    # Row comm
-                    new_comm = new_obs.dist.comm_row
-                elif comm_equal(data.comm, self.dist.comm_col):
-                    # Col comm
-                    new_comm = new_obs.dist.comm_col
-                else:
-                    # Full obs comm
-                    new_comm = new_obs.dist.comm.comm_group
-                new_obs.shared.create(name, data.shape, dtype=data.dtype, comm=new_comm)
-                offset = None
-                dval = None
-                if new_comm is None or new_comm.rank == 0:
-                    offset = tuple([0 for x in data.shape])
-                    dval = data.data
-                new_obs.shared[name].set(dval, offset=offset, fromrank=0)
+                new_obs.shared._assign_mpishared(
+                    name, data, self.shared.comm_type(name)
+                )
         for name, data in self.intervals.items():
             if intervals is None or name in intervals:
                 timespans = [(x.start, x.stop) for x in data]

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -790,13 +790,21 @@ class SharedDataManager(MutableMapping):
         )
         obs.shared["times"].set(timestamps, offset=(0,), fromrank=0)
 
-        # Create from existing MPIShared object:
+        # Create from existing MPIShared object on the column communicator:
         sharedtime = MPIShared((obs.n_local_samples,), np.float32, obs.comm_col)
         sharedtime[:] = timestamps
-        obs.shared["times"] = sharedtime
+        obs.shared["times"] = (sharedtime, "column")
 
         # Create from array on one process, pre-communication needed:
-        obs.shared["times"] = timestamps
+        obs.shared["times"] = (timestamps, "column")
+
+    If you are creating data products shared over the whole group communicator, you
+    may leave off the "group" communicator type:
+
+        if obs.comm_col_rank == 0:
+            obs.shared["stuff"] = np.ones(100)
+        else:
+            obs.shared["stuff"] = None
 
     After creation, you can access a given object by name with standard dictionary
     syntax:

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -6,6 +6,8 @@ import sys
 
 from collections.abc import MutableMapping, Mapping
 
+from typing import NamedTuple
+
 import numpy as np
 
 from astropy import units as u
@@ -754,17 +756,21 @@ class DetDataManager(MutableMapping):
         return not self.__eq__(other)
 
 
+class SharedDataType(NamedTuple):
+    """The shared data object and a string specifying the comm type."""
+
+    shm: MPIShared
+    type: str
+
+
 class SharedDataManager(MutableMapping):
     """Class used to manage shared data objects in an Observation.
 
-    New objects can be created with the "create()" method:
+    New objects can be created with the "create_*()" methods:
 
-        obs.shared.create(name, shape=None, dtype=None, comm=None)
-
-    The communicator defaults to sharing the data across the observation comm, but
-    other options would be to pass in the observation comm_row or comm_col communicators
-    in order to share common detector information across the process grid row or to
-    share telescope data across the process grid column.
+        obs.shared.create_group(name, shape=None, dtype=None)
+        obs.shared.create_row(name, shape=None, dtype=None)
+        obs.shared.create_column(name, shape=None, dtype=None)
 
     You can also create shared objects by assignment from an existing MPIShared object
     or an array on one process.  In the case of creating from an array assignment, an
@@ -777,11 +783,10 @@ class SharedDataManager(MutableMapping):
             timestamps = np.arange(obs.n_local_samples, dtype=np.float32)
 
         # Explicitly create the shared data and assign:
-        obs.shared.create(
+        obs.shared.create_column(
             "times",
             shape=(obs.n_local_samples,),
-            dtype=np.float32,
-            comm=obs.comm_col
+            dtype=np.float32
         )
         obs.shared["times"].set(timestamps, offset=(0,), fromrank=0)
 
@@ -808,23 +813,22 @@ class SharedDataManager(MutableMapping):
         self.n_detectors = len(dist.dets[dist.comm.group_rank])
         self.n_samples = dist.samps[dist.comm.group_rank].n_elem
         self.dist = dist
+        # The internal dictionary stores tuples containing the shared
+        # data object and a string specifying which communicator it
+        # is distributed over:  "group", "row", or "column".
         self._internal = dict()
 
-    def create(self, name, shape, dtype=None, comm=None):
-        """Create a shared memory buffer.
+    def create_group(self, name, shape, dtype=None):
+        """Create a shared memory buffer on the group communicator.
 
         This buffer will be replicated across all nodes used by the processes owning
         the observation.  This uses the MPIShared class, which falls back to a simple
         numpy array if MPI is not being used.
 
         Args:
-            name (str): Name of the shared memory object (e.g. "boresight").
+            name (str): Name of the shared memory object.
             shape (tuple): The shape of the new buffer.
             dtype (np.dtype): Use this dtype for each element.
-            comm (MPI.Comm): The communicator to use for the shared data.  If None
-                then the communicator for the observation is used.  Other options
-                would be to specify the grid_comm_row (for shared detector objects) or
-                grid_comm_col (for shared timestream objects).
 
         Returns:
             None
@@ -836,47 +840,9 @@ class SharedDataManager(MutableMapping):
             log.error(msg)
             raise RuntimeError(msg)
 
-        shared_comm = comm
-        shared_comm_node = None
-        shared_comm_rank_node = None
-        if shared_comm is None:
-            # Use the observation group communicator.
-            shared_comm = self.dist.comm.comm_group
-            shared_comm_node = self.dist.comm.comm_group_node
-            shared_comm_rank_node = self.dist.comm.comm_group_node_rank
-
-        if comm_equal(self.dist.comm.comm_group, shared_comm):
-            # This is shared over the whole observation communicator, so it
-            # may have any shape.
-            shared_comm_node = self.dist.comm.comm_group_node
-            shared_comm_rank_node = self.dist.comm.comm_group_node_rank
-        elif comm_equal(self.dist.comm_row, shared_comm):
-            # This is shared over the row communicator, so the leading
-            # dimension must be the number of local detectors.
-            if shape[0] != self.n_detectors:
-                msg = f"When creating shared data '{name}' on the row communicator, "
-                msg += f"the leading dimension should be the number of local "
-                msg += f"detectors ({self.n_detectors}).  Shape given = {shape}."
-                log.error(msg)
-                raise RuntimeError(msg)
-            shared_comm_node = self.dist.comm_row_node
-            shared_comm_rank_node = self.dist.comm_row_rank_node
-        elif comm_equal(self.dist.comm_col, shared_comm):
-            # This is shared over the column communicator, so the leading
-            # dimension must be the number of local samples.
-            if shape[0] != self.n_samples:
-                msg = f"When creating shared data '{name}' on the column communicator, "
-                msg += f"the leading dimension should be the number of local "
-                msg += f"samples ({self.n_samples}).  Shape given = {shape}"
-                log.error(msg)
-                raise RuntimeError(msg)
-            shared_comm_node = self.dist.comm_col_node
-            shared_comm_rank_node = self.dist.comm_col_rank_node
-        else:
-            msg = f"When creating shared data '{name}', you must use either the "
-            msg += "observation communicator or the row or column communicators."
-            log.error(msg)
-            raise RuntimeError(msg)
+        shared_comm = self.dist.comm.comm_group
+        shared_comm_node = self.dist.comm.comm_group_node
+        shared_comm_rank_node = self.dist.comm.comm_group_node_rank
 
         shared_dtype = dtype
 
@@ -885,108 +851,314 @@ class SharedDataManager(MutableMapping):
             shared_dtype = np.float64
 
         # Create the data object
-        self._internal[name] = MPIShared(
-            shape,
-            shared_dtype,
-            shared_comm,
-            comm_node=shared_comm_node,
-            comm_node_rank=shared_comm_rank_node,
+        self._internal[name] = SharedDataType(
+            MPIShared(
+                shape,
+                shared_dtype,
+                shared_comm,
+                comm_node=shared_comm_node,
+                comm_node_rank=shared_comm_rank_node,
+            ),
+            "group",
         )
 
         return
 
+    def create_row(self, name, shape, dtype=None):
+        """Create a shared memory buffer on the process row communicator.
+
+        This buffer will be replicated across all nodes used by the processes in the process grid row.  This uses the MPIShared class, which falls back to a simple
+        numpy array if MPI is not being used.
+
+        Args:
+            name (str): Name of the shared memory object (e.g. "beams").
+            shape (tuple): The shape of the new buffer.
+            dtype (np.dtype): Use this dtype for each element.
+
+        Returns:
+            None
+
+        """
+        log = Logger.get()
+        if name in self._internal:
+            msg = "Observation data with name '{}' already exists.".format(name)
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        # This is shared over the row communicator, so the leading
+        # dimension must be the number of local detectors.
+        if shape[0] != self.n_detectors:
+            msg = f"When creating shared data '{name}' on the row communicator, "
+            msg += f"the leading dimension should be the number of local "
+            msg += f"detectors ({self.n_detectors}).  Shape given = {shape}."
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        shared_comm = self.dist.comm_row
+        shared_comm_node = self.dist.comm_row_node
+        shared_comm_rank_node = self.dist.comm_row_rank_node
+
+        shared_dtype = dtype
+
+        # Use defaults for dtype if not set
+        if shared_dtype is None:
+            shared_dtype = np.float64
+
+        # Create the data object
+        self._internal[name] = SharedDataType(
+            MPIShared(
+                shape,
+                shared_dtype,
+                shared_comm,
+                comm_node=shared_comm_node,
+                comm_node_rank=shared_comm_rank_node,
+            ),
+            "row",
+        )
+
+        return
+
+    def create_column(self, name, shape, dtype=None):
+        """Create a shared memory buffer on the process column communicator.
+
+        This buffer will be replicated across all nodes used by the processes in the
+        process grid column.  This uses the MPIShared class, which falls back to a
+        simple numpy array if MPI is not being used.
+
+        Args:
+            name (str): Name of the shared memory object (e.g. "boresight").
+            shape (tuple): The shape of the new buffer.
+            dtype (np.dtype): Use this dtype for each element.
+
+        Returns:
+            None
+
+        """
+        log = Logger.get()
+        if name in self._internal:
+            msg = "Observation data with name '{}' already exists.".format(name)
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        # This is shared over the column communicator, so the leading
+        # dimension must be the number of local samples.
+        if shape[0] != self.n_samples:
+            msg = f"When creating shared data '{name}' on the column communicator, "
+            msg += f"the leading dimension should be the number of local "
+            msg += f"samples ({self.n_samples}).  Shape given = {shape}"
+            log.error(msg)
+            raise RuntimeError(msg)
+        shared_comm = self.dist.comm_col
+        shared_comm_node = self.dist.comm_col_node
+        shared_comm_rank_node = self.dist.comm_col_rank_node
+
+        shared_dtype = dtype
+
+        # Use defaults for dtype if not set
+        if shared_dtype is None:
+            shared_dtype = np.float64
+
+        # Create the data object
+        self._internal[name] = SharedDataType(
+            MPIShared(
+                shape,
+                shared_dtype,
+                shared_comm,
+                comm_node=shared_comm_node,
+                comm_node_rank=shared_comm_rank_node,
+            ),
+            "column",
+        )
+
+        return
+
+    def create_type(self, commtype, name, shape, dtype=None):
+        """Create a shared memory buffer of the specified type.
+
+        This is a convenience function that calls `create_group()`, `create_row()`,
+        or `create_column()` based on the value of commtype.
+
+        Args:
+            commtype (str):  "group", "row", or "column".
+            name (str): Name of the shared memory object (e.g. "boresight").
+            shape (tuple): The shape of the new buffer.
+            dtype (np.dtype): Use this dtype for each element.
+
+        Returns:
+            None
+
+        """
+        log = Logger.get()
+        if name in self._internal:
+            msg = "Observation data with name '{}' already exists.".format(name)
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        if commtype == "row":
+            self.create_row(name, shape, dtype=dtype)
+        elif commtype == "column":
+            self.create_column(name, shape, dtype=dtype)
+        elif commtype == "group":
+            self.create_group(name, shape, dtype=dtype)
+        else:
+            raise ValueError(f"Invalid communicator type '{commtype}'")
+
+    # Get the comm type for a key
+
+    def comm_type(self, key):
+        """Return the communicator type for a key.
+
+        The valid types are "group", "row", and "column".
+
+        Args:
+            key (str):  The object name.
+
+        Returns:
+            (str):  The communicator name over which it is shared.
+
+        """
+        return self._internal[key].type
+
     # Mapping methods
 
     def __getitem__(self, key):
-        return self._internal[key]
+        return self._internal[key].shm
 
     def __delitem__(self, key):
         if key in self._internal:
-            self._internal[key].close()
+            self._internal[key].shm.close()
             del self._internal[key]
+
+    def _comm_from_type(self, commstr):
+        """Get the comm from the type string"""
+        if commstr == "row":
+            return self.dist.comm_row
+        elif commstr == "column":
+            return self.dist.comm_col
+        elif commstr == "group":
+            return self.dist.comm.comm_group
+        else:
+            raise ValueError(f"Invalid communicator type '{commstr}'")
+
+    def _valid_commtype(self, commstr, comm):
+        """Helper function to check that a comm matches the specified type."""
+        shcomm = self._comm_from_type(commstr)
+        if comm_equivalent(shcomm, comm):
+            return True
+        else:
+            return False
+
+    def _assign_array(self, key, value, commtype):
+        """Helper function to assign an array on one process to a shared object."""
+        if key in self._internal:
+            # Object already exists, so force the commtype
+            commtype = self._internal[key].type
+
+        # Get the communicator for this object
+        shcomm = self._comm_from_type(commtype)
+
+        # Verify that we only have incoming data on one process
+        fromrank = 0
+        myrank = 0
+        if shcomm is not None:
+            myrank = shcomm.rank
+            nproc = shcomm.size
+            check_rank = np.zeros(nproc, dtype=np.int32)
+            check_result = np.zeros(nproc, dtype=np.int32)
+            if value is not None:
+                check_rank[myrank] = 1
+            shcomm.Allreduce(check_rank, check_result, op=MPI.SUM)
+            tot = np.sum(check_result)
+            if tot > 1:
+                msg = "When assigning an array to a shared object, only one process"
+                msg += " should have a non-None value"
+                raise ValueError(msg)
+            fromrank = np.where(check_result == 1)[0][0]
+
+        # Create the object if needed
+        if key not in self._internal:
+            shshape = None
+            shdtype = None
+            if myrank == fromrank:
+                shshape = value.shape
+                shdtype = value.dtype
+            if shcomm is not None:
+                shshape = shcomm.bcast(shshape, root=fromrank)
+                shdtype = shcomm.bcast(shdtype, root=fromrank)
+            self.create_type(commtype, key, shshape, dtype=shdtype)
+
+        # Assign
+        off = None
+        if myrank == fromrank:
+            if value.shape != self._internal[key].shm.shape:
+                raise ValueError(
+                    "When assigning directly to a shared object, the value must have the same dimensions"
+                )
+            off = tuple([0 for x in self._internal[key].shm.shape])
+        self._internal[key].shm.set(value, offset=off, fromrank=fromrank)
+
+    def _assign_mpishared(self, key, value, commtype):
+        log = Logger.get()
+        if key not in self._internal:
+            # Create the object, and check that value comm is correct.
+            if not self._valid_commtype(commtype, value.comm):
+                msg = f"Assignment value for '{key}' ('{commtype}') "
+                msg += "has incorrect communicator."
+                log.error(msg)
+                raise RuntimeError(msg)
+            self.create_type(commtype, key, value.shape, dtype=value.dtype)
+        else:
+            # Verify that communicators and dimensions match
+            if not self._valid_commtype(self._internal[key].type, value.comm):
+                msg = "Direct assignment object must have equivalent communicator."
+                log.error(msg)
+                raise RuntimeError(msg)
+            if value.shape != self._internal[key].shm.shape:
+                msg = "Direct assignment of shared object must have the same shape."
+                log.error(msg)
+                raise RuntimeError(msg)
+            if value.dtype != self._internal[key].shm.dtype:
+                msg = "Direct assignment of shared object must have the same dtype."
+                log.error(msg)
+                raise RuntimeError(msg)
+
+        # Assign data from just one process.
+        offset = None
+        dval = None
+        if value.comm is None or value.comm.rank == 0:
+            offset = tuple([0 for x in self._internal[key].shm.shape])
+            dval = value.data
+        self._internal[key].shm.set(dval, offset=offset, fromrank=0)
 
     def __setitem__(self, key, value):
         log = Logger.get()
-        if isinstance(value, MPIShared):
+        if key in self._internal:
             # This is an existing shared object.
-            if key not in self._internal:
-                self.create(
-                    key,
-                    shape=value.shape,
-                    dtype=value.dtype,
-                    comm=self.dist.comm.comm_group,
-                )
+            if isinstance(value, MPIShared):
+                self._assign_mpishared(key, value, self._internal[key].type)
             else:
-                # Verify that communicators and dimensions match
-                if value.shape != self._internal[key].shape:
-                    msg = "Direct assignment of shared object must have the same shape."
-                    log.error(msg)
-                    raise RuntimeError(msg)
-                if value.dtype != self._internal[key].dtype:
-                    msg = "Direct assignment of shared object must have the same dtype."
-                    log.error(msg)
-                    raise RuntimeError(msg)
-                if not comm_equivalent(value.comm, self._internal[key].comm):
-                    msg = "Direct assignment object must have equivalent communicator."
-                    log.error(msg)
-                    raise RuntimeError(msg)
-            # Assign from just one process.
-            offset = None
-            dval = None
-            if value.comm is None or value.comm.rank == 0:
-                offset = tuple([0 for x in self._internal[key].shape])
-                dval = value.data
-            self._internal[key].set(dval, offset=offset, fromrank=0)
+                # This must be an array on exactly one process.
+                self._assign_array(key, value, self._internal[key].type)
         else:
-            # This must be an array on one process.
-            if key not in self._internal:
-                # We need to create it.  In that case we use the default communicator
-                # (the full observation comm).  We also need to get the array
-                # properties to all processes in order to create the object.
-                if self.dist.comm.comm_group is None:
-                    # No MPI
-                    self.create(key, shape=value.shape, dtype=value.dtype)
-                    offset = tuple([0 for x in self._internal[key].shape])
-                    self._internal[key].set(value, offset=offset, fromrank=0)
+            # Creating a new object
+            if isinstance(value, (tuple, list, SharedDataType)) and len(value) == 2:
+                # We are specifying the data and the comm type
+                dvalue = value[0]
+                tvalue = value[1]
+                if isinstance(dvalue, MPIShared):
+                    # The passed value is already an MPIShared object
+                    self._assign_mpishared(key, dvalue, tvalue)
                 else:
-                    shp = None
-                    dt = None
-                    check_rank = np.zeros((self.dist.comm.group_size,), dtype=np.int32)
-                    check_result = np.zeros(
-                        (self.dist.comm.group_size,), dtype=np.int32
-                    )
-                    if value is not None:
-                        shp = value.shape
-                        dt = value.dtype
-                        check_rank[self.dist.comm.group_rank] = 1
-                    self.dist.comm.comm_group.Allreduce(
-                        check_rank, check_result, op=MPI.SUM
-                    )
-                    tot = np.sum(check_result)
-                    if tot > 1:
-                        msg = "When creating shared data with [] notation, only "
-                        msg += "one process may have a non-None value for the data"
-                        log.error_rank(msg)
-                        raise RuntimeError(msg)
-
-                    from_rank = np.where(check_result == 1)[0][0]
-                    shp = self.dist.comm.comm_group.bcast(shp, root=from_rank)
-                    dt = self.dist.comm.comm_group.bcast(dt, root=from_rank)
-                    self.create(key, shape=shp, dtype=dt)
-                    offset = None
-                    if self.dist.comm.group_rank == from_rank:
-                        offset = tuple([0 for x in self._internal[key].shape])
-                    self._internal[key].set(value, offset=offset, fromrank=from_rank)
+                    # This is a simple array on one process
+                    self._assign_array(key, dvalue, tvalue)
             else:
-                # Already exists, just do the assignment
-                slc = None
-                if value is not None:
-                    if value.shape != self._internal[key].shape:
-                        raise ValueError(
-                            "When assigning directly to a shared object, the value must have the same dimensions"
-                        )
-                    slc = tuple([slice(0, x) for x in self._internal[key].shape])
-                self._internal[key][slc] = value
+                # We are specifying just the data, so the comm type
+                # is assumed to be the group comm
+                if isinstance(value, MPIShared):
+                    self._assign_mpishared(key, value, "group")
+                else:
+                    # This is a simple array on one process
+                    self._assign_array(key, value, "group")
 
     def __iter__(self):
         return iter(self._internal)
@@ -996,7 +1168,7 @@ class SharedDataManager(MutableMapping):
 
     def clear(self):
         for k in self._internal.keys():
-            self._internal[k].close()
+            self._internal[k].shm.close()
 
     def __del__(self):
         if hasattr(self, "_internal"):
@@ -1023,18 +1195,23 @@ class SharedDataManager(MutableMapping):
             log.verbose(f"  keys {self._internal.keys()} != {other._internal.keys()}")
             return False
         for k in self._internal.keys():
-            if self._internal[k].shape != other._internal[k].shape:
+            if self._internal[k].shm.shape != other._internal[k].shm.shape:
                 log.verbose(
-                    f"  key {k} shape {self._internal[k].shape} != {other._internal[k].shape}"
+                    f"  key {k} shape {self._internal[k].shm.shape} != {other._internal[k].shm.shape}"
                 )
                 return False
-            if self._internal[k].dtype != other._internal[k].dtype:
+            if self._internal[k].shm.dtype != other._internal[k].shm.dtype:
                 log.verbose(
-                    f"  key {k} dtype {self._internal[k].dtype} != {other._internal[k].dtype}"
+                    f"  key {k} dtype {self._internal[k].shm.dtype} != {other._internal[k].shm.dtype}"
                 )
                 return False
-            if not comm_equivalent(self._internal[k].comm, other._internal[k].comm):
-                log.verbose(f"  key {k} shape comms not equivalent")
+            if not comm_equivalent(
+                self._internal[k].shm.comm, other._internal[k].shm.comm
+            ):
+                log.verbose(f"  key {k} comms not equivalent")
+                return False
+            if self._internal[k].type != other._internal[k].type:
+                log.verbose(f"  key {k} comm types not equal")
                 return False
         return True
 
@@ -1047,26 +1224,28 @@ class SharedDataManager(MutableMapping):
             shared_bytes = 0
             node_bytes = 0
             node_rank = 0
-            if self._internal[k].nodecomm is not None:
-                node_rank = self._internal[k].nodecomm.rank
+            if self._internal[k].shm.nodecomm is not None:
+                node_rank = self._internal[k].shm.nodecomm.rank
             if node_rank == 0:
                 node_elems = 1
-                for d in self._internal[k].shape:
+                for d in self._internal[k].shm.shape:
                     node_elems *= d
-                node_bytes += node_elems * self._internal[k].data.itemsize
-            if self._internal[k].comm is None:
+                node_bytes += node_elems * self._internal[k].shm.data.itemsize
+            if self._internal[k].shm.comm is None:
                 shared_bytes = node_bytes
             else:
-                shared_bytes = self._internal[k].comm.allreduce(node_bytes, op=MPI.SUM)
+                shared_bytes = self._internal[k].shm.comm.allreduce(
+                    node_bytes, op=MPI.SUM
+                )
             bytes += shared_bytes
         return bytes
 
     def __repr__(self):
         val = "<SharedDataManager"
         for k in self._internal.keys():
-            val += "\n    {}: shape = {}, dtype = {}".format(
-                k, self._internal[k].shape, self._internal[k].dtype
-            )
+            val += f"\n    {k} ({self._internal[k].type}): "
+            val += f"shape = {self._internal[k].shm.shape}, "
+            val += f"dtype = {self._internal[k].shm.dtype}"
         val += ">"
         return val
 

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -640,7 +640,7 @@ def redistribute_shared_data(
         commtype = shared_manager.comm_type(field)
         if commtype == "group":
             # Using full group communicator, just copy to new data manager.
-            new_shared_manager._assign_mpishared(field, shobj, commtype)
+            new_shared_manager.assign_mpishared(field, shobj, commtype)
             continue
 
         # Full shape of the object

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -30,6 +30,7 @@ from .observation_data import (
     DetDataManager,
     SharedDataManager,
     IntervalsManager,
+    SharedDataType,
 )
 
 from .observation_view import DetDataView, SharedView, View, ViewManager, ViewInterface
@@ -636,144 +637,145 @@ def redistribute_shared_data(
 
     for field in shared_manager.keys():
         shobj = shared_manager[field]
-        if comm_equal(shobj.comm, old_dist.comm.comm_group):
-            # Using full group communicator, just copy to the new data manager.
-            new_shared_manager[field] = shobj
-        else:
-            # Full shape of the object
-            shp = shobj.shape
+        commtype = shared_manager.comm_type(field)
+        if commtype == "group":
+            # Using full group communicator, just copy to new data manager.
+            new_shared_manager._assign_mpishared(field, shobj, commtype)
+            continue
 
-            # Buffer type
-            buffer_class, _ = dtype_to_aligned(shobj.dtype)
-            mpibytesize, mpitype = mpi_data_type(shobj.comm, shobj.dtype)
+        # Full shape of the object
+        shp = shobj.shape
 
-            # Shape of the non-leading dimensions
-            other_shape = None
-            n_per_leading = 1
-            if len(shp) > 1:
-                other_shape = shp[1:]
-                for dim in other_shape:
-                    n_per_leading *= dim
+        # Buffer type
+        buffer_class, _ = dtype_to_aligned(shobj.dtype)
+        mpibytesize, mpitype = mpi_data_type(shobj.comm, shobj.dtype)
 
-            # slices for non-leading dimensions
-            dim_slices = None
-            if other_shape is not None:
-                dim_slices = [slice(0, x, 1) for x in other_shape]
+        # Shape of the non-leading dimensions
+        other_shape = None
+        n_per_leading = 1
+        if len(shp) > 1:
+            other_shape = shp[1:]
+            for dim in other_shape:
+                n_per_leading *= dim
 
-            if comm_equal(shobj.comm, old_dist.comm_row):
-                # Shared in the sample direction.
-                if shp[0] != old_det_n:
-                    msg = f"Shared object {field} uses the row communicator, "
-                    msg += f"but has leading dimension {shp[0]} rather than the "
-                    msg += f"number of local detectors ({old_det_n}).  "
-                    msg += f"Cannot redistribute."
-                    raise RuntimeError(msg)
+        # slices for non-leading dimensions
+        dim_slices = None
+        if other_shape is not None:
+            dim_slices = [slice(0, x, 1) for x in other_shape]
 
-                # Redistribution send / recv slices
-                send_info = [None for x in range(shobj.comm.size)]
-                recv_info = [None for x in range(shobj.comm.size)]
-
-                if old_dist.comm_row_rank == 0:
-                    # We are sending something
-                    send_info = list()
-                    for rproc, sinfo in enumerate(det_send_info):
-                        proc_slices = None
-                        if sinfo is not None and rproc % new_dist.comm_row_size == 0:
-                            proc_slices = [sinfo]
-                            if dim_slices is not None:
-                                proc_slices.extend(dim_slices)
-                            proc_slices = tuple(proc_slices)
-                        send_info.append(proc_slices)
-                if new_dist.comm_row_rank == 0:
-                    # We are receiving something
-                    recv_info = list()
-                    for sproc, rinfo in enumerate(det_recv_info):
-                        proc_slices = None
-                        if rinfo is not None and sproc % old_dist.comm_row_size == 0:
-                            proc_slices = [rinfo]
-                            if dim_slices is not None:
-                                proc_slices.extend(dim_slices)
-                            proc_slices = tuple(proc_slices)
-                        recv_info.append(proc_slices)
-
-                # Create the new object
-                new_shp = [new_det_n]
-                if other_shape is not None:
-                    new_shp.extend(other_shape)
-
-                new_shared_manager.create(
-                    field, new_shp, dtype=shobj.dtype, comm=new_dist.comm_row
-                )
-
-                # Redistribute
-                redistribute_buffer(
-                    old_dist.comm.comm_group,
-                    buffer_class,
-                    mpitype,
-                    shobj.data,
-                    new_shared_manager[field].data,
-                    send_info,
-                    recv_info,
-                )
-            elif comm_equal(shobj.comm, old_dist.comm_col):
-                # Shared in the detector direction
-                shp = shobj.shape
-                if shp[0] != old_samp_n:
-                    msg = f"Shared object {field} uses the column communicator, "
-                    msg += f"but has leading dimension {shp[0]} rather than the "
-                    msg += f"number of local samples {old_samp_n}.  "
-                    msg += f"Cannot redistribute."
-                    raise RuntimeError(msg)
-
-                # Redistribution send / recv slices
-                send_info = [None for x in range(shobj.comm.size)]
-                recv_info = [None for x in range(shobj.comm.size)]
-                if old_dist.comm_col_rank == 0:
-                    # We are sending something
-                    send_info = list()
-                    for rproc, sinfo in enumerate(samp_send_info):
-                        proc_slices = None
-                        if sinfo is not None and rproc % new_dist.comm_col_size == 0:
-                            proc_slices = [sinfo]
-                            if dim_slices is not None:
-                                proc_slices.extend(dim_slices)
-                            proc_slices = tuple(proc_slices)
-                        send_info.append(proc_slices)
-                if new_dist.comm_col_rank == 0:
-                    # We are receiving something
-                    recv_info = list()
-                    for sproc, rinfo in enumerate(samp_recv_info):
-                        proc_slices = None
-                        if rinfo is not None and sproc % old_dist.comm_col_size == 0:
-                            proc_slices = [rinfo]
-                            if dim_slices is not None:
-                                proc_slices.extend(dim_slices)
-                            proc_slices = tuple(proc_slices)
-                        recv_info.append(proc_slices)
-
-                # Create the new object
-                new_shp = [new_samp_n]
-                if other_shape is not None:
-                    new_shp.extend(other_shape)
-                new_shared_manager.create(
-                    field, new_shp, dtype=shobj.dtype, comm=new_dist.comm_col
-                )
-
-                # Redistribute
-                redistribute_buffer(
-                    old_dist.comm.comm_group,
-                    buffer_class,
-                    mpitype,
-                    shobj.data,
-                    new_shared_manager[field].data,
-                    send_info,
-                    recv_info,
-                )
-            else:
-                msg = "Only shared objects using the group, row, and column "
-                msg += "communicators can be redistributed"
-                log.error(msg)
+        if commtype == "row":
+            # Shared in the sample direction.
+            if shp[0] != old_det_n:
+                msg = f"Shared object {field} uses the row communicator, "
+                msg += f"but has leading dimension {shp[0]} rather than the "
+                msg += f"number of local detectors ({old_det_n}).  "
+                msg += f"Cannot redistribute."
                 raise RuntimeError(msg)
+
+            # Redistribution send / recv slices
+            send_info = [None for x in range(shobj.comm.size)]
+            recv_info = [None for x in range(shobj.comm.size)]
+
+            if old_dist.comm_row_rank == 0:
+                # We are sending something
+                send_info = list()
+                for rproc, sinfo in enumerate(det_send_info):
+                    proc_slices = None
+                    if sinfo is not None and rproc % new_dist.comm_row_size == 0:
+                        proc_slices = [sinfo]
+                        if dim_slices is not None:
+                            proc_slices.extend(dim_slices)
+                        proc_slices = tuple(proc_slices)
+                    send_info.append(proc_slices)
+            if new_dist.comm_row_rank == 0:
+                # We are receiving something
+                recv_info = list()
+                for sproc, rinfo in enumerate(det_recv_info):
+                    proc_slices = None
+                    if rinfo is not None and sproc % old_dist.comm_row_size == 0:
+                        proc_slices = [rinfo]
+                        if dim_slices is not None:
+                            proc_slices.extend(dim_slices)
+                        proc_slices = tuple(proc_slices)
+                    recv_info.append(proc_slices)
+
+            # Create the new object
+            new_shp = [new_det_n]
+            if other_shape is not None:
+                new_shp.extend(other_shape)
+
+            new_shared_manager.create_row(field, new_shp, dtype=shobj.dtype)
+
+            # Redistribute
+            redistribute_buffer(
+                old_dist.comm.comm_group,
+                buffer_class,
+                mpitype,
+                shobj.data,
+                new_shared_manager[field].data,
+                send_info,
+                recv_info,
+            )
+        elif commtype == "column":
+            # Shared in the detector direction
+            shp = shobj.shape
+            if shp[0] != old_samp_n:
+                msg = f"Shared object {field} uses the column communicator, "
+                msg += f"but has leading dimension {shp[0]} rather than the "
+                msg += f"number of local samples {old_samp_n}.  "
+                msg += f"Cannot redistribute."
+                raise RuntimeError(msg)
+
+            # Redistribution send / recv slices
+            send_info = [None for x in range(shobj.comm.size)]
+            recv_info = [None for x in range(shobj.comm.size)]
+            if old_dist.comm_col_rank == 0:
+                # We are sending something
+                send_info = list()
+                for rproc, sinfo in enumerate(samp_send_info):
+                    proc_slices = None
+                    if sinfo is not None and rproc % new_dist.comm_col_size == 0:
+                        proc_slices = [sinfo]
+                        if dim_slices is not None:
+                            proc_slices.extend(dim_slices)
+                        proc_slices = tuple(proc_slices)
+                    send_info.append(proc_slices)
+            if new_dist.comm_col_rank == 0:
+                # We are receiving something
+                recv_info = list()
+                for sproc, rinfo in enumerate(samp_recv_info):
+                    proc_slices = None
+                    if rinfo is not None and sproc % old_dist.comm_col_size == 0:
+                        proc_slices = [rinfo]
+                        if dim_slices is not None:
+                            proc_slices.extend(dim_slices)
+                        proc_slices = tuple(proc_slices)
+                    recv_info.append(proc_slices)
+
+            # Create the new object
+            new_shp = [new_samp_n]
+            if other_shape is not None:
+                new_shp.extend(other_shape)
+            new_shared_manager.create_column(field, new_shp, dtype=shobj.dtype)
+
+            # Redistribute
+            redistribute_buffer(
+                old_dist.comm.comm_group,
+                buffer_class,
+                mpitype,
+                shobj.data,
+                new_shared_manager[field].data,
+                send_info,
+                recv_info,
+            )
+        else:
+            # Note- this code should never be executed, since the commtype value
+            # comes from an existing object and is therefore guaranteed to be
+            # valid.
+            msg = "Only shared objects using the group, row, and column "
+            msg += "communicators can be redistributed"
+            log.error(msg)
+            raise RuntimeError(msg)
 
     return new_shared_manager
 

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -108,7 +108,7 @@ class Copy(Operator):
                 for in_key, out_key in self.shared:
                     # Although this is an internal function, the input arguments come
                     # from existing shared objects and so should already be valid.
-                    ob.shared._assign_mpishared(
+                    ob.shared.assign_mpishared(
                         out_key, ob.shared[in_key], ob.shared.comm_type(in_key)
                     )
 

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -106,42 +106,11 @@ class Copy(Operator):
 
             if self.shared is not None:
                 for in_key, out_key in self.shared:
-                    if out_key in ob.shared:
-                        if ob.shared[in_key].comm is not None:
-                            comp = MPI.Comm.Compare(
-                                ob.shared[out_key].comm, ob.shared[in_key].comm
-                            )
-                            if comp not in (MPI.IDENT, MPI.CONGRUENT):
-                                msg = "Cannot copy to existing shared key {} with a different communicator".format(
-                                    out_key
-                                )
-                                log.error(msg)
-                                raise RuntimeError(msg)
-                        if ob.shared[out_key].dtype != ob.shared[in_key].dtype:
-                            msg = "Cannot copy to existing shared key {} with different dtype".format(
-                                out_key
-                            )
-                            log.error(msg)
-                            raise RuntimeError(msg)
-                        if ob.shared[out_key].shape != ob.shared[in_key].shape:
-                            msg = "Cannot copy to existing shared key {} with different shape".format(
-                                out_key
-                            )
-                            log.error(msg)
-                            raise RuntimeError(msg)
-                    else:
-                        ob.shared.create(
-                            out_key,
-                            shape=ob.shared[in_key].shape,
-                            dtype=ob.shared[in_key].dtype,
-                            comm=ob.shared[in_key].comm,
-                        )
-                    # Only one process per node copies the shared data.
-                    if (
-                        ob.shared[in_key].nodecomm is None
-                        or ob.shared[in_key].nodecomm.rank == 0
-                    ):
-                        ob.shared[out_key]._flat[:] = ob.shared[in_key]._flat
+                    # Although this is an internal function, the input arguments come
+                    # from existing shared objects and so should already be valid.
+                    ob.shared._assign_mpishared(
+                        out_key, ob.shared[in_key], ob.shared.comm_type(in_key)
+                    )
 
             if self.detdata is not None:
                 # Get the detectors we are using for this observation

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -222,13 +222,11 @@ class Demodulate(Operator):
                     demod_dets.append(f"{prefix}_{det}")
             n_local = demod_obs.n_local_samples
 
-            demod_obs.shared.create(self.times, (n_local,), comm=demod_obs.comm_col)
+            demod_obs.shared.create_column(self.times, (n_local,))
             demod_obs.shared[self.times].set(demod_times, offset=(0,), fromrank=0)
-            demod_obs.shared.create(
-                self.boresight, (n_local, 4), comm=demod_obs.comm_col
-            )
-            demod_obs.shared.create(
-                self.shared_flags, (n_local,), dtype=np.uint8, comm=demod_obs.comm_col
+            demod_obs.shared.create_column(self.boresight, (n_local, 4))
+            demod_obs.shared.create_column(
+                self.shared_flags, (n_local,), dtype=np.uint8
             )
 
             demod_obs.detdata.ensure(

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -91,11 +91,10 @@ class FlagIntervals(Operator):
             # byte width is in place.  Otherwise create it.
 
             if self.shared_flags not in ob.shared:
-                ob.shared.create(
+                ob.shared.create_column(
                     self.shared_flags,
                     shape=(ob.n_local_samples,),
                     dtype=fdtype,
-                    comm=ob.comm_col,
                 )
 
             # The intervals / view is common between all processes in a column of the

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -747,47 +747,40 @@ class SimGround(Operator):
             # Create and set shared objects for timestamps, position, velocity, and
             # boresight.
 
-            ob.shared.create(
+            ob.shared.create_column(
                 self.times,
                 shape=(ob.n_local_samples,),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.position,
                 shape=(ob.n_local_samples, 3),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.velocity,
                 shape=(ob.n_local_samples, 3),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.azimuth,
                 shape=(ob.n_local_samples,),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.elevation,
                 shape=(ob.n_local_samples,),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.boresight_azel,
                 shape=(ob.n_local_samples, 4),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.boresight_radec,
                 shape=(ob.n_local_samples, 4),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
 
             # Optionally initialize detector data

--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -111,9 +111,7 @@ def simulate_hwp_response(
 
     # Store the angle and / or the Mueller matrix
     if ob_angle_key is not None:
-        ob.shared.create(
-            ob_angle_key, shape=(n_sample,), dtype=np.float64, comm=ob.comm_col
-        )
+        ob.shared.create_column(ob_angle_key, shape=(n_sample,), dtype=np.float64)
         ob.shared[ob_angle_key].set(hwp_angle, offset=(0,), fromrank=0)
 
     return

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -86,7 +86,7 @@ def satellite_scanning(
 
     first_samp = ob.local_index_offset
     n_samp = ob.n_local_samples
-    ob.shared.create(ob_key, shape=(n_samp, 4), dtype=np.float64, comm=ob.comm_col)
+    ob.shared.create_column(ob_key, shape=(n_samp, 4), dtype=np.float64)
 
     # Temporary buffer
     boresight = None
@@ -455,29 +455,25 @@ class SimSatellite(Operator):
 
             # Create shared objects for timestamps, common flags, position,
             # and velocity.
-            ob.shared.create(
+            ob.shared.create_column(
                 self.times,
                 shape=(ob.n_local_samples,),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.shared_flags,
                 shape=(ob.n_local_samples,),
                 dtype=np.uint8,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.position,
                 shape=(ob.n_local_samples, 3),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
-            ob.shared.create(
+            ob.shared.create_column(
                 self.velocity,
                 shape=(ob.n_local_samples, 3),
                 dtype=np.float64,
-                comm=ob.comm_col,
             )
 
             # Rank zero of each grid column creates the data

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -190,7 +190,7 @@ class SimScanSynchronousSignal(Operator):
 
         if comm is not None:
             npix = comm.bcast(npix)
-        obs.shared.create(self.sss_map, shape=(npix,), dtype=dtype)
+        obs.shared.create_group(self.sss_map, shape=(npix,), dtype=dtype)
         obs.shared[self.sss_map].set(sss_map, fromrank=0)
         obs["sss_realization"] = self.realization
 

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -341,35 +341,30 @@ def create_healpix_ring_satellite(mpicomm, obs_per_group=1, nside=64):
         ob = Observation(toastcomm, tele, n_samples=nsamp, name=oname, uid=oid)
         # Create shared objects for timestamps, common flags, boresight, position,
         # and velocity.
-        ob.shared.create(
+        ob.shared.create_column(
             defaults.times,
             shape=(ob.n_local_samples,),
             dtype=np.float64,
-            comm=ob.comm_col,
         )
-        ob.shared.create(
+        ob.shared.create_column(
             defaults.shared_flags,
             shape=(ob.n_local_samples,),
             dtype=np.uint8,
-            comm=ob.comm_col,
         )
-        ob.shared.create(
+        ob.shared.create_column(
             defaults.position,
             shape=(ob.n_local_samples, 3),
             dtype=np.float64,
-            comm=ob.comm_col,
         )
-        ob.shared.create(
+        ob.shared.create_column(
             defaults.velocity,
             shape=(ob.n_local_samples, 3),
             dtype=np.float64,
-            comm=ob.comm_col,
         )
-        ob.shared.create(
+        ob.shared.create_column(
             defaults.boresight_radec,
             shape=(ob.n_local_samples, 4),
             dtype=np.float64,
-            comm=ob.comm_col,
         )
         # Rank zero of each grid column creates the data
         stamps = None
@@ -573,11 +568,10 @@ def fake_flags(
     for ob in data.obs:
         ob.detdata.ensure(det_name, sample_shape=(), dtype=np.uint8)
         if shared_name not in ob.shared:
-            ob.shared.create(
+            ob.shared.create_column(
                 shared_name,
                 shape=(ob.n_local_samples,),
                 dtype=np.uint8,
-                comm=ob.comm_col,
             )
         half = ob.n_local_samples // 2
         fshared = None

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -171,6 +171,8 @@ class ConfigTest(MPITestCase):
         fakefile = os.path.join(self.outdir, "types_fake.toml")
         if self.toastcomm.world_rank == 0:
             dump_toml(fakefile, fakeconf)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
 
         loadconf = None
         if self.toastcomm.world_rank == 0:
@@ -190,6 +192,8 @@ class ConfigTest(MPITestCase):
         conf_file = os.path.join(self.outdir, "multi_defaults.toml")
         if self.toastcomm.world_rank == 0:
             dump_toml(conf_file, defaults)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
 
         # Now change some values
         testops["mem_count"].prefix = "newpref"
@@ -204,6 +208,8 @@ class ConfigTest(MPITestCase):
         conf2_file = os.path.join(self.outdir, "multi_conf.toml")
         if self.toastcomm.world_rank == 0:
             dump_toml(conf2_file, conf)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
 
         # Options for testing
         arg_opts = [
@@ -250,6 +256,8 @@ class ConfigTest(MPITestCase):
         conf_file = os.path.join(self.outdir, "roundtrip_conf.toml")
         if self.toastcomm.world_rank == 0:
             dump_toml(conf_file, conf)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
 
         new_conf = None
         if self.toastcomm.world_rank == 0:
@@ -284,6 +292,8 @@ class ConfigTest(MPITestCase):
         conf_file = os.path.join(self.outdir, "run_conf.toml")
         if self.toastcomm.world_rank == 0:
             dump_toml(conf_file, conf_pipe)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
 
         run = create_from_config(conf_pipe)
 


### PR DESCRIPTION
Our current shared data management within an observation has an ambiguity that this PR resolves.  We currently only support shared objects that use either the group communicator or the communicator along rows or columns of the process grid within an observation.  This allows us to re-use communicators for all shared objects.  The way we currently determine (when assigning, redistributing, copying, etc) which of those communicators is being used by a shared object is to compare the communicator with the 3 possibilities using an MPI function.

In the case that MPI is not being used or the group size is small, the communicators used by shared objects may be `None` and it is ambiguous which of the 3 data sharing schemes is intended.  This in turn presents a challenge when consistently converting that data into other forms in memory or during I/O.

This work explicitly stores the "communicator type" ("group", "row", or "column") for each shared object.  The existing `create()` function is split into 3 functions (one for each communicator type).  It also includes some cleanups internal to the `SharedDataManager` class, as well as expanded unit tests.