### PR TITLE
More I/O cleanups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,11 @@ conf["entry_points"] = {
         "toast_ground_schedule = toast.scripts.toast_ground_schedule:main",
         "toast_satellite_schedule = toast.scripts.toast_satellite_schedule:main",
         "toast_benchmark_satellite = toast.scripts.toast_benchmark_satellite:main",
+        "toast_benchmark_ground_setup = toast.scripts.toast_benchmark_ground_setup:main",
+        "toast_benchmark_ground = toast.scripts.toast_benchmark_ground:main",
+        "toast_healpix_convert = toast.scripts.toast_healpix_convert:main",
+        "toast_healpix_coadd = toast.scripts.toast_healpix_coadd:main",
+        "toast_hdf5_to_spt3g = toast.scripts.toast_hdf5_to_spt3g:main",
         "toast_timing_plot = toast.scripts.toast_timing_plot:main",
     ]
 }

--- a/src/toast/io/CMakeLists.txt
+++ b/src/toast/io/CMakeLists.txt
@@ -5,5 +5,6 @@ install(FILES
     __init__.py
     observation_hdf_save.py
     observation_hdf_load.py
+    observation_hdf_utils.py
     DESTINATION ${PYTHON_SITE}/toast/io
 )

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -32,10 +32,15 @@ from ..weather import SimWeather
 
 from ..observation import Observation
 
+from .observation_hdf_utils import check_dataset_buffer_size
+
 
 @function_timer
-def load_hdf5_shared(obs, hgrp, fields):
+def load_hdf5_shared(obs, hgrp, fields, log_prefix, parallel):
     log = Logger.get()
+
+    timer = Timer()
+    timer.start()
 
     # Get references to the distribution of detectors and samples
     proc_rows = obs.dist.process_rows
@@ -79,17 +84,28 @@ def load_hdf5_shared(obs, hgrp, fields):
         # Load the data on one process of the communicator
         data = None
         if shcomm is None or shcomm.rank == 0:
+            msg = f"Shared field {field} ({comm_type})"
+            check_dataset_buffer_size(msg, slc, dtype, parallel)
             data = np.array(ds[slc], copy=False).astype(obs.shared[field].dtype)
 
         obs.shared[field].set(data, fromrank=0)
         del ds
 
+        log.verbose_rank(
+            f"{log_prefix}  Shared finished {field} read in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
+
     return
 
 
 @function_timer
-def load_hdf5_detdata(obs, hgrp, fields):
+def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
     log = Logger.get()
+
+    timer = Timer()
+    timer.start()
 
     # Get references to the distribution of detectors and samples
     dist_samps = obs.dist.samps
@@ -109,9 +125,19 @@ def load_hdf5_detdata(obs, hgrp, fields):
         dtype = ds.dtype
         units = u.Unit(str(ds.attrs["units"]))
 
+        detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
+        hf_slice = [
+            slice(det_off, det_off + det_nelem, 1),
+            slice(samp_off, samp_off + samp_nelem, 1),
+        ]
         sample_shape = None
         if len(full_shape) > 2:
             sample_shape = full_shape[2:]
+            for dim in full_shape[2:]:
+                detdata_slice.append(slice(0, dim))
+                hf_slice.append(slice(0, dim))
+        detdata_slice = tuple(detdata_slice)
+        hf_slice = tuple(hf_slice)
 
         # All processes create their local detector data
         obs.detdata.create(
@@ -123,14 +149,24 @@ def load_hdf5_detdata(obs, hgrp, fields):
         )
 
         # All processes independently load their data
-        obs.detdata[field][:] = ds[
-            det_off : det_off + det_nelem, samp_off : samp_off + samp_nelem
-        ]
+        msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
+        check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
+        ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
+        log.verbose_rank(
+            f"{log_prefix}  Detdata finished {field} read in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
         del ds
 
 
 @function_timer
-def load_hdf5_intervals(obs, hgrp, times, fields):
+def load_hdf5_intervals(obs, hgrp, times, fields, log_prefix, parallel):
+    log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
     for field in list(hgrp.keys()):
         if fields is not None and field not in fields:
             continue
@@ -143,6 +179,11 @@ def load_hdf5_intervals(obs, hgrp, times, fields):
 
         obs.intervals.create(field, global_times, times, fromrank=0)
         del ds
+        log.verbose_rank(
+            f"{log_prefix}  Intervals finished {field} read in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
 
 
 # FIXME:  Add options here to prune detectors on load.
@@ -157,6 +198,7 @@ def load_hdf5(
     detdata=None,
     shared=None,
     intervals=None,
+    force_serial=False,
 ):
     """Load an HDF5 observation.
 
@@ -174,6 +216,8 @@ def load_hdf5(
         detdata (list):  Only save this list of detdata objects.
         shared (list):  Only save this list of shared objects.
         intervals (list):  Only save this list of intervals objects.
+        force_serial (bool):  If True, do not use HDF5 parallel support,
+            even if it is available.
 
     Returns:
         (Observation):  The constructed observation.
@@ -182,36 +226,46 @@ def load_hdf5(
     log = Logger.get()
     env = Environment.get()
     parallel = have_hdf5_parallel()
+    if force_serial:
+        parallel = False
+
+    timer = Timer()
+    timer.start()
+    log_prefix = f"HDF5 load {os.path.basename(path)}: "
 
     # Open the file and get the root group.  In both serial and parallel HDF5,
     # multiple readers are supported.  We open the file with all processes to
     # enable reading detector and shared data in parallel.
     hf = None
     hfgroup = None
-    file_version = None
+
     if parallel:
         hf = h5py.File(path, "r", driver="mpio", comm=comm.comm_group)
         hgroup = hf
-
     else:
         hf = h5py.File(path, "r")
         hgroup = hf
+    log.debug_rank(
+        f"{log_prefix}  Opened file {path} in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
 
     # Data format version check
-    file_version = hgroup.attrs["toast_format_version"]
+    file_version = int(hgroup.attrs["toast_format_version"])
     if file_version != 0:
         msg = f"HDF5 file '{path}' using unsupported data format {file_version}"
         log.error(msg)
         raise RuntimeError(msg)
 
     # Observation properties
-    obs_name = hgroup.attrs["observation_name"]
-    obs_uid = hgroup.attrs["observation_uid"]
+    obs_name = str(hgroup.attrs["observation_name"])
+    obs_uid = int(hgroup.attrs["observation_uid"])
     obs_dets = json.loads(hgroup.attrs["observation_detectors"])
     obs_det_sets = None
     if hgroup.attrs["observation_detector_sets"] != "NONE":
         obs_det_sets = json.loads(hgroup.attrs["observation_detector_sets"])
-    obs_samples = hgroup.attrs["observation_samples"]
+    obs_samples = int(hgroup.attrs["observation_samples"])
     obs_sample_sets = None
     if hgroup.attrs["observation_sample_sets"] != "NONE":
         obs_sample_sets = [
@@ -225,30 +279,30 @@ def load_hdf5(
     # generalize this and allow use of other classes.
 
     inst_group = hgroup["instrument"]
-    telescope_name = inst_group.attrs["telescope_name"]
-    telescope_class_name = inst_group.attrs["telescope_class"]
-    telescope_uid = inst_group.attrs["telescope_uid"]
+    telescope_name = str(inst_group.attrs["telescope_name"])
+    telescope_class_name = str(inst_group.attrs["telescope_class"])
+    telescope_uid = int(inst_group.attrs["telescope_uid"])
 
-    site_name = inst_group.attrs["site_name"]
-    site_class_name = inst_group.attrs["site_class"]
-    site_uid = inst_group.attrs["site_uid"]
+    site_name = str(inst_group.attrs["site_name"])
+    site_class_name = str(inst_group.attrs["site_class"])
+    site_uid = int(inst_group.attrs["site_uid"])
 
     site = None
     if "site_alt_m" in inst_group.attrs:
         # This is a ground based site
-        site_alt_m = inst_group.attrs["site_alt_m"]
-        site_lat_deg = inst_group.attrs["site_lat_deg"]
-        site_lon_deg = inst_group.attrs["site_lon_deg"]
+        site_alt_m = float(inst_group.attrs["site_alt_m"])
+        site_lat_deg = float(inst_group.attrs["site_lat_deg"])
+        site_lon_deg = float(inst_group.attrs["site_lon_deg"])
 
         weather = None
         if "site_weather_name" in inst_group.attrs:
-            weather_name = inst_group.attrs["site_weather_name"]
-            weather_realization = inst_group.attrs["site_weather_realization"]
+            weather_name = str(inst_group.attrs["site_weather_name"])
+            weather_realization = int(inst_group.attrs["site_weather_realization"])
             weather_max_pwv = None
             if inst_group.attrs["site_weather_max_pwv"] != "NONE":
-                weather_max_pwv = inst_group.attrs["site_weather_max_pwv"]
+                weather_max_pwv = float(inst_group.attrs["site_weather_max_pwv"])
             weather_time = datetime.datetime.fromtimestamp(
-                inst_group.attrs["site_weather_time"]
+                float(inst_group.attrs["site_weather_time"])
             )
             weather = SimWeather(
                 time=weather_time,
@@ -275,6 +329,12 @@ def load_hdf5(
         telescope_name, uid=telescope_uid, focalplane=focalplane, site=site
     )
     del inst_group
+
+    log.debug_rank(
+        f"{log_prefix} Loaded instrument properties in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
 
     # Create the observation
 
@@ -318,6 +378,8 @@ def load_hdf5(
             else:
                 obs[obj_name] = np.array(obj)
         del obj
+        if parallel and obs.comm.comm_group is not None:
+            obs.comm.comm_group.barrier()
 
     # Now extract attributes
     units_pat = re.compile(r"(.*)_units")
@@ -336,21 +398,49 @@ def load_hdf5(
 
     del meta_group
 
+    log.debug_rank(
+        f"{log_prefix} Finished other metadata in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
+
     # Load shared data
 
     shared_group = hgroup["shared"]
-    load_hdf5_shared(obs, shared_group, shared)
+    load_hdf5_shared(obs, shared_group, shared, log_prefix, parallel)
+    log.debug_rank(
+        f"{log_prefix} Finished shared data in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
 
     # Load intervals
 
     intervals_group = hgroup["intervals"]
     intervals_times = intervals_group.attrs["times"]
-    load_hdf5_intervals(obs, intervals_group, obs.shared[intervals_times], intervals)
+    load_hdf5_intervals(
+        obs,
+        intervals_group,
+        obs.shared[intervals_times],
+        intervals,
+        log_prefix,
+        parallel,
+    )
+    log.debug_rank(
+        f"{log_prefix} Finished intervals in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
 
     # Load detector data
 
     detdata_group = hgroup["detdata"]
-    load_hdf5_detdata(obs, detdata_group, detdata)
+    load_hdf5_detdata(obs, detdata_group, detdata, log_prefix, parallel)
+    log.debug_rank(
+        f"{log_prefix} Finished detector data in",
+        comm=comm.comm_group,
+        timer=timer,
+    )
 
     del shared_group
     del intervals_group

--- a/src/toast/io/observation_hdf_utils.py
+++ b/src/toast/io/observation_hdf_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import numpy as np
+
+import re
+import datetime
+
+from astropy import units as u
+
+import h5py
+
+import json
+
+from ..utils import (
+    Environment,
+    Logger,
+    import_from_name,
+    dtype_to_aligned,
+    have_hdf5_parallel,
+)
+
+from ..mpi import MPI
+
+from ..timing import Timer, function_timer, GlobalTimers
+
+from ..instrument import GroundSite, SpaceSite, Focalplane, Telescope
+
+from ..weather import SimWeather
+
+from ..observation import Observation
+
+
+def check_dataset_buffer_size(msg, slices, dtype, parallel):
+    """Check the buffer size that will be used for I/O.
+
+    When using HDF5 parallel I/O, reading or writing to a dataset with
+    a buffer size > 2GB will cause an error.  This function checks the
+    buffer size and issues a warning to provide more user feedback.
+
+    Args:
+        msg (str):  Message to write
+        slices (tuple):  The slices that will be used for I/O
+        dtype (numpy.dtype):  The data type
+        parallel (bool):  Whether parallel h5py is enabled.
+
+    Returns:
+        None
+
+    """
+    log = Logger.get()
+    if not parallel:
+        # No issues
+        return
+    nelem = 1
+    for slc in slices:
+        nelem *= slc.stop - slc.start
+    nbytes = nelem * dtype.itemsize
+    if nbytes >= 2147483647:
+        wmsg = f"{msg}:  buffer size of {nbytes} bytes > 2^31 - 1. "
+        wmsg += "  HDF5 parallel I/O will likely fail."
+        log.warning(wmsg)

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -65,6 +65,10 @@ class LoadHDF5(Operator):
         help="The size of the rectangular process grid in the detector direction.",
     )
 
+    force_serial = Bool(
+        False, help="Use serial HDF5 operations, even if parallel support available"
+    )
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
@@ -146,6 +150,7 @@ class LoadHDF5(Operator):
                 detdata=detdata_fields,
                 shared=shared_fields,
                 intervals=intervals_fields,
+                force_serial=self.force_serial,
             )
 
             data.obs.append(ob)

--- a/src/toast/ops/save_spt3g.py
+++ b/src/toast/ops/save_spt3g.py
@@ -49,6 +49,8 @@ class SaveSpt3g(Operator):
         help="Export class to create frames from an observation",
     )
 
+    purge = Bool(False, help="If True, delete observation data as it is saved")
+
     @traitlets.validate("obs_export")
     def _check_export(self, proposal):
         ex = proposal["value"]
@@ -117,9 +119,17 @@ class SaveSpt3g(Operator):
                 )
                 save_pipe.Run()
 
+                del save_pipe
+                del emitter
+
             if ob.comm.comm_group is not None:
                 ob.comm.comm_group.barrier()
 
+            if self.purge:
+                ob.clear()
+
+        if self.purge:
+            data.obs.clear()
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -10,9 +10,9 @@ install(PROGRAMS
     toast_benchmark_satellite
     toast_benchmark_ground
     toast_benchmark_ground_setup
-    benchmarking_utilities.py
     toast_healpix_convert
     toast_healpix_coadd
+    toast_hdf5_to_spt3g
     DESTINATION bin
 )
 

--- a/src/toast/scripts/toast_hdf5_to_spt3g
+++ b/src/toast/scripts/toast_hdf5_to_spt3g
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""
+This script loads HDF5 format data and exports to SPT3G format data.
+"""
+
+import os
+import sys
+import shutil
+import re
+
+import argparse
+
+import numpy as np
+
+from astropy import units as u
+
+import toast
+import toast.ops
+
+from toast.timing import gather_timers, dump
+
+from toast import spt3g as t3g
+from spt3g import core as c3g
+
+from toast.observation import default_values as defaults
+
+
+def parse_arguments():
+    """
+    Defines and parses the arguments for the script.
+    """
+    # defines the parameters of the script
+    parser = argparse.ArgumentParser(
+        description="Convert TOAST HDF5 data to SPT3G format"
+    )
+
+    # The operators we want to configure from the command line or a parameter file.
+    operators = [
+        toast.ops.LoadHDF5(
+            name="load_hdf5",
+        ),
+        toast.ops.SaveSpt3g(name="save_spt3g"),
+    ]
+
+    # Parse all of the operator configuration
+    config, args, jobargs = toast.parse_config(parser, operators=operators)
+
+    return config, args, jobargs
+
+
+def main():
+    env = toast.utils.Environment.get()
+    log = toast.utils.Logger.get()
+    env.enable_function_timers()
+    global_timer = toast.timing.GlobalTimers.get()
+    global_timer.start("toast_hdf5_to_spt3g (total)")
+
+    config, args, jobargs = parse_arguments()
+
+    # Instantiate our objects that were configured from the command line / files
+    job = toast.create_from_config(config)
+    job_ops = job.operators
+
+    # Use a group size of one
+    comm = toast.Comm(groupsize=1)
+
+    # Create the (initially empty) data
+    data = toast.Data(comm=comm)
+
+    # Load the data.
+    log.info_rank(
+        f"Loading HDF5 data from {job_ops.load_hdf5.volume}", comm=comm.comm_world
+    )
+    job_ops.load_hdf5.process_rows = 1
+    job_ops.load_hdf5.apply(data)
+
+    # Build up the lists of objects to export from the first observation
+
+    noise_models = list()
+    meta_arrays = list()
+    shared = list()
+    detdata = list()
+    intervals = list()
+
+    msg = "Exporting observation fields:"
+
+    ob = data.obs[0]
+    for k, v in ob.shared.items():
+        g3name = f"shared_{k}"
+        if re.match(r".*boresight.*", k) is not None:
+            # These are quaternions
+            msg += f"\n  (shared):    {k} (quaternions)"
+            shared.append((k, g3name, c3g.G3VectorQuat))
+        elif k == defaults.times:
+            # Timestamps are handled separately
+            continue
+        else:
+            msg += f"\n  (shared):    {k}"
+            shared.append((k, g3name, None))
+    for k, v in ob.detdata.items():
+        msg += f"\n  (detdata):   {k}"
+        detdata.append((k, k, None))
+    for k, v in ob.intervals.items():
+        msg += f"\n  (intervals): {k}"
+        intervals.append((k, k))
+    for k, v in ob.items():
+        if isinstance(v, toast.noise.Noise):
+            msg += f"\n  (noise):     {k}"
+            noise_models.append((k, k))
+        elif isinstance(v, np.ndarray) and len(v.shape) > 0:
+            if isinstance(v, u.Quantity):
+                raise NotImplementedError("Writing array quantities not yet supported")
+            msg += f"\n  (meta arr):  {k}"
+            meta_arrays.append((k, k))
+        else:
+            msg += f"\n  (meta):      {k}"
+
+    log.info_rank(msg, comm=comm.comm_world)
+
+    # Export the data
+
+    meta_exporter = t3g.export_obs_meta(
+        noise_models=noise_models,
+        meta_arrays=meta_arrays,
+    )
+    data_exporter = t3g.export_obs_data(
+        shared_names=shared,
+        det_names=detdata,
+        interval_names=intervals,
+        compress=True,
+    )
+    exporter = t3g.export_obs(
+        meta_export=meta_exporter,
+        data_export=data_exporter,
+        export_rank=0,
+    )
+
+    log.info_rank(
+        f"Exporting SPT3G data to {job_ops.save_spt3g.directory}", comm=comm.comm_world
+    )
+    job_ops.save_spt3g.obs_export = exporter
+    job_ops.save_spt3g.purge = True
+    job_ops.save_spt3g.apply(data)
+
+    # dumps all the timing information
+    global_timer.stop("toast_hdf5_to_spt3g (total)")
+    alltimers = gather_timers(comm=comm.comm_world)
+    if comm.world_rank == 0:
+        out = os.path.join(job_ops.save_spt3g.directory, "timing")
+        dump(alltimers, out)
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -222,6 +222,8 @@ class export_obs_meta(object):
 
     @function_timer
     def __call__(self, obs):
+        log = Logger.get()
+        log.verbose(f"Create observation frame for {obs.name}")
         # Construct observation frame
         ob = c3g.G3Frame(c3g.G3FrameType.Observation)
         ob["observation_name"] = c3g.G3String(obs.name)
@@ -353,6 +355,7 @@ class export_obs_data(object):
 
     @function_timer
     def __call__(self, obs):
+        log = Logger.get()
         frame_intervals = self._frame_intervals
         if frame_intervals is None:
             # We are using the sample set distribution for our frame boundaries.
@@ -379,6 +382,15 @@ class export_obs_data(object):
         output = list()
         frame_view = obs.view[frame_intervals]
         for ivw, tview in enumerate(frame_view.shared[self._timestamp_names[0]]):
+            msg = f"Create scan frame {obs.name}:{ivw} with fields:"
+            msg += f"\n  shared:  {self._timestamp_names[1]}"
+            nms = ", ".join([y for x, y, z in self._shared_names])
+            msg += f", {nms}"
+            nms = ", ".join([y for x, y, z in self._det_names])
+            msg += f"\n  detdata:  {nms}"
+            nms = ", ".join([y for x, y in self._interval_names])
+            msg += f"\n  intervals:  {nms}"
+            log.verbose(msg)
             # Construct the Scan frame
             frame = c3g.G3Frame(c3g.G3FrameType.Scan)
             # Add timestamps

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -96,6 +96,9 @@ class IoHdf5Test(MPITestCase):
                 )
                 obfiles.append(obf)
 
+            if self.comm is not None:
+                self.comm.barrier()
+
             # Import the data
             check_data = Data(comm=data.comm)
 


### PR DESCRIPTION
This includes a variety of I/O related things:
 
- Add scripts to setup.py that were missing
    
- Add more timing and logging to HDF5 loading
    
- When using parallel HDF5, warn the user if the per-process buffer size exceeds the 2^31 byte limit of MPI
    
- Use dataset read_direct() and write_direct() rather than fancy indexing in case it saves a copy
    
- Add explicit typecast when loading attributes for builtin observation metadata
    
- When writing spt3g data, add an option to purge the observation data copy