### PR TITLE
Support using the Weather class as a container

### DIFF
--- a/src/toast/tests/weather.py
+++ b/src/toast/tests/weather.py
@@ -6,6 +6,8 @@ from datetime import datetime
 
 import numpy as np
 
+import astropy.units as u
+
 from .mpi import MPITestCase
 
 import numpy.testing as nt
@@ -17,25 +19,39 @@ class WeatherTest(MPITestCase):
     def setUp(self):
         pass
 
+    def get_props(self, w):
+        val = w.time
+        val = w.ice_water
+        val = w.liquid_water
+        val = w.pwv
+        val = w.humidity
+        val = w.surface_pressure
+        val = w.surface_temperature
+        val = w.air_temperature
+        val = w.west_wind
+        val = w.south_wind
+
+    def test_base(self):
+        date = datetime.now()
+        real = Weather(
+            time=date,
+            ice_water=1.0e-4 * u.mm,
+            liquid_water=1.0e-4 * u.mm,
+            pwv=2.0 * u.mm,
+            humidity=0.005 * u.mm,
+            surface_pressure=53000 * u.Pa,
+            surface_temperature=273.0 * u.Kelvin,
+            air_temperature=270.0 * u.Kelvin,
+            west_wind=2.0 * (u.meter / u.second),
+            south_wind=1.0 * (u.meter / u.second),
+        )
+        self.get_props(real)
+
     def test_sim(self):
         date = datetime.now()
 
         sim_atacama = SimWeather(time=date, name="atacama", site_uid=1)
-        sim_pole = SimWeather(time=date, name="south_pole", site_uid=2)
+        self.get_props(sim_atacama)
 
-        # for name, sim in zip(["atacama", "south_pole"], [sim_atacama, sim_pole]):
-        #     print(
-        #         "{} (uid = {}, realiz. = {}):".format(
-        #             name, sim._site_uid, sim._realization
-        #         )
-        #     )
-        #     print("  time = ", sim.time)
-        #     print("  ice_water = ", sim.ice_water)
-        #     print("  liquid_water = ", sim.liquid_water)
-        #     print("  pwv = ", sim.pwv)
-        #     print("  humidity = ", sim.humidity)
-        #     print("  surface_pressure = ", sim.surface_pressure)
-        #     print("  surface_temperature = ", sim.surface_temperature)
-        #     print("  air_temperature = ", sim.air_temperature)
-        #     print("  west_wind = ", sim.west_wind)
-        #     print("  south_wind = ", sim.south_wind)
+        sim_pole = SimWeather(time=date, name="south_pole", site_uid=2)
+        self.get_props(sim_pole)

--- a/src/toast/weather.py
+++ b/src/toast/weather.py
@@ -28,13 +28,50 @@ class Weather(object):
     these are constant, under the assumption that the weather changes slowly during a
     good science observation.
 
+    This base class can be used directly to hold values specified at construction.
+
+    Args:
+        time (datetime):  A python date/time in UTC.
+        ice_water (Quantity):  Precipitable ice water.
+        liquid_water (Quantity):  Precipitable liquid water.
+        pwv (Quantity):  Precipitable water vapor.
+        humidity (Quantity):  Specific humidity at 10m altitude.
+        surface_pressure (Quantity):  Surface pressure.
+        surface_temperature (Quantity):  Surface temperature.
+        air_temperature (Quantity):  Air temperature at 10m altitude.
+        west_wind (Quantity):  Eastward moving wind at 10m altitude.
+        south_wind (Quantity):  Northward moving wind at 10m altitude.
+
     """
 
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        time=None,
+        ice_water=None,
+        liquid_water=None,
+        pwv=None,
+        humidity=None,
+        surface_pressure=None,
+        surface_temperature=None,
+        air_temperature=None,
+        west_wind=None,
+        south_wind=None,
+    ):
+        self._time_val = time
+        self._ice_water_val = ice_water
+        self._liquid_water_val = liquid_water
+        self._pwv_val = pwv
+        self._humidity_val = humidity
+        self._surface_pressure_val = surface_pressure
+        self._surface_temperature_val = surface_temperature
+        self._air_temperature_val = air_temperature
+        self._west_wind_val = west_wind
+        self._south_wind_val = south_wind
 
     def _time(self):
-        raise NotImplementedError("Derived class must implement _time()")
+        if self._time_val is None:
+            raise NotImplementedError("Base class _time() called, but has no value")
+        return self._time_val
 
     @property
     def time(self):
@@ -42,7 +79,11 @@ class Weather(object):
         return self._time()
 
     def _ice_water(self):
-        raise NotImplementedError("Derived class must implement _ice_water()")
+        if self._ice_water_val is None:
+            raise NotImplementedError(
+                "Base class _ice_water() called, but has no value"
+            )
+        return self._ice_water_val
 
     @property
     def ice_water(self):
@@ -50,7 +91,11 @@ class Weather(object):
         return self._ice_water()
 
     def _liquid_water(self):
-        raise NotImplementedError("Derived class must implement _liquid_water()")
+        if self._liquid_water_val is None:
+            raise NotImplementedError(
+                "Base class _liquid_water() called, but has no value"
+            )
+        return self._liquid_water_val
 
     @property
     def liquid_water(self):
@@ -58,7 +103,9 @@ class Weather(object):
         return self._liquid_water()
 
     def _pwv(self):
-        raise NotImplementedError("Derived class must implement _pwv()")
+        if self._pwv_val is None:
+            raise NotImplementedError("Base class _pwv() called, but has no value")
+        return self._pwv_val
 
     @property
     def pwv(self):
@@ -66,7 +113,9 @@ class Weather(object):
         return self._pwv()
 
     def _humidity(self):
-        raise NotImplementedError("Derived class must implement _humidity()")
+        if self._humidity_val is None:
+            raise NotImplementedError("Base class _humidity() called, but has no value")
+        return self._humidity_val
 
     @property
     def humidity(self):
@@ -74,7 +123,11 @@ class Weather(object):
         return self._humidity()
 
     def _surface_pressure(self):
-        raise NotImplementedError("Derived class must implement _surface_pressure()")
+        if self._surface_pressure_val is None:
+            raise NotImplementedError(
+                "Base class _surface_pressure() called, but has no value"
+            )
+        return self._surface_pressure_val
 
     @property
     def surface_pressure(self):
@@ -82,7 +135,11 @@ class Weather(object):
         return self._surface_pressure()
 
     def _surface_temperature(self):
-        raise NotImplementedError("Derived class must implement _surface_temperature()")
+        if self._surface_temperature_val is None:
+            raise NotImplementedError(
+                "Base class _surface_temperature() called, but has no value"
+            )
+        return self._surface_temperature_val
 
     @property
     def surface_temperature(self):
@@ -90,7 +147,11 @@ class Weather(object):
         return self._surface_temperature()
 
     def _air_temperature(self):
-        raise NotImplementedError("Derived class must implement _air_temperature()")
+        if self._air_temperature_val is None:
+            raise NotImplementedError(
+                "Base class _air_temperature() called, but has no value"
+            )
+        return self._air_temperature_val
 
     @property
     def air_temperature(self):
@@ -98,7 +159,11 @@ class Weather(object):
         return self._air_temperature()
 
     def _west_wind(self):
-        raise NotImplementedError("Derived class must implement _west_wind()")
+        if self._west_wind_val is None:
+            raise NotImplementedError(
+                "Base class _west_wind() called, but has no value"
+            )
+        return self._west_wind_val
 
     @property
     def west_wind(self):
@@ -106,7 +171,11 @@ class Weather(object):
         return self._west_wind()
 
     def _south_wind(self):
-        raise NotImplementedError("Derived class must implement _south_wind()")
+        if self._south_wind_val is None:
+            raise NotImplementedError(
+                "Base class _south_wind() called, but has no value"
+            )
+        return self._south_wind_val
 
     @property
     def south_wind(self):


### PR DESCRIPTION
For real weather measurements or simulations of specific conditions, we want to be able to fully specify the weather properties.  This minor changes makes the base class just a container to hold values.  This can then be used in workflows where the site weather properties are loaded from disk, for example.  Fixes #472 