### PR TITLE
Fix the ElevationNoise operator

### DIFF
--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -104,6 +104,11 @@ class Noise(object):
         """(list): list of strings containing the PSD names."""
         return self._keys
 
+    @property
+    def mixing_matrix(self):
+        """(dict): the full mixing matrix."""
+        return self._mixmatrix
+
     def multiply_ntt(self, key, data):
         """Filter the data with noise covariance."""
         raise NotImplementedError("multiply_ntt not yet implemented")

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ install(FILES
     io_hdf5.py
     ops_noise_estim.py
     ops_yield_cut.py
+    ops_elevation_noise.py
     accelerator.py
     DESTINATION ${PYTHON_SITE}/toast/tests
 )

--- a/src/toast/tests/ops_elevation_noise.py
+++ b/src/toast/tests/ops_elevation_noise.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import sys
+
+import numpy as np
+
+from astropy import units as u
+
+from .mpi import MPITestCase
+
+from .. import ops as ops
+
+from ..mpi import MPI
+
+from ..data import Data
+
+from ._helpers import create_outdir, create_ground_data
+
+
+class ElevationNoiseTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+    def test_create_new(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model=default_model.noise_model,
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(noise_model=el_model.out_model)
+        sim_noise.apply(data)
+
+    def test_replace(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Make an elevation-dependent noise model, overwriting original
+        el_model = ops.ElevationNoise(
+            noise_model=default_model.noise_model,
+            out_model=None,
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(noise_model=el_model.noise_model)
+        sim_noise.apply(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -72,6 +72,7 @@ from . import ops_demodulate as test_ops_demodulate
 from . import ops_filterbin as test_ops_filterbin
 from . import ops_noise_estim as test_ops_noise_estim
 from . import ops_yield_cut as test_ops_yield_cut
+from . import ops_elevation_noise as test_ops_elevation_noise
 
 from . import covariance as test_covariance
 
@@ -208,6 +209,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_ops_filterbin))
         suite.addTest(loader.loadTestsFromModule(test_ops_noise_estim))
         suite.addTest(loader.loadTestsFromModule(test_ops_yield_cut))
+        suite.addTest(loader.loadTestsFromModule(test_ops_elevation_noise))
 
         suite.addTest(loader.loadTestsFromModule(test_covariance))
 


### PR DESCRIPTION
Ensure that the elevation noise operator always creates a new noise model, rather than changing it in place.  The input noise model may be a purely analytic one, and so it should not be modified in place.