### PR TITLE
Fix performance issue with detector weights

### DIFF
--- a/src/toast/io/observation_hdf_utils.py
+++ b/src/toast/io/observation_hdf_utils.py
@@ -130,6 +130,7 @@ class H5File(object):
     The open file handle will be None on processes other than rank 0.
 
     """
+
     def __init__(self, name, mode, comm=None, force_serial=False):
         self.handle = hdf5_open(name, mode, comm=comm, force_serial=force_serial)
 

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -86,7 +86,7 @@ class Noise(object):
                 raise TypeError("Each PSD array must be a Quantity")
             # Ensure that the PSDs are convertible to expected units
             try:
-                test_convert = psds[key].to_value(u.K ** 2 * u.second)
+                test_convert = psds[key].to_value(u.K**2 * u.second)
             except Exception:
                 raise ValueError("Each PSD must be convertible to K**2 * s")
             self._freqs[key] = np.copy(freqs[key])
@@ -204,7 +204,7 @@ class Noise(object):
                 rate = self.rate(k)
                 first = np.searchsorted(freq, rate * 0.2, side="left")
                 last = np.searchsorted(freq, rate * 0.4, side="right")
-                noisevar = np.median(psd[first:last].to_value(u.K ** 2 * u.second))
+                noisevar = np.median(psd[first:last].to_value(u.K**2 * u.second))
                 invvar = 1.0 / noisevar
                 for det in self.detectors:
                     if k in mix[det] and mix[det][k] != 0:
@@ -404,7 +404,7 @@ class Noise(object):
                     self._rates[key] = rate * u.Hz
                     self._indices[key] = indx
                     self._freqs[key] = u.Quantity(freq, u.Hz)
-                    self._psds[key] = u.Quantity(psdrow, u.K ** 2 * u.second)
+                    self._psds[key] = u.Quantity(psdrow, u.K**2 * u.second)
                 del pds
 
         # Broadcast the results
@@ -461,8 +461,8 @@ class Noise(object):
                 return False
         for k, v in self._psds.items():
             if not np.allclose(
-                v.to_value(u.K ** 2 * u.second),
-                other._psds[k].to_value(u.K ** 2 * u.second),
+                v.to_value(u.K**2 * u.second),
+                other._psds[k].to_value(u.K**2 * u.second),
             ):
                 return False
         return True

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -105,7 +105,36 @@ class InstrumentTest(MPITestCase):
         npix = 1
         ring = 1
         # NOTE: increase the number here to test performance of huge focalplanes.
-        while 2 * npix <= 5000:
+        while 2 * npix <= 2000:
+            npix += 6 * ring
+            ring += 1
+        fp = fake_hexagon_focalplane(
+            n_pix=npix,
+            sample_rate=rate,
+            psd_fmin=1.0e-5 * u.Hz,
+            psd_net=0.05 * u.K * np.sqrt(1 * u.second),
+            psd_fknee=(rate / 2000.0),
+        )
+        nse = fp.noise
+        freqs = {x: nse.freq(x) for i, x in enumerate(nse.keys)}
+        psds = {x: nse.psd(x) for i, x in enumerate(nse.keys)}
+        indices = {x: 100 + i for i, x in enumerate(nse.keys)}
+        model = Noise(
+            detectors=fp.detectors,
+            freqs=freqs,
+            psds=psds,
+            indices=indices,
+            mixmatrix=nse.mixing_matrix,
+        )
+        for d in fp.detectors:
+            wt = model.detector_weight(d)
+
+    def test_noise_corr_weights(self):
+        rate = 200.0 * u.Hz
+        npix = 1
+        ring = 1
+        # NOTE: increase the number here to test performance of huge focalplanes.
+        while 2 * npix <= 2000:
             npix += 6 * ring
             ring += 1
         fp = fake_hexagon_focalplane(

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -45,7 +45,7 @@ class InstrumentTest(MPITestCase):
         nse = Noise(
             detnames,
             {x: u.Quantity(freqs, u.Hz) for x in streams},
-            {x: u.Quantity(np.ones(len(freqs)), u.K ** 2 * u.second) for x in streams},
+            {x: u.Quantity(np.ones(len(freqs)), u.K**2 * u.second) for x in streams},
             mixmatrix=mix,
         )
 

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -19,6 +19,8 @@ from ..noise import Noise
 
 from ..noise_sim import AnalyticNoise
 
+from ..instrument_sim import fake_hexagon_focalplane
+
 from ..io import H5File
 
 from ._helpers import create_outdir
@@ -43,7 +45,7 @@ class InstrumentTest(MPITestCase):
         nse = Noise(
             detnames,
             {x: u.Quantity(freqs, u.Hz) for x in streams},
-            {x: u.Quantity(np.ones(len(freqs)), u.K**2 * u.second) for x in streams},
+            {x: u.Quantity(np.ones(len(freqs)), u.K ** 2 * u.second) for x in streams},
             mixmatrix=mix,
         )
 
@@ -82,7 +84,9 @@ class InstrumentTest(MPITestCase):
             with H5File(
                 nse_file, "w", comm=self.comm, force_serial=(droot == "serial")
             ) as f:
-                nse.save_hdf5(f.handle, comm=self.comm, force_serial=(droot == "serial"))
+                nse.save_hdf5(
+                    f.handle, comm=self.comm, force_serial=(droot == "serial")
+                )
 
         if self.comm is not None:
             self.comm.barrier()
@@ -91,5 +95,58 @@ class InstrumentTest(MPITestCase):
             nse_file = os.path.join(self.outdir, f"sim_noise_{droot}.h5")
             new_nse = AnalyticNoise()
             with H5File(nse_file, "r", comm=self.comm) as f:
-                new_nse.load_hdf5(f.handle, comm=self.comm, force_serial=(droot == "serial"))
+                new_nse.load_hdf5(
+                    f.handle, comm=self.comm, force_serial=(droot == "serial")
+                )
             self.assertTrue(nse == new_nse)
+
+    def test_noise_weights(self):
+        rate = 200.0 * u.Hz
+        npix = 1
+        ring = 1
+        # NOTE: increase the number here to test performance of huge focalplanes.
+        while 2 * npix <= 5000:
+            npix += 6 * ring
+            ring += 1
+        fp = fake_hexagon_focalplane(
+            n_pix=npix,
+            sample_rate=rate,
+            psd_fmin=1.0e-5 * u.Hz,
+            psd_net=0.05 * u.K * np.sqrt(1 * u.second),
+            psd_fknee=(rate / 2000.0),
+        )
+        nse = fp.noise
+        corr_freqs = {f"noise_{i}": nse.freq(x) for i, x in enumerate(fp.detectors)}
+        corr_psds = {f"noise_{i}": nse.psd(x) for i, x in enumerate(fp.detectors)}
+        corr_indices = {f"noise_{i}": 100 + i for i, x in enumerate(fp.detectors)}
+        corr_mix = dict()
+        ndet = len(fp.detectors)
+        for i, x in enumerate(fp.detectors):
+            if i == 0:
+                corr_mix[x] = {
+                    f"noise_{ndet-1}": 0.25,
+                    f"noise_{i}": 0.5,
+                    f"noise_{i+1}": 0.25,
+                }
+            elif i == ndet - 1:
+                corr_mix[x] = {
+                    f"noise_{i-1}": 0.25,
+                    f"noise_{i}": 0.5,
+                    f"noise_{0}": 0.25,
+                }
+            else:
+                corr_mix[x] = {
+                    f"noise_{i-1}": 0.25,
+                    f"noise_{i}": 0.5,
+                    f"noise_{i+1}": 0.25,
+                }
+        model = Noise(
+            detectors=fp.detectors,
+            freqs=corr_freqs,
+            psds=corr_psds,
+            mixmatrix=corr_mix,
+            indices=corr_indices,
+        )
+
+        for d in fp.detectors:
+            wt = model.detector_weight(d)


### PR DESCRIPTION
For extremely large focalplanes, the computation of the detector weights in a noise model was very slow.  This work uses numpy `searchsorted()` rather than boolean logic to speed things up.