### PR TITLE
Dc1 tweaks006

### DIFF
--- a/src/libtoast/src/toast_atm.cpp
+++ b/src/libtoast/src/toast_atm.cpp
@@ -225,7 +225,7 @@ void toast::atm_sim_compress_flag_hits_rank(
         }
         double x = xstart + ix * xstep;
 
-        # pragma omp parallel for schedule(static, 10)
+        # pragma omp parallel for schedule(static, 4)
         for (int64_t iy = 0; iy < ny; ++iy) {
             double y = ystart + iy * ystep;
 
@@ -259,7 +259,7 @@ void toast::atm_sim_compress_flag_extend_rank(
             continue;
         }
 
-        # pragma omp parallel for schedule(static, 10)
+        # pragma omp parallel for schedule(static, 4)
         for (int64_t iy = 1; iy < ny; ++iy) {
             for (int64_t iz = 1; iz < nz; ++iz) {
                 int64_t offset = ix * xstride + iy * ystride + iz * zstride;

--- a/src/toast/atm.py
+++ b/src/toast/atm.py
@@ -377,6 +377,12 @@ class AtmSim(object):
 
             slice += 1
 
+        if self._rank == 0 and slice < self._ntask:
+            log.warning(
+                f"Not enough work for all MPI processes: there were {slice} "
+                f"slices and {self._ntask} MPI tasks."
+            )
+
         slice_starts = np.array(slice_starts, dtype=np.int32)
         slice_stops = np.array(slice_stops, dtype=np.int32)
 

--- a/src/toast/atm.py
+++ b/src/toast/atm.py
@@ -377,9 +377,9 @@ class AtmSim(object):
 
             slice += 1
 
-        if self._rank == 0 and slice < self._ntask:
+        if self._rank == 0 and slice + 1 < self._ntask:
             log.warning(
-                f"Not enough work for all MPI processes: there were {slice} "
+                f"Not enough work for all MPI processes: there were {slice + 1} "
                 f"slices and {self._ntask} MPI tasks."
             )
 

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -448,6 +448,13 @@ class Focalplane(object):
             log.debug_rank(f"Loading focalplane from {file}", comm=comm)
             self.load_hdf5(file, comm=comm)
 
+        if thinfp is not None:
+            # Pick only every `thinfp` pixel on the focal plane
+            ndet = len(self.detector_data)
+            for idet in range(ndet - 1, -1, -1):
+                if int(idet // 2) % thinfp != 0:
+                    del self.detector_data[idet]
+
         # Add UID if not given
         if "uid" not in self.detector_data.colnames:
             self.detector_data.add_column(
@@ -458,9 +465,6 @@ class Focalplane(object):
 
         # Build index of detector to table row
         self._det_to_row = {y["name"]: x for x, y in enumerate(self.detector_data)}
-
-        if thinfp is not None:
-            raise RuntimeError("thinfp not implemented yet.")
 
         if self.field_of_view is None:
             self._compute_fov()

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -423,6 +423,7 @@ class Focalplane(object):
         file (str):  Load the focalplane from this file.
         comm (MPI.Comm):  If loading from a file, optional communicator to broadcast
             across.
+        thinfp (int):  Only sample the detectors in the file.
 
     """
 
@@ -436,6 +437,7 @@ class Focalplane(object):
         sample_rate=None,
         file=None,
         comm=None,
+        thinfp=None,
     ):
         log = Logger.get()
         self.detector_data = detector_data
@@ -456,6 +458,9 @@ class Focalplane(object):
 
         # Build index of detector to table row
         self._det_to_row = {y["name"]: x for x, y in enumerate(self.detector_data)}
+
+        if thinfp is not None:
+            raise RuntimeError("thinfp not implemented yet.")
 
         if self.field_of_view is None:
             self._compute_fov()

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -413,6 +413,8 @@ class Focalplane(object):
         "elevation_noise_a" and "elevation_noise_c":  Parameters of elevation scaling
             noise model: PSD_{out} = PSD_{ref} * (a / sin(el) + c)^2.  Only applicable
             to ground data.
+        "pwv_a0", "pwv_a1" and "pwv_a2":  quadratic fit of the NET modulation by
+            PWV.  Only applicable to ground data.
 
     Args:
         detector_data (QTable):  Table of detector properties.

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -482,8 +482,9 @@ def exception_guard(comm=None):
         msg = "".join(lines)
         log.error(msg)
         # kills the job
-        if comm is None:
-            os._exit(1)
+        if comm is None or comm.size == 1:
+            # Raising the exception allows for debugging
+            raise
         else:
             if comm.size > 1:
                 # gives other processes a bit of time to see whether

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -18,6 +18,10 @@ from ..noise_sim import AnalyticNoise
 
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
 
+from ..observation import default_values as defaults
+
+from ..intervals import IntervalList
+
 from .. import qarray as qa
 
 from .operator import Operator
@@ -51,6 +55,8 @@ class ElevationNoise(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
     noise_model = Unicode(
         "noise_model", help="The observation key containing the input noise model"
     )
@@ -66,7 +72,9 @@ class ElevationNoise(Operator):
     )
 
     view = Unicode(
-        None, allow_none=True, help="Use this view of the data in all observations"
+        None, allow_none=True, help="Use this view of the data in all observations.  "
+        "Use 'middle' if the middle 10 seconds of each observation is enough to "
+        "determine the effective observing elevation",
     )
 
     noise_a = Float(
@@ -141,53 +149,69 @@ class ElevationNoise(Operator):
             log.error(msg)
             raise RuntimeError(msg)
 
-        for ob in data.obs:
-            focalplane = ob.telescope.focalplane
+        for obs in data.obs:
+            obs_data = data.select(obs_uid=obs.uid)
+            focalplane = obs.telescope.focalplane
+
+            if self.view == "middle" and self.view not in obs.intervals:
+                # Create a view that is just one minute in the middle
+                length = 10.  # in seconds
+                times = obs.shared[self.times]
+                t_start = times[0]
+                t_stop = times[-1]
+                t_middle = np.mean([t_start, t_stop])
+                t_start = max(t_start, t_middle - length / 2)
+                t_stop = min(t_stop, t_middle + length / 2)
+                obs.intervals[self.view] = IntervalList(
+                    timestamps=times, timespans=[(t_start, t_stop)]
+                )
 
             # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors)
+            dets = obs.select_local_detectors(detectors)
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
 
             # Check that the noise model exists
-            if self.noise_model not in ob:
+            if self.noise_model not in obs:
                 msg = "Noise model {self.noise_model} does not exist in " \
-                    "observation {ob.name}"
+                    "observation {obs.name}"
                 raise RuntimeError(msg)
 
             # Check that the view in the detector pointing operator covers
             # all the samples needed by this operator
 
             view = self.view
+            detector_pointing_view = self.detector_pointing.view
             if view is None:
                 # Use the same data view as detector pointing
                 view = self.detector_pointing.view
             elif self.detector_pointing.view is not None:
                 # Check that our view is fully covered by detector pointing
-                intervals = ob.intervals[self.view]
-                detector_intervals = ob.intervals[self.detector_pointing.view]
+                intervals = obs.intervals[self.view]
+                detector_intervals = obs.intervals[self.detector_pointing.view]
                 intersection = detector_intervals & intervals
                 if intersection != intervals:
                     msg = f"view {self.view} is not fully covered by valid " \
                         "detector pointing"
                     raise RuntimeError(msg)
+            self.detector_pointing.view = view
 
-            noise = ob[self.noise_model]
+            noise = obs[self.noise_model]
 
             out_noise = None
             if self.out_model is None or self.noise_model == self.out_model:
                 out_noise = noise
             else:
-                ob[self.out_model] = copy.deepcopy(noise)
-                out_noise = ob[self.out_model]
+                obs[self.out_model] = copy.deepcopy(noise)
+                out_noise = obs[self.out_model]
 
             # We are building up a data product (a noise model) which has values for
             # all detectors.  For each detector we need to expand the detector pointing.
             # Since the contributions for all views contribute to the scaling for each
             # detector, we loop over detectors first and then views.
 
-            views = ob.view[view]
+            views = obs.view[view]
 
             # The flags are common to all detectors, so we compute them once.
 
@@ -227,7 +251,8 @@ class ElevationNoise(Operator):
                     modulate_pwv = False
 
                 # Compute detector quaternions one detector at a time.
-                self.detector_pointing.apply(data, detectors=[det])
+                self.detector_pointing.apply(obs_data, detectors=[det])
+
                 el_view = list()
                 for vw in range(len(views)):
                     # Detector elevation
@@ -246,12 +271,15 @@ class ElevationNoise(Operator):
                 # Scale the PSD
                 el_factor = noise_a / np.sin(el) + noise_c
                 if modulate_pwv:
-                    pwv = ob.telescope.site.weather.pwv.to_value(u.mm)
+                    pwv = obs.telescope.site.weather.pwv.to_value(u.mm)
                     pwv_factor = pwv_a0 + pwv_a1 * pwv + pwv_a2 * pwv ** 2
                 else:
                     pwv_factor = 1
 
                 out_noise.psd(det)[:] *= el_factor ** 2 * pwv_factor ** 2
+
+            self.detector_pointing.view = detector_pointing_view
+
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -104,7 +104,7 @@ class ElevationNoise(Operator):
         " If not set, look for one in the Focalplane.",
     )
 
-    modulate_pwv = Bool(True, help="If True, modulate the NET based on PWV")
+    modulate_pwv = Bool(False, help="If True, modulate the NET based on PWV")
 
     @traitlets.validate("detector_pointing")
     def _check_detector_pointing(self, proposal):

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -291,8 +291,6 @@ class Madam(Operator):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        if not available():
-            raise RuntimeError("Madam is either not installed or MPI is disabled")
         self._cached = False
         self._logprefix = "Madam:"
 
@@ -324,8 +322,8 @@ class Madam(Operator):
     def _exec(self, data, detectors=None):
         log = Logger.get()
 
-        if not available:
-            raise RuntimeError("libmadam is not available")
+        if not available():
+            raise RuntimeError("Madam is either not installed or MPI is disabled")
 
         if len(data.obs) == 0:
             raise RuntimeError(

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -92,6 +92,8 @@ class SimGround(Operator):
         help="Name of built-in weather site (e.g. 'atacama', 'south_pole') or path to HDF5 file",
     )
 
+    realization = Int(0, help="The realization index")
+
     schedule = Instance(
         klass=GroundSchedule, allow_none=True, help="Instance of a GroundSchedule"
     )
@@ -701,6 +703,7 @@ class SimGround(Operator):
                         time=mid_time,
                         name=self.weather,
                         site_uid=site.uid,
+                        realization=self.realization,
                         max_pwv=self.max_pwv,
                         median_weather=self.median_weather,
                     )
@@ -710,6 +713,7 @@ class SimGround(Operator):
                         time=mid_time,
                         file=self.weather,
                         site_uid=site.uid,
+                        realization=self.realization,
                         max_pwv=self.max_pwv,
                         median_weather=self.median_weather,
                     )

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -229,7 +229,7 @@ def oscillate_el(
     tt = times - times[0]
     # Shift the starting time by a random phase
     np.random.seed(int(times[0] % 2 ** 32))
-    tt += np.random.rand() / self._el_mod_rate
+    tt += np.random.rand() / el_mod_rate
 
     if el_mod_sine:
         # elevation is modulated along a sine wave

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -243,6 +243,7 @@ class SimAtmosphere(Operator):
                 "view",
                 "quats",
                 "weights",
+                "mode",
             ]:
                 if not detweights.has_trait(trt):
                     msg = f"detector_weights operator should have a '{trt}' trait"

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -332,12 +332,16 @@ class Patch(object):
         self.step += 1
         self.el_min = self.el_min0
         self.el_max = self.el_max0
-        self.elevations = self.elevations0
-        self.az_min = 0
-        if self.alternate:
-            self.az_max = np.pi
-        else:
-            self.az_max = 2 * np.pi
+        try:
+            self.elevations = self.elevations0
+            self.az_min = 0
+            if self.alternate:
+                self.az_max = np.pi
+            else:
+                self.az_max = 2 * np.pi
+        except AttributeError:
+            # HorizontalPatch does not maintain a list of elevations
+            pass
         return
 
     def visible(

--- a/src/toast/scripts/toast_healpix_coadd
+++ b/src/toast/scripts/toast_healpix_coadd
@@ -26,8 +26,12 @@ from toast.pixels_io import (
     filename_is_hdf5,
     read_healpix,
     write_healpix,
+    write_healpix_fits,
+    write_healpix_hdf5,
 )
 from toast._libtoast import cov_eigendecompose_diag, cov_apply_diag
+from toast import PixelDistribution, PixelData
+from toast.covariance import covariance_invert, covariance_apply
 
 
 def main():
@@ -193,66 +197,86 @@ def main():
         if noiseweighted_sum is None:
             noiseweighted_sum = np.zeros([nnz, npix], dtype=float)
             invcov_sum = np.zeros([nnz2, npix], dtype=float)
-        if rank == 0:
-            comm.Reduce(MPI.IN_PLACE, noiseweighted_sum, op=MPI.SUM, root=0)
-            comm.Reduce(MPI.IN_PLACE, invcov_sum, op=MPI.SUM, root=0)
-        else:
-            comm.Reduce(noiseweighted_sum, None, op=MPI.SUM, root=0)
-            comm.Reduce(invcov_sum, None, op=MPI.SUM, root=0)
+        comm.Allreduce(MPI.IN_PLACE, noiseweighted_sum, op=MPI.SUM)
+        comm.Allreduce(MPI.IN_PLACE, invcov_sum, op=MPI.SUM)
         log.info_rank(f"Reduced inputs in", timer=timer, comm=comm)
-        if rank != 0:
-            del noiseweighted_sum
-            del invcov_sum
-
-    nsubmap = npix
-    npix_submap = 1
 
     if args.invcov is not None:
-        log.info(f"Writing {args.invcov}")
+        log.info_rank(f"Writing {args.invcov}", comm=comm)
         if rank == 0:
             write_healpix(
                 args.invcov, invcov_sum, nest=True, overwrite=True, dtype=dtype
             )
         log.info_rank(f"Wrote {args.invcov} in", timer=timer, comm=comm)
 
+    # Assign submaps, invert and apply local portions of the matrix
+
+    npix_submap = 12 * args.nside_submap ** 2
+    nsubmap = npix // npix_submap
+    local_submaps = [submap for submap in range(nsubmap) if submap % ntask == rank]
+    dist = PixelDistribution(
+        n_pix=npix, n_submap=nsubmap, local_submaps=local_submaps, comm=comm
+    )
+    dist_map = PixelData(dist, float, n_value=nnz)
+    dist_cov = PixelData(dist, float, n_value=nnz2)
+    for local_submap, global_submap in enumerate(local_submaps):
+        pix_start = global_submap * npix_submap
+        pix_stop = pix_start + npix_submap
+        dist_map.data[local_submap] = noiseweighted_sum[:, pix_start : pix_stop].T
+        dist_cov.data[local_submap] = invcov_sum[:, pix_start : pix_stop].T
+    del noiseweighted_sum
+    del invcov_sum
+
     log.info_rank("Inverting matrix", comm=comm)
-    if rank == 0:
-        rcond = np.zeros(npix, dtype=float)
-        cov = invcov_sum.T.ravel().astype(float).copy()
-        del invcov_sum
-        cov_eigendecompose_diag(
-            nsubmap, npix_submap, nnz, cov, rcond, args.rcond_limit, True
-        )
+    dist_rcond = PixelData(dist, float, n_value=1)
+    covariance_invert(dist_cov, args.rcond_limit, rcond=dist_rcond, use_alltoallv=True)
     log.info_rank(f"Inverted matrix", timer=timer, comm=comm)
 
     if args.rcond is not None:
         log.info_rank(f"Writing {args.rcond}", comm=comm)
-        if rank == 0:
-            write_healpix(args.rcond, rcond, nest=True, overwrite=True, dtype=dtype)
+        if filename_is_fits(args.rcond):
+            write_healpix_fits(dist_rcond, args.rcond, nest=True)
+        else:
+            write_healpix_hdf5(
+                dist_rcond,
+                args.rcond,
+                nest=True,
+                single_precision=not args.double_precision,
+                force_serial=True
+            )
         log.info_rank(f"Wrote {args.rcond}", timer=timer, comm=comm)
-    if rank == 0:
-        del rcond
+    del dist_rcond
 
-    log.info("Applying matrix")
-    if rank == 0:
-        coadd_map = noiseweighted_sum.T.ravel().astype(float).copy()
-        del noiseweighted_sum
-        cov_apply_diag(nsubmap, npix_submap, nnz, cov.data, coadd_map.data)
+    log.info_rank("Applying matrix", comm=comm)
+    covariance_apply(dist_cov, dist_map, use_alltoallv=True)
     log.info_rank(f"Applied matrix in", timer=timer, comm=comm)
 
     if args.cov is not None:
         log.info_rank(f"Writing {args.cov}", comm=comm)
-        if rank == 0:
-            cov = cov.reshape(npix, -1).T.copy()
-            write_healpix(args.cov, cov, nest=True, overwrite=True, dtype=dtype)
+        if filename_is_fits(args.cov):
+            write_healpix_fits(dist_cov, args.cov, nest=True)
+        else:
+            write_healpix_hdf5(
+                dist_cov,
+                args.cov,
+                nest=True,
+                single_precision=not args.double_precision,
+                force_serial=True
+            )
         log.info_rank(f"Wrote {args.cov}", timer=timer, comm=comm)
-    if rank == 0:
-        del cov
+    del dist_cov
 
     log.info_rank(f"Writing {args.outmap}", comm=comm)
-    if rank == 0:
-        coadd_map = coadd_map.reshape(npix, -1).T.copy()
-        write_healpix(args.outmap, coadd_map, nest=True, overwrite=True, dtype=dtype)
+    if filename_is_fits(args.outmap):
+        write_healpix_fits(dist_map, args.outmap, nest=True)
+    else:
+        write_healpix_hdf5(
+            dist_map,
+            args.outmap,
+            nest=True,
+            single_precision=not args.double_precision,
+            force_serial=True
+        )
     log.info_rank(f"Wrote {args.outmap}", timer=timer, comm=comm)
 
     log.info_rank(f"Co-add done in", timer=timer0, comm=comm)

--- a/src/toast/scripts/toast_healpix_coadd
+++ b/src/toast/scripts/toast_healpix_coadd
@@ -86,7 +86,20 @@ def main():
         help="Reciprocal condition number limit",
     )
 
+    parser.add_argument(
+        "--double_precision",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Output in double precision",
+    )
+
     args = parser.parse_args()
+
+    if args.double_precision:
+        dtype = np.float64
+    else:
+        dtype = np.float32
 
     noiseweighted_sum = None
     invcov_sum = None
@@ -197,7 +210,9 @@ def main():
     if args.invcov is not None:
         log.info(f"Writing {args.invcov}")
         if rank == 0:
-            write_healpix(args.invcov, invcov_sum, nest=True, overwrite=True)
+            write_healpix(
+                args.invcov, invcov_sum, nest=True, overwrite=True, dtype=dtype
+            )
         log.info_rank(f"Wrote {args.invcov} in", timer=timer, comm=comm)
 
     log.info_rank("Inverting matrix", comm=comm)
@@ -213,7 +228,7 @@ def main():
     if args.rcond is not None:
         log.info_rank(f"Writing {args.rcond}", comm=comm)
         if rank == 0:
-            write_healpix(args.rcond, rcond, nest=True, overwrite=True)
+            write_healpix(args.rcond, rcond, nest=True, overwrite=True, dtype=dtype)
         log.info_rank(f"Wrote {args.rcond}", timer=timer, comm=comm)
     if rank == 0:
         del rcond
@@ -229,7 +244,7 @@ def main():
         log.info_rank(f"Writing {args.cov}", comm=comm)
         if rank == 0:
             cov = cov.reshape(npix, -1).T.copy()
-            write_healpix(args.cov, cov, nest=True, overwrite=True)
+            write_healpix(args.cov, cov, nest=True, overwrite=True, dtype=dtype)
         log.info_rank(f"Wrote {args.cov}", timer=timer, comm=comm)
     if rank == 0:
         del cov
@@ -237,10 +252,13 @@ def main():
     log.info_rank(f"Writing {args.outmap}", comm=comm)
     if rank == 0:
         coadd_map = coadd_map.reshape(npix, -1).T.copy()
-        write_healpix(args.outmap, coadd_map, nest=True, overwrite=True)
+        write_healpix(args.outmap, coadd_map, nest=True, overwrite=True, dtype=dtype)
     log.info_rank(f"Wrote {args.outmap}", timer=timer, comm=comm)
 
     log.info_rank(f"Co-add done in", timer=timer0, comm=comm)
+
+    if comm is not None:
+        comm.Barrier()
 
     return
 

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -626,7 +626,10 @@ def main():
     # Get optional MPI parameters
     comm, procs, rank = toast.get_world()
 
-    nthread = os.environ["OMP_NUM_THREADS"]
+    if "OMP_NUM_THREADS" in os.environ:
+        nthread = os.environ["OMP_NUM_THREADS"]
+    else:
+        nthread = "unknown number of"
     log.info_rank(
         f"Executing workflow with {procs} MPI tasks, each with "
         f"{nthread} OpenMP threads at {datetime.datetime.now()}",

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -273,7 +273,6 @@ def simulate_data(job, toast_comm, telescope, schedule):
 
     ops.elevation_model.noise_model = ops.default_model.noise_model
     ops.elevation_model.detector_pointing = ops.det_pointing_azel
-    ops.elevation_model.view = ops.det_pointing_azel.view
     ops.elevation_model.apply(data)
     log.info_rank("  Created elevation noise model in", comm=world_comm, timer=timer)
 

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -95,6 +95,13 @@ def parse_config(operators, templates, comm):
         help="Override focalplane sampling rate [Hz]",
     )
 
+    parser.add_argument(
+        "--thinfp",
+        required=False,
+        type=int,
+        help="Only sample the provided focalplane pixels",
+    )
+
     # Build a config dictionary starting from the operator defaults, overriding with any
     # config files specified with the '--config' commandline option, followed by any
     # individually specified parameter overrides.
@@ -130,7 +137,7 @@ def load_instrument_and_schedule(args, comm):
     else:
         sample_rate = None
     focalplane = toast.instrument.Focalplane(
-        file=args.focalplane, comm=comm, sample_rate=sample_rate
+        file=args.focalplane, comm=comm, sample_rate=sample_rate, thinfp=args.thinfp
     )
     log.info_rank("Loaded focalplane in", comm=comm, timer=timer)
     mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)


### PR DESCRIPTION
This PR introduces a number of small tweaks:

- Issue a warning when atmospheric simulation does not have enough work for all tasks
- add a shortcut when distributing observations to a group of maximum size
- add PWV modulation support to elevation noise model
- add `thinfp` parameter to loading focalplane data
- raise the actual exception instead of `exit()` when running serially
- speed up elevation noise significantly by only expanding the pointing in the middle of the observation
- add option to apply an extra scaling to NET in the elevation noise operator
- add `realization` trait to sim_ground so that simulated weather conforms to the right realization
- fix a branching bug in interpolating azimuth for sampled atmosphere
- add helpful error messages to loading HDF5 files
- fix a bug in scheduler related to horizontal patches and observing breaks
- allow user to control the output precision in `healpix_coadd` script