### PR TITLE
Add an interactive jupyter widget for Observation display.

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,11 +1,8 @@
 # Tutorial
 
-The TOAST tutorial is based on a series of notebooks that were presented
-in past workshops. You can find them inside the `tutorial` directory in
-the [top level of the source
-tree](https://github.com/hpc4cmb/toast/tree/master/tutorial). These
-notebooks are designed to be run interactively from a laptop or
-workstation. To avoid adding binary objects to the git repository, these
-notebooks do not have any outputs saved. You can either run them to view
-the output or you can browse a copy of the [generated output
-here](https://portal.nersc.gov/project/cmb/toast-tutorial/).
+The following tutorials are notebooks designed to walk through different aspects of using TOAST.  I addition to the normal TOAST dependencies, running these notebooks require a few additional packages:
+
+- [wurlitzer](https://pypi.org/project/wurlitzer/)
+- [ipywidgets](https://pypi.org/project/ipywidgets/)
+- [plotly](https://pypi.org/project/plotly/)
+- [plotly-resampler](https://pypi.org/project/plotly-resampler/)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-The following tutorials are notebooks designed to walk through different aspects of using TOAST.  I addition to the normal TOAST dependencies, running these notebooks require a few additional packages:
+The following tutorials are notebooks designed to walk through different aspects of using TOAST.  In addition to the normal TOAST dependencies, running these notebooks requires a few additional packages:
 
 - [wurlitzer](https://pypi.org/project/wurlitzer/)
 - [ipywidgets](https://pypi.org/project/ipywidgets/)

--- a/docs/tutorial_intro.ipynb
+++ b/docs/tutorial_intro.ipynb
@@ -867,7 +867,7 @@
    "source": [
     "## Observation Quicklook\n",
     "\n",
-    "There is an interactive \"widget\" we can use to quickly look at one of our observation contents.  Try create some more plot tabs."
+    "There is an interactive \"widget\" we can use to quickly look at one of our observation contents.  Try to create some more plot tabs using the button on the bottom of the summary tab."
    ]
   },
   {

--- a/docs/tutorial_intro.ipynb
+++ b/docs/tutorial_intro.ipynb
@@ -20,15 +20,21 @@
     "# Built-in modules\n",
     "import sys\n",
     "import os\n",
+    "from datetime import datetime\n",
     "\n",
     "# External modules\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import astropy.units as u\n",
     "\n",
+    "# For interactive visualization of observations\n",
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display, clear_output\n",
+    "import plotly.graph_objects as go\n",
+    "\n",
     "# TOAST\n",
     "import toast\n",
-    "\n",
+    "import toast.widgets as tw\n",
     "\n",
     "# Capture C++ output in the jupyter cells\n",
     "%load_ext wurlitzer\n",
@@ -176,6 +182,7 @@
     "samples = 10\n",
     "\n",
     "ob = toast.Observation(\n",
+    "    toast.Comm(),\n",
     "    telescope, \n",
     "    name=\"2020-07-31_A\", \n",
     "    n_samples=samples\n",
@@ -397,13 +404,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create some time stamps by assigning from an existing array on one process.\n",
-    "# When running with multiple processes, this syntax has extra communication.\n",
-    "ob.shared[\"times\"] = np.arange(ob.n_local_samples, dtype=np.float64)\n",
+    "# Shared data that is common to multiple detectors is shared across each \"column\"\n",
+    "# of the process grid within a group.\n",
+    "\n",
+    "# Some fake timestamps:\n",
+    "ob.shared.create_column(\"times\", (ob.n_local_samples,)) # Defaults to float64\n",
+    "ob.shared[\"times\"][:] = np.arange(ob.n_local_samples, dtype=np.float64)\n",
     "print(ob.shared[\"times\"])\n",
     "\n",
     "# Create and initialize to zero some boresight quaternions\n",
-    "ob.shared.create(\"boresight_radec\", shape=(ob.n_local_samples, 4), dtype=np.float64)\n",
+    "ob.shared.create_column(\"boresight_radec\", shape=(ob.n_local_samples, 4), dtype=np.float64)\n",
     "print(ob.shared[\"boresight_radec\"])"
    ]
   },
@@ -440,7 +450,7 @@
     "full_data = np.tile(nullquat, ob.n_local_samples).reshape((-1, 4))\n",
     "\n",
     "# In the serial case, simple assignment works just like array assignment\n",
-    "ob.shared[\"boresight_radec\"][:] = full_data\n",
+    "ob.shared[\"boresight_radec\"][:, :] = full_data\n",
     "\n",
     "# When running with MPI, the set() method avoids some communication\n",
     "ob.shared[\"boresight_radec\"].set(full_data, fromrank=0)\n",
@@ -708,11 +718,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = toast.Data()\n",
+    "test_data = toast.Data()\n",
     "\n",
-    "print(data)\n",
+    "print(test_data)\n",
     "\n",
-    "print(data.obs)"
+    "print(test_data.obs)"
    ]
   },
   {
@@ -800,8 +810,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from toast.schedule_sim_satellite import create_satellite_schedule\n",
+    "\n",
     "simsat.telescope = telescope\n",
-    "simsat.num_observations = 3\n",
+    "simsat.schedule = create_satellite_schedule(\n",
+    "    prefix=\"test_\",\n",
+    "    mission_start=datetime(2023, 2, 23),\n",
+    "    observation_time=0.5 * u.hour,\n",
+    "    gap_time=0 * u.second,\n",
+    "    num_observations=3,\n",
+    "    prec_period=90 * u.minute,\n",
+    "    spin_period=10 * u.minute,\n",
+    ")\n",
     "\n",
     "print(simsat)"
    ]
@@ -822,7 +842,7 @@
     "# This is equivalent to single call to \"exec()\" with all processes,\n",
     "# and then a call to \"finalize()\".\n",
     "\n",
-    "simsat.apply(data)"
+    "simsat.apply(test_data)"
    ]
   },
   {
@@ -831,7 +851,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(data)"
+    "print(test_data)"
    ]
   },
   {
@@ -839,6 +859,24 @@
    "metadata": {},
    "source": [
     "For this trivial case, we use the `apply()` method of the operator, which simply calls `exec()` once and then `finalize()`.  When running a more complicated pipeline, the `exec()` method might be called multiple times on different detector sets (for example) before calling `finalize()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Observation Quicklook\n",
+    "\n",
+    "There is an interactive \"widget\" we can use to quickly look at one of our observation contents.  Try create some more plot tabs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tw.ObservationWidget(test_data.obs[0])"
    ]
   },
   {
@@ -873,9 +911,16 @@
    "outputs": [],
    "source": [
     "simsat = ops.SimSatellite(\n",
-    "    num_observations=2, \n",
-    "    observation_time=5 * u.minute,\n",
     "    telescope=telescope\n",
+    ")\n",
+    "simsat.schedule = create_satellite_schedule(\n",
+    "    prefix=\"test_\",\n",
+    "    mission_start=datetime(2023, 2, 23),\n",
+    "    observation_time=5 * u.minute,\n",
+    "    gap_time=0 * u.second,\n",
+    "    num_observations=2,\n",
+    "    prec_period=90 * u.minute,\n",
+    "    spin_period=10 * u.minute,\n",
     ")\n",
     "\n",
     "default_noise = ops.DefaultNoiseModel()"
@@ -1042,7 +1087,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run = tc.create(newconf)\n",
+    "run = tc.create_from_config(newconf)\n",
     "print(run)"
    ]
   },
@@ -1059,7 +1104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_simsat = run[\"operators\"][\"other_simsat\"]\n",
+    "new_simsat = run.operators.other_simsat\n",
     "print(new_simsat)"
    ]
   },

--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -136,6 +136,7 @@ install(FILES
     schedule.py
     schedule_sim_ground.py
     schedule_sim_satellite.py
+    widgets.py
     "RELEASE"
     DESTINATION ${PYTHON_SITE}/toast
 )

--- a/src/toast/widgets.py
+++ b/src/toast/widgets.py
@@ -1,0 +1,440 @@
+# Copyright (c) 2022-2022 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+from datetime import datetime, timezone, timedelta
+import re
+import copy
+
+import numpy as np
+import ipywidgets as widgets
+from IPython.display import display, clear_output
+import plotly.graph_objects as go
+from plotly_resampler import FigureResampler
+
+from .observation import default_values as defaults
+from .pixels import PixelData
+from .noise import Noise
+from .intervals import IntervalList
+
+
+class ObservationWidget(object):
+    """Interactive widget for exploring observation data.
+
+    Args:
+        obs (Observation):  The observation to display.
+
+    """
+
+    not_selected = "(None)"
+
+    def __init__(self, obs):
+        self.obs = obs
+
+        self._layout_box = widgets.Layout(
+            justify_content="space-between",
+            grid_gap="10px",
+            padding="5px",
+        )
+        self._layout_bordered_box = widgets.Layout(
+            border="solid 1px",
+            justify_content="space-between",
+            grid_gap="10px",
+            padding="5px",
+        )
+
+        self.app = widgets.Tab()
+
+        self.close_buttons = dict()
+
+        self._observation_summary()
+        display(self.app)
+
+    def _key_value_table(
+        self, title, data, key_name, val_name, height, width_percent=100
+    ):
+        """Create a 2-column table of values from a dictionary."""
+        keys = list(sorted(data.keys()))
+        keydata = [str(data[x]) for x in keys]
+        w_data = go.FigureWidget(
+            data=[
+                go.Table(
+                    header=dict(values=[key_name, val_name]),
+                    cells=dict(values=[keys, keydata]),
+                )
+            ],
+            layout=go.Layout(
+                title_text=title,
+                margin=go.layout.Margin(
+                    l=20,  # left margin
+                    r=20,  # right margin
+                    b=20,  # bottom margin
+                    t=40,  # top margin
+                ),
+                height=height,
+            ),
+        )
+        return widgets.Box(
+            [w_data],
+            layout=widgets.Layout(width=f"{width_percent}%", overflow_y="auto"),
+        )
+
+    def _timeselect_widget(self):
+        """Create a widget that selects a timestamp field and zone."""
+        time_list = list()
+        for k in self.obs.shared.keys():
+            sdata, scom = self.obs.shared._internal[k]
+            sshape = sdata.shape
+            if (scom == "column") and (
+                len(sshape) == 1 or (len(sshape) == 2 and sshape[1] == 1)
+            ):
+                time_list.append(k)
+        w_times = widgets.Dropdown(
+            options=time_list,
+            value=defaults.times,
+            description="Time Field:",
+            layout=widgets.Layout(width="90%"),
+        )
+        zones = [timezone(timedelta(hours=(x - 12))) for x in list(range(24))]
+        tz_opts = [(x.tzname(None), y) for y, x in enumerate(zones)]
+        w_zone = widgets.Dropdown(
+            options=tz_opts,
+            value=12,
+            description="Displayed As:",
+            layout=widgets.Layout(width="90%"),
+        )
+
+        def response_time(change):
+            """Recompute the datetime labels when the time field or zone changes."""
+            w_times.timedates = [
+                datetime.fromtimestamp(x, tz=zones[w_zone.value])
+                for x in self.obs.shared[w_times.value].data
+            ]
+
+        response_time(None)
+        w_times.observe(response_time, names="value")
+        w_zone.observe(response_time, names="value")
+        return w_times, w_zone
+
+    def _detselect_widget(self):
+        """Create a widget that selects detectors."""
+        det_names = ["ALL"]
+        det_names.extend(self.obs.local_detectors)
+        w_dets = widgets.SelectMultiple(
+            options=det_names,
+            value=[det_names[1]],
+            description="Detectors:",
+        )
+        return w_dets
+
+    def _interval_select_widget(self):
+        """Create a widget that selects intervals."""
+        inames = [self.not_selected]
+        inames.extend(self.obs.intervals.keys())
+        w_intr = widgets.SelectMultiple(
+            options=inames,
+            value=[inames[0]],
+            description="Intervals:",
+        )
+        return w_intr
+
+    def _close_tab(self, b):
+        """Close a tab associated with a close button."""
+        tabindex = self.close_buttons[b]
+        if tabindex >= len(self.app.children):
+            # Ignore the fake click when the button is created.
+            return
+        current_children = list(self.app.children)
+        try:
+            # Pre v8 this was private.
+            current_titles = {int(x): y for x, y in self.app._titles.items()}
+        except:
+            current_titles = {int(x): y for x, y in self.app.titles}
+        new_children = list()
+        new_titles = dict()
+        for tb in range(0, tabindex):
+            new_children.append(current_children[tb])
+            new_titles[tb] = current_titles[tb]
+        for tb in range(tabindex + 1, len(self.app.children)):
+            new_children.append(current_children[tb])
+            new_titles[tb - 1] = current_titles[tb]
+        del current_children[tabindex]
+        del self.close_buttons[b]
+        for k in list(self.close_buttons.keys()):
+            if self.close_buttons[k] > tabindex:
+                self.close_buttons[k] -= 1
+        self.app.children = new_children
+        for tb in range(len(self.app.children)):
+            self.app.set_title(tb, new_titles[tb])
+
+    def _detdata_display(self, name):
+        """Create a detector data display widget."""
+
+        # Create a button to close this tab
+        this_tab = len(self.app.children)
+        close_button = widgets.Button(
+            description="Close",
+            button_style="danger",
+            tooltip=f"Close",
+            layout=widgets.Layout(width="10%"),
+        )
+        close_button.on_click(self._close_tab)
+        self.close_buttons[close_button] = this_tab
+
+        w_times, w_zone = self._timeselect_widget()
+        tz_layout = widgets.Layout(
+            justify_content="space-between",
+            grid_gap="10px",
+            padding="5px",
+            width="30%",
+        )
+        w_timezone = widgets.VBox(
+            [w_times, w_zone],
+            layout=self._layout_box,
+        )
+
+        sel_layout = widgets.Layout(width="30%")
+        w_dets = self._detselect_widget()
+        w_dets.layout = sel_layout
+        w_intr = self._interval_select_widget()
+        w_intr.layout = sel_layout
+
+        w_topbar = widgets.HBox(
+            children=[w_timezone, w_dets, w_intr, close_button],
+            layout=self._layout_box,
+        )
+
+        fig = FigureResampler(go.Figure())
+        w_plot = widgets.Output()
+
+        def response(change):
+            det_list = list()
+            if w_dets.value[0] == "ALL":
+                det_list.extend(self.obs.local_detectors)
+            else:
+                det_list.extend(w_dets.value)
+            # To save plotting time, pre-compute the union of selected intervals
+            plot_intr = None
+            for ilist in w_intr.value:
+                if ilist == self.not_selected:
+                    continue
+                if plot_intr is None:
+                    plot_intr = IntervalList(
+                        self.obs.shared[w_times.value].data,
+                        intervals=self.obs.intervals[ilist],
+                    )
+                else:
+                    plot_intr |= self.obs.intervals[ilist]
+
+            fig.data = list()
+            fig.layout["shapes"] = list()
+
+            # with w_plot.batch_update():
+            for det in det_list:
+                fig.add_trace(
+                    go.Scatter(
+                        mode="lines",
+                        name=det,
+                    ),
+                    hf_x=w_times.timedates,
+                    hf_y=self.obs.detdata[name][det].astype(np.float32),
+                )
+            intr_shapes = dict()
+            if plot_intr is not None:
+                plot_intr.simplify()
+                for intr in plot_intr:
+                    begin = intr.first
+                    end = intr.last
+                    shp_name = f"interval_{begin}"
+                    intr_shapes[shp_name] = go.layout.Shape(
+                        type="rect",
+                        x0=w_times.timedates[begin],
+                        x1=w_times.timedates[end],
+                        y0=0,
+                        y1=1,
+                        xref="x",
+                        yref="y domain",
+                        line_width=0,
+                        fillcolor="gray",
+                        opacity=0.3,
+                    )
+            fig.update_layout(
+                title=dict(text=f"Detector Data ({name})"),
+                barmode="overlay",
+                xaxis_title="Time",
+                xaxis_tickformat="%H:%M:%S<br>%m-%d<br>%Y",
+                yaxis_title="Detector Value",
+                margin=go.layout.Margin(
+                    l=10,  # left margin
+                    r=10,  # right margin
+                    b=20,  # bottom margin
+                    t=40,  # top margin
+                ),
+                shapes=list(intr_shapes.values()),
+            )
+            with w_plot:
+                clear_output(wait=True)
+                fig.show_dash(mode="inline")
+
+        response(None)
+        w_times.observe(response, names="value")
+        w_zone.observe(response, names="value")
+        w_dets.observe(response, names="value")
+        w_intr.observe(response, names="value")
+
+        new_tab = widgets.VBox(
+            [
+                w_topbar,
+                w_plot,
+            ],
+            layout=widgets.Layout(border="solid 1px"),
+        )
+
+        new_children = list(self.app.children)
+        new_children.append(new_tab)
+        self.app.children = new_children
+        self.app.set_title(len(self.app.children) - 1, f"{name}")
+
+    def _new_plot(self, b):
+        """Create the proper type of plot"""
+        if self.create_plot_select.value == self.not_selected:
+            return
+        # FIXME:  call shared vs shared plot here if Y is a shared field
+        # Extract detdata name
+        det_pat = re.compile(r"Detector (.*)")
+        det_mat = det_pat.match(self.create_plot_select.value)
+        if det_mat is not None:
+            detdata_name = det_mat.group(1)
+            self._detdata_display(detdata_name)
+
+    def _plot_create(self):
+        """Create a new plot activation."""
+        # Allowable X axis vectors are shared data with one value per
+        # sample.
+        # self.x_list = [self.not_selected]
+        # shared_list = list()
+        # for k in self.obs.shared.keys():
+        #     sdata, scom = self.obs.shared._internal[k]
+        #     sshape = sdata.shape
+        #     if (scom == "column") and (len(sshape) == 1 or (len(sshape) == 2 and sshape[1] == 1)):
+        #         shared_list.append(k)
+        # self.x_list.extend(shared_list)
+        # For Y, we can plot the same shared data plus single-valued detector data.
+        self.obj_list = [self.not_selected]
+        for k in self.obs.detdata.keys():
+            dshape = self.obs.detdata[k].detector_shape
+            if len(dshape) == 1 or (len(dshape) == 2 and dshape[1] == 1):
+                self.obj_list.append(f"Detector {k}")
+
+        # FIXME:  Restore this once we can plot shared vs shared
+        # self.y_list.extend(shared_list)
+
+        self.create_plot_select = widgets.Dropdown(
+            options=self.obj_list,
+            value=self.not_selected,
+            description="Data:",
+        )
+
+        self.create_button = widgets.Button(
+            description="Create",
+            button_style="primary",
+            tooltip=f"Create",
+            layout=widgets.Layout(width=f"25%"),
+        )
+        self.create_button.on_click(self._new_plot)
+
+        w_create_plot = widgets.HBox(
+            [
+                widgets.Label(value="New Plot:"),
+                self.create_plot_select,
+                self.create_button,
+            ],
+            layout=self._layout_bordered_box,
+        )
+        return w_create_plot
+
+    def _observation_summary(self):
+        """Create the observation summary tab."""
+        header = widgets.HBox(
+            [
+                widgets.Label(value=f'  Name: "{self.obs.name}"'),
+                widgets.Label(value=f"UID: {self.obs.uid}"),
+                widgets.Label(value=f"Samples: {self.obs.n_all_samples}"),
+                widgets.Label(value="  "),
+            ],
+            layout=self._layout_bordered_box,
+        )
+        info = [header]
+
+        tele = self.obs.telescope
+        tele_info = {
+            "Name": tele.name,
+            "UID": tele.uid,
+            "Site": tele.site.name,
+            "Focalplane": "fake",
+        }
+        w_tele = self._key_value_table(
+            "Telescope", tele_info, "Property", "Value", 300, width_percent=100
+        )
+
+        meta_info = dict()
+        for k, v in self.obs.items():
+            meta_info[k] = str(v)
+        w_meta = self._key_value_table(
+            "Metadata", meta_info, "Property", "Value", 300, width_percent=100
+        )
+
+        w_telemeta = widgets.VBox([w_tele, w_meta], layout=widgets.Layout(width="40%"))
+
+        shared_info = dict()
+        for k in self.obs.shared.keys():
+            sdata, comtype = self.obs.shared._internal[k]
+            shared_info[k] = f"{sdata.shape} of {sdata.dtype} (comm={comtype})"
+        w_shared = self._key_value_table(
+            "Shared Data", shared_info, "Field", "Info", 200, width_percent=100
+        )
+
+        det_info = dict()
+        for k in self.obs.detdata.keys():
+            ddata = self.obs.detdata[k]
+            ndet = len(ddata.detectors)
+            det_info[
+                k
+            ] = f"{ndet} dets: {ddata.shape} of {ddata.dtype} (unit='{ddata.units}')"
+        w_detdata = self._key_value_table(
+            "Detector Data", det_info, "Field", "Info", 200, width_percent=100
+        )
+
+        intr_info = dict()
+        for k in self.obs.intervals.keys():
+            idata = self.obs.intervals[k]
+            nintr = len(idata)
+            intr_info[k] = f"{nintr} spans"
+        w_intr = self._key_value_table(
+            "Intervals", intr_info, "Name", "Info", 200, width_percent=100
+        )
+
+        w_datacol = widgets.VBox(
+            [w_shared, w_detdata, w_intr], layout=widgets.Layout(width="60%")
+        )
+
+        info.append(
+            widgets.HBox(
+                [
+                    w_telemeta,
+                    w_datacol,
+                ],
+            )
+        )
+
+        # Plot creation
+        info.append(self._plot_create())
+
+        new_children = list(self.app.children)
+        new_children.append(
+            widgets.VBox(
+                info,
+            )
+        )
+        self.app.children = new_children
+        self.app.set_title(len(self.app.children) - 1, "Observation")


### PR DESCRIPTION
This creates a small widget for displaying metadata and plotting detector data.  Also add this widget to the intro tutorial.  The plots make use of `plotly` and the `plotly-resampler` package which speeds up plotting of many data points.  Multiple detectors and intervals can be displayed at once.  The `toast.widgets` file is not imported default, so this does not introduce any new required dependencies. 
![toast_widget_1](https://user-images.githubusercontent.com/84221/165252691-b095ea72-4895-49ea-9dfb-2df9d67bfdc4.png)
![toast_widgets_2](https://user-images.githubusercontent.com/84221/165252724-0f3a1f8b-2bec-4a25-9ea2-c83e8dcc9aa3.png)
![toast_widgets_3](https://user-images.githubusercontent.com/84221/165252750-5281604d-d8aa-41e7-a3e3-f602636ea884.png)
