### PR TITLE
Ground sim tweaks

### DIFF
--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -102,6 +102,11 @@ class SimGround(Operator):
         0, help="The (integer) timezone offset in hours from UTC to apply to schedule"
     )
 
+    randomize_phase = Bool(
+        False,
+        help="If True, the Constant Elevation Scan will begin at a randomized phase.",
+    )
+
     scan_rate_az = Quantity(
         1.0 * u.degree / u.second,
         help="The sky or mount azimuth scanning rate.  See `fix_rate_on_sky`",
@@ -606,6 +611,7 @@ class SimGround(Operator):
                 scan_min_az,
                 scan_max_az,
                 cosecant_modulation=self.scan_cosecant_modulation,
+                randomize_phase=self.randomize_phase,
             )
 
             # Do any adjustments to the El motion

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -559,16 +559,8 @@ def simulate_ces_scan(
     # sample rate are enforced and the stop time is adjusted if needed to
     # produce a whole number of samples.
 
-    samples = int((t_stop - t_start) * rate) + 1
-    t_stop = t_start + ((samples - 1) / rate)
-
-    times = np.linspace(
-        t_start,
-        t_stop,
-        num=samples,
-        endpoint=True,
-        dtype=np.float64,
-    )
+    samples = int((t_stop - t_start) * rate)
+    times = t_start + np.arange(samples) / rate
 
     tmin, tmax = tvec[0], tvec[-1]
     tdelta = tmax - tmin

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -418,6 +418,7 @@ def simulate_ces_scan(
     scan_max_az,
     cosecant_modulation=False,
     nstep=10000,
+    randomize_phase=False,
 ):
     """Simulate a constant elevation scan."""
 
@@ -565,9 +566,15 @@ def simulate_ces_scan(
     tmin, tmax = tvec[0], tvec[-1]
     tdelta = tmax - tmin
 
+    if randomize_phase:
+        np.random.seed(int(t_start % 2**32))
+        t_off = -tdelta * np.random.rand()
+    else:
+        t_off = 0
+
     # For interpolation, shift the times to zero
     tvec -= tmin
-    t_interp = (times - tmin) % tdelta
+    t_interp = (times - tmin - t_off) % tdelta
 
     az_sample = np.interp(t_interp, tvec, azvec)
     el_sample = np.zeros_like(az_sample) + el
@@ -584,7 +591,6 @@ def simulate_ces_scan(
 
     # Repeat time intervals to cover the timestamps
     n_repeat = 1 + int((times[-1] - tmin) / tdelta)
-    t_off = 0
     for rp in range(n_repeat):
         ival_scan_leftright.append(
             (range_scan_leftright[0] + t_off, range_scan_leftright[1] + t_off)
@@ -624,7 +630,10 @@ def simulate_ces_scan(
         ival_throw_rightleft,
     ]:
         first = tuple(ival[-1])
-        if first[0] < times[0]:
+        if first[1] < times[0]:
+            # Whole interval before the start
+            del ival[0]
+        elif first[0] < times[0]:
             # interval is truncated
             ival[0] = (times[0], first[1])
         last = tuple(ival[-1])

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -162,3 +162,86 @@ class SimGroundTest(MPITestCase):
             hp.mollview(hits, xsize=1600, max=50, nest=pixels.nest)
             plt.savefig(outfile)
             plt.close()
+
+    def test_phase(self):
+        # Slow sampling
+        fp = fake_hexagon_focalplane(
+            n_pix=self.npix,
+            sample_rate=10.0 * u.Hz,
+        )
+
+        site = GroundSite("Atacama", "-22:57:30", "-67:47:10", 5200.0 * u.meter)
+
+        tele = Telescope("telescope", focalplane=fp, site=site)
+
+        sch_file = os.path.join(self.outdir, "exec_schedule.txt")
+        schedule = None
+
+        if self.comm is None or self.comm.rank == 0:
+            run_scheduler(
+                opts=[
+                    "--site-name",
+                    site.name,
+                    "--telescope",
+                    tele.name,
+                    "--site-lon",
+                    "{}".format(site.earthloc.lon.to_value(u.degree)),
+                    "--site-lat",
+                    "{}".format(site.earthloc.lat.to_value(u.degree)),
+                    "--site-alt",
+                    "{}".format(site.earthloc.height.to_value(u.meter)),
+                    "--patch",
+                    "small_patch,1,40,-40,44,-44",
+                    "--start",
+                    "2020-01-01 00:00:00",
+                    "--stop",
+                    "2020-01-01 12:00:00",
+                    "--out",
+                    sch_file,
+                ]
+            )
+            schedule = GroundSchedule()
+            schedule.read(sch_file)
+        if self.comm is not None:
+            schedule = self.comm.bcast(schedule, root=0)
+
+        data1 = Data(self.toastcomm)
+        data2 = Data(self.toastcomm)
+
+        sim_ground = ops.SimGround(
+            name="sim_ground",
+            telescope=tele,
+            schedule=schedule,
+            hwp_angle=defaults.hwp_angle,
+            hwp_rpm=1.0,
+            max_pwv=5 * u.mm,
+        )
+        sim_ground.apply(data1)
+        sim_ground.randomize_phase = True
+        sim_ground.apply(data2)
+
+        # Verify the two boresights are in different phase
+
+        az1 = data1.obs[0].shared["azimuth"][:]
+        az2 = data2.obs[0].shared["azimuth"][:]
+
+        assert np.std(az1 - az2) > 1e-10
+
+        # Verify that the flags still identify left-right scans correctly
+
+        flags1 = data1.obs[0].shared["flags"][:]
+        flags2 = data2.obs[0].shared["flags"][:]
+
+        good1 = np.logical_and(
+            flags1 & sim_ground.leftright_mask != 0,
+            flags1 & sim_ground.turnaround_mask == 0,
+        )
+        good2 = np.logical_and(
+            flags2 & sim_ground.leftright_mask != 0,
+            flags2 & sim_ground.turnaround_mask == 0,
+        )
+
+        step1 = np.median(np.diff(az1[good1]))
+        step2 = np.median(np.diff(az2[good2]))
+
+        assert np.abs((step1 - step2) / step1) < 1e-3


### PR DESCRIPTION
Two small tweaks:
- timestamps from `SimGround` now end before the commanded end time.  This way two consecutive observations avoid having one sample overlaps
- user can instruct the operator to begin the constant elevation scan at a randomized phase