### PR TITLE
HDF5 Observation I/O

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -237,7 +237,7 @@ conf["install_requires"] = [
     "matplotlib",
     "psutil",
     "h5py",
-    "pshmem>=0.2.9",
+    "pshmem>=0.2.10",
     "astropy",
     "healpy",
     "ephem",

--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -126,6 +126,7 @@ install(DIRECTORY
 )
 
 # Process the sub directories
+add_subdirectory(io)
 add_subdirectory(tests)
 add_subdirectory(ops)
 add_subdirectory(templates)

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -726,7 +726,9 @@ class Focalplane(object):
             if isinstance(handle, h5py.Group):
                 self.detector_data = read_table_hdf5(handle, path="focalplane")
             else:
-                self.detector_data = QTable.read(file, format="hdf5", path="focalplane")
+                self.detector_data = QTable.read(
+                    handle, format="hdf5", path="focalplane"
+                )
             # Only use the sampling rate recorded in the file if it was not
             # overridden in the constructor
             if self.sample_rate is None:
@@ -759,7 +761,11 @@ class Focalplane(object):
             self.detector_data.meta["field_of_view"] = self.field_of_view
             if isinstance(handle, h5py.Group):
                 write_table_hdf5(
-                    self.detector_data, handle, path="focalplane", overwrite=True
+                    self.detector_data,
+                    handle,
+                    path="focalplane",
+                    serialize_meta=True,
+                    overwrite=True,
                 )
             else:
                 self.detector_data.write(

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -33,7 +33,7 @@ from .timing import function_timer, Timer
 from . import qarray as qa
 
 from .noise_sim import AnalyticNoise
-from .utils import Logger, Environment, name_UID
+from .utils import Logger, Environment, name_UID, table_write_parallel_hdf5
 
 from . import qarray
 
@@ -759,13 +759,16 @@ class Focalplane(object):
         self.detector_data.meta["sample_rate"] = self.sample_rate
         self.detector_data.meta["field_of_view"] = self.field_of_view
         if isinstance(handle, h5py.Group):
-            write_table_hdf5(
-                self.detector_data,
-                handle,
-                path="focalplane",
-                serialize_meta=True,
-                overwrite=True,
+            table_write_parallel_hdf5(
+                self.detector_data, handle, "focalplane", comm=comm
             )
+            # write_table_hdf5(
+            #     self.detector_data,
+            #     handle,
+            #     path="focalplane",
+            #     serialize_meta=True,
+            #     overwrite=True,
+            # )
         else:
             if comm is None or comm.rank == 0:
                 self.detector_data.write(

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -756,18 +756,18 @@ class Focalplane(object):
             None
 
         """
-        if comm is None or comm.rank == 0:
-            self.detector_data.meta["sample_rate"] = self.sample_rate
-            self.detector_data.meta["field_of_view"] = self.field_of_view
-            if isinstance(handle, h5py.Group):
-                write_table_hdf5(
-                    self.detector_data,
-                    handle,
-                    path="focalplane",
-                    serialize_meta=True,
-                    overwrite=True,
-                )
-            else:
+        self.detector_data.meta["sample_rate"] = self.sample_rate
+        self.detector_data.meta["field_of_view"] = self.field_of_view
+        if isinstance(handle, h5py.Group):
+            write_table_hdf5(
+                self.detector_data,
+                handle,
+                path="focalplane",
+                serialize_meta=True,
+                overwrite=True,
+            )
+        else:
+            if comm is None or comm.rank == 0:
                 self.detector_data.write(
                     handle,
                     format="hdf5",

--- a/src/toast/io/CMakeLists.txt
+++ b/src/toast/io/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 install(FILES
     __init__.py
-    observation_hdf.py
+    observation_hdf_save.py
+    observation_hdf_load.py
     DESTINATION ${PYTHON_SITE}/toast/io
 )

--- a/src/toast/io/CMakeLists.txt
+++ b/src/toast/io/CMakeLists.txt
@@ -1,0 +1,8 @@
+
+# Install the python files
+
+install(FILES
+    __init__.py
+    observation_hdf.py
+    DESTINATION ${PYTHON_SITE}/toast/io
+)

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -4,4 +4,6 @@
 
 # Namespace imports
 
-from .observation_hdf import save_hdf5
+from .observation_hdf_save import save_hdf5
+
+from .observation_hdf_load import load_hdf5

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+# Namespace imports
+
+from .observation_hdf import save_hdf5

--- a/src/toast/io/observation_hdf.py
+++ b/src/toast/io/observation_hdf.py
@@ -1,0 +1,231 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import numpy as np
+
+from astropy import units as u
+
+import h5py
+
+import json
+
+from ..utils import Environment, Logger, have_hdf5_parallel, object_fullname
+
+from ..mpi import MPI
+
+from ..timing import Timer, function_timer, GlobalTimers
+
+from ..instrument import GroundSite
+
+
+@function_timer
+def save_hdf5(
+    obs,
+    meta=None,
+    detdata=None,
+    shared=None,
+    intervals=None,
+    dir=None,
+    root=None,
+    config=None,
+):
+    """Save an observation to HDF5.
+
+    This function writes an observation either to a new file in the specified directory,
+    or as a new HDF5 child group under the specified root.  In either case, the name is
+    built from the observation name and the observation UID.
+
+    The telescope information is written to a sub-dataset.
+
+    By default, all detdata, shared, intervals, and noise models are dumped as
+    individual datasets.  A subset of objects may be specified with a list of names
+    passed to the corresponding function arguments.
+
+    When dumping arbitrary metadata, scalars are stored as attributes of the observation
+    "meta" group.  Any objects in the metadata which have a `save_hdf5()` method are
+    passed a group and the name of the new dataset to create.  Other objects are
+    attempted to be dumped by h5py and a warning is printed if it fails.  The list of
+    metadata objects to dump can be given explicitly.
+
+    Args:
+        obs (Observation):  The observation to write.
+
+    Returns:
+        None
+
+    """
+    log = Logger.get()
+    env = Environment.get()
+    parallel = have_hdf5_parallel()
+
+    if dir is None and root is None:
+        raise ValueError(
+            "You must specify either the parent directory or parent HDF5 group"
+        )
+
+    if dir is not None and root is not None:
+        raise ValueError(
+            "Cannot specify both the parent directory and the parent HDF5 group"
+        )
+
+    if obs.name is None:
+        raise RuntimeError("Cannot save observations that have no name")
+
+    namestr = f"{obs.name}_{obs.uid}"
+
+    if dir is not None:
+        # Create the file and get the root group
+        hfpath = os.path.join(dir, f"{namestr}.h5")
+        hfpath_temp = f"{hfpath}.tmp"
+        if parallel:
+            hf = h5py.File(hfpath_temp, "w", driver="mpio", comm=obs.comm.comm_group)
+            hgroup = hf
+        elif obs.comm.group_rank == 0:
+            hf = h5py.File(hfpath_temp, "w")
+            hgroup = hf
+    else:
+        # We already have an open handle.  Create a subgroup with our name.
+        if parallel or obs.comm.group_rank == 0:
+            hgroup = root.create_group(namestr)
+
+    # Participating processes now go and create all sub-groups and datasets
+    if parallel or obs.comm.group_rank == 0:
+        # Record the software versions and config
+        hgroup.attrs["toast_version"] = env.version()
+        if config is not None:
+            hgroup.attrs["job_config"] = json.dumps(config)
+
+        # Observation properties
+        hgroup.attrs["observation_name"] = obs.name
+        hgroup.attrs["observation_uid"] = obs.uid
+        # hgroup.attrs["observation_detector_sets"] = obs.all_detector_sets
+
+        # Instrument properties
+        inst_group = hgroup.create_group("instrument")
+        inst_group.attrs["telescope_name"] = obs.telescope.name
+        inst_group.attrs["telescope_class"] = object_fullname(obs.telescope.__class__)
+        inst_group.attrs["telescope_uid"] = obs.telescope.uid
+        site = obs.telescope.site
+        inst_group.attrs["site_name"] = site.name
+        inst_group.attrs["site_class"] = object_fullname(site.__class__)
+        inst_group.attrs["site_uid"] = site.uid
+        if isinstance(site, GroundSite):
+            inst_group.attrs["site_lat_deg"] = site.earthloc.lat.to_value(u.degree)
+            inst_group.attrs["site_lon_deg"] = site.earthloc.lon.to_value(u.degree)
+            inst_group.attrs["site_alt_m"] = site.earthloc.height.to_value(u.meter)
+            if site.weather is not None:
+                if hasattr(site.weather, "name"):
+                    # This is a simulated weather object, dump it.
+                    inst_group.attrs["site_weather_name"] = site.weather.name
+                    inst_group.attrs[
+                        "site_weather_realization"
+                    ] = site.weather.realization
+                    if site.weather.max_pwv is None:
+                        inst_group.attrs["site_weather_max_pwv"] = "NONE"
+                    else:
+                        inst_group.attrs["site_weather_max_pwv"] = site.weather.max_pwv
+                    inst_group.attrs[
+                        "site_weather_time"
+                    ] = site.weather.time.timestamp()
+        obs.telescope.focalplane.save_hdf5(inst_group, comm=obs.comm.comm_group)
+
+        meta_group = hgroup.create_group("metadata")
+        for k, v in obs.items():
+            if hasattr(v, "save_hdf5"):
+                kgroup = meta_group.create_group(k)
+                v.save_hdf5(kgroup, comm=obs.comm.comm_group)
+            else:
+                try:
+                    meta_group.attrs[k] = v
+                except ValueError as e:
+                    msg = f"Failed to store obs key '{k}' = '{v}' as an attribute ({e})"
+                    log.verbose_rank(msg, comm=obs.comm.comm_group)
+
+        shared_group = hgroup.create_group("shared")
+        detdata_group = hgroup.create_group("detdata")
+        intervals_group = hgroup.create_group("intervals")
+
+    # Dump shared data
+
+    # FIXME:  When dumping data from a serial job, we have no mechanism for detecting
+    # if a shared object is shared across the row, column, or group communicators.
+
+    for skey, sdata in obs.shared.items():
+        sdims = None
+        sdtype = None
+        commstr = None
+        if obs.comm.group_rank == 0:
+            sdtype = sdata.dtype
+            if (
+                sdata.comm is None
+                or MPI.Comm.Compare(sdata.comm, obs.comm.comm_group) == MPI.IDENT
+            ):
+                # Using the group comm
+                sdims = sdata.shape
+                commstr = "group"
+            elif MPI.Comm.Compare(sdata.comm, obs.comm_row) == MPI.IDENT:
+                # Using the row comm.  Compute total shape.
+                sdims = (len(obs.all_detectors),) + sdata.shape[1:]
+                commstr = "row"
+            elif MPI.Comm.Compare(sdata.comm, obs.comm_col) == MPI.IDENT:
+                # Using the col comm.  Compute total shape.
+                sdims = (obs.n_all_samples,) + sdata.shape[1:]
+                commstr = "col"
+            else:
+                msg = f"Shared object '{skey}' cannot be written- only the "
+                msg += "group, row, and column communicators are supported"
+                log.error(msg)
+                raise ValueError(msg)
+        if obs.comm.comm_group is not None:
+            sdims = obs.comm.comm_group.bcast(sdims, root=0)
+            sdtype = obs.comm.comm_group.bcast(sdtype, root=0)
+            commstr = obs.comm.comm_group.bcast(commstr, root=0)
+        if parallel or obs.comm.group_rank == 0:
+            sds = shared_group.create_dataset(skey, sdims, dtype=sdtype)
+            sds.attrs["comm"] = commstr
+        # Rank zero of each comm writes the data
+        if sdata.comm is None or (commstr == "group" and obs.comm.group_rank == 0):
+            sds[:] = sdata.data
+        elif commstr == "row":
+            if parallel:
+                # The first process in each row of the grid has direct access to the
+                # dataset.
+                if obs.comm_row_rank == 0:
+                sds[
+                    obs.local_index_offset : obs.local_index_offset + obs.n_local_samples
+                ] = sdata.data
+            else:
+                # Only the root process of the group has access to the file.
+                # Communicate the data for writing, by looping over all process
+                # rows and sending data from the first process in each row.
+                for prow in range(obs.comm_col_size):
+                    if obs.comm_col_rank == prow and obs.comm_row_rank == 0:
+                        if prow == 0:
+                            # This is the root process of the whole group- just write
+                            # our piece.
+                            sds[obs.dist.]
+                        else:
+                            # My turn to send
+                    elif obs.comm.group_rank == 0:
+                        # Root process of group receives and writes
+
+
+        elif commstr == "col" and obs.comm_col_rank == 0:
+            sds[
+                obs.local_index_offset : obs.local_index_offset + obs.n_local_samples
+            ] = sdata.data
+
+    if parallel or obs.comm.group_rank == 0:
+        hf.flush()
+        hf.close()
+
+    if obs.comm.comm_group is not None:
+        obs.comm.comm_group.barrier()
+
+    # Move file into place
+    if obs.comm.group_rank == 0:
+        os.rename(hfpath_temp, hfpath)
+
+    return

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -188,12 +188,21 @@ def load_hdf5(
     # enable reading detector and shared data in parallel.
     hf = None
     hfgroup = None
+    file_version = None
     if parallel:
         hf = h5py.File(path, "r", driver="mpio", comm=comm.comm_group)
         hgroup = hf
+
     else:
         hf = h5py.File(path, "r")
         hgroup = hf
+
+    # Data format version check
+    file_version = hgroup.attrs["toast_format_version"]
+    if file_version != 0:
+        msg = f"HDF5 file '{path}' using unsupported data format {file_version}"
+        log.error(msg)
+        raise RuntimeError(msg)
 
     # Observation properties
     obs_name = hgroup.attrs["observation_name"]

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -196,11 +196,16 @@ def load_hdf5(
     obs_name = hgroup.attrs["observation_name"]
     obs_uid = hgroup.attrs["observation_uid"]
     obs_dets = json.loads(hgroup.attrs["observation_detectors"])
-    obs_det_sets = json.loads(hgroup.attrs["observation_detector_sets"])
+    obs_det_sets = None
+    if hgroup.attrs["observation_detector_sets"] != "NONE":
+        obs_det_sets = json.loads(hgroup.attrs["observation_detector_sets"])
     obs_samples = hgroup.attrs["observation_samples"]
-    obs_sample_sets = [
-        [int(x) for x in y] for y in json.loads(hgroup.attrs["observation_sample_sets"])
-    ]
+    obs_sample_sets = None
+    if hgroup.attrs["observation_sample_sets"] != "NONE":
+        obs_sample_sets = [
+            [int(x) for x in y]
+            for y in json.loads(hgroup.attrs["observation_sample_sets"])
+        ]
 
     # Instrument properties
 

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import numpy as np
+
+from astropy import units as u
+
+import h5py
+
+import json
+
+from ..utils import (
+    Environment,
+    Logger,
+    have_hdf5_parallel,
+    import_from_name,
+    dtype_to_aligned,
+)
+
+from ..mpi import MPI
+
+from ..timing import Timer, function_timer, GlobalTimers
+
+from ..instrument import GroundSite, SpaceSite
+
+from ..weather import SimWeather
+
+
+@function_timer
+def load_hdf5_shared(obs, hgrp, fields):
+    log = Logger.get()
+    parallel = have_hdf5_parallel()
+    return
+
+
+@function_timer
+def load_hdf5_detdata(obs, hgrp, fields):
+    pass
+
+
+@function_timer
+def load_hdf5_intervals(obs, hgrp, fields):
+    pass
+
+
+# FIXME:  Add options here to prune detectors on load.
+
+
+@function_timer
+def load_hdf5(
+    path,
+    comm,
+    process_rows=None,
+    meta=None,
+    detdata=None,
+    shared=None,
+    intervals=None,
+):
+    """Load an HDF5 observation.
+
+    By default, all detdata, shared, intervals, and noise models are loaded into
+    memory.  A subset of objects may be specified with a list of names
+    passed to the corresponding function arguments.
+
+    Args:
+        path (str):  The path to the file on disk.
+        comm (toast.Comm):  The toast communicator to use.
+        process_rows (int):  (Optional) The size of the rectangular process grid
+            in the detector direction.  This number must evenly divide into the size of
+            comm.  If not specified, defaults to the size of the communicator.
+        meta (list):  Only save this list of metadata objects.
+        detdata (list):  Only save this list of detdata objects.
+        shared (list):  Only save this list of shared objects.
+        intervals (list):  Only save this list of intervals objects.
+
+    Returns:
+        (Observation):  The constructed observation.
+
+    """
+    log = Logger.get()
+    env = Environment.get()
+    parallel = have_hdf5_parallel()
+
+    # Open the file and get the root group.  In both serial and parallel HDF5,
+    # multiple readers are supported.  We open the file with all processes to
+    # enable reading detector and shared data in parallel.
+    hf = None
+    hfgroup = None
+    if parallel:
+        hf = h5py.File(path, "r", driver="mpio", comm=comm.comm_group)
+        hgroup = hf
+    else:
+        hf = h5py.File(path, "r")
+        hgroup = hf
+
+    # Observation properties
+    obs_name = hgroup.attrs["observation_name"]
+    obs_uid = hgroup.attrs["observation_uid"]
+    # det_sets = hgroup.attrs["observation_detector_sets"]
+
+    # Instrument properties
+
+    # FIXME:  We should add save / load methods to these classes to
+    # generalize this and allow use of other classes.
+
+    inst_group = hgroup["instrument"]
+    telescope_name = inst_group.attrs["telescope_name"]
+    telescope_class_name = inst_group.attrs["telescope_class"]
+    telescope_uid = inst_group.attrs["telescope_uid"] = obs.telescope.uid
+
+    site_name = inst_group.attrs["site_name"]
+    site_class_name = inst_group.attrs["site_class"]
+    site_uid = inst_group.attrs["site_uid"]
+
+    site = None
+    if "site_alt_m" in inst_group.attrs:
+        # This is a ground based site
+        site_alt_m = inst_group.attrs["site_alt_m"]
+        site_lat_deg = inst_group.attrs["site_lat_deg"]
+        site_lon_deg = inst_group.attrs["site_lon_deg"]
+
+        weather = None
+        if "site_weather_name" in inst_group.attrs:
+            weather_name = inst_group.attrs["site_weather_name"]
+            weather_realization = inst_group.attrs["site_weather_realization"]
+            weather_max_pwv = None
+            if inst_group.attrs["site_weather_max_pwv"] != "NONE":
+                weather_max_pwv = inst_group.attrs["site_weather_max_pwv"]
+            weather_time = inst_group.attrs["site_weather_time"]
+            weather = SimWeather(
+                time=weather_time,
+                name=weather_name,
+                site_uid=site_uid,
+                realization=weather_realization,
+                max_pwv=weather_max_pwv,
+                median_weather=False,
+            )
+        site = GroundSite(
+            site_name,
+            site_lat_deg * u.degree,
+            site_lon_deg * u.degree,
+            site_alt_m * u.meter,
+            uid=site_uid,
+            weather=weather,
+        )
+    else:
+        site = SpaceSite(site_name, uid=site_uid)
+
+    focalplane = Focalplane()
+    focalplane.load_hdf5(inst_group["focalplane"], comm=comm.comm_group)
+
+    telescope = Telescope(
+        telescope_name, uid=telescope_uid, focalplane=focalplane, site=site
+    )
+
+    # Create the observation
+
+    # Load other metadata
+
+    meta_group = hgroup.create_group("metadata")
+    for k, v in obs.items():
+        if hasattr(v, "save_hdf5"):
+            kgroup = meta_group.create_group(k)
+            v.save_hdf5(kgroup, comm=obs.comm.comm_group)
+        else:
+            try:
+                meta_group.attrs[k] = v
+            except ValueError as e:
+                msg = f"Failed to store obs key '{k}' = '{v}' as an attribute ({e})"
+                log.verbose_rank(msg, comm=obs.comm.comm_group)
+
+    # Load shared data
+
+    # Load intervals
+
+    # Load detector data
+
+    shared_group = hgroup.create_group("shared")
+    detdata_group = hgroup.create_group("detdata")
+    intervals_group = hgroup.create_group("intervals")
+    intervals_group.attrs["times"] = times
+
+    return

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -32,8 +32,11 @@ from ..observation_dist import global_interval_times
 
 
 @function_timer
-def save_hdf5_shared(obs, hgrp, fields, parallel):
+def save_hdf5_shared_parallel(obs, hgrp, fields, log_prefix):
     log = Logger.get()
+
+    timer = Timer()
+    timer.start()
 
     # Get references to the distribution of detectors and samples
     proc_rows = obs.dist.process_rows
@@ -53,6 +56,7 @@ def save_hdf5_shared(obs, hgrp, fields, parallel):
         scomm = obs.shared.comm_type(field)
         sdata = obs.shared[field]
         sdtype = sdata.dtype
+
         if scomm == "group":
             sshape = sdata.shape
         elif scomm == "column":
@@ -63,105 +67,165 @@ def save_hdf5_shared(obs, hgrp, fields, parallel):
         # The buffer class to use for allocating receive buffers
         bufclass, _ = dtype_to_aligned(sdtype)
 
-        # Participating processes create the dataset
-
-        hdata = None
-        if parallel or obs.comm.group_rank == 0:
-            hdata = hgrp.create_dataset(field, sshape, dtype=sdtype)
-            hdata.attrs["comm_type"] = scomm
+        # All processes create the dataset
+        hdata = hgrp.create_dataset(field, sshape, dtype=sdtype)
+        hdata.attrs["comm_type"] = scomm
 
         # If we have parallel support, the rank zero of each comm can write
-        # independently.  Otherwise, send data to rank zero of the group
-        # for writing.
+        # independently.
 
         if scomm == "group":
             # Easy...
             if obs.comm.group_rank == 0:
                 hdata[:] = sdata.data
         elif scomm == "column":
-            if parallel:
-                # Rank zero of each column writes
-                if sdata.comm is None or sdata.comm.rank == 0:
-                    hdata[
-                        obs.local_index_offset : obs.local_index_offset
-                        + obs.n_local_samples
-                    ] = sdata.data
-            else:
-                # Send data to root process
-                for proc in range(proc_cols):
-                    # Process grid is indexed row-major, so the rank-zero process
-                    # of each column is just the first row of the grid.
-                    group_rank = proc
-                    # Leading data range for this process
-                    off = dist_samps[group_rank].offset
-                    nelem = dist_samps[group_rank].n_elem
-                    nflat = nelem * np.prod(sshape[1:])
-                    shp = (nelem,) + sshape[1:]
-                    if group_rank == 0:
-                        # Root process writes local data
-                        if obs.comm.group_rank == 0:
-                            hdata[off : off + nelem] = sdata.data
-                    elif group_rank == obs.comm.group_rank:
-                        # We are sending
-                        obs.comm.comm_group.Send(
-                            sdata.data.flatten(), dest=0, tag=group_rank
-                        )
-                    elif obs.comm.group_rank == 0:
-                        # We are receiving and writing
-                        recv = bufclass(nflat)
-                        obs.comm.comm_group.Recv(
-                            recv, source=group_rank, tag=group_rank
-                        )
-                        hdata[off : off + nelem] = recv.array().reshape(shp)
-                        recv.clear()
-                        del recv
-                    if obs.comm.comm_group is not None:
-                        obs.comm.comm_group.barrier()
+            # Rank zero of each column writes
+            if sdata.comm is None or sdata.comm.rank == 0:
+                hdata[
+                    obs.local_index_offset : obs.local_index_offset
+                    + obs.n_local_samples
+                ] = sdata.data
         else:
-            if parallel:
-                # Rank zero of each row writes
-                if sdata.comm is None or sdata.comm.rank == 0:
-                    off = dist_dets[obs.comm.group_rank].offset
-                    nelem = dist_dets[obs.comm.group_rank].n_elem
-                    hdata[off : off + nelem] = sdata.data
-            else:
-                # Send data to root process
-                for proc in range(proc_rows):
-                    # Process grid is indexed row-major, so the rank-zero process
-                    # of each row is strided by the number of columns.
-                    group_rank = proc * proc_cols
-                    # Leading data range for this process
-                    off = dist_dets[group_rank].offset
-                    nelem = dist_dets[group_rank].n_elem
-                    nflat = nelem * np.prod(sshape[1:])
-                    shp = (nelem,) + sshape[1:]
-                    if group_rank == 0:
-                        # Root process writes local data
-                        if obs.comm.group_rank == 0:
-                            hdata[off : off + nelem] = sdata.data
-                    elif group_rank == obs.comm.group_rank:
-                        # We are sending
-                        obs.comm.comm_group.Send(
-                            sdata.data.flatten(), dest=0, tag=group_rank
-                        )
-                    elif obs.comm.group_rank == 0:
-                        # We are receiving and writing
-                        recv = bufclass(nflat)
-                        obs.comm.comm_group.Recv(
-                            recv, source=group_rank, tag=group_rank
-                        )
-                        hdata[off : off + nelem] = recv.array().reshape(shp)
-                        recv.clear()
-                        del recv
-                    if obs.comm.comm_group is not None:
-                        obs.comm.comm_group.barrier()
+            # Rank zero of each row writes
+            if sdata.comm is None or sdata.comm.rank == 0:
+                off = dist_dets[obs.comm.group_rank].offset
+                nelem = dist_dets[obs.comm.group_rank].n_elem
+                hdata[off : off + nelem] = sdata.data
 
+        log.verbose_rank(
+            f"{log_prefix}  Shared finished {field} parallel write in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
         del hdata
 
 
 @function_timer
-def save_hdf5_detdata(obs, hgrp, fields, parallel):
+def save_hdf5_shared_serial(obs, hgrp, fields, log_prefix):
     log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
+    # Get references to the distribution of detectors and samples
+    proc_rows = obs.dist.process_rows
+    proc_cols = obs.dist.comm.group_size // proc_rows
+    dist_samps = obs.dist.samps
+    dist_dets = obs.dist.det_indices
+
+    n_fields = len(fields)
+
+    for ifield, field in enumerate(fields):
+        tag_offset = ifield * obs.comm.group_size
+
+        if field not in obs.shared:
+            msg = f"Shared data '{field}' does not exist in observation "
+            msg += f"{obs.name}.  Skipping."
+            log.warning_rank(msg, comm=obs.comm.comm_group)
+            continue
+
+        # Compute properties of the full set of data across the observation
+
+        scomm = obs.shared.comm_type(field)
+        sdata = obs.shared[field]
+        sdtype = sdata.dtype
+
+        if scomm == "group":
+            sshape = sdata.shape
+        elif scomm == "column":
+            sshape = (obs.n_all_samples,) + sdata.shape[1:]
+        else:
+            sshape = (len(obs.all_detectors),) + sdata.shape[1:]
+
+        # The buffer class to use for allocating receive buffers
+        bufclass, _ = dtype_to_aligned(sdtype)
+
+        # Rank zero of the group creates the dataset
+        hdata = None
+        if obs.comm.group_rank == 0:
+            hdata = hgrp.create_dataset(field, sshape, dtype=sdtype)
+            hdata.attrs["comm_type"] = scomm
+
+        # Send data to rank zero of the group for writing.
+
+        if scomm == "group":
+            # Easy...
+            if obs.comm.group_rank == 0:
+                hdata[:] = sdata.data
+        elif scomm == "column":
+            # Send data to root process
+            for proc in range(proc_cols):
+                # Process grid is indexed row-major, so the rank-zero process
+                # of each column is just the first row of the grid.
+                send_rank = proc
+
+                # Leading data range for this process
+                off = dist_samps[send_rank].offset
+                nelem = dist_samps[send_rank].n_elem
+                nflat = nelem * np.prod(sshape[1:])
+                shp = (nelem,) + sshape[1:]
+                if send_rank == 0:
+                    # Root process writes local data
+                    if obs.comm.group_rank == 0:
+                        hdata[off : off + nelem] = sdata.data
+                elif send_rank == obs.comm.group_rank:
+                    # We are sending
+                    obs.comm.comm_group.Send(
+                        sdata.data.flatten(), dest=0, tag=tag_offset + send_rank
+                    )
+                elif obs.comm.group_rank == 0:
+                    # We are receiving and writing
+                    recv = bufclass(nflat)
+                    obs.comm.comm_group.Recv(
+                        recv, source=send_rank, tag=tag_offset + send_rank
+                    )
+                    hdata[off : off + nelem] = recv.array().reshape(shp)
+                    recv.clear()
+                    del recv
+        else:
+            # Send data to root process
+            for proc in range(proc_rows):
+                # Process grid is indexed row-major, so the rank-zero process
+                # of each row is strided by the number of columns.
+                send_rank = proc * proc_cols
+                # Leading data range for this process
+                off = dist_dets[send_rank].offset
+                nelem = dist_dets[send_rank].n_elem
+                nflat = nelem * np.prod(sshape[1:])
+                shp = (nelem,) + sshape[1:]
+                if send_rank == 0:
+                    # Root process writes local data
+                    if obs.comm.group_rank == 0:
+                        hdata[off : off + nelem] = sdata.data
+                elif send_rank == obs.comm.group_rank:
+                    # We are sending
+                    obs.comm.comm_group.Send(
+                        sdata.data.flatten(), dest=0, tag=tag_offset + send_rank
+                    )
+                elif obs.comm.group_rank == 0:
+                    # We are receiving and writing
+                    recv = bufclass(nflat)
+                    obs.comm.comm_group.Recv(
+                        recv, source=send_rank, tag=tag_offset + send_rank
+                    )
+                    hdata[off : off + nelem] = recv.array().reshape(shp)
+                    recv.clear()
+                    del recv
+
+        log.verbose_rank(
+            f"{log_prefix}  Shared finished {field} serial write in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
+        del hdata
+
+
+@function_timer
+def save_hdf5_detdata_parallel(obs, hgrp, fields, log_prefix):
+    log = Logger.get()
+
+    timer = Timer()
+    timer.start()
 
     # Get references to the distribution of detectors and samples
     proc_rows = obs.dist.process_rows
@@ -194,96 +258,198 @@ def save_hdf5_detdata(obs, hgrp, fields, parallel):
         # The buffer class to use for allocating receive buffers
         bufclass, _ = dtype_to_aligned(ddtype)
 
-        # Participating processes create the dataset
+        # All processes create the dataset
+        hdata = hgrp.create_dataset(field, dshape, dtype=ddtype)
+        hdata.attrs["units"] = local_data.units.to_string()
 
+        # If we have parallel support, every process can write independently.
+        samp_off = dist_samps[obs.comm.group_rank].offset
+        samp_nelem = dist_samps[obs.comm.group_rank].n_elem
+        det_off = dist_dets[obs.comm.group_rank].offset
+        det_nelem = dist_dets[obs.comm.group_rank].n_elem
+        with hdata.collective:
+            hdata[
+                det_off : det_off + det_nelem, samp_off : samp_off + samp_nelem
+            ] = local_data
+
+        del hdata
+        log.verbose_rank(
+            f"{log_prefix}  Detdata finished {field} parallel write in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
+
+
+@function_timer
+def save_hdf5_detdata_serial(obs, hgrp, fields, log_prefix):
+    log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
+    # Get references to the distribution of detectors and samples
+    proc_rows = obs.dist.process_rows
+    proc_cols = obs.dist.comm.group_size // proc_rows
+    dist_samps = obs.dist.samps
+    dist_dets = obs.dist.det_indices
+
+    # We are using the group communicator
+    comm = obs.comm.comm_group
+    nproc = obs.comm.group_size
+    rank = obs.comm.group_rank
+
+    n_fields = len(fields)
+
+    for ifield, field in enumerate(fields):
+        tag_offset = ifield * obs.comm.group_size
+        if field not in obs.detdata:
+            msg = f"Detdata data '{field}' does not exist in observation "
+            msg += f"{obs.name}.  Skipping."
+            log.warning_rank(msg, comm=comm)
+            continue
+
+        local_data = obs.detdata[field]
+        if local_data.detectors != obs.local_detectors:
+            msg = f"Data data '{field}' does not contain all local detectors."
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        # Compute properties of the full set of data across the observation
+
+        ddtype = local_data.dtype
+        dshape = (len(obs.all_detectors), obs.n_all_samples)
+        dvalshape = None
+        if len(local_data.detector_shape) > 1:
+            dvalshape = local_data.detector_shape[1:]
+            dshape += dvalshape
+
+        # The buffer class to use for allocating receive buffers
+        bufclass, _ = dtype_to_aligned(ddtype)
+
+        # Only the root process creates the dataset
         hdata = None
-        if parallel or obs.comm.group_rank == 0:
+        if rank == 0:
             hdata = hgrp.create_dataset(field, dshape, dtype=ddtype)
             hdata.attrs["units"] = local_data.units.to_string()
 
-        # If we have parallel support, every process can write independently.
-        # Otherwise, send data to rank zero of the group for writing.
+        # Send data to rank zero of the group for writing.
 
-        if parallel:
-            samp_off = dist_samps[obs.comm.group_rank].offset
-            samp_nelem = dist_samps[obs.comm.group_rank].n_elem
-            det_off = dist_dets[obs.comm.group_rank].offset
-            det_nelem = dist_dets[obs.comm.group_rank].n_elem
-            with hdata.collective:
+        for proc in range(nproc):
+            # Data ranges for this process
+            samp_off = dist_samps[proc].offset
+            samp_nelem = dist_samps[proc].n_elem
+            det_off = dist_dets[proc].offset
+            det_nelem = dist_dets[proc].n_elem
+            nflat = det_nelem * samp_nelem
+            shp = (det_nelem, samp_nelem)
+            if dvalshape is not None:
+                nflat *= dvalshape
+                shp += dvalshape
+            if proc == 0:
+                # Root process writes local data
+                if rank == 0:
+                    hdata[
+                        det_off : det_off + det_nelem,
+                        samp_off : samp_off + samp_nelem,
+                    ] = local_data
+            elif proc == rank:
+                # We are sending
+                comm.Send(local_data.flatdata, dest=0, tag=tag_offset + proc)
+            elif rank == 0:
+                # We are receiving and writing
+                recv = bufclass(nflat)
+                comm.Recv(recv, source=proc, tag=tag_offset + proc)
                 hdata[
                     det_off : det_off + det_nelem, samp_off : samp_off + samp_nelem
-                ] = local_data
-        else:
-            # Send data to root process
-            for proc in range(obs.comm.group_size):
-                # Data ranges for this process
-                samp_off = dist_samps[proc].offset
-                samp_nelem = dist_samps[proc].n_elem
-                det_off = dist_dets[proc].offset
-                det_nelem = dist_dets[proc].n_elem
-                nflat = det_nelem * samp_nelem
-                shp = (det_nelem, samp_nelem)
-                if dvalshape is not None:
-                    nflat *= dvalshape
-                    shp += dvalshape
-                if proc == 0:
-                    # Root process writes local data
-                    if obs.comm.group_rank == 0:
-                        hdata[
-                            det_off : det_off + det_nelem,
-                            samp_off : samp_off + samp_nelem,
-                        ] = local_data
-                elif proc == obs.comm.group_rank:
-                    # We are sending
-                    obs.comm.comm_group.Send(local_data.flatdata, dest=0, tag=proc)
-                elif obs.comm.group_rank == 0:
-                    # We are receiving and writing
-                    recv = bufclass(nflat)
-                    obs.comm.comm_group.Recv(recv, source=proc, tag=proc)
-                    hdata[
-                        det_off : det_off + det_nelem, samp_off : samp_off + samp_nelem
-                    ] = recv.array().reshape(shp)
-                    recv.clear()
-                    del recv
-                if obs.comm.comm_group is not None:
-                    obs.comm.comm_group.barrier()
-
+                ] = recv.array().reshape(shp)
+                recv.clear()
+                del recv
+        log.verbose_rank(
+            f"{log_prefix}  Detdata finished {field} serial write in",
+            comm=comm,
+            timer=timer,
+        )
         del hdata
 
 
 @function_timer
-def save_hdf5_intervals(obs, hgrp, fields, parallel):
+def save_hdf5_intervals_parallel(obs, hgrp, fields, log_prefix):
     log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
+    # We are using the group communicator
+    comm = obs.comm.comm_group
+    nproc = obs.comm.group_size
+    rank = obs.comm.group_rank
 
     for field in fields:
         if field not in obs.intervals:
             msg = f"Intervals '{field}' does not exist in observation "
             msg += f"{obs.name}.  Skipping."
-            log.warning_rank(msg, comm=obs.comm.comm_group)
+            log.warning_rank(msg, comm=comm)
             continue
 
         # Get the list of start / stop tuples on the rank zero process
         ilist = global_interval_times(obs.dist, obs.intervals, field, join=False)
 
         n_list = None
-        if obs.comm.group_rank == 0:
+        if rank == 0:
             n_list = len(ilist)
-        if obs.comm.comm_group is not None:
-            n_list = obs.comm.comm_group.bcast(n_list, root=0)
+        if comm is not None:
+            n_list = comm.bcast(n_list, root=0)
 
-        # Participating processes create the dataset
-        hdata = None
-        if parallel or obs.comm.group_rank == 0:
-            hdata = hgrp.create_dataset(field, (2, n_list), dtype=np.float64)
+        # All processes create the dataset
+        hdata = hgrp.create_dataset(field, (2, n_list), dtype=np.float64)
 
         # Only the root process writes
-        if obs.comm.group_rank == 0:
+        if rank == 0:
             hdata[:, :] = np.transpose(np.array(ilist))
 
-        if obs.comm.comm_group is not None:
-            obs.comm.comm_group.barrier()
-
+        # Free object
         del hdata
+
+        log.verbose_rank(
+            f"{log_prefix}  Intervals finished {field} parallel write in",
+            comm=comm,
+            timer=timer,
+        )
+
+
+@function_timer
+def save_hdf5_intervals_serial(obs, hgrp, fields, log_prefix):
+    log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
+    # We are using the group communicator
+    comm = obs.comm.comm_group
+    nproc = obs.comm.group_size
+    rank = obs.comm.group_rank
+
+    for field in fields:
+        if field not in obs.intervals:
+            msg = f"Intervals '{field}' does not exist in observation "
+            msg += f"{obs.name}.  Skipping."
+            log.warning_rank(msg, comm=comm)
+            continue
+
+        # Get the list of start / stop tuples on the rank zero process
+        ilist = global_interval_times(obs.dist, obs.intervals, field, join=False)
+
+        # Root process creates the dataset and writes
+        if rank == 0:
+            hdata = hgrp.create_dataset(field, (2, len(ilist)), dtype=np.float64)
+            hdata[:, :] = np.transpose(np.array(ilist))
+            del hdata
+
+        log.verbose_rank(
+            f"{log_prefix}  Intervals finished {field} serial write in",
+            comm=comm,
+            timer=timer,
+        )
 
 
 @function_timer
@@ -340,6 +506,10 @@ def save_hdf5(
     if obs.name is None:
         raise RuntimeError("Cannot save observations that have no name")
 
+    timer = Timer()
+    timer.start()
+    log_prefix = f"HDF5 save {obs.name}: "
+
     namestr = f"{obs.name}_{obs.uid}"
     hfpath = os.path.join(dir, f"{namestr}.h5")
     hfpath_temp = f"{hfpath}.tmp"
@@ -347,12 +517,28 @@ def save_hdf5(
     # Create the file and get the root group
     hf = None
     hgroup = None
+    vtimer = Timer()
+    vtimer.start()
     if parallel:
         hf = h5py.File(hfpath_temp, "w", driver="mpio", comm=obs.comm.comm_group)
         hgroup = hf
+        log.verbose_rank(
+            f"{log_prefix}  Opened temp file {hfpath_temp} in parallel in",
+            comm=obs.comm.comm_group,
+            timer=vtimer,
+        )
     elif obs.comm.group_rank == 0:
         hf = h5py.File(hfpath_temp, "w")
         hgroup = hf
+        log.verbose_rank(
+            f"{log_prefix}  Opened temp file {hfpath_temp} on rank zero in",
+            comm=None,
+            timer=vtimer,
+        )
+
+    save_comm = None
+    if parallel:
+        save_comm = obs.comm.comm_group
 
     shared_group = None
     detdata_group = None
@@ -362,6 +548,7 @@ def save_hdf5(
         hgroup.attrs["toast_version"] = env.version()
         if config is not None:
             hgroup.attrs["job_config"] = json.dumps(config)
+        hgroup.attrs["toast_format_version"] = 0
 
         # Observation properties
         hgroup.attrs["observation_name"] = obs.name
@@ -380,6 +567,12 @@ def save_hdf5(
         hgroup.attrs["observation_detector_sets"] = obs_all_det_sets
         hgroup.attrs["observation_samples"] = obs.n_all_samples
         hgroup.attrs["observation_sample_sets"] = obs_all_samp_sets
+
+        log.verbose_rank(
+            f"{log_prefix}  Wrote observation attributes (parallel={parallel}) in",
+            comm=save_comm,
+            timer=vtimer,
+        )
 
         # Instrument properties
         inst_group = hgroup.create_group("instrument")
@@ -408,21 +601,36 @@ def save_hdf5(
                     inst_group.attrs[
                         "site_weather_time"
                     ] = site.weather.time.timestamp()
-        obs.telescope.focalplane.save_hdf5(inst_group, comm=obs.comm.comm_group)
+        log.verbose_rank(
+            f"{log_prefix}  Wrote instrument attributes (parallel={parallel}) in",
+            comm=save_comm,
+            timer=vtimer,
+        )
+        obs.telescope.focalplane.save_hdf5(
+            inst_group, comm=obs.comm.comm_group, force_serial=force_serial
+        )
+        log.verbose_rank(
+            f"{log_prefix}  Wrote focalplane (parallel={parallel}) in",
+            comm=save_comm,
+            timer=vtimer,
+        )
         del inst_group
+
+        log.debug_rank(
+            f"{log_prefix} finished instrument model",
+            comm=save_comm,
+            timer=timer,
+        )
 
         meta_group = hgroup.create_group("metadata")
 
-        save_comm = None
-        if parallel:
-            save_comm = obs.comm.comm_group
         for k, v in obs.items():
             if meta is not None and k not in meta:
                 continue
             if hasattr(v, "save_hdf5"):
                 kgroup = meta_group.create_group(k)
                 kgroup.attrs["class"] = object_fullname(v.__class__)
-                v.save_hdf5(kgroup, comm=save_comm)
+                v.save_hdf5(kgroup, comm=save_comm, force_serial=force_serial)
                 del kgroup
             elif isinstance(v, u.Quantity):
                 if isinstance(v.value, np.ndarray):
@@ -446,8 +654,19 @@ def save_hdf5(
                 except ValueError as e:
                     msg = f"Failed to store obs key '{k}' = '{v}' as an attribute ({e})"
                     log.verbose_rank(msg, comm=save_comm)
+            log.verbose_rank(
+                f"{log_prefix}  Meta finished {k} (parallel={parallel}) in",
+                comm=save_comm,
+                timer=vtimer,
+            )
 
         del meta_group
+
+        log.debug_rank(
+            f"{log_prefix} Finished metadata",
+            comm=save_comm,
+            timer=timer,
+        )
 
         shared_group = hgroup.create_group("shared")
         detdata_group = hgroup.create_group("detdata")
@@ -469,21 +688,47 @@ def save_hdf5(
     else:
         if times not in fields:
             fields.append(times)
+    if parallel:
+        save_hdf5_shared_parallel(obs, shared_group, fields, log_prefix)
+    else:
+        save_hdf5_shared_serial(obs, shared_group, fields, log_prefix)
 
-    save_hdf5_shared(obs, shared_group, fields, parallel)
+    log.debug_rank(
+        f"{log_prefix} finished shared data",
+        comm=obs.comm.comm_group,
+        timer=timer,
+    )
 
     if detdata is None:
         fields = list(obs.detdata.keys())
     else:
         fields = list(detdata)
-    save_hdf5_detdata(obs, detdata_group, fields, parallel)
+    if parallel:
+        save_hdf5_detdata_parallel(obs, detdata_group, fields, log_prefix)
+    else:
+        save_hdf5_detdata_serial(obs, detdata_group, fields, log_prefix)
+
+    log.debug_rank(
+        f"{log_prefix} finished detector data",
+        comm=obs.comm.comm_group,
+        timer=timer,
+    )
 
     if intervals is None:
         fields = list(obs.intervals.keys())
     else:
         fields = list(intervals)
     if dump_intervals:
-        save_hdf5_intervals(obs, intervals_group, fields, parallel)
+        if parallel:
+            save_hdf5_intervals_parallel(obs, intervals_group, fields, log_prefix)
+        else:
+            save_hdf5_intervals_serial(obs, intervals_group, fields, log_prefix)
+
+    log.debug_rank(
+        f"{log_prefix} finished intervals data",
+        comm=obs.comm.comm_group,
+        timer=timer,
+    )
 
     # Close file if we opened it
 

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -205,9 +205,7 @@ def save_hdf5_detdata(obs, hgrp, fields):
         hdata = None
         if parallel or obs.comm.group_rank == 0:
             hdata = hgrp.create_dataset(field, dshape, dtype=ddtype)
-            print(f"detdata {field} has units {local_data.units.to_string()}")
             hdata.attrs["units"] = local_data.units.to_string()
-            print(f"unit attr now {hdata.attrs['units']}")
 
         # If we have parallel support, every process can write independently.
         # Otherwise, send data to rank zero of the group for writing.
@@ -369,7 +367,16 @@ def save_hdf5(
         # Observation properties
         hgroup.attrs["observation_name"] = obs.name
         hgroup.attrs["observation_uid"] = obs.uid
-        # hgroup.attrs["observation_detector_sets"] = obs.all_detector_sets
+
+        obs_all_dets = json.dumps(obs.all_detectors)
+        obs_all_det_sets = json.dumps(obs.all_detector_sets)
+        obs_all_samp_sets = json.dumps(
+            [[str(x) for x in y] for y in obs.all_sample_sets]
+        )
+        hgroup.attrs["observation_detectors"] = obs_all_dets
+        hgroup.attrs["observation_detector_sets"] = obs_all_det_sets
+        hgroup.attrs["observation_samples"] = obs.n_all_samples
+        hgroup.attrs["observation_sample_sets"] = obs_all_samp_sets
 
         # Instrument properties
         inst_group = hgroup.create_group("instrument")

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -370,10 +370,14 @@ def save_hdf5(
         hgroup.attrs["observation_uid"] = obs.uid
 
         obs_all_dets = json.dumps(obs.all_detectors)
-        obs_all_det_sets = json.dumps(obs.all_detector_sets)
-        obs_all_samp_sets = json.dumps(
-            [[str(x) for x in y] for y in obs.all_sample_sets]
-        )
+        obs_all_det_sets = "NONE"
+        if obs.all_detector_sets is not None:
+            obs_all_det_sets = json.dumps(obs.all_detector_sets)
+        obs_all_samp_sets = "NONE"
+        if obs.all_sample_sets is not None:
+            obs_all_samp_sets = json.dumps(
+                [[str(x) for x in y] for y in obs.all_sample_sets]
+            )
         hgroup.attrs["observation_detectors"] = obs_all_dets
         hgroup.attrs["observation_detector_sets"] = obs_all_det_sets
         hgroup.attrs["observation_samples"] = obs.n_all_samples

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -3,13 +3,18 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 from typing import Type
+import re
 import numpy as np
+
+import hashlib
 
 from astropy import units as u
 
 import h5py
 
 from .timing import function_timer
+
+from .utils import have_hdf5_parallel
 
 
 class Noise(object):
@@ -211,49 +216,99 @@ class Noise(object):
         """
         return self._detector_weight(det)
 
-    def _save_base_hdf5(self, hf, comm=None):
-        """Write internal data to an open HDF5 file."""
-        for k in self._freqs.keys():
-            # Create a dataset for this key
-            ds = hf.create_dataset(k, (len(self._freqs[k]), 2), dtype=np.float64)
-            # Store the rate and index as attributes
-            ds.attrs["rate"] = self._rates[k].to_value(u.Hz)
-            ds.attrs["index"] = self._indices[k]
-            if comm is None or comm.rank == 0:
-                ds[:] = np.stack(
-                    [
-                        self._freqs[k].to_value(u.Hz),
-                        self._psds[k].to_value(u.K ** 2 * u.second),
-                    ],
-                    axis=-1,
-                )
-            del ds
-        # Now store the mixing matrix as a separate dataset
+    def _save_base_hdf5(self, hf, comm=None, force_serial=False):
+        """Write internal data to an open HDF5 group."""
+        parallel = have_hdf5_parallel()
+        if force_serial:
+            parallel = False
+        participating = parallel or comm is None or comm.rank == 0
+
+        # First store the mixing matrix as a separate dataset, and find the maximum
+        # string length used for the keys.
+
         mixdata = list()
         maxstr = 0
-        for k, v in self._mixmatrix.items():
-            if len(k) > maxstr:
-                maxstr = len(k)
-            for other, val in v.items():
-                if len(other) > maxstr:
-                    maxstr = len(other)
-                mixdata.append((k, other, val))
+        for det, streams in self._mixmatrix.items():
+            maxstr = max(maxstr, len(det))
+            for strm, weight in streams.items():
+                maxstr = max(maxstr, len(strm))
+                mixdata.append((det, strm, weight))
         maxstr += 1
         mixdtype = np.dtype(f"a{maxstr}, a{maxstr}, f8")
-        ds = hf.create_dataset("mixing_matrix", (len(mixdata),), dtype=mixdtype)
-        if comm is None or comm.rank == 0:
-            ds[:] = np.array(mixdata, dtype=mixdtype)
-        del ds
+        if participating:
+            ds = hf.create_dataset("mixing_matrix", (len(mixdata),), dtype=mixdtype)
+            if comm is None or comm.rank == 0:
+                ds[:] = np.array(mixdata, dtype=mixdtype)
+            del ds
 
-    def _save_hdf5(self, handle, comm=None, **kwargs):
+        # Each stream psd can potentially have a unique set of frequencies, but in
+        # practice we usually have a just one or a few.  To reduce the number of
+        # datasets created, we group PSDs according to the frequency vectors.
+        #
+        # NOTE:  We assume here that any frequency array whose first and last several
+        # elements are equal are themselves equal.  This should cover all cases.
+
+        psd_sets = dict()
+        for k in self.keys:
+            freq = self.freq(k)
+            freq_str = f"{freq[:2]} {freq[-3:]}"
+            fhash = hashlib.md5(freq_str.encode("utf8")).hexdigest()
+            if fhash not in psd_sets:
+                psd_sets[fhash] = {
+                    "freq": freq,
+                    "indices": list(),
+                    "psds": list(),
+                    "keys": list(),
+                }
+            psd_sets[fhash]["psds"].append(self.psd(k))
+            psd_sets[fhash]["indices"].append(self.index(k))
+            psd_sets[fhash]["keys"].append(k)
+
+        # Create a dataset for each set of PSDs.  Also create separate datasets
+        # for the name and index of each PSD.
+        if participating:
+            for fhash, props in psd_sets.items():
+                freq = props["freq"]
+                psds = props["psds"]
+                indx = props["indices"]
+                keys = props["keys"]
+                nrows = 1 + len(psds)
+                ncols = len(freq)
+                ds = hf.create_dataset(fhash, (nrows, ncols), dtype=np.float64)
+                if comm is None or comm.rank == 0:
+                    ds[0] = freq
+                    ds[1:] = np.array(psds, dtype=np.float64)
+                del ds
+                ds = hf.create_dataset(f"{fhash}_indices", len(psds), dtype=np.int32)
+                if comm is None or comm.rank == 0:
+                    ds[:] = indx
+                del ds
+                keytype = np.dtype(f"a{maxstr}")
+                ds = hf.create_dataset(f"{fhash}_keys", len(psds), dtype=keytype)
+                if comm is None or comm.rank == 0:
+                    ds[:] = np.array(keys, dtype=keytype)
+                del ds
+
+    def _save_hdf5(self, handle, comm=None, force_serial=False, **kwargs):
         """Internal method which can be overridden by derived classes."""
+        parallel = have_hdf5_parallel()
+        if force_serial:
+            parallel = False
         if isinstance(handle, h5py.Group):
-            self._save_base_hdf5(handle, comm=comm)
+            self._save_base_hdf5(handle, comm=comm, force_serial=force_serial)
         else:
-            with h5py.File(handle, "w") as hf:
-                self._save_base_hdf5(hf, comm=comm)
+            hf = None
+            if parallel:
+                hf = h5py.File(handle, "w", driver="mpio", comm=comm)
+            elif comm is None or comm.rank == 0:
+                hf = h5py.File(handle, "w")
+            self._save_base_hdf5(hf, comm=comm, force_serial=force_serial)
+            if hf is not None:
+                hf.flush()
+                hf.close()
+            del hf
 
-    def save_hdf5(self, handle, comm=None, **kwargs):
+    def save_hdf5(self, handle, comm=None, force_serial=False, **kwargs):
         """Save the noise object to an HDF5 file.
 
         Args:
@@ -264,35 +319,64 @@ class Noise(object):
             None
 
         """
-        self._save_hdf5(handle, comm=comm, **kwargs)
+        self._save_hdf5(handle, comm=comm, force_serial=force_serial, **kwargs)
 
     def _load_base_hdf5(self, hf, comm=None):
-        """Read internal data from an open HDF5 file"""
+        """Read internal data from an open HDF5 group"""
         self._freqs = dict()
         self._psds = dict()
         self._rates = dict()
         self._indices = dict()
         self._mixmatrix = dict()
+        indx_pat = re.compile(r"(.*)_indices")
+        key_pat = re.compile(r"(.*)_keys")
+
+        # First load the mixing matrix, which provides all the key and detector names
+
+        dets = set()
+        keys = set()
+        for det, key, val in hf["mixing_matrix"]:
+            det = det.decode("utf-8")
+            key = key.decode("utf-8")
+            dets.add(det)
+            keys.add(key)
+            if det not in self._mixmatrix:
+                self._mixmatrix[det] = dict()
+            self._mixmatrix[det][key] = val
+        self._keys = list(sorted(keys))
+        self._dets = list(sorted(dets))
+
         for dsname in hf.keys():
-            ds = hf[dsname]
+            if indx_pat.match(dsname) is not None:
+                # Will be processed as part of the associated dataset below
+                continue
+            if key_pat.match(dsname) is not None:
+                # Will be processed as part of the associated dataset below
+                continue
             if dsname == "mixing_matrix":
-                dets = set()
-                keys = set()
-                for det, key, val in ds:
-                    det = det.decode("utf-8")
-                    key = key.decode("utf-8")
-                    dets.add(det)
-                    keys.add(key)
-                    if det not in self._mixmatrix:
-                        self._mixmatrix[det] = dict()
-                    self._mixmatrix[det][key] = val
-                self._keys = list(sorted(keys))
-                self._dets = list(sorted(dets))
-            else:
-                self._rates[dsname] = ds.attrs["rate"] * u.Hz
-                self._indices[dsname] = ds.attrs["index"]
-                self._freqs[dsname] = u.Quantity(ds[:, 0], u.Hz)
-                self._psds[dsname] = u.Quantity(ds[:, 1], u.K ** 2 * u.second)
+                # Already processed above
+                continue
+            indx_name = f"{dsname}_indices"
+            keys_name = f"{dsname}_keys"
+            if indx_name not in hf.keys() and keys_name not in hf.keys():
+                # This is not a PSD set
+                continue
+            # Before loading the PSD data, load the stream names and indices
+            ds = hf[keys_name]
+            psd_keys = [x.decode() for x in ds]
+            del ds
+            ds = hf[indx_name]
+            psd_indices = list(ds)
+            del ds
+
+            ds = hf[dsname]
+            freq = ds[0]
+            rate = 2.0 * freq[-1]
+            for key, indx, psdrow in zip(psd_keys, psd_indices, ds[1:]):
+                self._rates[key] = rate * u.Hz
+                self._indices[key] = indx
+                self._freqs[key] = u.Quantity(freq, u.Hz)
+                self._psds[key] = u.Quantity(psdrow, u.K ** 2 * u.second)
             del ds
 
     def _load_hdf5(self, handle, comm=None, **kwargs):

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -227,6 +227,7 @@ class Noise(object):
                     ],
                     axis=-1,
                 )
+            del ds
         # Now store the mixing matrix as a separate dataset
         mixdata = list()
         maxstr = 0
@@ -242,6 +243,7 @@ class Noise(object):
         ds = hf.create_dataset("mixing_matrix", (len(mixdata),), dtype=mixdtype)
         if comm is None or comm.rank == 0:
             ds[:] = np.array(mixdata, dtype=mixdtype)
+        del ds
 
     def _save_hdf5(self, handle, comm=None, **kwargs):
         """Internal method which can be overridden by derived classes."""
@@ -271,7 +273,8 @@ class Noise(object):
         self._rates = dict()
         self._indices = dict()
         self._mixmatrix = dict()
-        for dsname, ds in hf.items():
+        for dsname in hf.keys():
+            ds = hf[dsname]
             if dsname == "mixing_matrix":
                 dets = set()
                 keys = set()
@@ -290,6 +293,7 @@ class Noise(object):
                 self._indices[dsname] = ds.attrs["index"]
                 self._freqs[dsname] = u.Quantity(ds[:, 0], u.Hz)
                 self._psds[dsname] = u.Quantity(ds[:, 1], u.K ** 2 * u.second)
+            del ds
 
     def _load_hdf5(self, handle, comm=None, **kwargs):
         """Internal method which can be overridden by derived classes."""

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -347,8 +347,8 @@ class DetectorData(object):
             val = "<DetectorData (view)"
         else:
             val = "<DetectorData"
-        val += " {} detectors each with shape {} and type {}:".format(
-            len(self._detectors), self._shape[1:], self._dtype
+        val += " {} detectors each with shape {}, type {}, units {}:".format(
+            len(self._detectors), self._shape[1:], self._dtype, self._units
         )
         if self._shape[1] <= 4:
             for d in self._detectors:
@@ -724,8 +724,11 @@ class DetDataManager(MutableMapping):
             len(self.detectors), self.samples
         )
         for k in self._internal.keys():
-            val += "\n    {}: shape = {}, dtype = {}".format(
-                k, self._internal[k].shape, self._internal[k].dtype
+            val += "\n    {}: shape={}, dtype={}, units='{}'".format(
+                k,
+                self._internal[k].shape,
+                self._internal[k].dtype,
+                self._internal[k].units,
             )
         val += ">"
         return val
@@ -1252,8 +1255,8 @@ class SharedDataManager(MutableMapping):
         val = "<SharedDataManager"
         for k in self._internal.keys():
             val += f"\n    {k} ({self._internal[k].type}): "
-            val += f"shape = {self._internal[k].shdata.shape}, "
-            val += f"dtype = {self._internal[k].shdata.dtype}"
+            val += f"shape={self._internal[k].shdata.shape}, "
+            val += f"dtype={self._internal[k].shdata.dtype}"
         val += ">"
         return val
 

--- a/src/toast/ops/CMakeLists.txt
+++ b/src/toast/ops/CMakeLists.txt
@@ -54,5 +54,7 @@ install(FILES
     stokes_weights.py
     pixels_healpix.py
     filterbin.py
+    save_hdf5.py
+    load_hdf5.py
     DESTINATION ${PYTHON_SITE}/toast/ops
 )

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -99,3 +99,7 @@ from .stokes_weights import StokesWeights
 from .pixels_healpix import PixelsHealpix
 
 from .filterbin import FilterBin, combine_observation_matrix
+
+from .save_hdf5 import SaveHDF5
+
+from .load_hdf5 import LoadHDF5

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -305,7 +305,7 @@ class Demodulate(Operator):
         times = obs.shared[self.times].data.copy()
         if self.nskip != 1:
             offset = obs.local_index_offset
-            times = times[offset % self.nskip :: self.nskip]
+            times = np.array(times[offset % self.nskip :: self.nskip])
         return times
 
     @function_timer
@@ -383,7 +383,7 @@ class Demodulate(Operator):
         # flag invalid samples in both ends
         flags[: wkernel // 2] |= self.demod_flag_mask
         flags[-(wkernel // 2) :] |= self.demod_flag_mask
-        new_flags = flags[offset % self.nskip :: self.nskip]
+        new_flags = np.array(flags[offset % self.nskip :: self.nskip])
         return new_flags
 
     @function_timer
@@ -469,7 +469,7 @@ class Demodulate(Operator):
 
         quats = obs.shared[self.boresight].data
         demod_obs.shared[self.boresight].set(
-            quats[offset % self.nskip :: self.nskip],
+            np.array(quats[offset % self.nskip :: self.nskip]),
             offset=(0, 0),
             fromrank=0,
         )

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -348,6 +348,10 @@ class FilterBin(Operator):
         False, help="If True, output maps are in HDF5 rather than FITS format."
     )
 
+    write_hdf5_serial = Bool(
+        False, help="If True, force serial HDF5 write of output maps."
+    )
+
     reset_pix_dist = Bool(
         False,
         help="Clear any existing pixel distribution.  Useful when applying"
@@ -1164,6 +1168,7 @@ class FilterBin(Operator):
 
         log = Logger.get()
         timer = Timer()
+        timer.start()
 
         hits_name = f"{self.name}_hits"
         invcov_name = f"{self.name}_invcov"
@@ -1221,6 +1226,7 @@ class FilterBin(Operator):
                             data[key],
                             fname,
                             nest=self.binning.pixel_pointing.nest,
+                            force_serial=self.write_hdf5_serial,
                         )
                     else:
                         # Standard FITS output

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -42,7 +42,7 @@ class LoadHDF5(Operator):
         None, allow_none=True, help="Top-level directory containing the data volume"
     )
 
-    # FIXME:  We should add a filtering mechanism here to dump a subset of
+    # FIXME:  We should add a filtering mechanism here to load a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
     meta = List(None, allow_none=True, help="Only load this list of meta objects")

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import traitlets
+
+import os
+import glob
+
+import numpy as np
+
+import h5py
+
+from ..utils import Logger
+
+from ..dist import distribute_discrete
+
+from ..traits import trait_docs, Int, Unicode, List, Bool
+
+from ..timing import function_timer
+
+from .operator import Operator
+
+from ..observation import default_values as defaults
+
+from ..io import load_hdf5
+
+
+@trait_docs
+class LoadHDF5(Operator):
+    """Operator which loads HDF5 data files into observations.
+
+    This operator expects a top-level volume directory.
+
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    volume = Unicode(
+        None, allow_none=True, help="Top-level directory containing the data volume"
+    )
+
+    # FIXME:  We should add a filtering mechanism here to dump a subset of
+    # observations and / or detectors, as well as figure out subdirectory organization.
+
+    meta = List(None, allow_none=True, help="Only load this list of meta objects")
+
+    detdata = List(None, allow_none=True, help="Only load this list of detdata objects")
+
+    shared = List(None, allow_none=True, help="Only load this list of shared objects")
+
+    intervals = List(
+        None, allow_none=True, help="Only load this list of intervals objects"
+    )
+
+    sort_by_size = Bool(
+        False, help="If True, sort observations by size before load balancing"
+    )
+
+    process_rows = Int(
+        None,
+        allow_none=True,
+        help="The size of the rectangular process grid in the detector direction.",
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        log = Logger.get()
+
+        meta_fields = None
+        if self.meta is not None and len(self.meta) > 0:
+            meta_fields = list(self.meta)
+
+        shared_fields = None
+        if self.shared is not None and len(self.shared) > 0:
+            shared_fields = list(self.shared)
+
+        detdata_fields = None
+        if self.detdata is not None and len(self.detdata) > 0:
+            detdata_fields = list(self.detdata)
+
+        intervals_fields = None
+        if self.intervals is not None and len(self.intervals) > 0:
+            intervals_fields = list(self.intervals)
+
+        # FIXME:  Eventually we will use the volume index / DB to select observations
+        # and their sizes for a load-balanced assignment.  For now, we read this from
+        # the file.
+
+        # One global process computes the list of observations and their approximate
+        # relative size.
+
+        def _get_obs_samples(path):
+            n_samp = 0
+            with h5py.File(path, "r") as hf:
+                n_samp = int(hf.attrs["observation_samples"])
+            return n_samp
+
+        obs_props = list()
+        if data.comm.world_rank == 0:
+            for root, dirs, files in os.walk(self.volume):
+                # Process top-level files
+                obsfiles = glob.glob(os.path.join(root, "*.h5"))
+                if len(obsfiles) > 0:
+                    # Root directory contains observations
+                    for ofile in sorted(obsfiles):
+                        fsize = _get_obs_samples(ofile)
+                        obs_props.append((fsize, ofile))
+                # Also process sub-directories one level deep
+                for d in dirs:
+                    obsfiles = glob.glob(os.path.join(root, d, "*.h5"))
+                    if len(obsfiles) > 0:
+                        # This directory contains observations
+                        for ofile in sorted(obsfiles):
+                            fsize = _get_obs_samples(ofile)
+                            obs_props.append((fsize, ofile))
+                break
+        if self.sort_by_size:
+            obs_props.sort(key=lambda x: x[0])
+        else:
+            obs_props.sort(key=lambda x: x[1])
+        if data.comm.comm_world is not None:
+            obs_props = data.comm.comm_world.bcast(obs_props, root=0)
+
+        # Distribute observations among groups
+
+        obs_sizes = [x[0] for x in obs_props]
+        groupdist = distribute_discrete(obs_sizes, data.comm.ngroups)
+        group_firstobs = groupdist[data.comm.group].offset
+        group_numobs = groupdist[data.comm.group].n_elem
+
+        # Every group loads its observations
+        for obindx in range(group_firstobs, group_firstobs + group_numobs):
+            obfile = obs_props[obindx][1]
+
+            ob = load_hdf5(
+                obfile,
+                data.comm,
+                process_rows=self.process_rows,
+                meta=meta_fields,
+                detdata=detdata_fields,
+                shared=shared_fields,
+                intervals=intervals_fields,
+            )
+
+            data.obs.append(ob)
+
+        return
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        return dict()
+
+    def _provides(self):
+        return dict()
+
+    def _accelerators(self):
+        return list()

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -135,6 +135,10 @@ class MapMaker(Operator):
         False, help="If True, outputs are in HDF5 rather than FITS format."
     )
 
+    write_hdf5_serial = Bool(
+        False, help="If True, force serial HDF5 write of output maps."
+    )
+
     write_noiseweighted_map = Bool(
         False,
         help="If True, write the noise-weighted map",
@@ -810,6 +814,7 @@ class MapMaker(Operator):
                         fname,
                         nest=map_binning.pixel_pointing.nest,
                         single_precision=True,
+                        force_serial=self.write_hdf5_serial,
                     )
                 else:
                     # Standard FITS output

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -117,10 +117,10 @@ class BuildHitMap(Operator):
             raise RuntimeError(msg)
 
         dist = data[self.pixel_dist]
-        if data.comm.world_rank == 0:
-            log.debug(
-                "Building hit map with pixel_distribution {}".format(self.pixel_dist)
-            )
+        log.verbose_rank(
+            f"Building hit map with pixel_distribution {self.pixel_dist}",
+            comm=data.comm.comm_world,
+        )
 
         hits = None
         if self.hits in data:
@@ -313,12 +313,10 @@ class BuildInverseCovariance(Operator):
             raise RuntimeError(msg)
 
         dist = data[self.pixel_dist]
-        if data.comm.world_rank == 0:
-            log.debug(
-                "Building inverse covariance with pixel_distribution {}".format(
-                    self.pixel_dist
-                )
-            )
+        log.verbose_rank(
+            f"Building inverse covariance with pixel_distribution {self.pixel_dist}",
+            comm=data.comm.comm_world,
+        )
 
         invcov = None
         weight_nnz = None

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ..utils import Logger
 
-from ..traits import trait_docs, Int, Unicode, List, Dict
+from ..traits import trait_docs, Int, Unicode, List, Dict, Bool
 
 from ..timing import function_timer
 
@@ -51,6 +51,10 @@ class SaveHDF5(Operator):
     times = Unicode(defaults.times, help="Observation shared key for timestamps")
 
     config = Dict(None, allow_none=True, help="Write this job config to the file")
+
+    force_serial = Bool(
+        False, help="Use serial HDF5 operations, even if parallel support available"
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -107,7 +107,7 @@ class SaveHDF5(Operator):
                 shared=shared_fields,
                 intervals=intervals_fields,
                 config=self.config,
-                times=self.times,
+                times=str(self.times),
                 force_serial=self.force_serial,
             )
 

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import traitlets
+
+import numpy as np
+
+from ..utils import Logger
+
+from ..traits import trait_docs, Int, Unicode, List, Dict
+
+from ..timing import function_timer
+
+from .operator import Operator
+
+from ..observation import default_values as defaults
+
+from ..io import save_hdf5
+
+
+@trait_docs
+class SaveHDF5(Operator):
+    """Operator which saves observations to HDF5.
+
+    This creates a file for each observation.
+
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    volume = Unicode("toast_out_hdf5", help="Top-level directory for the data volume")
+
+    # FIXME:  We should add a filtering mechanism here to dump a subset of
+    # observations and / or detectors, as well as figure out subdirectory organization.
+
+    meta = List(None, allow_none=True, help="Only save this list of meta objects")
+
+    detdata = List(None, allow_none=True, help="Only save this list of detdata objects")
+
+    shared = List(None, allow_none=True, help="Only save this list of shared objects")
+
+    intervals = List(
+        None, allow_none=True, help="Only save this list of intervals objects"
+    )
+
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
+    config = Dict(None, allow_none=True, help="Write this job config to the file")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        log = Logger.get()
+
+        # One process creates the top directory
+        if data.comm.world_rank == 0:
+            os.makedirs(self.volume, exist_ok=True)
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        meta_fields = None
+        if self.meta is not None and len(self.meta) > 0:
+            meta_fields = list(self.meta)
+
+        shared_fields = None
+        if self.shared is not None and len(self.shared) > 0:
+            shared_fields = list(self.shared)
+
+        detdata_fields = None
+        if self.detdata is not None and len(self.detdata) > 0:
+            detdata_fields = list(self.detdata)
+
+        intervals_fields = None
+        if self.intervals is not None and len(self.intervals) > 0:
+            intervals_fields = list(self.intervals)
+
+        for ob in data.obs:
+            # Observations must have a name for this to work
+            if ob.name is None:
+                raise RuntimeError(
+                    "Observations must have a name in order to save to HDF5 format"
+                )
+
+            # Check to see if any detector data objects are temporary and have just
+            # a partial list of detectors.  Delete these.
+
+            for dd in list(ob.detdata.keys()):
+                if ob.detdata[dd].detectors != ob.local_detectors:
+                    del ob.detdata[dd]
+
+            outpath = save_hdf5(
+                ob,
+                self.volume,
+                meta=meta_fields,
+                detdata=detdata_fields,
+                shared=shared_fields,
+                intervals=intervals_fields,
+                config=self.config,
+                times=self.times,
+            )
+
+        return
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "meta": list(),
+            "detdata": list(),
+            "intervals": list(),
+            "shared": [
+                self.times,
+            ],
+        }
+        if self.meta is not None:
+            req["meta"].extend(self.meta)
+        if self.detdata is not None:
+            req["detdata"].extend(self.detdata)
+        if self.intervals is not None:
+            req["intervals"].extend(self.intervals)
+        if self.shared is not None:
+            req["shared"].extend(self.shared)
+        return req
+
+    def _provides(self):
+        return dict()
+
+    def _accelerators(self):
+        return list()

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -108,6 +108,7 @@ class SaveHDF5(Operator):
                 intervals=intervals_fields,
                 config=self.config,
                 times=self.times,
+                force_serial=self.force_serial,
             )
 
         return

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -271,6 +271,18 @@ class SimSatellite(Operator):
 
     velocity = Unicode(defaults.velocity, help="Observation shared key for velocity")
 
+    det_data = Unicode(
+        defaults.det_data,
+        allow_none=True,
+        help="Observation detdata key to initialize",
+    )
+
+    det_flags = Unicode(
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to initialize",
+    )
+
     @traitlets.validate("telescope")
     def _check_telescope(self, proposal):
         tele = proposal["value"]
@@ -536,6 +548,16 @@ class SimSatellite(Operator):
                 hwp_step=self.hwp_step,
                 hwp_step_time=self.hwp_step_time,
             )
+
+            # Optionally initialize detector data
+
+            dets = ob.select_local_detectors(detectors)
+
+            if self.det_data is not None:
+                ob.detdata.ensure(self.det_data, dtype=np.float64, detectors=dets)
+
+            if self.det_flags is not None:
+                ob.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=dets)
 
             data.obs.append(ob)
 

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -458,8 +458,7 @@ def write_healpix_hdf5(
             dtype = np.int32
 
     if have_hdf5_parallel():
-        # Open the file for parallel access.  This will only work
-        # if HDF5 and h5py were compiled with MPI
+        # Open the file for parallel access.
         with h5py.File(path, "w", driver="mpio", comm=dist.comm) as f:
             # Each process writes their own submaps to the file
             dset = f.create_dataset(

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -397,7 +397,7 @@ def read_healpix_hdf5(pix, path, nest=True, comm_bytes=10000000):
 
 @function_timer
 def write_healpix_hdf5(
-    pix, path, nest=True, comm_bytes=10000000, single_precision=False
+    pix, path, nest=True, comm_bytes=10000000, single_precision=False, serial=True
 ):
     """Write pixel data to a HEALPix format HDF5 dataset.
 
@@ -410,6 +410,8 @@ def write_healpix_hdf5(
         nest (bool): If True, data is in NESTED ordering, else data is in RING.
         comm_bytes (int): The approximate message size to use.
         single_precision (bool): If True, write floats and integers in single precision
+        serial (bool):  If True, use the serial h5py implementation, even if
+            parallel support is available.
 
     Returns:
         None
@@ -457,7 +459,7 @@ def write_healpix_hdf5(
         elif dtype == np.int64:
             dtype = np.int32
 
-    if have_hdf5_parallel():
+    if have_hdf5_parallel() and not serial:
         # Open the file for parallel access.
         with h5py.File(path, "w", driver="mpio", comm=dist.comm) as f:
             # Each process writes their own submaps to the file

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -415,7 +415,6 @@ def write_healpix_hdf5(
         None
 
     """
-    global hdf5_is_parallel
     log = Logger.get()
 
     # The distribution

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -397,7 +397,7 @@ def read_healpix_hdf5(pix, path, nest=True, comm_bytes=10000000):
 
 @function_timer
 def write_healpix_hdf5(
-    pix, path, nest=True, comm_bytes=10000000, single_precision=False, serial=True
+    pix, path, nest=True, comm_bytes=10000000, single_precision=False, force_serial=True
 ):
     """Write pixel data to a HEALPix format HDF5 dataset.
 
@@ -410,7 +410,7 @@ def write_healpix_hdf5(
         nest (bool): If True, data is in NESTED ordering, else data is in RING.
         comm_bytes (int): The approximate message size to use.
         single_precision (bool): If True, write floats and integers in single precision
-        serial (bool):  If True, use the serial h5py implementation, even if
+        force_serial (bool):  If True, use the serial h5py implementation, even if
             parallel support is available.
 
     Returns:
@@ -459,7 +459,7 @@ def write_healpix_hdf5(
         elif dtype == np.int64:
             dtype = np.int32
 
-    if have_hdf5_parallel() and not serial:
+    if have_hdf5_parallel() and not force_serial:
         # Open the file for parallel access.
         with h5py.File(path, "w", driver="mpio", comm=dist.comm) as f:
             # Each process writes their own submaps to the file

--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -104,6 +104,20 @@ def parse_arguments():
         action="store_true",
         help="Save simulated data to SPT3G format.",
     )
+    parser.add_argument(
+        "--save_hdf5",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Save simulated data to HDF5 format.",
+    )
+    parser.add_argument(
+        "--max_n_det",
+        required=False,
+        default=None,
+        type=int,
+        help="Override the maximum number of detectors",
+    )
     if toast.ops.madam.available():
         parser.add_argument(
             "--madam",
@@ -144,6 +158,7 @@ def parse_arguments():
             tau=5 * u.ms,
             tau_sigma=0.01,
         ),
+        toast.ops.SaveHDF5(name="save_hdf5", enabled=False),
         toast.ops.Statistics(name="filtered_statistics"),
         toast.ops.GroundFilter(name="groundfilter"),
         toast.ops.PolyFilter(name="polyfilter1D"),
@@ -181,9 +196,10 @@ def parse_arguments():
     # hardcoded arguments
     # focal plane
     args.sample_rate = 100  # sample_rate is nb sample per second.
-    args.max_detector = (
-        2054  # Hex-packed 1027 pixels (18 rings) times two dets per pixel.
-    )
+    args.max_detector = 2054
+    if args.max_n_det is not None:
+        args.max_detector = args.max_n_det
+
     args.width = 10.0
     args.psd_net = 50.0e-6
     args.psd_fmin = 1.0e-5
@@ -468,6 +484,11 @@ def main():
     # Apply a time constant
     job_ops.convolve_time_constant.apply(data)
     log.info_rank("Convolved time constant in", comm=world_comm, timer=timer)
+
+    # Optionally save to HDF5 in our output directory
+    job_ops.save_hdf5.volume = os.path.join(args.out_dir, "data")
+    job_ops.save_hdf5.apply(data)
+    log.info_rank("Saved data to HDF5 in", comm=world_comm, timer=timer)
 
     # Optionally save data to SPT3G format.  This is expensive and the configuration
     # is specific to this particular workflow, which is why the details are not

--- a/src/toast/scripts/toast_benchmark_ground_setup
+++ b/src/toast/scripts/toast_benchmark_ground_setup
@@ -119,8 +119,14 @@ def parse_arguments():
         "SETTING_SCAN_35,HORIZONTAL,1.00,210.00,330.00,35.00,1500",
     ]
     args.schedule_start = "2027-01-01 00:00:00"
+
+    args.schedule_stop = "2027-04-01 00:00:00"
+
+    # This produces about 26000 scans:
     # args.schedule_stop = "2027-12-31 00:00:00"
-    args.schedule_stop = "2027-01-01 01:00:00"
+
+    # This produces 75 scans:
+    # args.schedule_stop = "2027-01-01 01:00:00"
 
     # scan map
     args.nside = 4096

--- a/src/toast/scripts/toast_benchmark_satellite
+++ b/src/toast/scripts/toast_benchmark_satellite
@@ -110,6 +110,7 @@ def parse_arguments():
         toast.ops.PointingDetectorSimple(name="det_pointing"),
         toast.ops.PixelsHealpix(name="pixels"),
         toast.ops.StokesWeights(name="weights", mode="IQU"),
+        toast.ops.SaveHDF5(name="save_hdf5", enabled=False),
         toast.ops.BinMap(name="binner", pixel_dist="pix_dist"),
         toast.ops.MapMaker(
             name="mapmaker",
@@ -292,6 +293,11 @@ def main():
     # Simulate detector noise
     job_ops.sim_noise.apply(data)
     log.info_rank("Simulated detector noise in", comm=world_comm, timer=timer)
+
+    # Optionally save to HDF5 in our output directory
+    job_ops.save_hdf5.volume = os.path.join(args.out_dir, "data")
+    job_ops.save_hdf5.apply(data)
+    log.info_rank("Saved data to HDF5 in", comm=world_comm, timer=timer)
 
     # Destripe and/or bin TOD
     if toast.ops.madam.available() and args.madam:

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -278,14 +278,14 @@ class export_obs_meta(object):
         # Serialize focalplane to HDF5 bytes and write to frame.
         byte_writer = io.BytesIO()
         with h5py.File(byte_writer, "w") as f:
-            obs.telescope.focalplane.save_hdf5(f)
+            obs.telescope.focalplane.save_hdf5(f, comm=None, force_serial=True)
         cal["focalplane"] = c3g.G3VectorUnsignedChar(byte_writer.getvalue())
         del byte_writer
 
         # Serialize noise models
         for m_in, m_out in self._noise_models:
             byte_writer = io.BytesIO()
-            obs[m_in].save_hdf5(byte_writer)
+            obs[m_in].save_hdf5(byte_writer, comm=None, force_serial=True)
             cal[m_out] = c3g.G3VectorUnsignedChar(byte_writer.getvalue())
             del byte_writer
             cal[f"{m_out}_class"] = c3g.G3String(object_fullname(obs[m_in].__class__))

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -278,7 +278,7 @@ class export_obs_meta(object):
         # Serialize focalplane to HDF5 bytes and write to frame.
         byte_writer = io.BytesIO()
         with h5py.File(byte_writer, "w") as f:
-            obs.telescope.focalplane.write(f)
+            obs.telescope.focalplane.save_hdf5(f)
         cal["focalplane"] = c3g.G3VectorUnsignedChar(byte_writer.getvalue())
         del byte_writer
 

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -57,5 +57,6 @@ install(FILES
     ops_sss.py
     ops_demodulate.py
     ops_filterbin.py
+    io_hdf5.py
     DESTINATION ${PYTHON_SITE}/toast/tests
 )

--- a/src/toast/tests/instrument.py
+++ b/src/toast/tests/instrument.py
@@ -36,14 +36,14 @@ class InstrumentTest(MPITestCase):
         check_file = os.path.join(self.outdir, "check.h5")
 
         if self.comm is None or self.comm.rank == 0:
-            fp.write(fp_file)
+            fp.save_hdf5(fp_file)
         if self.comm is not None:
             self.comm.barrier()
 
-        newfp = Focalplane(file=fp_file)
+        newfp = Focalplane(file=fp_file, comm=self.comm)
 
         if self.comm is None or self.comm.rank == 0:
-            newfp.write(check_file)
+            newfp.save_hdf5(check_file)
         if self.comm is not None:
             self.comm.barrier()
 
@@ -88,11 +88,11 @@ class InstrumentTest(MPITestCase):
         check_file = os.path.join(self.outdir, "check_full.h5")
 
         if self.comm is None or self.comm.rank == 0:
-            fp.write(fp_file)
+            fp.save_hdf5(fp_file)
         if self.comm is not None:
             self.comm.barrier()
 
-        newfp = Focalplane(file=fp_file)
+        newfp = Focalplane(file=fp_file, comm=self.comm)
 
         # Test getting noise PSD
         psd = newfp.noise.psd(names[-1])
@@ -104,7 +104,7 @@ class InstrumentTest(MPITestCase):
         result2 = newfp.bandpass.convolve(names[-1], freqs, values, rj=True)
 
         if self.comm is None or self.comm.rank == 0:
-            newfp.write(check_file)
+            newfp.save_hdf5(check_file)
         if self.comm is not None:
             self.comm.barrier()
 
@@ -125,6 +125,6 @@ class InstrumentTest(MPITestCase):
         fake_file = os.path.join(self.outdir, "fake_hex.h5")
 
         if self.comm is None or self.comm.rank == 0:
-            fp.write(fake_file)
+            fp.save_hdf5(fake_file)
         if self.comm is not None:
             self.comm.barrier()

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -3,6 +3,7 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
+import sys
 
 import numpy as np
 
@@ -86,9 +87,20 @@ class IoHdf5Test(MPITestCase):
 
         # Export the data, and make a copy for later comparison.
         original = list()
+        obfiles = list()
         for ob in data.obs:
             original.append(ob.duplicate(times="times"))
-            save_hdf5(ob, datadir, config=config)
+            try:
+                obf = save_hdf5(ob, datadir, config=config)
+                obfiles.append(obf)
+            except:
+                import traceback
+
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
+                lines = [f"Proc {self.comm.rank}: {x}" for x in lines]
+                msg = "".join(lines)
+                print(msg)
 
         # # Import the data
         # check_data = Data(comm=data.comm)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -17,7 +17,7 @@ from ..mpi import MPI
 
 from ..data import Data
 
-from ..io import save_hdf5
+from ..io import save_hdf5, load_hdf5
 
 from ..config import build_config
 
@@ -102,11 +102,11 @@ class IoHdf5Test(MPITestCase):
                 msg = "".join(lines)
                 print(msg)
 
-        # # Import the data
-        # check_data = Data(comm=data.comm)
+        # Import the data
+        check_data = Data(comm=data.comm)
 
-        # for obframes in g3data:
-        #     check_data.obs.append(importer(obframes))
+        for hfile in obfiles:
+            check_data.obs.append(load_hdf5(hfile, check_data.comm))
 
         # for ob in check_data.obs:
         #     ob.redistribute(ob.comm_size, times="times")
@@ -116,3 +116,34 @@ class IoHdf5Test(MPITestCase):
         #     if ob != orig:
         #         print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
         #     self.assertTrue(ob == orig)
+
+    # def test_save_load_ops(self):
+    #     rank = 0
+    #     if self.comm is not None:
+    #         rank = self.comm.rank
+
+    #     datadir = os.path.join(self.outdir, "save_load_ops")
+    #     if rank == 0:
+    #         os.makedirs(datadir)
+    #     if self.comm is not None:
+    #         self.comm.barrier()
+
+    #     data, config = self.create_data()
+
+    #     # Make a copy for later comparison.
+    #     original = list()
+    #     for ob in data.obs:
+    #         original.append(ob.duplicate(times="times"))
+
+    #     saver = ops.SaveHDF5(volume=datadir, config=config)
+    #     saver.apply(data)
+
+    #     check_data = Data(data.comm)
+    #     loader = ops.LoadHDF5(volumne=datadir)
+    #     loader.apply(check_data)
+
+    #     # # Verify
+    #     # for ob, orig in zip(check_data.obs, original):
+    #     #     if ob != orig:
+    #     #         print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
+    #     #     self.assertTrue(ob == orig)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -88,7 +88,7 @@ class IoHdf5Test(MPITestCase):
         original = list()
         for ob in data.obs:
             original.append(ob.duplicate(times="times"))
-            save_hdf5(ob, dir=datadir, config=config)
+            save_hdf5(ob, datadir, config=config)
 
         # # Import the data
         # check_data = Data(comm=data.comm)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+
+from astropy import units as u
+
+from .mpi import MPITestCase
+
+from .. import ops as ops
+
+from ..mpi import MPI
+
+from ..data import Data
+
+from ..io import save_hdf5
+
+from ..config import build_config
+
+from ._helpers import create_outdir, create_ground_data
+
+
+class IoHdf5Test(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+    def create_data(self):
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model="noise_model",
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(noise_model=el_model.out_model)
+        sim_noise.apply(data)
+
+        config = build_config(
+            [
+                detpointing_azel,
+                default_model,
+                el_model,
+                sim_noise,
+            ]
+        )
+
+        # Make another detdata object with units for testing
+        for ob in data.obs:
+            ob.detdata.create("alt_signal", dtype=np.float64, units=u.Kelvin)
+            ob.detdata["alt_signal"][:] = 2.725 * np.ones(
+                (len(ob.local_detectors), ob.n_local_samples)
+            )
+
+        return data, config
+
+    def test_save_load(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "save_load")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        data, config = self.create_data()
+
+        # Export the data, and make a copy for later comparison.
+        original = list()
+        for ob in data.obs:
+            original.append(ob.duplicate(times="times"))
+            save_hdf5(ob, dir=datadir, config=config)
+
+        # # Import the data
+        # check_data = Data(comm=data.comm)
+
+        # for obframes in g3data:
+        #     check_data.obs.append(importer(obframes))
+
+        # for ob in check_data.obs:
+        #     ob.redistribute(ob.comm_size, times="times")
+
+        # # Verify
+        # for ob, orig in zip(check_data.obs, original):
+        #     if ob != orig:
+        #         print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
+        #     self.assertTrue(ob == orig)

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -45,11 +45,10 @@ class InstrumentTest(MPITestCase):
 
         nse_file = os.path.join(self.outdir, "noise.h5")
 
-        if self.comm is None or self.comm.rank == 0:
-            nse.save_hdf5(nse_file)
-            new_nse = Noise()
-            new_nse.load_hdf5(nse_file)
-            self.assertTrue(nse == new_nse)
+        nse.save_hdf5(nse_file, comm=self.comm)
+        new_nse = Noise()
+        new_nse.load_hdf5(nse_file, comm=self.comm)
+        self.assertTrue(nse == new_nse)
 
     def test_analytic_hdf5(self):
         detnames = ["det_01a", "det_01b", "det_02a", "det_02b"]
@@ -70,8 +69,7 @@ class InstrumentTest(MPITestCase):
 
         nse_file = os.path.join(self.outdir, "sim_noise.h5")
 
-        if self.comm is None or self.comm.rank == 0:
-            nse.save_hdf5(nse_file)
-            new_nse = AnalyticNoise()
-            new_nse.load_hdf5(nse_file)
-            self.assertTrue(nse == new_nse)
+        nse.save_hdf5(nse_file, comm=self.comm)
+        new_nse = AnalyticNoise()
+        new_nse.load_hdf5(nse_file, comm=self.comm)
+        self.assertTrue(nse == new_nse)

--- a/src/toast/tests/ops_mapmaker_solve.py
+++ b/src/toast/tests/ops_mapmaker_solve.py
@@ -205,9 +205,6 @@ class MapmakerSolveTest(MPITestCase):
             low=-1000.0, high=1000.0, size=data["amplitudes"][tmpl.name].n_local
         )
 
-        for ob in data.obs:
-            ob.detdata.create(defaults.det_data)
-
         tmatrix.amplitudes = "amplitudes"
         tmatrix.det_data = defaults.det_data
         tmatrix.data = data

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -78,6 +78,7 @@ from . import template_offset as test_template_offset
 from . import template_fourier2d as test_template_fourier2d
 from . import template_subharmonic as test_template_subharmonic
 
+from . import io_hdf5 as test_io_hdf5
 
 #
 # from . import psd_math as testpsdmath
@@ -208,6 +209,8 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_template_offset))
         suite.addTest(loader.loadTestsFromModule(test_template_fourier2d))
         suite.addTest(loader.loadTestsFromModule(test_template_subharmonic))
+
+        suite.addTest(loader.loadTestsFromModule(test_io_hdf5))
 
         #
         # suite.addTest(loader.loadTestsFromModule(testopssimsss))

--- a/src/toast/tests/template_fourier2d.py
+++ b/src/toast/tests/template_fourier2d.py
@@ -36,10 +36,6 @@ class TemplateFourier2DTest(MPITestCase):
         noise_model = ops.DefaultNoiseModel()
         noise_model.apply(data)
 
-        # Create some empty detector data
-        for ob in data.obs:
-            ob.detdata.create(defaults.det_data, dtype=np.float64)
-
         tmpl = Fourier2D(
             det_data=defaults.det_data,
             det_flags=None,

--- a/src/toast/tests/template_offset.py
+++ b/src/toast/tests/template_offset.py
@@ -36,10 +36,6 @@ class TemplateOffsetTest(MPITestCase):
         noise_model = ops.DefaultNoiseModel()
         noise_model.apply(data)
 
-        # Create some empty detector data
-        for ob in data.obs:
-            ob.detdata.create(defaults.det_data, dtype=np.float64)
-
         # Use 1/10 of an observation as the baseline length.  Make it not evenly
         # divisible in order to test handling of the final amplitude.
         ob_time = (

--- a/src/toast/tests/template_subharmonic.py
+++ b/src/toast/tests/template_subharmonic.py
@@ -36,10 +36,6 @@ class TemplateSubHarmonicTest(MPITestCase):
         noise_model = ops.DefaultNoiseModel()
         noise_model.apply(data)
 
-        # Create some empty detector data
-        for ob in data.obs:
-            ob.detdata.create(defaults.det_data, dtype=np.float64)
-
         tmpl = SubHarmonic(
             det_data=defaults.det_data,
             det_flags=None,

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -324,6 +324,12 @@ def simulate_data(job, toast_comm, telescope, schedule):
     ops.mem_count.prefix = "After simulating noise"
     ops.mem_count.apply(data)
 
+    # Optionally write out the data
+    if ops.save_hdf5.volume is None:
+        ops.save_hdf5.volume = os.path.join(args.out_dir, "data")
+    ops.save_hdf5.apply(data)
+    log.info_rank("Saved HDF5 data in", comm=world_comm, timer=timer)
+
     return data
 
 
@@ -591,6 +597,7 @@ def main():
         toast.ops.TimeConstant(
             name="convolve_time_constant", deconvolve=False, enabled=False
         ),
+        toast.ops.SaveHDF5(name="save_hdf5", enabled=False),
         toast.ops.SimNoise(name="sim_noise"),
         toast.ops.PixelsHealpix(name="pixels_radec"),
         toast.ops.StokesWeights(name="weights_radec", mode="IQU"),

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -211,6 +211,12 @@ def simulate_data(job, toast_comm, telescope, schedule):
     ops.sim_noise.apply(data)
     log.info_rank("Simulated detector noise in", comm=world_comm, timer=timer)
 
+    # Optionally write out the data
+    if ops.save_hdf5.volume is None:
+        ops.save_hdf5.volume = os.path.join(args.out_dir, "data")
+    ops.save_hdf5.apply(data)
+    log.info_rank("Saved HDF5 data in", comm=world_comm, timer=timer)
+
     return data
 
 
@@ -288,6 +294,7 @@ def main():
         toast.ops.TimeConstant(
             name="deconvolve_time_constant", deconvolve=True, enabled=False
         ),
+        toast.ops.SaveHDF5(name="save_hdf5", enabled=False),
         toast.ops.BinMap(name="binner", pixel_dist="pix_dist"),
         toast.ops.MapMaker(name="mapmaker"),
         toast.ops.PixelsHealpix(name="pixels_final", enabled=False),


### PR DESCRIPTION
This PR adds support for round-trip save and load to HDF5, using MPI-IO if available.  There may be some small tweaks to this before merging and after more tests at scale on systems at NERSC.

Still for future work is porting additional features from the tidas package.