### PR TITLE
TEB convolution  in TOAST3  

### DIFF
--- a/src/toast/_libtoast/common.cpp
+++ b/src/toast/_libtoast/common.cpp
@@ -58,7 +58,6 @@ std::vector <char> align_format <double> () {
     return std::vector <char> ({'d'});
 }
 
-
 FakeMemPool & FakeMemPool::get() {
     static FakeMemPool instance;
     return instance;
@@ -70,22 +69,23 @@ void * FakeMemPool::create(void * buffer, size_t nbytes) {
     auto log = toast::Logger::get();
     if (n != 0) {
         o << "FakeMemPool:  on create, host ptr " << buffer
-        << " with " << nbytes << " bytes is already present "
-        << "with " << mem_size.at(buffer) << " bytes";
+          << " with " << nbytes << " bytes is already present "
+          << "with " << mem_size.at(buffer) << " bytes";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     }
+
     // Add to the map
     o.str("");
     o << "FakeMemPool:  creating entry for host ptr "
-    << buffer << " with " << nbytes << " bytes";
+      << buffer << " with " << nbytes << " bytes";
     log.verbose(o.str().c_str());
     mem_size[buffer] = nbytes;
     mem[buffer] = malloc(nbytes);
     if (mem.at(buffer) == NULL) {
         o.str("");
         o << "FakeMemPool:  on create, host ptr " << buffer
-        << " with " << nbytes << " bytes, device allocation failed";
+          << " with " << nbytes << " bytes, device allocation failed";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     }
@@ -99,7 +99,7 @@ void FakeMemPool::remove(void * buffer, size_t nbytes) {
     if (n == 0) {
         o.str("");
         o << "FakeMemPool:  host ptr " << buffer
-        << " is not present- cannot delete";
+          << " is not present- cannot delete";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     } else {
@@ -107,14 +107,14 @@ void FakeMemPool::remove(void * buffer, size_t nbytes) {
         if (nb != nbytes) {
             o.str("");
             o << "FakeMemPool:  on delete, host ptr " << buffer << " has "
-            << nb << " bytes instead of " << nbytes;
+              << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
     }
     o.str("");
     o << "FakeMemPool:  removing entry for host ptr "
-    << buffer << " with " << nbytes << " bytes";
+      << buffer << " with " << nbytes << " bytes";
     log.verbose(o.str().c_str());
     mem_size.erase(buffer);
     free(mem.at(buffer));
@@ -133,7 +133,7 @@ void * FakeMemPool::copyin(void * buffer, size_t nbytes) {
         if (nb < nbytes) {
             o.str("");
             o << "FakeMemPool:  on copyin, host ptr " << buffer << " has "
-            << nb << " bytes instead of " << nbytes;
+              << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
@@ -141,8 +141,8 @@ void * FakeMemPool::copyin(void * buffer, size_t nbytes) {
     ptr = mem.at(buffer);
     o.str("");
     o << "FakeMemPool:  copy in host ptr "
-    << buffer << " with " << nbytes << " bytes to device "
-    << ptr;
+      << buffer << " with " << nbytes << " bytes to device "
+      << ptr;
     log.verbose(o.str().c_str());
     void * temp = memcpy(ptr, buffer, nbytes);
     return mem.at(buffer);
@@ -156,7 +156,7 @@ void FakeMemPool::copyout(void * buffer, size_t nbytes) {
     if (n == 0) {
         o.str("");
         o << "FakeMemPool:  host ptr " << buffer
-        << " is not present- cannot copy out";
+          << " is not present- cannot copy out";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     } else {
@@ -164,7 +164,7 @@ void FakeMemPool::copyout(void * buffer, size_t nbytes) {
         if (nb < nbytes) {
             o.str("");
             o << "FakeMemPool:  on copyout, host ptr " << buffer << " has "
-            << nb << " bytes instead of " << nbytes;
+              << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
@@ -172,9 +172,10 @@ void FakeMemPool::copyout(void * buffer, size_t nbytes) {
     void * ptr = mem.at(buffer);
     o.str("");
     o << "FakeMemPool:  copy out host ptr "
-    << buffer << " with " << nbytes << " bytes from device "
-    << ptr;
+      << buffer << " with " << nbytes << " bytes from device "
+      << ptr;
     void * temp = memcpy(buffer, ptr, nbytes);
+
     // Even if we copyout a portion of the buffer, remove the full thing.
     remove(buffer, nb);
 }
@@ -186,7 +187,7 @@ void FakeMemPool::update_device(void * buffer, size_t nbytes) {
     if (n == 0) {
         o.str("");
         o << "FakeMemPool:  host ptr " << buffer
-        << " is not present- cannot update device";
+          << " is not present- cannot update device";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     } else {
@@ -194,7 +195,7 @@ void FakeMemPool::update_device(void * buffer, size_t nbytes) {
         if (nb < nbytes) {
             o.str("");
             o << "FakeMemPool:  on update device, host ptr " << buffer << " has "
-            << nb << " bytes instead of " << nbytes;
+              << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
@@ -202,7 +203,7 @@ void FakeMemPool::update_device(void * buffer, size_t nbytes) {
     void * dev = mem.at(buffer);
     o.str("");
     o << "FakeMemPool:  update device from host ptr "
-    << buffer << " with " << nbytes << " to " << dev;
+      << buffer << " with " << nbytes << " to " << dev;
     void * temp = memcpy(dev, buffer, nbytes);
 }
 
@@ -213,7 +214,7 @@ void FakeMemPool::update_self(void * buffer, size_t nbytes) {
     if (n == 0) {
         o.str("");
         o << "FakeMemPool:  host ptr " << buffer
-        << " is not present- cannot update host";
+          << " is not present- cannot update host";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     } else {
@@ -221,7 +222,7 @@ void FakeMemPool::update_self(void * buffer, size_t nbytes) {
         if (nb < nbytes) {
             o.str("");
             o << "FakeMemPool:  on update self, host ptr " << buffer << " has "
-            << nb << " bytes instead of " << nbytes;
+              << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
@@ -229,7 +230,7 @@ void FakeMemPool::update_self(void * buffer, size_t nbytes) {
     void * dev = mem.at(buffer);
     o.str("");
     o << "FakeMemPool:  update host ptr "
-    << buffer << " with " << nbytes << " from " << dev;
+      << buffer << " with " << nbytes << " from " << dev;
     void * temp = memcpy(buffer, dev, nbytes);
 }
 
@@ -244,7 +245,7 @@ int FakeMemPool::present(void * buffer, size_t nbytes) {
             auto log = toast::Logger::get();
             std::ostringstream o;
             o << "FakeMemPool:  host ptr " << buffer << " is present"
-            << ", but has " << nb << " bytes instead of " << nbytes;
+              << ", but has " << nb << " bytes instead of " << nbytes;
             log.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
         }
@@ -259,7 +260,7 @@ void * FakeMemPool::device_ptr(void * buffer) {
     if (n == 0) {
         o.str("");
         o << "FakeMemPool:  host ptr " << buffer
-        << " is not present- cannot get device pointer";
+          << " is not present- cannot get device pointer";
         log.error(o.str().c_str());
         throw std::runtime_error(o.str().c_str());
     }
@@ -267,19 +268,18 @@ void * FakeMemPool::device_ptr(void * buffer) {
 }
 
 void FakeMemPool::dump() {
-    for(auto & p : mem_size) {
+    for (auto & p : mem_size) {
         void * dev = mem.at(p.first);
         std::cout << "FakeMemPool table:  " << p.first << ": "
-        << p.second << " bytes on dev at " << dev << std::endl;
+                  << p.second << " bytes on dev at " << dev << std::endl;
     }
     return;
 }
 
-FakeMemPool::FakeMemPool() : mem_size(), mem() {
-}
+FakeMemPool::FakeMemPool() : mem_size(), mem() {}
 
 FakeMemPool::~FakeMemPool() {
-    for(auto & p : mem) {
+    for (auto & p : mem) {
         free(p.second);
     }
     mem_size.clear();

--- a/src/toast/_libtoast/common.hpp
+++ b/src/toast/_libtoast/common.hpp
@@ -128,9 +128,7 @@ std::unique_ptr <C> aligned_uptr(size_t n) {
     return std::unique_ptr <C> (new C(n));
 }
 
-
 class FakeMemPool {
-
     public:
 
         static FakeMemPool & get();
@@ -151,10 +149,10 @@ class FakeMemPool {
         ~FakeMemPool();
 
     private:
+
         FakeMemPool();
         std::unordered_map <void *, size_t> mem_size;
         std::unordered_map <void *, void *> mem;
-
 };
 
 bool fake_openacc();

--- a/src/toast/atm.py
+++ b/src/toast/atm.py
@@ -1133,8 +1133,8 @@ class AtmSim(object):
         self._nr = 1000
 
         self._rmin_kolmo = 0.0
-        diag = np.sqrt(self._delta_x ** 2 + self._delta_y ** 2)
-        self._rmax_kolmo = np.sqrt(diag ** 2 + self._delta_z ** 2) * 1.01
+        diag = np.sqrt(self._delta_x**2 + self._delta_y**2)
+        self._rmax_kolmo = np.sqrt(diag**2 + self._delta_z**2) * 1.01
 
         self._rstep = (self._rmax_kolmo - self._rmin_kolmo) / (self._nr - 1)
 

--- a/src/toast/dipole.py
+++ b/src/toast/dipole.py
@@ -51,10 +51,10 @@ def dipole(det_pointing, vel=None, solar=None, cmb=2.72548 * u.Kelvin, freq=0 * 
 
         solar_speed = np.sqrt(np.sum(solar * solar, axis=0))
 
-        vpar = (array_dot(vel, solar) / solar_speed ** 2) * solar
+        vpar = (array_dot(vel, solar) / solar_speed**2) * solar
         vperp = vel - vpar
 
-        vdot = 1.0 / (1.0 + array_dot(solar, vel) * inv_light ** 2)
+        vdot = 1.0 / (1.0 + array_dot(solar, vel) * inv_light**2)
         invgamma = np.sqrt(1.0 - (solar_speed * inv_light) ** 2)
 
         vpar += solar
@@ -79,7 +79,7 @@ def dipole(det_pointing, vel=None, solar=None, cmb=2.72548 * u.Kelvin, freq=0 * 
     freq_hz = freq.to_value(u.Hz)
 
     if freq_hz == 0:
-        inv_gamma = np.sqrt(1.0 - beta ** 2)
+        inv_gamma = np.sqrt(1.0 - beta**2)
         num = 1.0 - beta * np.sum(v * direct, axis=1)
         dipoletod = cmb_kelvin * (inv_gamma / num - 1.0)
     else:
@@ -87,6 +87,6 @@ def dipole(det_pointing, vel=None, solar=None, cmb=2.72548 * u.Kelvin, freq=0 * 
         fx = constants.h * freq_hz / (constants.k * cmb_kelvin)
         fcor = (fx / 2) * (np.exp(fx) + 1) / (np.exp(fx) - 1)
         bt = beta * np.sum(v * direct, axis=1)
-        dipoletod = cmb_kelvin * (bt + fcor * bt ** 2)
+        dipoletod = cmb_kelvin * (bt + fcor * bt**2)
 
     return dipoletod

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -563,7 +563,7 @@ class Focalplane(object):
                 quat = row["quat"]
                 a = quat[3]
                 d = quat[2]
-                pol_angle = np.arctan2(2 * a * d, a ** 2 - d ** 2) % np.pi
+                pol_angle = np.arctan2(2 * a * d, a**2 - d**2) % np.pi
                 row["pol_angle"] = pol_angle * u.radian
 
     @function_timer

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -345,7 +345,7 @@ def rhomb_dim(npix):
 
     """
     dim = int(np.sqrt(float(npix)))
-    if dim ** 2 != npix:
+    if dim**2 != npix:
         raise ValueError("number of pixels for a rhombus wafer must be square")
     return dim
 
@@ -501,7 +501,7 @@ def rhombus_layout(
         if pixrow >= dim:
             relrow = (2 * dim - 2) - pixrow
         colang = (float(pixcol) - float(relrow) / 2.0) * pixdiam
-        distang = np.sqrt(rowang ** 2 + colang ** 2)
+        distang = np.sqrt(rowang**2 + colang**2)
         zang = np.cos(distang)
         pixdir = np.array([colang, rowang, zang], dtype=np.float64)
         norm = np.sqrt(np.dot(pixdir, pixdir))
@@ -591,6 +591,7 @@ def fake_hexagon_focalplane(
             Column(name="name", data=[x for x in det_data.keys()]),
             Column(name="quat", data=[det_data[x]["quat"] for x in det_data.keys()]),
             Column(name="pol_leakage", length=n_det, unit=None),
+            Column(name="psi_pol", length=n_det, unit=u.rad),
             Column(name="fwhm", length=n_det, unit=u.arcmin),
             Column(name="psd_fmin", length=n_det, unit=u.Hz),
             Column(name="psd_fknee", length=n_det, unit=u.Hz),
@@ -610,6 +611,10 @@ def fake_hexagon_focalplane(
         det_table[idet]["name"] = det
         det_table[idet]["quat"] = det_data[det]["quat"]
         det_table[idet]["pol_leakage"] = epsilon
+        if det.endswith("A"):
+            det_table[idet]["psi_pol"] = 0 * u.rad
+        else:
+            det_table[idet]["psi_pol"] = np.pi / 2 * u.rad
         det_table[idet]["fwhm"] = fwhm * (
             1 + np.random.randn() * fwhm_sigma.to_value(fwhm.unit)
         )

--- a/src/toast/job.py
+++ b/src/toast/job.py
@@ -24,7 +24,7 @@ def get_node_mem(world_comm, node_rank):
         (int):  The minimum number of bytes of available node memory.
 
     """
-    min_avail = 2 ** 62
+    min_avail = 2**62
     max_avail = 0
     if node_rank == 0:
         vmem = psutil.virtual_memory()._asdict()
@@ -97,7 +97,7 @@ def job_group_size(
 
     """
     log = Logger.get()
-    gb = 1024 ** 3
+    gb = 1024**3
 
     rank = 0
     procs = 1

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -84,7 +84,7 @@ class Noise(object):
                 raise TypeError("Each PSD array must be a Quantity")
             # Ensure that the PSDs are convertible to expected units
             try:
-                test_convert = psds[key].to_value(u.K ** 2 * u.second)
+                test_convert = psds[key].to_value(u.K**2 * u.second)
             except Exception:
                 raise ValueError("Each PSD must be convertible to K**2 * s")
             self._freqs[key] = np.copy(freqs[key])
@@ -200,7 +200,7 @@ class Noise(object):
                 psd = self.psd(k)
                 rate = self.rate(k)
                 ind = np.logical_and(freq > rate * 0.2, freq < rate * 0.4)
-                noisevar = np.median(psd[ind].to_value(u.K ** 2 * u.second))
+                noisevar = np.median(psd[ind].to_value(u.K**2 * u.second))
                 for det in self.detectors:
                     wt = self.weight(det, k)
                     if wt != 0.0:
@@ -385,7 +385,7 @@ class Noise(object):
                 self._rates[key] = rate * u.Hz
                 self._indices[key] = indx
                 self._freqs[key] = u.Quantity(freq, u.Hz)
-                self._psds[key] = u.Quantity(psdrow, u.K ** 2 * u.second)
+                self._psds[key] = u.Quantity(psdrow, u.K**2 * u.second)
             del ds
 
     def _load_hdf5(self, handle, comm=None, **kwargs):

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -137,7 +137,7 @@ class AnalyticNoise(Noise):
         return self._NET[det]
 
     def _detector_weight(self, det):
-        return 1.0 / (self._NET[det] ** 2).to_value(u.K ** 2 * u.second)
+        return 1.0 / (self._NET[det] ** 2).to_value(u.K**2 * u.second)
 
     def _save_hdf5(self, handle, comm=None, force_serial=False, **kwargs):
         """Internal method which can be overridden by derived classes."""

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -61,7 +61,7 @@ from .mapmaker import MapMaker
 
 from .madam import Madam, madam_params_from_mapmaker
 
-from .conviqt import SimConviqt, SimWeightedConviqt
+from .conviqt import SimConviqt, SimWeightedConviqt, SimTEBConviqt
 
 from .sim_gaindrifts import GainDrifter
 from .sim_crosstalk import CrossTalk, MitigateCrossTalk

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -260,7 +260,7 @@ class SimConviqt(Operator):
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(detector=det, mc=self.mc)
-            
+
             beam = self.get_beam(beam_file, det, verbose)
 
             detector = self.get_detector(det)
@@ -572,7 +572,7 @@ class SimWeightedConviqt(SimConviqt):
     the beam time-dependent, constantly mapping the co- and cross polar
     responses on to each other.  In OpSimConviqt we assume the beam to be static.
     """
-    
+
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         if not self.available:
@@ -610,8 +610,8 @@ class SimWeightedConviqt(SimConviqt):
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(detector=det, mc=self.mc)
-             
-            beamI00 ,beam0I0,beam00I= self.get_beam(beam_file , det, verbose)
+
+            beamI00, beam0I0, beam00I = self.get_beam(beam_file, det, verbose)
 
             detector = self.get_detector(det)
 
@@ -651,20 +651,26 @@ class SimWeightedConviqt(SimConviqt):
                 timer.report_clear(f"conviqt process detector {det}")
 
         return
-    
+
     def get_beam(self, beamfile, det, verbose):
         timer = Timer()
         timer.start()
         beam_file_i00 = beamfile.replace(".fits", "_I000.fits")
         beam_file_0i0 = beamfile.replace(".fits", "_0I00.fits")
         beam_file_00i = beamfile.replace(".fits", "_00I0.fits")
-        beami00 = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_i00, self.comm)
-        beam0i0 = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_0i0, self.comm)
-        beam00i = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_00i, self.comm)
-            
+        beami00 = conviqt.Beam(
+            self.lmax, self.beammmax, self.pol, beam_file_i00, self.comm
+        )
+        beam0i0 = conviqt.Beam(
+            self.lmax, self.beammmax, self.pol, beam_file_0i0, self.comm
+        )
+        beam00i = conviqt.Beam(
+            self.lmax, self.beammmax, self.pol, beam_file_00i, self.comm
+        )
+
         if verbose:
             timer.report_clear(f"initialize beam for detector {det}")
-        return beami00,beam0i0,beam00i 
+        return beami00, beam0i0, beam00i
 
 
 class SimTEBConviqt(SimConviqt):
@@ -679,8 +685,7 @@ class SimTEBConviqt(SimConviqt):
     :math:`skyT_lm * beamT_lm, skyE_lm * Re{P}, skyB_lm * Im{P}`.
 
     For extra details please refer to [this note ](https://giuspugl.github.io/reports/Notes_TEB_convolution.html)
-
-"""
+    """
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
@@ -714,13 +719,13 @@ class SimTEBConviqt(SimConviqt):
             else:
                 sky_file = self.sky_file.format(detector=det, mc=self.mc)
             sky = self.get_sky(sky_file, det, verbose)
-            
+
             if det in self.beam_file_dict:
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(detector=det, mc=self.mc)
 
-            beam_T, beam_E, beam_B  = self.get_beam(beam_file, det,verbose)
+            beam_T, beam_E, beam_B = self.get_beam(beam_file, det, verbose)
 
             detector = self.get_detector(det)
 
@@ -731,17 +736,17 @@ class SimTEBConviqt(SimConviqt):
 
             convolved_data = self.convolve(sky, beam_T, detector, pnt, det, verbose)
 
-            del pnt,
-            # Q-beam convolution
+            del (pnt,)
+            # E-beam convolution
             pnt = self.get_buffer(theta, phi, psi, det, verbose)
             convolved_data += np.cos(2 * psi_pol) * self.convolve(
-                        sky, beam_E, detector, pnt, det, verbose
-                            )
-            del pnt,
-            # U-beam convolution
+                sky, beam_E, detector, pnt, det, verbose
+            )
+            del (pnt,)
+            # B-beam convolution
             pnt = self.get_buffer(theta, phi, psi, det, verbose)
             convolved_data += np.sin(2 * psi_pol) * self.convolve(
-                sky , beam_B , detector, pnt, det, verbose
+                sky, beam_B, detector, pnt, det, verbose
             )
             del theta, phi, psi
 
@@ -754,13 +759,13 @@ class SimTEBConviqt(SimConviqt):
             )
             self.save(data, det, convolved_data, verbose)
 
-            del pnt, detector, beam_T, beam_E,beam_B, sky
+            del pnt, detector, beam_T, beam_E, beam_B, sky
 
             if verbose:
                 timer.report_clear(f"conviqt process detector {det}")
 
         return
-    
+
     def get_beam(self, beamfile, det, verbose):
         timer = Timer()
         timer.start()
@@ -770,7 +775,7 @@ class SimTEBConviqt(SimConviqt):
         beamT = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_T, self.comm)
         beamE = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_E, self.comm)
         beamB = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_B, self.comm)
-            
+
         if verbose:
             timer.report_clear(f"initialize beam for detector {det}")
-        return beamT,beamE,beamB 
+        return beamT, beamE, beamB

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -260,7 +260,7 @@ class SimConviqt(Operator):
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(detector=det, mc=self.mc)
-
+            
             beam = self.get_beam(beam_file, det, verbose)
 
             detector = self.get_detector(det)
@@ -572,7 +572,7 @@ class SimWeightedConviqt(SimConviqt):
     the beam time-dependent, constantly mapping the co- and cross polar
     responses on to each other.  In OpSimConviqt we assume the beam to be static.
     """
-
+    
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         if not self.available:
@@ -610,13 +610,8 @@ class SimWeightedConviqt(SimConviqt):
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(detector=det, mc=self.mc)
-            beam_file_i00 = beam_file.replace(".fits", "_I000.fits")
-            beam_file_0i0 = beam_file.replace(".fits", "_0I00.fits")
-            beam_file_00i = beam_file.replace(".fits", "_00I0.fits")
-
-            beamI00 = self.get_beam(beam_file_i00, det, verbose)
-            beam0I0 = self.get_beam(beam_file_0i0, det, verbose)
-            beam00I = self.get_beam(beam_file_00i, det, verbose)
+             
+            beamI00 ,beam0I0,beam00I= self.get_beam(beam_file , det, verbose)
 
             detector = self.get_detector(det)
 
@@ -656,7 +651,20 @@ class SimWeightedConviqt(SimConviqt):
                 timer.report_clear(f"conviqt process detector {det}")
 
         return
-
+    
+    def get_beam(self, beamfile, det, verbose):
+        timer = Timer()
+        timer.start()
+        beam_file_i00 = beamfile.replace(".fits", "_I000.fits")
+        beam_file_0i0 = beamfile.replace(".fits", "_0I00.fits")
+        beam_file_00i = beamfile.replace(".fits", "_00I0.fits")
+        beami00 = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_i00, self.comm)
+        beam0i0 = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_0i0, self.comm)
+        beam00i = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_00i, self.comm)
+            
+        if verbose:
+            timer.report_clear(f"initialize beam for detector {det}")
+        return beami00,beam0i0,beam00i 
 
 
 class SimTEBConviqt(SimConviqt):

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -714,11 +714,13 @@ class SimTEBConviqt(SimConviqt):
             else:
                 sky_file = self.sky_file.format(detector=det, mc=self.mc)
             sky = self.get_sky(sky_file, det, verbose)
+            
+            if det in self.beam_file_dict:
+                beam_file = self.beam_file_dict[det]
+            else:
+                beam_file = self.beam_file.format(detector=det, mc=self.mc)
 
-            beam_file = self.beam_file.format(detector=det, mc=self.mc)
-            beam_T = self.get_beam(beam_file.replace(".fits","_T.fits"), det, verbose)
-            beam_E = self.get_beam(beam_file.replace(".fits","_E.fits"), det, verbose)
-            beam_B = self.get_beam(beam_file.replace(".fits","_B.fits"), det, verbose)
+            beam_T, beam_E, beam_B  = self.get_beam(beam_file, det,verbose)
 
             detector = self.get_detector(det)
 
@@ -758,3 +760,17 @@ class SimTEBConviqt(SimConviqt):
                 timer.report_clear(f"conviqt process detector {det}")
 
         return
+    
+    def get_beam(self, beamfile, det, verbose):
+        timer = Timer()
+        timer.start()
+        beam_file_T = beamfile.replace(".fits", "_T.fits")
+        beam_file_E = beamfile.replace(".fits", "_E.fits")
+        beam_file_B = beamfile.replace(".fits", "_B.fits")
+        beamT = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_T, self.comm)
+        beamE = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_E, self.comm)
+        beamB = conviqt.Beam(self.lmax, self.beammmax, self.pol, beam_file_B, self.comm)
+            
+        if verbose:
+            timer.report_clear(f"initialize beam for detector {det}")
+        return beamT,beamE,beamB 

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -400,7 +400,7 @@ class Demodulate(Operator):
             # qweights = eta * cos(2 * psi_det + 4 * psi_hwp)
             # uweights = eta * sin(2 * psi_det + 4 * psi_hwp)
             iweights, qweights, uweights = weights.T
-            etainv = 1 / np.sqrt(qweights ** 2 + uweights ** 2)
+            etainv = 1 / np.sqrt(qweights**2 + uweights**2)
 
             det_data = demod_obs.detdata[self.det_data]
             det_data[f"demod0_{det}"] = lowpass(signal)

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -114,7 +114,7 @@ class SparseTemplates:
         """Normalize templates"""
         for start, stop, template in zip(self.starts, self.stops, self.templates):
             if good is None:
-                norm = np.sum(template ** 2) ** 0.5
+                norm = np.sum(template**2) ** 0.5
             else:
                 norm = np.sum((template * good[start:stop]) ** 2) ** 0.5
             template /= norm

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -230,8 +230,8 @@ class FlagSSO(Operator):
                     # This is the planar approximation for squared angular distance
                     x = (az - sso_az) * cosel
                     y = el - sso_el
-                    rsquared = x ** 2 + y ** 2
-                    inside = rsquared < radius ** 2
+                    rsquared = x**2 + y**2
+                    inside = rsquared < radius**2
                 flags[inside] |= self.det_flag_mask
 
         return

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -693,7 +693,7 @@ class Madam(Operator):
                 for det in all_dets:
                     if det not in ob.local_detectors:
                         continue
-                    psd = nse.psd(det).to_value(u.K ** 2 * u.second) * nse_scale ** 2
+                    psd = nse.psd(det).to_value(u.K**2 * u.second) * nse_scale**2
                     detw = nse.detector_weight(det)
                     if det not in psds:
                         psds[det] = [(0.0, psd, detw)]

--- a/src/toast/ops/madam_utils.py
+++ b/src/toast/ops/madam_utils.py
@@ -36,7 +36,7 @@ def log_time_memory(
 
         if data.comm.group_rank == 0:
             msg = "{} {} Group {} memory = {:0.2f} GB".format(
-                prefix, mem_msg, data.comm.group, toast_bytes / 1024 ** 2
+                prefix, mem_msg, data.comm.group, toast_bytes / 1024**2
             )
             log.debug(msg)
         if full_mem:

--- a/src/toast/ops/memory_counter.py
+++ b/src/toast/ops/memory_counter.py
@@ -54,7 +54,7 @@ class MemoryCounter(Operator):
     def _finalize(self, data, **kwargs):
         log = Logger.get()
         if not self.silent:
-            total_gb = self.total_bytes / 2 ** 30
+            total_gb = self.total_bytes / 2**30
             if data.comm.comm_group_rank is not None:
                 total_gb = data.comm.comm_group_rank.allreduce(total_gb)
             if data.comm.world_rank == 0:

--- a/src/toast/ops/pixels_healpix.py
+++ b/src/toast/ops/pixels_healpix.py
@@ -144,8 +144,8 @@ class PixelsHealpix(Operator):
 
     def _set_hpix(self, nside, nside_submap):
         self.hpix = HealpixPixels(nside)
-        self._n_pix = 12 * nside ** 2
-        self._n_pix_submap = 12 * nside_submap ** 2
+        self._n_pix = 12 * nside**2
+        self._n_pix_submap = 12 * nside_submap**2
         self._n_submap = (nside // nside_submap) ** 2
         self._local_submaps = None
 
@@ -278,9 +278,9 @@ class PixelsHealpix(Operator):
                             fslice = flags[bslice].reshape(-1)
 
                         # Pixel buffer
-                        pxslice = views.detdata[self.pixels][vw][
-                            det, bslice
-                        ].reshape(-1)
+                        pxslice = views.detdata[self.pixels][vw][det, bslice].reshape(
+                            -1
+                        )
 
                         if self.single_precision:
                             pbuf = np.zeros(len(pxslice), dtype=np.int64)
@@ -302,8 +302,7 @@ class PixelsHealpix(Operator):
 
                     if self.create_dist is not None:
                         self._local_submaps[
-                            views.detdata[self.pixels][vw][det]
-                            // self._n_pix_submap
+                            views.detdata[self.pixels][vw][det] // self._n_pix_submap
                         ] = 1
 
         return

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -118,7 +118,7 @@ class PolyFilter2D(Operator):
         if detectors is not None:
             raise RuntimeError("PolyFilter2D cannot be run on subsets of detectors")
         norder = self.order + 1
-        nmode = norder ** 2
+        nmode = norder**2
         pat = re.compile(self.pattern)
 
         for obs in data.obs:
@@ -259,7 +259,7 @@ class PolyFilter2D(Operator):
                     continue
                 idet = detector_index[det]
                 theta, phi = detector_position[det]
-                detector_templates[idet] = theta ** xorders * phi ** yorders
+                detector_templates[idet] = theta**xorders * phi**yorders
 
             gt.stop("Poly2D:  Detector setup")
 

--- a/src/toast/ops/save_spt3g.py
+++ b/src/toast/ops/save_spt3g.py
@@ -115,7 +115,7 @@ class SaveSpt3g(Operator):
                 save_pipe.Add(
                     c3g.G3MultiFileWriter,
                     filename=os.path.join(ob_dir, "frames-%05u.g3"),
-                    size_limit=int(self.framefile_mb * 1024 ** 2),
+                    size_limit=int(self.framefile_mb * 1024**2),
                 )
                 save_pipe.Run()
 

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -96,7 +96,7 @@ class GainDrifter(Operator):
 
     def get_psd(self, f):
         return (
-            self.sigma_drift ** 2
+            self.sigma_drift**2
             * (self.fknee_drift.to_value(u.Hz) / f) ** self.alpha_drift
         )
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -113,12 +113,12 @@ class SimGround(Operator):
     )
 
     scan_accel_az = Quantity(
-        1.0 * u.degree / u.second ** 2,
+        1.0 * u.degree / u.second**2,
         help="Mount scanning rate acceleration for turnarounds",
     )
 
     scan_accel_el = Quantity(
-        1.0 * u.degree / u.second ** 2,
+        1.0 * u.degree / u.second**2,
         allow_none=True,
         help="Mount elevation rate acceleration.",
     )
@@ -550,9 +550,9 @@ class SimGround(Operator):
                     scan.az_min.to_value(u.radian),
                     scan.el.to_value(u.radian),
                     self.scan_rate_az.to_value(u.radian / u.second),
-                    self.scan_accel_az.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_az.to_value(u.radian / u.second**2),
                     self.scan_rate_el.to_value(u.radian / u.second),
-                    self.scan_accel_el.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_el.to_value(u.radian / u.second**2),
                     elnod_el,
                     elnod_az,
                     scan_min_az,
@@ -593,7 +593,7 @@ class SimGround(Operator):
                 scan.az_max.to_value(u.radian),
                 scan.az_min.to_value(u.radian),
                 self.scan_rate_az.to_value(u.radian / u.second),
-                self.scan_accel_az.to_value(u.radian / u.second ** 2),
+                self.scan_accel_az.to_value(u.radian / u.second**2),
                 scan_min_az,
                 scan_max_az,
                 cosecant_modulation=self.scan_cosecant_modulation,
@@ -605,7 +605,7 @@ class SimGround(Operator):
                     scan_times,
                     scan_el_data,
                     self.scan_rate_el.to_value(u.radian / u.second),
-                    self.scan_accel_el.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_el.to_value(u.radian / u.second**2),
                     scan_min_el,
                     scan_max_el,
                     self.el_mod_amplitude.to_value(u.radian),
@@ -618,7 +618,7 @@ class SimGround(Operator):
                     scan_az_data,
                     scan_el_data,
                     self.scan_rate_el.to_value(u.radian / u.second),
-                    self.scan_accel_el.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_el.to_value(u.radian / u.second**2),
                     scan_min_el,
                     scan_max_el,
                     self.el_mod_step.to_value(u.radian),
@@ -657,9 +657,9 @@ class SimGround(Operator):
                     scan_az_data[-1],
                     scan_el_data[-1],
                     self.scan_rate_az.to_value(u.radian / u.second),
-                    self.scan_accel_az.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_az.to_value(u.radian / u.second**2),
                     self.scan_rate_el.to_value(u.radian / u.second),
-                    self.scan_accel_el.to_value(u.radian / u.second ** 2),
+                    self.scan_accel_el.to_value(u.radian / u.second**2),
                     elnod_el,
                     elnod_az,
                     scan_min_az,
@@ -913,7 +913,7 @@ class SimGround(Operator):
             )
 
             obmem = ob.memory_use()
-            obmem_gb = obmem / 1024 ** 3
+            obmem_gb = obmem / 1024**3
             msg = f"Observation {ob.name} using {obmem_gb:0.2f} GB of total memory"
             log.debug_rank(msg, comm=ob.comm.comm_group)
 

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -24,7 +24,7 @@ def scan_time(coord_in, coord_out, scanrate, scan_accel):
     """
     d = np.abs(coord_in - coord_out)
     t_accel = scanrate / scan_accel
-    d_accel = 0.5 * scan_accel * t_accel ** 2
+    d_accel = 0.5 * scan_accel * t_accel**2
     if 2 * d_accel > d:
         # No time to reach scan speed
         d_accel = d / 2
@@ -46,7 +46,7 @@ def scan_profile(coord_in, coord_out, scanrate, scan_accel, times, nstep=10000):
 
     d = np.abs(coord_in - coord_out)
     t_accel = scanrate / scan_accel
-    d_accel = 0.5 * scan_accel * t_accel ** 2
+    d_accel = 0.5 * scan_accel * t_accel**2
     if 2 * d_accel > d:
         # No time to reach scan speed
         d_accel = d / 2
@@ -228,7 +228,7 @@ def oscillate_el(
     """
     tt = times - times[0]
     # Shift the starting time by a random phase
-    np.random.seed(int(times[0] % 2 ** 32))
+    np.random.seed(int(times[0] % 2**32))
     tt += np.random.rand() / el_mod_rate
 
     if el_mod_sine:
@@ -254,7 +254,7 @@ def oscillate_el(
         a = el_accel
         b = -0.5 * el_accel * t_mod
         c = 2 * el_mod_amplitude
-        if b ** 2 - 4 * a * c < 0:
+        if b**2 - 4 * a * c < 0:
             raise RuntimeError(
                 "Cannot perform {:.2f} deg elevation oscillation in {:.2f} s "
                 "with {:.2f} deg/s^2 acceleration".format(
@@ -262,8 +262,8 @@ def oscillate_el(
                     np.degrees(el_accel),
                 )
             )
-        root1 = (-b - np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
-        root2 = (-b + np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
+        root1 = (-b - np.sqrt(b**2 - 4 * a * c)) / (2 * a)
+        root2 = (-b + np.sqrt(b**2 - 4 * a * c)) / (2 * a)
         if root1 > 0:
             t_accel = root1
         else:
@@ -287,7 +287,7 @@ def oscillate_el(
         # accelerate
         t = np.linspace(0, t_accel, n)
         t_interp.append(t)
-        el_interp.append(0.5 * el_accel * t ** 2)
+        el_interp.append(0.5 * el_accel * t**2)
         # scan
         t_last = t_interp[-1][-1]
         el_last = el_interp[-1][-1]
@@ -299,7 +299,7 @@ def oscillate_el(
         el_last = el_interp[-1][-1]
         t = np.linspace(0, 2 * t_accel, n)
         t_interp.append(t_last + t)
-        el_interp.append(el_last + scanrate * t - 0.5 * el_accel * t ** 2)
+        el_interp.append(el_last + scanrate * t - 0.5 * el_accel * t**2)
         # scan
         t_last = t_interp[-1][-1]
         el_last = el_interp[-1][-1]
@@ -311,7 +311,7 @@ def oscillate_el(
         el_last = el_interp[-1][-1]
         t = np.linspace(0, t_accel, n)
         t_interp.append(t_last + t)
-        el_interp.append(el_last - scanrate * t + 0.5 * el_accel * t ** 2)
+        el_interp.append(el_last - scanrate * t + 0.5 * el_accel * t**2)
 
         t_interp = np.hstack(t_interp)
         el_interp = np.hstack(el_interp)
@@ -348,7 +348,7 @@ def step_el(
     # simulate a single elevation step at high resolution
 
     t_accel = el_rate / el_accel
-    el_step_accel = 0.5 * el_accel * t_accel ** 2
+    el_step_accel = 0.5 * el_accel * t_accel**2
     if el_step > 2 * el_step_accel:
         # Step is large enough to reach elevation scan rate
         t_scan = (el_step - 2 * el_step_accel) / el_rate
@@ -364,7 +364,7 @@ def step_el(
     # accelerate
     t = np.linspace(0, t_accel, n)
     t_interp.append(t)
-    el_interp.append(0.5 * el_accel * t ** 2)
+    el_interp.append(0.5 * el_accel * t**2)
     # scan
     if t_scan > 0:
         t_last = t_interp[-1][-1]
@@ -378,7 +378,7 @@ def step_el(
     el_rate_last = el_accel * t_accel
     t = np.linspace(0, t_accel, n)
     t_interp.append(t_last + t)
-    el_interp.append(el_last + el_rate_last * t - 0.5 * el_accel * t ** 2)
+    el_interp.append(el_last + el_rate_last * t - 0.5 * el_accel * t**2)
 
     t_interp = np.hstack(t_interp)
     t_interp -= t_interp[t_interp.size // 2]

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -576,10 +576,10 @@ class SimAtmosphere(Operator):
         obsid = obs.uid
 
         # site UID in higher bits, telescope UID in lower bits
-        key1 = site * 2 ** 32 + telescope
+        key1 = site * 2**32 + telescope
 
         # Observation UID in higher bits, realization and component in lower bits
-        key2 = obsid * 2 ** 32 + self.realization * 2 ** 16 + self.component
+        key2 = obsid * 2**32 + self.realization * 2**16 + self.component
 
         # This tracks the number of cones simulated due to the wind speed.
         counter1 = 0
@@ -746,7 +746,7 @@ class SimAtmosphere(Operator):
         # Translate the wind speed to time span of a correlated interval
         wx = weather.west_wind.to_value(u.meter / u.second)
         wy = weather.south_wind.to_value(u.meter / u.second)
-        w = np.sqrt(wx ** 2 + wy ** 2)
+        w = np.sqrt(wx**2 + wy**2)
         wind_time = self.wind_dist.to_value(u.meter) / w
 
         tmax = tmin + wind_time
@@ -816,7 +816,7 @@ class SimAtmosphere(Operator):
         T0_center = weather.air_temperature
         wx = weather.west_wind
         wy = weather.south_wind
-        w_center = np.sqrt(wx ** 2 + wy ** 2)
+        w_center = np.sqrt(wx**2 + wy**2)
         wdir_center = np.arctan2(wy, wx)
 
         azmin, azmax, elmin, elmax = scan_range

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -309,9 +309,9 @@ class ObserveAtmosphere(Operator):
                         )
 
                         if err != 0:
-                            #import pdb
-                            #import matplotlib.pyplot as plt
-                            #pdb.set_trace()
+                            # import pdb
+                            # import matplotlib.pyplot as plt
+                            # pdb.set_trace()
                             # Observing failed
                             if self.sample_rate is None:
                                 full_data = atmdata

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -303,7 +303,7 @@ class SimNoise(Operator):
                     sim_units = None
                     psd_units = nse.psd(key).unit
                     if self.det_data_units is not None:
-                        sim_units = self.det_data_units ** 2 * u.second
+                        sim_units = self.det_data_units**2 * u.second
                     else:
                         sim_units = psd_units
 
@@ -371,7 +371,7 @@ class SimNoise(Operator):
                     sim_units = None
                     psd_units = nse.psd(key).unit
                     if self.det_data_units is not None:
-                        sim_units = self.det_data_units ** 2 * u.second
+                        sim_units = self.det_data_units**2 * u.second
                     else:
                         sim_units = psd_units
                     psds[ikey][:] = nse.psd(key).to_value(sim_units)

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -141,8 +141,8 @@ class SimScanSynchronousSignal(Operator):
         telescope = obs.telescope.uid
         site = obs.telescope.site.uid
         obsindx = obs.uid
-        key1 = self.realization * 2 ** 32 + telescope * 2 ** 16 + self.component
-        key2 = site * 2 ** 16 + obsindx
+        key1 = self.realization * 2**32 + telescope * 2**16 + self.component
+        key2 = site * 2**16 + obsindx
         counter1 = 0
         counter2 = 0
         return key1, key2, counter1, counter2
@@ -167,7 +167,7 @@ class SimScanSynchronousSignal(Operator):
                 sss_map = hp.read_map(self.path, verbose=False, dtype=dtype)
                 npix = len(sss_map)
             else:
-                npix = 12 * self.nside ** 2
+                npix = 12 * self.nside**2
                 sss_map = rng.random(
                     npix,
                     key=(key1, key2),

--- a/src/toast/ops/statistics.py
+++ b/src/toast/ops/statistics.py
@@ -173,11 +173,11 @@ class Statistics(Operator):
                     signal = views.detdata[self.det_data][iview][det]
                     good_signal = signal[mask].copy() - means[idet]
                     # Variance
-                    stats[0, idet] += np.sum(good_signal ** 2)
+                    stats[0, idet] += np.sum(good_signal**2)
                     # Skewness
-                    stats[1, idet] += np.sum(good_signal ** 3)
+                    stats[1, idet] += np.sum(good_signal**3)
                     # Kurtosis
-                    stats[2, idet] += np.sum(good_signal ** 4)
+                    stats[2, idet] += np.sum(good_signal**4)
 
             if obs.comm.comm_group is not None:
                 stats = obs.comm.comm_group.reduce(stats, op=MPI.SUM)

--- a/src/toast/ops/stokes_weights.py
+++ b/src/toast/ops/stokes_weights.py
@@ -280,9 +280,9 @@ class StokesWeights(Operator):
                             fslice = flags[bslice].reshape(-1)
 
                         # Weight buffer
-                        wtslice = views.detdata[self.weights][vw][
-                            det, bslice
-                        ].reshape(-1)
+                        wtslice = views.detdata[self.weights][vw][det, bslice].reshape(
+                            -1
+                        )
 
                         if self.single_precision:
                             wbuf = np.zeros(len(wtslice), dtype=np.float64)

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -638,7 +638,7 @@ def write_healpix(filename, mapdata, nside_submap=16, *args, **kwargs):
         nside = hp.npix2nside(n_pix)
 
         nside_submap = min(nside_submap, nside)
-        n_pix_submap = 12 * nside_submap ** 2
+        n_pix_submap = 12 * nside_submap**2
 
         mode = "w-"
         if "overwrite" in kwargs and kwargs["overwrite"] == True:

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -194,7 +194,7 @@ class Patch(object):
     def get_area(self, observer, nside=32, equalize=False):
         self.update(observer)
         if self._area is None:
-            npix = 12 * nside ** 2
+            npix = 12 * nside**2
             hitmap = np.zeros(npix)
             for corner in self.corners:
                 corner.compute(observer)
@@ -407,7 +407,7 @@ class SSOPatch(Patch):
         self.name = name
         self.weight = weight
         self.radius = radius
-        self._area = np.pi * radius ** 2 / (4 * np.pi)
+        self._area = np.pi * radius**2 / (4 * np.pi)
         self.el_min0 = el_min
         self.el_min = el_min
         self.el_max = el_max
@@ -521,7 +521,7 @@ class CoolerCyclePatch(Patch):
             weight = (self.hold_time_max - hold_time) / (
                 self.hold_time_max - self.hold_time_min
             )
-            self.weight = self.weight0 * weight ** self.power
+            self.weight = self.weight0 * weight**self.power
         return
 
 
@@ -1221,13 +1221,13 @@ def get_pole_raster_scan(
 
     # Time it takes to perform one elevation step
     t_accel_el = el_rate / el_accel  # acceleration time
-    if el_accel * t_accel_el ** 2 > el_step:
+    if el_accel * t_accel_el**2 > el_step:
         # Telescope does not reach constant el_rate during the step.
         # The step is made of acceleration and deceleration
         t_el_step = 2 * np.sqrt(el_step / el_accel)
     else:
         # length of constant elevation rate scan
-        el_scan = el_step - el_accel * t_accel ** 2
+        el_scan = el_step - el_accel * t_accel**2
         # The elevation step is made of acceleration,
         # constant scan and deceleration
         t_el_step = 2 * t_accel_el + el_scan / el_rate
@@ -2544,7 +2544,7 @@ def parse_args(opts=None):
     start_timestamp = start_time.timestamp()
     if stop_time is None:
         # Keep scheduling until the desired number of operational days is full.
-        stop_timestamp = 2 ** 60
+        stop_timestamp = 2**60
     else:
         stop_timestamp = stop_time.timestamp()
     return args, start_timestamp, stop_timestamp
@@ -2872,7 +2872,7 @@ def parse_patches(args, observer, sun, moon, start_timestamp, stop_timestamp):
             title = scoord  # + ' patch locations'
             if polmap is None:
                 nside = 256
-                avoidance_map = np.zeros(12 * nside ** 2)
+                avoidance_map = np.zeros(12 * nside**2)
                 # hp.mollview(np.zeros(12) + hp.UNSEEN, coord=coord, cbar=False,
                 #            title='', sub=[1, 3, 1 + iplot], cmap=cmap)
             else:

--- a/src/toast/scripts/benchmarking_utilities.py
+++ b/src/toast/scripts/benchmarking_utilities.py
@@ -88,7 +88,7 @@ def get_mpi_settings(args, log, env):
         comm=world_comm,
     )
     if args.node_mem_gb is not None:
-        avail_node_bytes = int((1024 ** 3) * args.node_mem_gb)
+        avail_node_bytes = int((1024**3) * args.node_mem_gb)
         log.info_rank(
             f"Setting per-node available memory to {avail_node_bytes / (1024 ** 3) :0.2f} GB as requested",
             comm=world_comm,
@@ -356,7 +356,7 @@ def select_case(
     avail_node_bytes,
     full_pointing,
     world_comm,
-    per_process_overhead_bytes=1024 ** 3,
+    per_process_overhead_bytes=1024**3,
     target_proc_dets=200,
 ):
     """
@@ -527,7 +527,7 @@ def estimate_memory_overhead(
     """
     log = toast.utils.Logger.get()
     # Start with 1GB for everything else
-    base = 1024 ** 3
+    base = 1024**3
     # base = 0
 
     # Compute the bytes per pixel.  We have:
@@ -538,8 +538,8 @@ def estimate_memory_overhead(
     #   solved map (3 x float64):  24 bytes
     bytes_per_pixel = 8 + 24 + 8 + 48 + 24
 
-    n_pixel_solve = sky_fraction * 12 * nside_solve ** 2
-    n_pixel_final = 0 if nside_final is None else sky_fraction * 12 * nside_final ** 2
+    n_pixel_solve = sky_fraction * 12 * nside_solve**2
+    n_pixel_final = 0 if nside_final is None else sky_fraction * 12 * nside_final**2
 
     overhead = base + (n_pixel_solve + n_pixel_final) * bytes_per_pixel
 
@@ -566,7 +566,7 @@ def estimate_memory_overhead(
         # Scale factor between simulations
         scale = 10
         # Jump straight to the third (largest) iteration
-        rmax *= scale ** 2
+        rmax *= scale**2
         xstep *= scale
         ystep *= scale
         zstep *= scale
@@ -638,12 +638,12 @@ def create_input_maps(
 
     sig = 50.0
     numer = ell - 30.0
-    tspec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * numer ** 2 / sig ** 2)
+    tspec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * numer**2 / sig**2)
     tspec *= 2000.0
 
     sig = 100.0
     numer = ell - 500.0
-    espec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * numer ** 2 / sig ** 2)
+    espec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(-0.5 * numer**2 / sig**2)
     espec *= 1.0
 
     cls = (
@@ -769,8 +769,8 @@ def compute_science_metric(args, runtime, n_nodes, rank, log):
     det_factor = 2.0
     metric = (
         prefactor
-        * args.n_detector ** det_factor
-        * kilo_samples ** sample_factor
+        * args.n_detector**det_factor
+        * kilo_samples**sample_factor
         / (n_nodes * runtime)
     )
     if rank == 0:

--- a/src/toast/scripts/toast_healpix_coadd
+++ b/src/toast/scripts/toast_healpix_coadd
@@ -211,7 +211,7 @@ def main():
 
     # Assign submaps, invert and apply local portions of the matrix
 
-    npix_submap = 12 * args.nside_submap ** 2
+    npix_submap = 12 * args.nside_submap**2
     nsubmap = npix // npix_submap
     local_submaps = [submap for submap in range(nsubmap) if submap % ntask == rank]
     dist = PixelDistribution(
@@ -222,8 +222,8 @@ def main():
     for local_submap, global_submap in enumerate(local_submaps):
         pix_start = global_submap * npix_submap
         pix_stop = pix_start + npix_submap
-        dist_map.data[local_submap] = noiseweighted_sum[:, pix_start : pix_stop].T
-        dist_cov.data[local_submap] = invcov_sum[:, pix_start : pix_stop].T
+        dist_map.data[local_submap] = noiseweighted_sum[:, pix_start:pix_stop].T
+        dist_cov.data[local_submap] = invcov_sum[:, pix_start:pix_stop].T
     del noiseweighted_sum
     del invcov_sum
 
@@ -242,7 +242,7 @@ def main():
                 args.rcond,
                 nest=True,
                 single_precision=not args.double_precision,
-                force_serial=True
+                force_serial=True,
             )
         log.info_rank(f"Wrote {args.rcond}", timer=timer, comm=comm)
     del dist_rcond
@@ -261,7 +261,7 @@ def main():
                 args.cov,
                 nest=True,
                 single_precision=not args.double_precision,
-                force_serial=True
+                force_serial=True,
             )
         log.info_rank(f"Wrote {args.cov}", timer=timer, comm=comm)
     del dist_cov
@@ -275,7 +275,7 @@ def main():
             args.outmap,
             nest=True,
             single_precision=not args.double_precision,
-            force_serial=True
+            force_serial=True,
         )
     log.info_rank(f"Wrote {args.outmap}", timer=timer, comm=comm)
 

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -195,7 +195,7 @@ def from_g3_unit(gunit):
         return u.dimensionless_unscaled
 
 
-def compress_timestream(ts, params, rmstarget=2 ** 10, rmsmode="white"):
+def compress_timestream(ts, params, rmstarget=2**10, rmsmode="white"):
     """Use FLAC compression to compress a timestream.
 
     `ts` is a G3Timestream.  Returns a new G3Timestream for same samples as ts, but
@@ -261,9 +261,9 @@ def compress_timestream(ts, params, rmstarget=2 ** 10, rmsmode="white"):
             gain = rmstarget / rms
         # If the data have extreme outliers, we have to reduce the gain
         # to fit the 24-bit signed integer range
-        while amp * gain >= 2 ** 23:
+        while amp * gain >= 2**23:
             gain *= 0.5
-    elif amp * gain >= 2 ** 23:
+    elif amp * gain >= 2**23:
         raise RuntimeError("The specified gain and offset saturate the band.")
     v = np.round((v - offset) * gain)
     new_ts = c3g.G3Timestream(v)

--- a/src/toast/templates/offset.py
+++ b/src/toast/templates/offset.py
@@ -432,7 +432,7 @@ class Offset(Template):
     def _get_offset_psd(self, noise, freq, step_time, det):
         """Compute the PSD of the baseline offsets."""
         psdfreq = noise.freq(det).to_value(u.Hz)
-        psd = noise.psd(det).to_value(u.K ** 2 * u.second)
+        psd = noise.psd(det).to_value(u.K**2 * u.second)
         rate = noise.rate(det).to_value(u.Hz)
 
         # Remove the white noise component from the PSD

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -170,6 +170,7 @@ def create_satellite_data(
     sample_rate=10.0 * u.Hz,
     obs_time=10.0 * u.minute,
     pixel_per_process=1,
+    hwp_rpm=10.0,
 ):
     """Create a data object with a simple satellite sim.
 
@@ -211,12 +212,16 @@ def create_satellite_data(
 
     # Scan fast enough to cover some sky in a short amount of time.  Reduce the
     # angles to achieve a more compact hit map.
+    if hwp_rpm == 0 or hwp_rpm is None:
+        hwp_angle = None
+    else:
+        hwp_angle = defaults.hwp_angle
     sim_sat = ops.SimSatellite(
         name="sim_sat",
         telescope=tele,
         schedule=sch,
-        hwp_angle=defaults.hwp_angle,
-        hwp_rpm=10.0,
+        hwp_angle=hwp_angle,
+        hwp_rpm=hwp_rpm,
         spin_angle=5.0 * u.degree,
         prec_angle=10.0 * u.degree,
         detset_key="pixel",
@@ -322,7 +327,7 @@ def create_healpix_ring_satellite(mpicomm, obs_per_group=1, nside=64):
         toast.Data: the distributed data with named observations.
 
     """
-    nsamp = 12 * nside ** 2
+    nsamp = 12 * nside**2
     rate = 10.0
 
     toastcomm = create_comm(mpicomm)
@@ -485,7 +490,7 @@ def create_fake_sky_alm(lmax=128, fwhm=10 * u.degree, pol=True, pointsources=Fal
         nside = 512
         while nside < lmax:
             nside *= 2
-        npix = 12 * nside ** 2
+        npix = 12 * nside**2
         m = np.zeros(npix)
         for lon in np.linspace(-180, 180, 6):
             for lat in np.linspace(-80, 80, 6):
@@ -521,9 +526,9 @@ def create_fake_beam_alm(
     mmax=10,
     fwhm_x=10 * u.degree,
     fwhm_y=10 * u.degree,
-    pol = True, 
+    pol=True,
     separate_IQU=False,
-    separate_TP=False ,
+    separate_TP=False,
     detB_beam=False,
     normalize_beam=False,
 ):
@@ -532,25 +537,23 @@ def create_fake_beam_alm(
     nside = 2
     while nside < lmax:
         nside *= 2
-    npix = 12 * nside ** 2
+    npix = 12 * nside**2
     pix = np.arange(npix)
     x, y, z = hp.pix2vec(nside, pix, nest=False)
     sigma_z = fwhm_x.to_value(u.radian) / np.sqrt(8 * np.log(2))
     sigma_y = fwhm_y.to_value(u.radian) / np.sqrt(8 * np.log(2))
-    beam = np.exp(-((z ** 2 / 2 / sigma_z ** 2 + y ** 2 / 2 / sigma_y ** 2)))
+    beam = np.exp(-((z**2 / 2 / sigma_z**2 + y**2 / 2 / sigma_y**2)))
     beam[x < 0] = 0
     beam_map = np.zeros([3, npix])
     beam_map[0] = beam
-    beam_map[1] = beam
-    bl, blm = hp.anafast(beam_map, lmax=lmax, iter=0, alm=True, pol=pol)
-    hp.rotate_alm(blm, psi=0, theta=-np.pi / 2, phi=0)
-    
     if detB_beam:
         # we make sure that the two detectors within the same pair encode
         # two beams with the  flipped sign in Q   U beams
-        beam_map = hp.alm2map(blm, nside=nside, lmax=lmax, mmax=mmax)
-        beam_map[1:] *= -1
-        blm = hp.map2alm(beam_map, lmax=lmax, mmax=mmax)
+        beam_map[1] = -beam
+    else:
+        beam_map[1] = beam
+    blm = hp.map2alm(beam_map, lmax=lmax, mmax=mmax)
+    hp.rotate_alm(blm, psi=0, theta=-np.pi / 2, phi=0, lmax=lmax, mmax=mmax)
 
     if normalize_beam:
         # We make sure that the simulated beams are normalized in the test
@@ -558,38 +561,55 @@ def create_fake_beam_alm(
         # i.e. the monopole term in the map is left unchanged
         idx = hp.Alm.getidx(lmax=lmax, l=0, m=0)
         norm = 2 * np.pi * blm[0, idx].real
-        
-    else: 
-        norm=1. 
-    
+
+    else:
+        norm = 1.0
+
     blm /= norm
+    # DEBUG begin
+    # import matplotlib.pyplot as plt
+    # ref = hp.gauss_beam(fwhm_x.to_value(u.radian), lmax=lmax, pol=True).T ** 2
+    # bl = hp.alm2cl(blm)
+    # fig = plt.figure()
+    # for col, name in enumerate("TEB"):
+    #     plt.semilogx(bl[col] * (2 * np.pi) ** 2, label=f"blm {name}")
+    #     plt.semilogx(ref[col], label=f"ref {name}")
+    # plt.legend()
+    # fig.savefig("bl.png")
+    # DEBUG end
     if separate_IQU:
         empty = np.zeros_like(beam_map[0])
         beam_map_I = np.vstack([beam_map[0], empty, empty])
         beam_map_Q = np.vstack([empty, beam_map[1], empty])
         beam_map_U = np.vstack([empty, empty, beam_map[1]])
         try:
-            blmi00 = hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False, pol=True)/norm
-            blm0i0 = hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False, pol=True )/norm
-            blm00i= hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False, pol=True)/norm
+            blmi00 = (
+                hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False, pol=True)
+                / norm
+            )
+            blm0i0 = (
+                hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False, pol=True)
+                / norm
+            )
+            blm00i = (
+                hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False, pol=True)
+                / norm
+            )
         except TypeError:
             # older healpy which does not have verbose keyword
-            blmi00 = hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax,pol=True)/norm
-            blm0i0 = hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax,pol=True)/norm
-            blm00i = hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax,pol=True)/norm
-        return [blmi00,blm0i0,blm00i]
-    
-    elif separate_TP : 
-        #blmT=np.zeros_like(blm  ) 
-        #blmP=np.zeros_like(blm  ) 
-        
-        #blmT[0] =blm[0].copy() 
-        #blmP[0] =blm[1 ] + blm[2]  
-        
-        blmT =blm[0].copy() 
-        blmP =blm[1 ] + blm[2]  
-        
-        return [blmT, blmP ]  
+            blmi00 = hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, pol=True) / norm
+            blm0i0 = hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, pol=True) / norm
+            blm00i = hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, pol=True) / norm
+        for b_lm in blmi00, blm0i0, blm00i:
+            hp.rotate_alm(b_lm, psi=0, theta=-np.pi / 2, phi=0, lmax=lmax, mmax=mmax)
+        return [blmi00, blm0i0, blm00i]
+
+    elif separate_TP:
+        blmT = blm[0].copy()
+        blmP = blm.copy()
+        blmP[0] = 0
+
+        return [blmT, blmP]
     else:
         return blm
 
@@ -712,7 +732,7 @@ def create_ground_data(
         det_flags="flags",
         det_data="signal",
         shared_flags="flags",
-        scan_accel_az=3 * u.degree / u.second ** 2,
+        scan_accel_az=3 * u.degree / u.second**2,
     )
     sim_ground.apply(data)
 

--- a/src/toast/tests/instrument.py
+++ b/src/toast/tests/instrument.py
@@ -55,7 +55,7 @@ class InstrumentTest(MPITestCase):
         psd_fmin = np.ones(ndet) * 1e-5 * u.Hz
         psd_fknee = np.ones(ndet) * 1e-2 * u.Hz
         psd_alpha = np.ones(ndet) * 1.0
-        psd_NET = np.ones(ndet) * 1e-3 * u.K * u.s ** 0.5
+        psd_NET = np.ones(ndet) * 1e-3 * u.K * u.s**0.5
         # Bandpass parameters (optional)
         bandcenter = np.ones(ndet) * 1e2 * u.GHz
         bandwidth = bandcenter * 0.1

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -39,7 +39,7 @@ class InstrumentTest(MPITestCase):
         nse = Noise(
             detnames,
             {x: u.Quantity(freqs, u.Hz) for x in streams},
-            {x: u.Quantity(np.ones(len(freqs)), u.K ** 2 * u.second) for x in streams},
+            {x: u.Quantity(np.ones(len(freqs)), u.K**2 * u.second) for x in streams},
             mixmatrix=mix,
         )
 

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -134,9 +134,9 @@ class NoiseEstimTest(MPITestCase):
                 freq, psd = hdulist[2].data.field(0)
                 ax.loglog(freq, psd, label=label)
             net = obs.telescope.focalplane["D0A"]["psd_net"]
-            net = net.to_value(u.K / u.Hz ** 0.5)
+            net = net.to_value(u.K / u.Hz**0.5)
             ax.axhline(
-                net ** 2,
+                net**2,
                 label=f"NET = {net:.3f} K" + " / $\sqrt{\mathrm{Hz}}$",
                 linestyle="--",
                 color="k",

--- a/src/toast/tests/ops_pointing_healpix.py
+++ b/src/toast/tests/ops_pointing_healpix.py
@@ -24,7 +24,7 @@ class PointingHealpixTest(MPITestCase):
 
     def test_pointing_matrix_healpix2(self):
         nside = 64
-        npix = 12 * nside ** 2
+        npix = 12 * nside**2
         hpix = HealpixPixels(64)
         nest = True
         phivec = np.radians(

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -185,7 +185,7 @@ class PolyFilterTest(MPITestCase):
         # Add 2D polynomial modes.  The number of modes is larger than the
         # number of detectors to test handling of singular template matrices.
         norder = 5
-        coeff = np.arange(norder ** 2)
+        coeff = np.arange(norder**2)
         for obs in data.obs:
             for det in obs.local_detectors:
                 det_quat = obs.telescope.focalplane[det]["quat"]
@@ -196,7 +196,7 @@ class PolyFilterTest(MPITestCase):
                 icoeff = 0
                 for xorder in range(norder):
                     for yorder in range(norder):
-                        signal += coeff[icoeff] * theta ** xorder * phi ** yorder
+                        signal += coeff[icoeff] * theta**xorder * phi**yorder
                         icoeff += 1
                 # Add a different offset depending on the wafer
                 wafer = obs.telescope.focalplane[det]["wafer"]

--- a/src/toast/tests/ops_sim_gaindrifts.py
+++ b/src/toast/tests/ops_sim_gaindrifts.py
@@ -314,7 +314,7 @@ class SimGainTest(MPITestCase):
         sim_dipole.apply(data)
 
         # inject gain drift
-        responsivity = lambda x: -2 * x ** 3 + 5 * x ** 2 - 4 * x + 3
+        responsivity = lambda x: -2 * x**3 + 5 * x**2 - 4 * x + 3
         drifter = ops.GainDrifter(
             det_data=key,
             drift_mode="thermal_drift",

--- a/src/toast/tests/ops_sim_tod_conviqt.py
+++ b/src/toast/tests/ops_sim_tod_conviqt.py
@@ -55,10 +55,32 @@ class SimConviqtTest(MPITestCase):
             self.slm = create_fake_sky_alm(self.lmax, self.fwhm_sky)
 
             hp.write_alm(self.fname_sky, self.slm, lmax=self.lmax, overwrite=True)
-            hp.write_alm(self.fname_sky.replace(".fits","_T.fits"), self.slm[0] , lmax=self.lmax, overwrite=True)
-            hp.write_alm(self.fname_sky.replace(".fits","_E.fits"), self.slm[1] , lmax=self.lmax, overwrite=True)
-            hp.write_alm(self.fname_sky.replace(".fits","_B.fits"), self.slm[2] , lmax=self.lmax, overwrite=True)
-            
+
+            # Inputs for the TEB convolution
+            # FIXME : the TEB conviqt operator should do this match rather than leave it for the user
+            hp.write_alm(
+                self.fname_sky.replace(".fits", "_T.fits"),
+                self.slm[0],
+                lmax=self.lmax,
+                overwrite=True,
+            )
+            slm = self.slm.copy()
+            slm[0] = 0
+            hp.write_alm(
+                self.fname_sky.replace(".fits", "_EB.fits"),
+                slm,
+                lmax=self.lmax,
+                overwrite=True,
+            )
+            slm[1] = self.slm[2]
+            slm[2] = -self.slm[1]
+            hp.write_alm(
+                self.fname_sky.replace(".fits", "_BE.fits"),
+                slm,
+                lmax=self.lmax,
+                overwrite=True,
+            )
+
             self.blm = create_fake_beam_alm(
                 self.lmax,
                 self.mmax,
@@ -150,8 +172,9 @@ class SimConviqtTest(MPITestCase):
                 overwrite=True,
             )
 
-            # we explicitly store 3 separate beams for the T, E and B sky alm.
-            blm_T, blm_P  = create_fake_beam_alm(
+            # we explicitly store temperature and polarization beams
+            # FIXME : Another place where the operator should handle the decomposition.
+            blm_T, blm_P = create_fake_beam_alm(
                 self.lmax,
                 self.mmax,
                 fwhm_x=self.fwhm_beam,
@@ -160,7 +183,7 @@ class SimConviqtTest(MPITestCase):
                 detB_beam=False,
                 normalize_beam=True,
             )
-            blm_Tbot, blm_Pbot  = create_fake_beam_alm(
+            blm_Tbot, blm_Pbot = create_fake_beam_alm(
                 self.lmax,
                 self.mmax,
                 fwhm_x=self.fwhm_beam,
@@ -213,14 +236,14 @@ class SimConviqtTest(MPITestCase):
 
         fname2 = self.fname_beam.replace(".fits", "_bottom.fits")
 
-        self.beam_file_dict = {}
+        beam_file_dict = {}
         for det in data.obs[0].local_detectors:
             if det[-1] == "A":
-                self.beam_file_dict[det] = self.fname_beam
+                beam_file_dict[det] = self.fname_beam
             else:
-                self.beam_file_dict[det] = fname2
+                beam_file_dict[det] = fname2
 
-        return
+        return beam_file_dict
 
     def test_sim_conviqt(self):
         if not ops.conviqt.available():
@@ -232,7 +255,7 @@ class SimConviqtTest(MPITestCase):
         data = create_satellite_data(
             self.comm, obs_time=120 * u.min, pixel_per_process=2
         )
-        self.make_beam_file_dict(data)
+        beam_file_dict = self.make_beam_file_dict(data)
 
         # Generate timestreams
 
@@ -243,7 +266,7 @@ class SimConviqtTest(MPITestCase):
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file_dict=self.beam_file_dict,
+            beam_file_dict=beam_file_dict,
             dxx=False,
             det_data=key,
             pol=True,
@@ -340,12 +363,10 @@ class SimConviqtTest(MPITestCase):
             print("libconviqt not available, skipping tests")
             return
 
-        # Create a fake scan strategy that hits every pixel once.
-        #        data = create_healpix_ring_satellite(self.comm, nside=self.nside)
         data = create_satellite_data(
             self.comm, obs_time=120 * u.min, pixel_per_process=2
         )
-        self.make_beam_file_dict(data)
+        beam_file_dict = self.make_beam_file_dict(data)
 
         # Generate timestreams
 
@@ -356,7 +377,7 @@ class SimConviqtTest(MPITestCase):
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file_dict=self.beam_file_dict,
+            beam_file_dict=beam_file_dict,
             dxx=False,
             det_data=key1,
             pol=True,
@@ -372,7 +393,7 @@ class SimConviqtTest(MPITestCase):
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file_dict=self.beam_file_dict,
+            beam_file_dict=beam_file_dict,
             dxx=False,
             det_data=key2,
             pol=True,
@@ -409,7 +430,7 @@ class SimConviqtTest(MPITestCase):
         )
         cov_and_hits.apply(data)
 
-        binner  = ops.BinMap(
+        binner = ops.BinMap(
             pixel_dist="pixel_dist",
             covariance=cov_and_hits.covariance,
             det_flags=None,
@@ -418,14 +439,14 @@ class SimConviqtTest(MPITestCase):
             noise_model=default_model.noise_model,
             sync_type="alltoallv",
         )
-        
+
         binner.det_data = key1
         binner.binned = "binned1"
         binner.apply(data)
         binner.det_data = key2
         binner.binned = "binned2"
         binner.apply(data)
-        
+
         # Study the map on the root process
 
         toast_bin_path = os.path.join(self.outdir, f"toast_bin.{key1}.fits")
@@ -458,46 +479,47 @@ class SimConviqtTest(MPITestCase):
         # Create a fake scan strategy that hits every pixel once.
         #        data = create_healpix_ring_satellite(self.comm, nside=self.nside)
         data = create_satellite_data(
-            self.comm, obs_time=120 * u.min, pixel_per_process=2
+            self.comm,
+            obs_time=120 * u.min,
+            pixel_per_process=2,
+            hwp_rpm=None,
         )
-        self.make_beam_file_dict(data)
-        
-        
+
+        beam_file_dict = self.make_beam_file_dict(data)
+
         # Generate timestreams
 
         detpointing = ops.PointingDetectorSimple()
-        
-        
+
         key1 = "conviqt0"
         sim_conviqt = ops.SimConviqt(
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file_dict=self.beam_file_dict,
+            beam_file_dict=beam_file_dict,
             dxx=False,
             det_data=key1,
             pol=True,
             normalize_beam=False,
             fwhm=self.fwhm_sky,
         )
-    
+
         sim_conviqt.apply(data)
-        
+
         key2 = "tebconviqt"
-        
+
         sim_wconviqt = ops.SimTEBConviqt(
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file_dict=self.beam_file_dict,
-            dxx=False  ,
+            beam_file_dict=beam_file_dict,
+            dxx=False,
             det_data=key2,
-            pol=False ,
+            pol=True,
             normalize_beam=False,
             fwhm=self.fwhm_sky,
         )
-        
-            
+
         sim_wconviqt.apply(data)
         # Bin a map to study
 
@@ -527,7 +549,7 @@ class SimConviqtTest(MPITestCase):
         )
         cov_and_hits.apply(data)
 
-        binner  = ops.BinMap(
+        binner = ops.BinMap(
             pixel_dist="pixel_dist",
             covariance=cov_and_hits.covariance,
             det_flags=None,
@@ -536,14 +558,14 @@ class SimConviqtTest(MPITestCase):
             noise_model=default_model.noise_model,
             sync_type="alltoallv",
         )
-        
+
         binner.det_data = key1
         binner.binned = "binned1"
         binner.apply(data)
         binner.det_data = key2
         binner.binned = "binned2"
         binner.apply(data)
-        
+
         # Study the map on the root process
 
         toast_bin_path = os.path.join(self.outdir, f"toast_bin.{key1}.fits")
@@ -568,24 +590,233 @@ class SimConviqtTest(MPITestCase):
 
         return
 
-    """
     def test_sim_hwp(self):
         if not ops.conviqt.available():
             print("libconviqt not available, skipping tests")
             return
-        # Create a fake scan strategy that hits every pixel once.
-        data = create_satellite_data(self.comm)
-        # make a simple pointing matrix
-        detpointing = ops.PointingDetectorSimple()
+
+        data_wo_hwp = create_satellite_data(
+            self.comm,
+            obs_time=120 * u.min,
+            pixel_per_process=2,
+            hwp_rpm=None,
+        )
+        data_w_hwp = create_satellite_data(
+            self.comm,
+            obs_time=120 * u.min,
+            pixel_per_process=2,
+            hwp_rpm=100,
+        )
+        beam_file_dict_wo_hwp = self.make_beam_file_dict(data_wo_hwp)
+        beam_file_dict_w_hwp = self.make_beam_file_dict(data_w_hwp)
+
         # Generate timestreams
-        sim_conviqt = ops.SimWeightedConviqt(
+
+        detpointing = ops.PointingDetectorSimple()
+
+        key_wo_hwp = "conviqt_wo_hwp"
+        sim_wo_hwp_conviqt = ops.SimConviqt(
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file=self.fname_beam,
+            beam_file_dict=beam_file_dict_wo_hwp,
             dxx=False,
+            det_data=key_wo_hwp,
+            pol=True,
+            normalize_beam=False,
+            fwhm=self.fwhm_sky,
+            hwp_angle=None,
+        )
+
+        sim_wo_hwp_conviqt.apply(data_wo_hwp)
+
+        key_w_hwp = "tebconviqt_w_hwp"
+
+        sim_w_hwp_conviqt = ops.SimTEBConviqt(
+            comm=self.comm,
+            detector_pointing=detpointing,
+            sky_file=self.fname_sky,
+            beam_file_dict=beam_file_dict_w_hwp,
+            dxx=False,
+            det_data=key_w_hwp,
+            pol=True,
+            normalize_beam=False,
+            fwhm=self.fwhm_sky,
             hwp_angle="hwp_angle",
         )
-        sim_conviqt.exec(data)
+
+        sim_w_hwp_conviqt.apply(data_w_hwp)
+        # Bin a map to study
+
+        pixels = ops.PixelsHealpix(
+            nside=self.nside,
+            nest=False,
+            detector_pointing=detpointing,
+        )
+        pixels.apply(data_w_hwp)
+        pixels.apply(data_wo_hwp)
+
+        weights_wo_hwp = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=None,
+            detector_pointing=detpointing,
+        )
+        weights_wo_hwp.apply(data_wo_hwp)
+
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data_w_hwp)
+        default_model.apply(data_wo_hwp)
+
+        cov_and_hits_wo_hwp = ops.CovarianceAndHits(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights_wo_hwp,
+            noise_model=default_model.noise_model,
+            rcond_threshold=1.0e-6,
+            sync_type="alltoallv",
+        )
+        cov_and_hits_wo_hwp.apply(data_wo_hwp)
+
+        binner_wo_hwp = ops.BinMap(
+            pixel_dist="pixel_dist",
+            covariance=cov_and_hits_wo_hwp.covariance,
+            det_flags=None,
+            pixel_pointing=pixels,
+            stokes_weights=weights_wo_hwp,
+            noise_model=default_model.noise_model,
+            sync_type="alltoallv",
+        )
+
+        binner_wo_hwp.det_data = key_wo_hwp
+        binner_wo_hwp.binned = "binned_wo_hwp"
+        binner_wo_hwp.apply(data_wo_hwp)
+
+        weights_w_hwp = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle="hwp_angle",
+            detector_pointing=detpointing,
+        )
+        weights_w_hwp.apply(data_w_hwp)
+
+        cov_and_hits_w_hwp = ops.CovarianceAndHits(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights_w_hwp,
+            noise_model=default_model.noise_model,
+            rcond_threshold=1.0e-6,
+            sync_type="alltoallv",
+        )
+        cov_and_hits_w_hwp.apply(data_w_hwp)
+
+        binner_w_hwp = ops.BinMap(
+            pixel_dist="pixel_dist",
+            covariance=cov_and_hits_w_hwp.covariance,
+            det_flags=None,
+            pixel_pointing=pixels,
+            stokes_weights=weights_w_hwp,
+            noise_model=default_model.noise_model,
+            sync_type="alltoallv",
+        )
+        binner_w_hwp.det_data = key_w_hwp
+        binner_w_hwp.binned = "binned_w_hwp"
+        binner_w_hwp.apply(data_w_hwp)
+
+        # Study the map on the root process
+
+        toast_bin_path = os.path.join(self.outdir, f"toast_bin.{key_wo_hwp}.fits")
+        write_healpix_fits(
+            data_wo_hwp["binned_wo_hwp"], toast_bin_path, nest=pixels.nest
+        )
+        toast_bin_path = os.path.join(self.outdir, f"toast_bin.{key_w_hwp}.fits")
+        write_healpix_fits(data_w_hwp["binned_w_hwp"], toast_bin_path, nest=pixels.nest)
+
+        toast_hits_path = os.path.join(self.outdir, "toast_hits_wo_hwp.fits")
+        write_healpix_fits(
+            data_wo_hwp[cov_and_hits_wo_hwp.hits], toast_hits_path, nest=pixels.nest
+        )
+        toast_hits_path = os.path.join(self.outdir, "toast_hits_w_hwp.fits")
+        write_healpix_fits(
+            data_w_hwp[cov_and_hits_w_hwp.hits], toast_hits_path, nest=pixels.nest
+        )
+        fail = False
+        if self.rank == 0:
+            import matplotlib.pyplot as plt
+
+            bl_in = hp.gauss_beam(
+                self.fwhm_sky.to_value(u.radian), lmax=self.lmax, pol=True
+            ).T
+            bl_out = hp.gauss_beam(
+                self.fwhm_beam.to_value(u.radian), lmax=self.lmax, pol=True
+            ).T
+            slm = self.slm.copy()
+            bl_in[bl_in == 0] = 1
+            bl_out[bl_out == 0] = 1
+            for i in range(3):
+                slm[i] = hp.almxfl(slm[i], bl_out[i] / bl_in[i])
+            reference = hp.alm2map(slm, self.nside, lmax=self.lmax, pixwin=True)
+
+            mapfile = os.path.join(self.outdir, f"toast_bin.{key_wo_hwp}.fits")
+            mdata_wo_hwp = hp.read_map(mapfile, field=range(3))
+            mapfile = os.path.join(self.outdir, f"toast_bin.{key_w_hwp}.fits")
+            mdata_w_hwp = hp.read_map(mapfile, field=range(3))
+            diff = mdata_w_hwp - mdata_wo_hwp
+            for m in mdata_wo_hwp, mdata_w_hwp, diff:
+                m[m == 0] = hp.UNSEEN
+            reference[m == hp.UNSEEN] = hp.UNSEEN
+
+            args = {"rot": [156, 11], "xsize": 1200, "reso": 3, "cmap": "bwr"}
+            nrow, ncol = 3, 3
+            fig = plt.figure(figsize=[18, 12])
+            for col, stokes in enumerate("IQU"):
+                hp.gnomview(
+                    mdata_wo_hwp[col],
+                    **args,
+                    sub=[nrow, ncol, 1 + col],
+                    title=f"{stokes} w/o HWP",
+                )
+                hp.gnomview(
+                    mdata_w_hwp[col],
+                    **args,
+                    sub=[nrow, ncol, 4 + col],
+                    title=f"{stokes} w/ HWP",
+                )
+                hp.gnomview(
+                    reference[col],
+                    **args,
+                    sub=[nrow, ncol, 7 + col],
+                    title=f"{stokes} reference",
+                )
+            fname = os.path.join(self.outdir, "map_comparison_w_wo_hwp.png")
+            fig.savefig(fname)
+
+            cl_reference = hp.anafast(reference, lmax=self.lmax)
+            cl_out_wo_hwp = hp.anafast(mdata_wo_hwp, lmax=self.lmax)
+            cl_out_w_hwp = hp.anafast(mdata_w_hwp, lmax=self.lmax)
+
+            nrow, ncol = 2, 3
+            fig = plt.figure(figsize=[18, 12])
+            for col, spec in enumerate(["TT", "EE", "BB"]):
+                ax = fig.add_subplot(nrow, ncol, 1 + col)
+                ax.set_title(f"{spec}")
+                ax.semilogx(cl_reference[col], color="black", label="reference")
+                ax.semilogx(cl_out_wo_hwp[col], color="tab:blue", label="w/o HWP")
+                ax.semilogx(cl_out_w_hwp[col], color="tab:orange", label="w/ HWP")
+                ax = fig.add_subplot(nrow, ncol, 1 + ncol + col)
+                ax.set_title(f"{spec}")
+                ax.semilogx(
+                    cl_reference[col] / cl_out_wo_hwp[col],
+                    color="tab:blue",
+                    label="ref / w/o HWP",
+                )
+                ax.semilogx(
+                    cl_reference[col] / cl_out_w_hwp[col],
+                    color="tab:orange",
+                    label="ref / w/ HWP",
+                )
+            ax.legend(loc="best")
+            fname = os.path.join(self.outdir, "cl_comparison_w_wo_hwp.png")
+            fig.savefig(fname)
+
+            np.testing.assert_almost_equal(cl_out_wo_hwp, cl_out_w_hwp, decimal=2)
+
         return
-    """

--- a/src/toast/tests/ops_sim_tod_conviqt.py
+++ b/src/toast/tests/ops_sim_tod_conviqt.py
@@ -39,6 +39,7 @@ def create_fake_beam_alm(
     fwhm_y=10 * u.degree,
     pol=True,
     separate_IQU=False,
+    detB_beam=False 
 ):
 
     # pick an nside >= lmax to be sure that the a_lm will be fairly accurate
@@ -56,38 +57,54 @@ def create_fake_beam_alm(
     tmp_beam_map = np.zeros([3, npix ])
     tmp_beam_map[0] = beam
     tmp_beam_map[1] = beam
+     
+    
+        
     bl, blm = hp.anafast(tmp_beam_map, lmax=lmax, iter=0, alm=True,pol=True)
     hp.rotate_alm(blm, psi=0, theta=-np.pi/2, phi=0)
-    if pol and separate_IQU:
+    if   detB_beam : 
+        # we make sure that the two detectors within the same pair encode two beams with the  flipped sign in Q   U beams  
+        beam_map = hp.alm2map(blm, nside=nside, lmax=lmax , mmax=mmax)
+        beam_map[1:] *= (-1) 
+        blm=hp.map2alm (beam_map, lmax=lmax , mmax=mmax)
+    if   separate_IQU:
 
-        beam_map= hp.alm2map(blm, nside=nside) 
-        empty = np.zeros_like(beam_map[0])
+        empty = np.zeros_like(tmp_beam_map[0])
         
-        beam_map_I = np.vstack([beam_map[0], empty, empty])
-        beam_map_Q = np.vstack([empty, beam_map[0], empty])
-        beam_map_U = np.vstack([empty, empty, beam_map[0]])
+        beam_map_I = np.vstack([tmp_beam_map[0], empty, empty])
+        if   detB_beam : 
+
+            beam_map_Q = np.vstack([empty, -tmp_beam_map[0], empty])
+            beam_map_U = np.vstack([empty, empty, -tmp_beam_map[0]])
+        else: 
+            beam_map_Q = np.vstack([empty, tmp_beam_map[0], empty])
+            beam_map_U = np.vstack([empty, empty, tmp_beam_map[0]])
 
         try:
-            a_lm = [
-                hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False),
-                hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False),
-                hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False),
-            ]
+            almI = hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax, verbose=False)
+            almQ = hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax, verbose=False)
+            almU = hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax, verbose=False)
+             
+            
         except TypeError:
             # older healpy which does not have verbose keyword
-            a_lm = [
-                hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax),
-                hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax),
-                hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax),
-            ]
+            almI = hp.map2alm(beam_map_I, lmax=lmax, mmax=mmax )
+            almQ = hp.map2alm(beam_map_Q, lmax=lmax, mmax=mmax )
+            almU = hp.map2alm(beam_map_U, lmax=lmax, mmax=mmax )
+             
+        hp.rotate_alm(almI, psi=0, theta=-np.pi/2, phi=0)
+        hp.rotate_alm(almQ, psi=0, theta=-np.pi/2, phi=0)
+        hp.rotate_alm(almU, psi=0, theta=-np.pi/2, phi=0)
+        a_lm= [ almI, almQ, almU     ]
         return a_lm 
     else:
- 
-
         return blm
 
 class SimConviqtTest(MPITestCase):
     def setUp(self):
+        
+        
+        np.random.seed(777)
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
         self.outdir = create_outdir(self.comm, fixture_name)
 
@@ -115,11 +132,24 @@ class SimConviqtTest(MPITestCase):
                 fwhm_x=self.fwhm_beam,
                 fwhm_y=self.fwhm_beam,
             )
-            
+            self.blm_bottom= create_fake_beam_alm(
+                self.lmax,
+                self.mmax,
+                fwhm_x=self.fwhm_beam,
+                fwhm_y=self.fwhm_beam,
+                detB_beam=True 
+            )
             
             hp.write_alm(
                 self.fname_beam,
                 self.blm,
+                lmax=self.lmax,
+                mmax_in=self.mmax,
+                overwrite=True,
+            )
+            hp.write_alm(
+                self.fname_beam.replace(".fits", "_bottom.fits"),
+                self.blm_bottom,
                 lmax=self.lmax,
                 mmax_in=self.mmax,
                 overwrite=True,
@@ -130,6 +160,13 @@ class SimConviqtTest(MPITestCase):
                 fwhm_x=self.fwhm_beam,
                 fwhm_y=self.fwhm_beam,
                 separate_IQU=True,
+            )
+            blm_Ibot, blm_Qbot, blm_Ubot = create_fake_beam_alm(
+                self.lmax,
+                self.mmax,
+                fwhm_x=self.fwhm_beam,
+                fwhm_y=self.fwhm_beam,
+                separate_IQU=True, detB_beam=True 
             )
             hp.write_alm(
                 self.fname_beam.replace(".fits", "_I000.fits"),
@@ -148,6 +185,27 @@ class SimConviqtTest(MPITestCase):
             hp.write_alm(
                 self.fname_beam.replace(".fits", "_00I0.fits"),
                 blm_U,
+                lmax=self.lmax,
+                mmax_in=self.mmax,
+                overwrite=True,
+            )
+            hp.write_alm(
+                self.fname_beam.replace(".fits", "_bottom_I000.fits"),
+                blm_Ibot,
+                lmax=self.lmax,
+                mmax_in=self.mmax,
+                overwrite=True,
+            )
+            hp.write_alm(
+                self.fname_beam.replace(".fits", "_bottom_0I00.fits"),
+                blm_Qbot,
+                lmax=self.lmax,
+                mmax_in=self.mmax,
+                overwrite=True,
+            )
+            hp.write_alm(
+                self.fname_beam.replace(".fits", "_bottom_00I0.fits"),
+                blm_Ubot,
                 lmax=self.lmax,
                 mmax_in=self.mmax,
                 overwrite=True,
@@ -192,28 +250,24 @@ class SimConviqtTest(MPITestCase):
             self.comm.barrier()
 
         return
+    
+    
     def make_beam_file_dict(self,data) : 
         
-        beam_map  = hp.alm2map(self.blm, lmax=self.lmax, mmax=self.mmax , nside=self.nside) 
-        beam_map [1:] = (-1) *beam_map [1:]  
-        blm2 = hp.map2alm(beam_map, lmax=self.lmax, mmax=self.mmax ) 
+        
         fname2= self.fname_beam.replace('.fits', '_bottom.fits')
-        hp.write_alm(
-                fname2 ,
-                 blm2,
-                lmax=self.lmax,
-                mmax_in=self.mmax,
-                overwrite=True,
-            )
+        
         self.beam_file_dict={} 
         for det in data.obs[0].local_detectors:
             if det[-1]=="A" : 
                 self.beam_file_dict[det] = self.fname_beam 
             else: 
-                self.beam_file_dict[det] = fname2 
+                self.beam_file_dict[det] = fname2
+                
+                
         return 
             
-    def test_sim(self):
+    def test_sim_conviqt(self):
         if not ops.conviqt.available():
             print("libconviqt not available, skipping tests")
             return
@@ -232,7 +286,6 @@ class SimConviqtTest(MPITestCase):
             comm=self.comm,
             detector_pointing=detpointing,
             sky_file=self.fname_sky,
-            beam_file=self.fname_beam,
             beam_file_dict= self.beam_file_dict,
             dxx=False,
             det_data=key,
@@ -293,114 +346,166 @@ class SimConviqtTest(MPITestCase):
 
         fail = False
 
-        if self.rank == 10:
-            set_matplotlib_backend()
-
-            import matplotlib.pyplot as plt
-
+        if self.rank == 0:
             hitsfile = os.path.join(self.outdir, "toast_hits.fits")
+            
             hdata = hp.read_map(hitsfile)
-
-            hp.mollview(hdata, xsize=1600)
-            plt.savefig(os.path.join(self.outdir, "toast_hits.png"))
-            plt.close()
-
+            
+            footprint = np.ma.masked_not_equal(hdata, 0. ).mask
+            
             mapfile = os.path.join(self.outdir, "toast_bin.fits")
-            mdata = hp.read_map(mapfile)
+            mdata = hp.read_map(mapfile, field=range(3) )
 
-            hp.mollview(mdata, xsize=1600)
-            plt.savefig(os.path.join(self.outdir, "toast_bin.png"))
-            plt.close()
-
+            
             deconv = 1 / hp.gauss_beam(
                 self.fwhm_sky.to_value(u.radian),
                 lmax=self.lmax,
-                pol=False,
+                pol=False ,
             )
 
             smoothed = hp.alm2map(
-                hp.almxfl(self.slm[0], deconv),
+                [ hp.almxfl(self.slm[ii] , deconv)  for ii in range(3)] ,
                 self.nside,
                 lmax=self.lmax,
                 fwhm=self.fwhm_beam.to_value(u.radian),
                 verbose=False,
                 pixwin=False,
             )
-
+            smoothed[:, ~footprint] =0 
             cl_out = hp.anafast(mdata, lmax=self.lmax)
             cl_smoothed = hp.anafast(smoothed, lmax=self.lmax)
-
-            cl_in = hp.alm2cl(self.slm[0], lmax=self.lmax)
-            blsq = hp.alm2cl(self.blm[0], lmax=self.lmax, mmax=self.mmax)
-            blsq /= blsq[1]
-
-            gauss_blsq = hp.gauss_beam(
-                self.fwhm_beam.to_value(u.radian),
-                lmax=self.lmax,
-                pol=False,
-            )
-
-            sky = hp.alm2map(self.slm[0], self.nside, lmax=self.lmax, verbose=False)
-            beam = hp.alm2map(
-                self.blm[0],
-                self.nside,
-                lmax=self.lmax,
-                mmax=self.mmax,
-                verbose=False,
-            )
-
-            fig = plt.figure(figsize=[12, 8])
-            nrow, ncol = 2, 3
-            hp.mollview(sky, title="input sky", sub=[nrow, ncol, 1])
-            hp.mollview(mdata, title="output sky", sub=[nrow, ncol, 2])
-            hp.mollview(smoothed, title="smoothed sky", sub=[nrow, ncol, 3])
-            hp.mollview(beam, title="beam", sub=[nrow, ncol, 4], rot=[0, 90])
-
-            ell = np.arange(self.lmax + 1)
-            ax = fig.add_subplot(nrow, ncol, 5)
-            ax.plot(ell[1:], cl_in[1:], label="input")
-            ax.plot(ell[1:], cl_smoothed[1:], label="smoothed")
-            ax.plot(ell[1:], blsq[1:], label="beam")
-            ax.plot(ell[1:], gauss_blsq[1:], label="gauss beam")
-            ax.plot(ell[1:], 1 / deconv[1:] ** 2, label="1 / deconv")
-            ax.plot(
-                ell[1:],
-                cl_in[1:] * blsq[1:] * deconv[1:] ** 2,
-                label="input x beam x deconv",
-            )
-            ax.plot(ell[1:], cl_out[1:], label="output")
-            ax.legend(loc="best")
-            ax.set_xscale("log")
-            ax.set_yscale("log")
-            ax.set_ylim([1e-20, 1e1])
-
-            # For some reason, matplotlib hangs with multiple tasks,
-            # even if only one writes.  Uncomment these lines when debugging.
-            #
-            outfile = os.path.join(self.outdir, "cl_comparison.png")
-            plt.savefig(outfile)
-            plt.close()
-
-            compare = blsq > 1e-5
-            ref = cl_in[compare] * blsq[compare] * deconv[compare] ** 2
-            norm = np.mean(cl_out[compare] / ref)
-            print(norm * ref,cl_out[compare] )
-            if not np.allclose(
-                norm * ref,
-                cl_out[compare],
-                rtol=1e-5,
-                atol=1e-5,
-            ):
-                fail = True
-
-        if self.comm is not None:
-            fail = self.comm.bcast(fail, root=0)
-
-        self.assertFalse(fail)
-
+            
+            np.testing.assert_almost_equal(
+            cl_smoothed[0] ,
+                cl_out[0], decimal=2
+        )
+             
         return
-    """   
-     
+    
+    def test_sim_weighted_conviqt(self):
+        if not ops.conviqt.available():
+            print("libconviqt not available, skipping tests")
+            return
+
+        # Create a fake scan strategy that hits every pixel once.
+        #        data = create_healpix_ring_satellite(self.comm, nside=self.nside)
+        data = create_satellite_data(self.comm , obs_time=120*u.min, pixel_per_process=2 )
+        self. make_beam_file_dict(data)
+            
+        # Generate timestreams
+
+        detpointing = ops.PointingDetectorSimple()
+
+        key1 =  "conviqt"
+        sim_conviqt = ops.SimConviqt(
+            comm=self.comm,
+            detector_pointing=detpointing,
+            sky_file=self.fname_sky,
+            beam_file_dict= self.beam_file_dict,
+            dxx=False,
+            det_data=key1,
+            pol=True ,
+            normalize_beam= True    , 
+            fwhm=self.fwhm_sky,
+        )
+         
+        sim_conviqt.apply(data)
+
+        key2 =  "wconviqt"
+        
+        sim_wconviqt = ops.SimWeightedConviqt(
+            comm=self.comm,
+            detector_pointing=detpointing,
+            sky_file=self.fname_sky,
+            beam_file_dict = self.beam_file_dict,
+            dxx=False,
+            det_data=key2,
+            pol=True ,
+            normalize_beam=False   , #TODO:understand why if we set it to True we get both binned maps with nans 
+            fwhm=self.fwhm_sky,
+        )
+         
+        sim_wconviqt.apply(data)
+        # Bin a map to study
+
+        pixels = ops.PixelsHealpix(
+            nside=self.nside,
+            nest=False,
+            detector_pointing=detpointing,
+        )
+        pixels.apply(data)
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle= None ,
+            detector_pointing=detpointing,
+        )
+        weights.apply(data)
+
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        cov_and_hits = ops.CovarianceAndHits(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+            rcond_threshold=1.0e-6,
+            sync_type="alltoallv",
+        )
+        cov_and_hits.apply(data)
+
+        binner1 = ops.BinMap(
+            pixel_dist="pixel_dist",
+            covariance=cov_and_hits.covariance,
+            det_data=key1,
+            det_flags=None,
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+            sync_type="alltoallv",
+        )
+        binner1.apply(data)
+        binner2 = ops.BinMap(
+            pixel_dist="pixel_dist",
+            covariance=cov_and_hits.covariance,
+            det_data=key2,
+            det_flags=None,
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+            sync_type="alltoallv",
+        )
+        binner2.apply(data)
+        # Study the map on the root process
+
+        toast_bin_path = os.path.join(self.outdir, "toast_bin.conviqt.fits")
+        write_healpix_fits(data[binner1.binned], toast_bin_path, nest=pixels.nest)
+        toast_bin_path = os.path.join(self.outdir, "toast_bin.wconviqt.fits")
+        write_healpix_fits(data[binner2.binned], toast_bin_path, nest=pixels.nest)
+        
+        toast_hits_path = os.path.join(self.outdir, "toast_hits.fits")
+        write_healpix_fits(data[cov_and_hits.hits], toast_hits_path, nest=pixels.nest)
+
+        fail = False
+        if self.rank == 0:
+            mapfile = os.path.join(self.outdir, "toast_bin.conviqt.fits")
+            mdata = hp.read_map(mapfile, field=range(3) )
+            mapfile = os.path.join(self.outdir, "toast_bin.wconviqt.fits")
+            mdataw = hp.read_map(mapfile, field=range(3) )
+
+            
+            cl_out = hp.anafast(mdata, lmax=self.lmax)
+            cl_outw = hp.anafast(mdataw, lmax=self.lmax)
+            
+            np.testing.assert_almost_equal(
+              cl_out[0],
+                cl_outw[0], decimal=2
+        )
+             
+        return
+   
+    
+"""   
     def test_TEBconvolution(self):
         if not ops.conviqt.available():
             print("libconviqt not available, skipping tests")

--- a/src/toast/tests/ops_sim_tod_noise.py
+++ b/src/toast/tests/ops_sim_tod_noise.py
@@ -143,7 +143,7 @@ class SimNoiseTest(MPITestCase):
                     ax = fig.add_subplot(1, 1, 1, aspect="auto")
                     ax.loglog(
                         nse.freq(det).to_value(u.Hz),
-                        nse.psd(det).to_value(u.K ** 2 * u.second),
+                        nse.psd(det).to_value(u.K**2 * u.second),
                         marker="o",
                         c="red",
                         label="{}: rate={:0.1f} NET={:0.1f} fknee={:0.4f}, "
@@ -197,7 +197,7 @@ class SimNoiseTest(MPITestCase):
                     samples=ob.n_local_samples,
                     oversample=self.oversample,
                     freq=nse.freq(det).to_value(u.Hz),
-                    psd=nse.psd(det).to_value(u.K ** 2 * u.second),
+                    psd=nse.psd(det).to_value(u.K**2 * u.second),
                     py=True,
                 )
                 np.testing.assert_array_almost_equal(
@@ -326,7 +326,7 @@ class SimNoiseTest(MPITestCase):
                     samples=ob.n_local_samples,
                     oversample=self.oversample,
                     freq=nse.freq(det).to_value(u.Hz),
-                    psd=nse.psd(det).to_value(u.K ** 2 * u.second),
+                    psd=nse.psd(det).to_value(u.K**2 * u.second),
                     py=True,
                 )
                 pytod.clear()
@@ -411,7 +411,7 @@ class SimNoiseTest(MPITestCase):
                     buffer[offset : offset + len(tod)] = tod
                     rawpsd = np.fft.rfft(buffer)
                     norm = 1.0 / (sample_rate * ob.n_local_samples)
-                    rawpsd = norm * np.abs(rawpsd ** 2)
+                    rawpsd = norm * np.abs(rawpsd**2)
                     bpsd = np.bincount(checkbinmap, weights=rawpsd)
                     good = bcount > 0
                     bpsd[good] /= bcount[good]

--- a/src/toast/tests/pixels.py
+++ b/src/toast/tests/pixels.py
@@ -47,7 +47,7 @@ class PixelTest(MPITestCase):
         pass
 
     def _make_pixdist(self, nside, nsub, comm):
-        npix = 12 * nside ** 2
+        npix = 12 * nside**2
         valid_submaps = np.arange(0, nsub, 2, dtype=np.int32)
         # Make up some local submaps for each process
         local_submaps = None

--- a/src/toast/tests/template_amplitudes.py
+++ b/src/toast/tests/template_amplitudes.py
@@ -74,7 +74,7 @@ class TemplateTest(MPITestCase):
 
             dup = amps.duplicate()
             cdot = dup.dot(amps, comm_bytes=cbytes)
-            np.testing.assert_equal(cdot, (comm.world_size ** 2) * n_global)
+            np.testing.assert_equal(cdot, (comm.world_size**2) * n_global)
 
     def test_amplitudes_range(self):
         # Create a toast communicator with groups if possible
@@ -129,7 +129,7 @@ class TemplateTest(MPITestCase):
             cdot = dup.dot(amps, comm_bytes=cbytes)
             np.testing.assert_equal(
                 cdot,
-                (check_even ** 2 + check_odd ** 2) * n_global / 2,
+                (check_even**2 + check_odd**2) * n_global / 2,
             )
 
     def test_amplitudes_indexed(self):
@@ -171,7 +171,7 @@ class TemplateTest(MPITestCase):
             dup = amps.duplicate()
             cdot = dup.dot(amps, comm_bytes=cbytes)
             np.testing.assert_equal(
-                cdot, (check_even ** 2 + check_odd ** 2) * n_global / 2
+                cdot, (check_even**2 + check_odd**2) * n_global / 2
             )
 
     def test_amplitudes_group(self):
@@ -228,5 +228,5 @@ class TemplateTest(MPITestCase):
             cdot = dup.dot(amps, comm_bytes=cbytes)
             np.testing.assert_equal(
                 cdot,
-                (check_even ** 2 + check_odd ** 2) * n_global / 2,
+                (check_even**2 + check_odd**2) * n_global / 2,
             )

--- a/src/toast/unported/cache.py
+++ b/src/toast/unported/cache.py
@@ -372,7 +372,7 @@ class Cache(object):
             del ref
             tot += sz
             if not silent:
-                log.info(" - {:25} {:5.2f} MB".format(key, sz / 2 ** 20))
+                log.info(" - {:25} {:5.2f} MB".format(key, sz / 2**20))
         if not silent:
-            log.info(" {:27} {:5.2f} MB".format("TOTAL", tot / 2 ** 20))
+            log.info(" {:27} {:5.2f} MB".format("TOTAL", tot / 2**20))
         return tot

--- a/src/toast/unported/pipeline_tools/classes.py
+++ b/src/toast/unported/pipeline_tools/classes.py
@@ -17,7 +17,7 @@ from .. import qarray
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 
 
-def name2id(name, maxval=2 ** 16):
+def name2id(name, maxval=2**16):
     """Map a name into an index."""
     value = 0
     for c in name:
@@ -131,7 +131,7 @@ class Focalplane:
                     fsample = detdata["fsample"]
                 else:
                     fsample = self.sample_rate
-                detweight = 1.0 / (fsample * net ** 2)
+                detweight = 1.0 / (fsample * net**2)
                 self._detweights[detname] = detweight
         return self._detweights
 

--- a/src/toast/unported/pipelines/toast_benchmark.py
+++ b/src/toast/unported/pipelines/toast_benchmark.py
@@ -99,7 +99,7 @@ def fake_hexagon_focalplane(
 
 
 def get_node_mem(mpicomm, node_rank):
-    avail = 2 ** 62
+    avail = 2**62
     if node_rank == 0:
         vmem = psutil.virtual_memory()._asdict()
         avail = vmem["available"]
@@ -414,16 +414,16 @@ def job_config(mpicomm, cases):
     if rank == 0:
         log.info(
             "Minimum detected per-node memory available is {:0.2f} GB".format(
-                avail_node_bytes / (1024 ** 3)
+                avail_node_bytes / (1024**3)
             )
         )
 
     if args.node_mem_gb is not None:
-        avail_node_bytes = int((1024 ** 3) * args.node_mem_gb)
+        avail_node_bytes = int((1024**3) * args.node_mem_gb)
         if rank == 0:
             log.info(
                 "Setting per-node available memory to {:0.2f} GB as requested".format(
-                    avail_node_bytes / (1024 ** 3)
+                    avail_node_bytes / (1024**3)
                 )
             )
 
@@ -466,7 +466,7 @@ def job_config(mpicomm, cases):
                     case_name,
                     case_min_nodes,
                     procs_per_node,
-                    avail_node_bytes / (1024 ** 3),
+                    avail_node_bytes / (1024**3),
                 )
             )
 
@@ -550,7 +550,7 @@ def job_config(mpicomm, cases):
             f.write("MPI Processes = {}\n".format(procs))
             f.write("MPI Processes per node = {}\n".format(procs_per_node))
             f.write(
-                "Memory per node = {:0.2f} GB\n".format(avail_node_bytes / (1024 ** 3))
+                "Memory per node = {:0.2f} GB\n".format(avail_node_bytes / (1024**3))
             )
             f.write("Number of groups = {}\n".format(n_group))
             f.write("Group nodes = {}\n".format(group_nodes))
@@ -637,14 +637,14 @@ def create_input_maps(args):
         sig = 50.0
         numer = ell - 30.0
         tspec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(
-            -0.5 * numer ** 2 / sig ** 2
+            -0.5 * numer**2 / sig**2
         )
         tspec *= 2000.0
 
         sig = 100.0
         numer = ell - 500.0
         espec = (1.0 / (sig * np.sqrt(2.0 * np.pi))) * np.exp(
-            -0.5 * numer ** 2 / sig ** 2
+            -0.5 * numer**2 / sig**2
         )
         espec *= 1.0
 
@@ -1166,8 +1166,8 @@ def main():
     det_factor = 2.0
     metric = (
         prefactor
-        * n_detector ** det_factor
-        * kilo_samples ** sample_factor
+        * n_detector**det_factor
+        * kilo_samples**sample_factor
         / (n_nodes * runtime)
     )
     if rank == 0:

--- a/src/toast/unported/pipelines/toast_cache_test.py
+++ b/src/toast/unported/pipelines/toast_cache_test.py
@@ -89,7 +89,7 @@ def main():
     bytes_wttot = 3 * nsamptot * 4
 
     bytes_tot = bytes_sigtot + bytes_flagtot + bytes_pixtot + bytes_wttot
-    bytes_tot_mb = bytes_tot / 2 ** 20
+    bytes_tot_mb = bytes_tot / 2**20
     log.info(
         "{} total bytes ({:0.2f}MB) of data expected".format(bytes_tot, bytes_tot_mb)
     )
@@ -98,7 +98,7 @@ def main():
         log.info("Allocation loop {:02d}".format(lp))
         vmem = psutil.virtual_memory()._asdict()
         avstart = vmem["available"]
-        avstart_mb = avstart / 2 ** 20
+        avstart_mb = avstart / 2**20
         log.info("  Starting with {:0.2f}MB of available memory".format(avstart_mb))
 
         # The list of Caches, one per "observation"
@@ -126,7 +126,7 @@ def main():
 
         vmem = psutil.virtual_memory()._asdict()
         avpost = vmem["available"]
-        avpost_mb = avpost / 2 ** 20
+        avpost_mb = avpost / 2**20
         log.info("  After allocation, {:0.2f}MB of available memory".format(avpost_mb))
 
         diff = avstart_mb - avpost_mb
@@ -145,7 +145,7 @@ def main():
 
         vmem = psutil.virtual_memory()._asdict()
         avfinal = vmem["available"]
-        avfinal_mb = avfinal / 2 ** 20
+        avfinal_mb = avfinal / 2**20
         log.info(
             "  After destruction, {:0.2f}MB of available memory".format(avfinal_mb)
         )

--- a/src/toast/unported/pipelines/toast_cov_invert.py
+++ b/src/toast/unported/pipelines/toast_cov_invert.py
@@ -109,11 +109,11 @@ def main():
 
     nnz = int(((np.sqrt(8.0 * ncovnz) - 1.0) / 2.0) + 0.5)
 
-    npix = 12 * nside ** 2
+    npix = 12 * nside**2
     subnside = int(nside / 16)
     if subnside == 0:
         subnside = 1
-    subnpix = 12 * subnside ** 2
+    subnpix = 12 * subnside**2
     nsubmap = int(npix / subnpix)
 
     # divide the submaps as evenly as possible among processes

--- a/src/toast/unported/pipelines/toast_cov_rcond.py
+++ b/src/toast/unported/pipelines/toast_cov_rcond.py
@@ -84,11 +84,11 @@ def main():
         nside = mpiworld.bcast(nside, root=0)
         nnz = mpiworld.bcast(nnz, root=0)
 
-    npix = 12 * nside ** 2
+    npix = 12 * nside**2
     subnside = int(nside / 16)
     if subnside == 0:
         subnside = 1
-    subnpix = 12 * subnside ** 2
+    subnpix = 12 * subnside**2
     nsubmap = int(npix / subnpix)
 
     # divide the submaps as evenly as possible among processes

--- a/src/toast/unported/tests/binned.py
+++ b/src/toast/unported/tests/binned.py
@@ -57,10 +57,10 @@ class BinnedTest(MPITestCase):
         # Pixelization
 
         self.sim_nside = 32
-        self.sim_npix = 12 * self.sim_nside ** 2
+        self.sim_npix = 12 * self.sim_nside**2
 
         self.map_nside = 32
-        self.map_npix = 12 * self.map_nside ** 2
+        self.map_npix = 12 * self.map_nside**2
 
         # Scan strategy
 

--- a/src/toast/unported/tests/map_ground.py
+++ b/src/toast/unported/tests/map_ground.py
@@ -352,7 +352,7 @@ class MapGroundTest(MPITestCase):
                 # print("bmap = ", bins[mask])
                 weighted = bins[mask] * rthits
                 # print("weighted = ", weighted)
-                pixrms = np.sqrt(np.mean(weighted ** 2))
+                pixrms = np.sqrt(np.mean(weighted**2))
                 todrms = self.NET * np.sqrt(self.rate)
                 relerr = np.absolute(pixrms - todrms) / todrms
                 # print("pixrms = ", pixrms)

--- a/src/toast/unported/tests/ops_dipole.py
+++ b/src/toast/unported/tests/ops_dipole.py
@@ -52,7 +52,7 @@ class OpSimDipoleTest(MPITestCase):
 
         # Pixelization
         self.nside = 64
-        self.npix = 12 * self.nside ** 2
+        self.npix = 12 * self.nside**2
 
         # Samples per observation
         self.totsamp = self.npix

--- a/src/toast/unported/tests/ops_mapmaker.py
+++ b/src/toast/unported/tests/ops_mapmaker.py
@@ -81,7 +81,7 @@ class OpMapMakerTest(MPITestCase):
         self.nnz = 3
 
         # Samples per observation
-        self.npix = 12 * self.sim_nside ** 2
+        self.npix = 12 * self.sim_nside**2
         self.ninterval = 4
         self.totsamp = self.ninterval * self.npix
 
@@ -138,7 +138,7 @@ class OpMapMakerTest(MPITestCase):
 
         # Write processing masks
 
-        self.npix = 12 * self.map_nside ** 2
+        self.npix = 12 * self.map_nside**2
         pix = np.arange(self.npix)
         pix = hp.reorder(pix, r2n=True)
 

--- a/src/toast/unported/tests/ops_sim_pysm.py
+++ b/src/toast/unported/tests/ops_sim_pysm.py
@@ -33,7 +33,7 @@ def setup_toast_observations(self, nside):
 
     # Use one TOD sample per healpix pixel with the "spiral" pointing.
     self.nside = nside
-    self.totsamp = 12 * self.nside ** 2
+    self.totsamp = 12 * self.nside**2
     self.rate = 1.0
 
     # Chunks - one per process.

--- a/src/toast/unported/tod/memorycounter.py
+++ b/src/toast/unported/tod/memorycounter.py
@@ -81,9 +81,9 @@ class OpMemoryCounter(Operator):
                 - Max memory (group): {:.2f} GB\n\
                 Total memory: {:.2f} GB\n\
                 ".format(
-                (tot_task_max / 2 ** 30),
-                (tot_group_max / 2 ** 30),
-                (tot_world / 2 ** 30),
+                (tot_task_max / 2**30),
+                (tot_group_max / 2**30),
+                (tot_world / 2**30),
             )
             log.info(msg)
 

--- a/src/toast/unported/tod/sim_focalplane.py
+++ b/src/toast/unported/tod/sim_focalplane.py
@@ -311,7 +311,7 @@ def rhomb_dim(npix):
     For a rhombus layout, return the dimension of one side.
     """
     dim = int(np.sqrt(float(npix)))
-    if dim ** 2 != npix:
+    if dim**2 != npix:
         raise ValueError("number of pixels for a rhombus wafer must be square")
     return dim
 
@@ -458,7 +458,7 @@ def rhombus_layout(
         if pixrow >= dim:
             relrow = (2 * dim - 2) - pixrow
         colang = (float(pixcol) - float(relrow) / 2.0) * pixdiam
-        distang = np.sqrt(rowang ** 2 + colang ** 2)
+        distang = np.sqrt(rowang**2 + colang**2)
         zang = np.cos(distang)
         pixdir = np.array([colang, rowang, zang], dtype=np.float64)
         norm = np.sqrt(np.dot(pixdir, pixdir))

--- a/src/toast/unported/todmap/atm.py
+++ b/src/toast/unported/todmap/atm.py
@@ -1121,8 +1121,8 @@ class AtmSim(object):
         self._nr = 1000
 
         self._rmin_kolmo = 0.0
-        diag = np.sqrt(self._delta_x ** 2 + self._delta_y ** 2)
-        self._rmax_kolmo = np.sqrt(diag ** 2 + self._delta_z ** 2) * 1.01
+        diag = np.sqrt(self._delta_x**2 + self._delta_y**2)
+        self._rmax_kolmo = np.sqrt(diag**2 + self._delta_z**2) * 1.01
 
         self._rstep = (self._rmax_kolmo - self._rmin_kolmo) / (self._nr - 1)
 

--- a/src/toast/unported/todmap/madam.py
+++ b/src/toast/unported/todmap/madam.py
@@ -35,9 +35,9 @@ def count_caches(data, comm, nodecomm, madamcache, msg=""):
         print(
             "Node has {:.3f} GB allocated in TOAST TOD caches and "
             "{:.3f} GB in Madam caches ({:.3f} GB total) {}".format(
-                node_todsize / 2 ** 30,
-                node_cachesize / 2 ** 30,
-                (node_todsize + node_cachesize) / 2 ** 30,
+                node_todsize / 2**30,
+                node_cachesize / 2**30,
+                (node_todsize + node_cachesize) / 2**30,
                 msg,
             )
         )
@@ -529,7 +529,7 @@ class OpMadam(Operator):
                     noise_scale = 1
                 if nse is not None:
                     for det in detectors:
-                        psd = nse.psd(det) * noise_scale ** 2
+                        psd = nse.psd(det) * noise_scale**2
                         if det not in psds:
                             psds[det] = [(0, psd)]
                         else:
@@ -939,7 +939,7 @@ class OpMadam(Operator):
                         )
                         pixels[istart:istop] = self._madam_pixels[dslice]
                         offset += nn
-                    npix = 12 * nside ** 2
+                    npix = 12 * nside**2
                     good = np.logical_and(pixels >= 0, pixels < npix)
                     if not self._pixels_nested:
                         pixels[good] = hp.nest2ring(nside, pixels[good])

--- a/src/toast/unported/todmap/mapmaker.py
+++ b/src/toast/unported/todmap/mapmaker.py
@@ -1345,9 +1345,9 @@ class PCGSolver:
 class OpMapMaker(Operator):
 
     # Choose one bit in the common flags for storing gap information
-    gap_bit = 2 ** 7
+    gap_bit = 2**7
     # Choose one bit in the quality flags for storing processing mask
-    mask_bit = 2 ** 7
+    mask_bit = 2**7
 
     def __init__(
         self,
@@ -1380,7 +1380,7 @@ class OpMapMaker(Operator):
         pixels="pixels",
     ):
         self.nside = nside
-        self.npix = 12 * self.nside ** 2
+        self.npix = 12 * self.nside**2
         self.name = name
         self.nnz = nnz
         self.ncov = self.nnz * (self.nnz + 1) // 2

--- a/src/toast/unported/todmap/pointing.py
+++ b/src/toast/unported/todmap/pointing.py
@@ -92,7 +92,7 @@ class OpPointingHpix(Operator):
         self._keep_quats = keep_quats
         self._single_precision = single_precision
         self._nside_submap = min(nside, nside_submap)
-        self._npix_submap = 12 * self._nside_submap ** 2
+        self._npix_submap = 12 * self._nside_submap**2
         self._nsubmap = (self._nside // self._nside_submap) ** 2
         self._hit_submaps = np.zeros(self._nsubmap, dtype=np.bool)
 
@@ -278,7 +278,7 @@ class OpPointingHpix(Operator):
         nsubmap_name = "{}_nsubmap".format(self._pixels)
         data[nsubmap_name] = self._nsubmap
         npix_name = "{}_npix".format(self._pixels)
-        data[npix_name] = 12 * self._nside ** 2
+        data[npix_name] = 12 * self._nside**2
 
         return
 
@@ -370,7 +370,7 @@ class OpMuellerPointingHpix(Operator):
         self._keep_quats = keep_quats
         self._single_precision = single_precision
         self._nside_submap = min(nside, nside_submap)
-        self._npix_submap = 12 * self._nside_submap ** 2
+        self._npix_submap = 12 * self._nside_submap**2
         self._nsubmap = (self._nside // self._nside_submap) ** 2
         self._hit_submaps = np.zeros(self._nsubmap, dtype=np.bool)
         self._hwp_parameters_set = hwp_parameters_set
@@ -584,6 +584,6 @@ class OpMuellerPointingHpix(Operator):
         nsubmap_name = "{}_nsubmap".format(self._pixels)
         data[nsubmap_name] = self._nsubmap
         npix_name = "{}_npix".format(self._pixels)
-        data[npix_name] = 12 * self._nside ** 2
+        data[npix_name] = 12 * self._nside**2
 
         return

--- a/src/toast/unported/todmap/sim_det_atm.py
+++ b/src/toast/unported/todmap/sim_det_atm.py
@@ -498,8 +498,8 @@ class OpSimAtmosphere(Operator):
         telescope = self._get_from_obs("telescope_id", obs)
         site = self._get_from_obs("site_id", obs)
         obsindx = self._get_from_obs("id", obs)
-        key1 = self._realization * 2 ** 32 + telescope * 2 ** 16 + self._component
-        key2 = site * 2 ** 16 + obsindx
+        key1 = self._realization * 2**32 + telescope * 2**16 + self._component
+        key2 = site * 2**16 + obsindx
         counter1 = 0
         counter2 = 0
         return key1, key2, counter1, counter2
@@ -615,7 +615,7 @@ class OpSimAtmosphere(Operator):
         # Translate the wind speed to time span of a correlated interval
         wx = weather.west_wind
         wy = weather.south_wind
-        w = np.sqrt(wx ** 2 + wy ** 2)
+        w = np.sqrt(wx**2 + wy**2)
         self._wind_time = self._wind_dist / w
 
         tmax = tmin + self._wind_time
@@ -668,7 +668,7 @@ class OpSimAtmosphere(Operator):
         T0_center = weather.air_temperature
         wx = weather.west_wind
         wy = weather.south_wind
-        w_center = np.sqrt(wx ** 2 + wy ** 2)
+        w_center = np.sqrt(wx**2 + wy**2)
         wdir_center = np.arctan2(wy, wx)
 
         azmin, azmax, elmin, elmax = scan_range

--- a/src/toast/unported/todmap/sim_tod.py
+++ b/src/toast/unported/todmap/sim_tod.py
@@ -1076,7 +1076,7 @@ class TODGround(TOD):
         """
         d = np.abs(coord_in - coord_out)
         t_accel = scanrate / scan_accel
-        d_accel = 0.5 * scan_accel * t_accel ** 2
+        d_accel = 0.5 * scan_accel * t_accel**2
         if 2 * d_accel > d:
             # No time to reach scan speed
             d_accel = d / 2
@@ -1099,7 +1099,7 @@ class TODGround(TOD):
 
         d = np.abs(coord_in - coord_out)
         t_accel = scanrate / scan_accel
-        d_accel = 0.5 * scan_accel * t_accel ** 2
+        d_accel = 0.5 * scan_accel * t_accel**2
         if 2 * d_accel > d:
             # No time to reach scan speed
             d_accel = d / 2
@@ -1293,7 +1293,7 @@ class TODGround(TOD):
             a = self._scan_accel_el
             b = -0.5 * self._scan_accel_el * t_mod
             c = 2 * self._el_mod_amplitude
-            if b ** 2 - 4 * a * c < 0:
+            if b**2 - 4 * a * c < 0:
                 raise RuntimeError(
                     "Cannot perform {:.2f} deg elevation oscillation in {:.2f} s "
                     "with {:.2f} deg/s^2 acceleration".format(
@@ -1301,8 +1301,8 @@ class TODGround(TOD):
                         np.degrees(self._scan_accel_el),
                     )
                 )
-            root1 = (-b - np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
-            root2 = (-b + np.sqrt(b ** 2 - 4 * a * c)) / (2 * a)
+            root1 = (-b - np.sqrt(b**2 - 4 * a * c)) / (2 * a)
+            root2 = (-b + np.sqrt(b**2 - 4 * a * c)) / (2 * a)
             if root1 > 0:
                 t_accel = root1
             else:
@@ -1326,7 +1326,7 @@ class TODGround(TOD):
             # accelerate
             t = np.linspace(0, t_accel, n)
             t_interp.append(t)
-            el_interp.append(0.5 * self._scan_accel_el * t ** 2)
+            el_interp.append(0.5 * self._scan_accel_el * t**2)
             # scan
             t_last = t_interp[-1][-1]
             el_last = el_interp[-1][-1]
@@ -1339,7 +1339,7 @@ class TODGround(TOD):
             t = np.linspace(0, 2 * t_accel, n)
             t_interp.append(t_last + t)
             el_interp.append(
-                el_last + scanrate * t - 0.5 * self._scan_accel_el * t ** 2
+                el_last + scanrate * t - 0.5 * self._scan_accel_el * t**2
             )
             # scan
             t_last = t_interp[-1][-1]
@@ -1353,7 +1353,7 @@ class TODGround(TOD):
             t = np.linspace(0, t_accel, n)
             t_interp.append(t_last + t)
             el_interp.append(
-                el_last - scanrate * t + 0.5 * self._scan_accel_el * t ** 2
+                el_last - scanrate * t + 0.5 * self._scan_accel_el * t**2
             )
 
             t_interp = np.hstack(t_interp)
@@ -1377,7 +1377,7 @@ class TODGround(TOD):
         # simulate a single elevation step at high resolution
 
         t_accel = self._scanrate_el / self._scan_accel_el
-        el_accel = 0.5 * self._scan_accel_el * t_accel ** 2
+        el_accel = 0.5 * self._scan_accel_el * t_accel**2
         if el_step > 2 * el_accel:
             # Step is large enough to reach elevation scan rate
             t_scan = (el_step - 2 * el_accel) / self._scanrate_el
@@ -1393,7 +1393,7 @@ class TODGround(TOD):
         # accelerate
         t = np.linspace(0, t_accel, n)
         t_interp.append(t)
-        el_interp.append(0.5 * self._scan_accel_el * t ** 2)
+        el_interp.append(0.5 * self._scan_accel_el * t**2)
         # scan
         if t_scan > 0:
             t_last = t_interp[-1][-1]
@@ -1408,7 +1408,7 @@ class TODGround(TOD):
         t = np.linspace(0, t_accel, n)
         t_interp.append(t_last + t)
         el_interp.append(
-            el_last + el_rate_last * t - 0.5 * self._scan_accel_el * t ** 2
+            el_last + el_rate_last * t - 0.5 * self._scan_accel_el * t**2
         )
 
         t_interp = np.hstack(t_interp)

--- a/src/toast/unported/todmap/todmap_math.py
+++ b/src/toast/unported/todmap/todmap_math.py
@@ -521,10 +521,10 @@ def dipole(pntg, vel=None, solar=None, cmb=2.72548, freq=0):
 
         solar_speed = np.sqrt(np.sum(solar * solar, axis=0))
 
-        vpar = (array_dot(vel, solar) / solar_speed ** 2) * solar
+        vpar = (array_dot(vel, solar) / solar_speed**2) * solar
         vperp = vel - vpar
 
-        vdot = 1.0 / (1.0 + array_dot(solar, vel) * inv_light ** 2)
+        vdot = 1.0 / (1.0 + array_dot(solar, vel) * inv_light**2)
         invgamma = np.sqrt(1.0 - (solar_speed * inv_light) ** 2)
 
         vpar += solar
@@ -545,7 +545,7 @@ def dipole(pntg, vel=None, solar=None, cmb=2.72548, freq=0):
 
     dipoletod = None
     if freq == 0:
-        inv_gamma = np.sqrt(1.0 - beta ** 2)
+        inv_gamma = np.sqrt(1.0 - beta**2)
         num = 1.0 - beta * np.sum(v * direct, axis=1)
         dipoletod = cmb * (inv_gamma / num - 1.0)
     else:
@@ -553,6 +553,6 @@ def dipole(pntg, vel=None, solar=None, cmb=2.72548, freq=0):
         fx = constants.h * freq / (constants.k * cmb)
         fcor = (fx / 2) * (np.exp(fx) + 1) / (np.exp(fx) - 1)
         bt = beta * np.sum(v * direct, axis=1)
-        dipoletod = cmb * (bt + fcor * bt ** 2)
+        dipoletod = cmb * (bt + fcor * bt**2)
 
     return dipoletod

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -335,17 +335,17 @@ try:
                 vlist2 = np.array(vlist2, dtype=np.float64)
                 if key != "percent":
                     # From bytes to better units
-                    if np.amax(vlist) < 2 ** 20:
-                        vlist /= 2 ** 10
-                        vlist2 /= 2 ** 10
+                    if np.amax(vlist) < 2**20:
+                        vlist /= 2**10
+                        vlist2 /= 2**10
                         unit = "kB"
-                    elif np.amax(vlist) < 2 ** 30:
-                        vlist /= 2 ** 20
-                        vlist2 /= 2 ** 20
+                    elif np.amax(vlist) < 2**30:
+                        vlist /= 2**20
+                        vlist2 /= 2**20
                         unit = "MB"
                     else:
-                        vlist /= 2 ** 30
-                        vlist2 /= 2 ** 30
+                        vlist /= 2**30
+                        vlist2 /= 2**30
                         unit = "GB"
                 else:
                     unit = "% "
@@ -391,7 +391,6 @@ try:
         if comm is not None:
             comm.Barrier()
         return memstr
-
 
 except ImportError:
 


### PR DESCRIPTION
As suggested by @keskitalo , open a new PR from the developments in  https://github.com/hpc4cmb/toast/pull/505 

This implementation follows the approach implemented by Davide Maino. We perform  3 convolutions,     obtained by splitting both the sky into their {T,E,B} components and the beam alm     into the {T, P}   ones, with P being defined as `P=b_{lm}^E + b_{lm}^B`     The convolution  is performed by  coupling each IQU component of the signal propertly as:
    `skyT_lm * beamT_lm, skyE_lm * Re{beamP_lm}, skyB_lm * Im{beamP_lm}`. In this way, we are able to account for the polarized components of the simulated GRASP beams that were neglected with the Operator in https://github.com/hpc4cmb/toast/blob/38a5b2c5c79500d75811d23807a7d27f557d5818/src/toast/ops/conviqt.py#L571 


For extra details please refer to [this note ](https://giuspugl.github.io/reports/Notes_TEB_convolution.html) 