### PR TITLE
Uncrustify update

### DIFF
--- a/src/libtoast/include/toast/atm.hpp
+++ b/src/libtoast/include/toast/atm.hpp
@@ -51,7 +51,7 @@ bool atm_sim_in_cone(
     double const & maxdist,
     double const & cosel0,
     double const & sinel0
-    );
+);
 
 void atm_sim_compress_flag_hits_rank(
     int64_t nn,
@@ -80,7 +80,7 @@ void atm_sim_compress_flag_hits_rank(
     double maxdist,
     double cosel0,
     double sinel0
-    );
+);
 
 void atm_sim_compress_flag_extend_rank(
     uint8_t * hit,
@@ -93,7 +93,7 @@ void atm_sim_compress_flag_extend_rank(
     int64_t xstride,
     int64_t ystride,
     int64_t zstride
-    );
+);
 
 double atm_sim_interp(
     double const & x,
@@ -132,7 +132,7 @@ double atm_sim_interp(
     int64_t const * compressed_index,
     int64_t const * full_index,
     double const * realization
-    );
+);
 
 int atm_sim_observe(
     size_t nsamp,
@@ -176,7 +176,7 @@ int atm_sim_observe(
     int64_t * compressed_index,
     int64_t * full_index,
     double * realization
-    );
+);
 
 void atm_sim_kolmogorov_init_rank(
     int64_t nr,
@@ -189,7 +189,7 @@ void atm_sim_kolmogorov_init_rank(
     double lmax,
     int ntask,
     int rank
-    );
+);
 
 double atm_sim_kolmogorov(
     double const & r,
@@ -198,7 +198,7 @@ double atm_sim_kolmogorov(
     double const & rmax_kolmo,
     double const * kolmo_x,
     double const * kolmo_y
-    );
+);
 
 double atm_sim_cov_eval(
     int64_t const & nr,
@@ -213,7 +213,7 @@ double atm_sim_cov_eval(
     bool smooth,
     double xxstep,
     double zzstep
-    );
+);
 
 void atm_sim_ind2coord(
     double const & xstart,
@@ -233,7 +233,7 @@ void atm_sim_ind2coord(
     int64_t const * full_index,
     int64_t const & i,
     double * coord
-    );
+);
 
 int64_t atm_sim_coord2ind(
     double const & xstart,
@@ -252,7 +252,7 @@ int64_t atm_sim_coord2ind(
     double const & x,
     double const & y,
     double const & z
-    );
+);
 
 cholmod_sparse * atm_sim_build_sparse_covariance(
     int64_t ind_start,
@@ -280,14 +280,14 @@ cholmod_sparse * atm_sim_build_sparse_covariance(
     double xxstep,
     double zzstep,
     int rank
-    );
+);
 
 cholmod_sparse * atm_sim_sqrt_sparse_covariance(
     cholmod_sparse * cov,
     int64_t ind_start,
     int64_t ind_stop,
     int rank
-    );
+);
 
 void atm_sim_apply_sparse_covariance(
     cholmod_sparse * sqrt_cov,
@@ -299,7 +299,7 @@ void atm_sim_apply_sparse_covariance(
     uint64_t counter2,
     double * realization,
     int rank
-    );
+);
 
 void atm_sim_compute_slice(
     int64_t ind_start,
@@ -332,7 +332,7 @@ void atm_sim_compute_slice(
     uint64_t counter1,
     uint64_t counter2,
     double * realization
-    );
+);
 }
 
 #endif // ifdef HAVE_CHOLMOD

--- a/src/libtoast/include/toast/map_pixels.hpp
+++ b/src/libtoast/include/toast/map_pixels.hpp
@@ -33,9 +33,9 @@ void global_to_local(size_t nsamp,
                 global2local[
                     static_cast <T> (
                         static_cast <double> (global_pixels[i]) * npix_submap_inv
-                        )
+                    )
                 ]
-                );
+            );
         }
     }
 

--- a/src/libtoast/include/toast/tod_filter.hpp
+++ b/src/libtoast/include/toast/tod_filter.hpp
@@ -24,7 +24,7 @@ void filter_poly2D_solve(
     int64_t nsample, int32_t ndet, int32_t ngroup, int32_t nmode,
     int32_t const * det_group, double const * templates, uint8_t const * masks,
     double const * signals, double * coeff
-    );
+);
 }
 
 #endif // ifndef TOAST_TOD_FILTER_HPP

--- a/src/libtoast/src/toast_atm.cpp
+++ b/src/libtoast/src/toast_atm.cpp
@@ -89,7 +89,7 @@ bool toast::atm_sim_in_cone(
     double const & maxdist,
     double const & cosel0,
     double const & sinel0
-    ) {
+) {
     // Input coordinates are in the scan frame, rotate to horizontal frame
 
     double tstep = 1;
@@ -217,7 +217,7 @@ void toast::atm_sim_compress_flag_hits_rank(
     double maxdist,
     double cosel0,
     double sinel0
-    ) {
+) {
     double t_fake = -1.0;
     for (int64_t ix = 0; ix < nx; ++ix) {
         if (ix % ntask != rank) {
@@ -253,7 +253,7 @@ void toast::atm_sim_compress_flag_extend_rank(
     int64_t xstride,
     int64_t ystride,
     int64_t zstride
-    ) {
+) {
     for (int64_t ix = 1; ix < nx - 1; ++ix) {
         if (ix % ntask != rank) {
             continue;

--- a/src/libtoast/src/toast_atm_observe.cpp
+++ b/src/libtoast/src/toast_atm_observe.cpp
@@ -62,7 +62,7 @@ double toast::atm_sim_interp(
     int64_t const * compressed_index,
     int64_t const * full_index,
     double const * realization
-    ) {
+) {
     // Trilinear interpolation.  This function is called for every sample, so we
     // pass all arguments by reference / pointer.
 
@@ -191,7 +191,7 @@ double toast::atm_sim_interp(
                 t_in, delta_t, delta_az, elmin, elmax,
                 wx, wy, wz, xstep, ystep, zstep,
                 maxdist, cosel0, sinel0
-                    );
+                );
             auto & logger = toast::Logger::get();
             logger.error(o.str().c_str());
             throw std::runtime_error(o.str().c_str());
@@ -285,7 +285,7 @@ int toast::atm_sim_observe(
     int64_t * compressed_index,
     int64_t * full_index,
     double * realization
-    ) {
+) {
     // For each sample, integrate along the line of sight by summing
     // the atmosphere values. See Church (1995) Section 2.2, first equation.
     // We omit the optical depth factor which is close to unity.
@@ -436,7 +436,7 @@ int toast::atm_sim_observe(
                         maxdist, cosel0, sinel0,
                         nelem, compressed_index, full_index,
                         realization
-                        ) * (1. - z * zatm_inv);
+                               ) * (1. - z * zatm_inv);
                 } catch (const std::runtime_error & e) {
                     # pragma omp flush(error)
                     if (error == 0) {

--- a/src/libtoast/src/toast_atm_sim.cpp
+++ b/src/libtoast/src/toast_atm_sim.cpp
@@ -36,7 +36,7 @@ void toast::atm_sim_kolmogorov_init_rank(
     double lmax,
     int ntask,
     int rank
-    ) {
+) {
     // Numerically integrate the modified Kolmogorov spectrum for the
     // correlation function at grid points. We integrate down from
     // 10*kappamax to 0 for numerical precision
@@ -179,7 +179,7 @@ double toast::atm_sim_kolmogorov(
     double const & rmax_kolmo,
     double const * kolmo_x,
     double const * kolmo_y
-    ) {
+) {
     // Return autocovariance of a Kolmogorov process at separation r
 
     if (r == 0) return kolmo_y[0];
@@ -235,7 +235,7 @@ double toast::atm_sim_cov_eval(
     bool smooth,
     double xxstep,
     double zzstep
-    ) {
+) {
     // Evaluate the atmospheric absorption covariance between two coordinates
     // Church (1995) Eq.(6) & (9)
     // Coordinates are in the horizontal frame
@@ -329,7 +329,7 @@ double toast::atm_sim_cov_eval(
                         rmax_kolmo,
                         kolmo_x,
                         kolmo_y
-                        );
+                    );
 
                     val += chi1 * chi2;
                 }
@@ -358,7 +358,7 @@ void toast::atm_sim_ind2coord(
     int64_t const * full_index,
     int64_t const & i,
     double * coord
-    ) {
+) {
     // Translate a compressed index into xyz-coordinates
     // in the horizontal frame
 
@@ -399,7 +399,7 @@ int64_t toast::atm_sim_coord2ind(
     double const & x,
     double const & y,
     double const & z
-    ) {
+) {
     // Translate scan frame xyz-coordinates into a compressed index
 
     // TK: these are mixed types being implicitly cast back to int64.
@@ -453,7 +453,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
     double xxstep,
     double zzstep,
     int rank
-    ) {
+) {
     // Build a sparse covariance matrix.
 
     auto & chol = toast::CholmodCommon::get();
@@ -508,7 +508,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
                 full_index,
                 i + ind_start,
                 coord
-                );
+            );
             diagonal[i] = toast::atm_sim_cov_eval(
                 nr,
                 rmin_kolmo,
@@ -522,7 +522,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
                 smooth,
                 xxstep,
                 zzstep
-                );
+            );
         }
 
         # pragma omp for schedule(static, 10)
@@ -547,7 +547,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
                 full_index,
                 icol + ind_start,
                 colcoord
-                );
+            );
             for (int64_t irow = icol; irow < nelem; ++irow) {
                 // Evaluate the covariance between the two coordinates
                 double rowcoord[3];
@@ -569,7 +569,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
                     full_index,
                     irow + ind_start,
                     rowcoord
-                    );
+                );
 
                 // Skip pairs of volume elements that are further
                 // apart than maximum correlation distance
@@ -590,7 +590,7 @@ cholmod_sparse * toast::atm_sim_build_sparse_covariance(
                     smooth,
                     xxstep,
                     zzstep
-                    );
+                );
                 if (icol == irow) {
                     // Regularize the matrix by promoting the diagonal
                     val *= 1.01;
@@ -680,7 +680,7 @@ cholmod_sparse * toast::atm_sim_sqrt_sparse_covariance(
     int64_t ind_start,
     int64_t ind_stop,
     int rank
-    ) {
+) {
     // Cholesky-factorize the provided sparse matrix and return the
     // sparse matrix representation of the factorization
 
@@ -835,7 +835,7 @@ void toast::atm_sim_apply_sparse_covariance(
     uint64_t counter2,
     double * realization,
     int rank
-    ) {
+) {
     // Apply the Cholesky-decomposed (square-root) sparse covariance
     // matrix to a vector of Gaussian random numbers to impose the
     // desired correlation properties.
@@ -943,7 +943,7 @@ void toast::atm_sim_compute_slice(
     uint64_t counter1,
     uint64_t counter2,
     double * realization
-    ) {
+) {
     auto & chol = toast::CholmodCommon::get();
 
     auto & gt = toast::GlobalTimers::get();
@@ -976,7 +976,7 @@ void toast::atm_sim_compute_slice(
         xxstep,
         zzstep,
         rank
-        );
+    );
 
     gt.stop("atm_sim_build_sparse_covariance");
 
@@ -987,7 +987,7 @@ void toast::atm_sim_compute_slice(
         ind_start,
         ind_stop,
         rank
-        );
+    );
 
     gt.stop("atm_sim_sqrt_sparse_covariance");
 
@@ -1005,7 +1005,7 @@ void toast::atm_sim_compute_slice(
         counter2,
         realization,
         rank
-        );
+    );
 
     gt.stop("atm_sim_apply_sparse_covariance");
 

--- a/src/toast/_libtoast/atm.cpp
+++ b/src/toast/_libtoast/atm.cpp
@@ -195,7 +195,7 @@ void init_atm(py::module & m) {
                   counter1,
                   counter2,
                   raw_realiz
-                  );
+              );
               return;
           }, R"(
      Internal function used by AtmSim class.
@@ -323,7 +323,7 @@ void init_atm(py::module & m) {
                   raw_comp,
                   raw_full,
                   raw_realiz
-                  );
+              );
               return status;
           }, R"(
      Internal function used by AtmSim class.
@@ -388,7 +388,7 @@ void init_atm(py::module & m) {
                   maxdist,
                   cosel0,
                   sinel0
-                  );
+              );
               return;
           }, R"(
      Internal function used by AtmSim class.
@@ -432,7 +432,7 @@ void init_atm(py::module & m) {
                   xstride,
                   ystride,
                   zstride
-                  );
+              );
               return;
           }, R"(
      Internal function used by AtmSim class.
@@ -468,7 +468,7 @@ void init_atm(py::module & m) {
                   lmax,
                   ntask,
                   rank
-                  );
+              );
               return py::make_tuple(kolmo_x, kolmo_y);
           }, R"(
        Internal function used by AtmSim class.

--- a/src/toast/_libtoast/math_misc.cpp
+++ b/src/toast/_libtoast/math_misc.cpp
@@ -29,7 +29,7 @@ double integrate_simpson(py::array_t <double> x, py::array_t <double> f) {
             (2 - h2 / h1) * f1 +
             pow(h1 + h2, 2) / (h1 * h2) * f2 +
             (2 - h1 / h2) * f3
-            );
+        );
     }
 
     if (n % 2 == 0) {
@@ -42,7 +42,7 @@ double integrate_simpson(py::array_t <double> x, py::array_t <double> f) {
             (2 * pow(h1, 2) + 3 * h1 * h2) / (6 * (h2 + h1)) * f1 +
             (pow(h1, 2) + 3 * h1 * h2) / (6 * h2) * f2 -
             pow(h1, 3) / (6 * h2 * (h2 + h1)) * f2
-            );
+        );
     }
 
     return result;

--- a/src/toast/_libtoast/module.hpp
+++ b/src/toast/_libtoast/module.hpp
@@ -64,7 +64,7 @@ void register_aligned(py::module & m, char const * name) {
                 1,
                 {self.size()},
                 {sizeof(typename C::value_type)}
-                );
+            );
         })
     .def("__len__", [](const C & self) {
              return self.size();

--- a/src/toast/_libtoast/pixels.cpp
+++ b/src/toast/_libtoast/pixels.cpp
@@ -11,7 +11,7 @@ py::tuple global_to_local(
     py::array_t <T> global_pixels,
     size_t npix_submap,
     py::array_t <int64_t> global2local
-    ) {
+) {
     // Get raw pointers to input.
     py::buffer_info gpinfo = global_pixels.request();
     py::buffer_info glinfo = global2local.request();
@@ -36,7 +36,7 @@ py::tuple global_to_local(
     toast::global_to_local <T> (
         nsamp, global_pixels_raw, npix_submap,
         global_to_local_raw, local_submaps_raw, local_pixels_raw
-        );
+    );
     return py::make_tuple(local_submaps, local_pixels);
 }
 

--- a/src/toast/_libtoast/sys.cpp
+++ b/src/toast/_libtoast/sys.cpp
@@ -289,7 +289,7 @@ void init_sys(py::module & m) {
                 toast::Timer ret(
                     t[0].cast <double>(),
                     t[1].cast <size_t>()
-                    );
+                );
                 return ret;
             }));
 

--- a/src/toast/_libtoast/todmap_mapmaker.cpp
+++ b/src/toast/_libtoast/todmap_mapmaker.cpp
@@ -94,7 +94,7 @@ void expand_matrix(py::array_t <double> compressed_matrix,
                    int64_t nnz,
                    py::array_t <int64_t> indices,
                    py::array_t <int64_t> indptr
-                   ) {
+) {
     auto fast_matrix = compressed_matrix.unchecked <2>();
     auto fast_local_to_global = local_to_global.unchecked <1>();
     auto fast_indices = indices.mutable_unchecked <1>();

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -23,6 +23,7 @@ indent_access_spec=0
 indent_access_spec_body=true
 indent_paren_nl=false
 indent_paren_open_brace=true
+indent_paren_close = 2
 indent_comma_paren=false
 indent_bool_paren=false
 indent_square_nl=false


### PR DESCRIPTION
Change one uncrustify option to make the close parenthesis of function arguments line up with function name.  This more closely matches our python style.