### PR TITLE
Flag and import cleanup

### DIFF
--- a/src/format_source.sh
+++ b/src/format_source.sh
@@ -46,6 +46,14 @@ if [ ${bmajor} -le "21" ]; then
     fi
 fi
 
+isortexe=$(which isort)
+have_isort="yes"
+if [ "x${isortexe}" = "x" ]; then
+    echo "Cannot find the \"isort\" executable.  Is it in your PATH?"
+    echo "Skipping for now."
+    have_isort="no"
+fi
+
 # The uncrustify config file
 uncfg="${base}/uncrustify.cfg"
 
@@ -73,10 +81,17 @@ find "${base}/libtoast" "${base}/toast" \( -name "*.hpp" -or -name "*.cpp" \) \
 # Process directories with python files
 find "${base}/toast" "${base}/../workflows" -name "*.py" -and -not \
     -path '*pybind11/*' -exec ${blkexe} ${blkrun} '{}' + &
+if [ ${have_isort} = "yes" ]; then
+    find "${base}/toast" "${base}/../workflows" -name "*.py" -and -not \
+    -path '*pybind11/*' -exec ${isortexe} --profile black '{}' + &
+fi
 
 # Special case:  process files in the scripts directory which do not
 # have the .py extension
 find "${base}/toast/scripts" -name "toast_*" -exec ${blkexe} ${blkrun} '{}' + &
+if [ ${have_isort} = "yes" ]; then
+    find "${base}/toast/scripts" -name "toast_*" -exec ${isortexe} --profile black '{}' + &
+fi
 
 # Wait for the commands to finish
 wait

--- a/src/toast/__init__.py
+++ b/src/toast/__init__.py
@@ -43,8 +43,8 @@ CUDA_MEMPOOL_FRACTION=<float>
       exhaust the device memory.
 
 """
-import sys
 import os
+import sys
 
 # Get the package version from the libtoast environment if possible.  If this
 # import fails, it is likely due to the toast package being imported prior to
@@ -71,25 +71,16 @@ except ImportError:
     except:
         raise ImportError("Cannot read RELEASE file")
 
+from .config import create_from_config, load_config, parse_config
+from .data import Data
+from .instrument import Focalplane, GroundSite, SpaceSite, Telescope
+from .instrument_sim import fake_hexagon_focalplane
+from .intervals import Interval
+from .job import job_group_size
+
 # Namespace imports
 from .mpi import Comm, get_world
-
-from .timing import Timer, GlobalTimers
-
-from .intervals import Interval
-
 from .observation import Observation
-
-from .data import Data
-
-from .config import load_config, parse_config, create_from_config
-
-from .instrument import Telescope, Focalplane, GroundSite, SpaceSite
-
-from .instrument_sim import fake_hexagon_focalplane
-
+from .pixels import PixelData, PixelDistribution
+from .timing import GlobalTimers, Timer
 from .weather import Weather
-
-from .pixels import PixelDistribution, PixelData
-
-from .job import job_group_size

--- a/src/toast/atm.py
+++ b/src/toast/atm.py
@@ -3,20 +3,15 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-import numpy as np
-
-from astropy import units as u
 
 import h5py
-
-from .utils import Environment, Logger
-
-from .timing import Timer, function_timer, GlobalTimers
-
-from .rng import random as toast_rng
+import numpy as np
+from astropy import units as u
 
 from .mpi import MPI, MPIShared
-
+from .rng import random as toast_rng
+from .timing import GlobalTimers, Timer, function_timer
+from .utils import Environment, Logger
 
 available_utils = True
 try:
@@ -32,11 +27,11 @@ except ImportError:
 available_atm = available_utils
 try:
     from ._libtoast import (
-        atm_sim_compute_slice,
-        atm_sim_observe,
-        atm_sim_compress_flag_hits_rank,
         atm_sim_compress_flag_extend_rank,
+        atm_sim_compress_flag_hits_rank,
+        atm_sim_compute_slice,
         atm_sim_kolmogorov_init_rank,
+        atm_sim_observe,
     )
 except ImportError:
     available_atm = False

--- a/src/toast/aux/weather/convert.py
+++ b/src/toast/aux/weather/convert.py
@@ -3,10 +3,9 @@
 import os
 import sys
 
-import numpy as np
-
 import fitsio
 import h5py
+import numpy as np
 
 infile = sys.argv[1]
 outfile = sys.argv[2]

--- a/src/toast/config.py
+++ b/src/toast/config.py
@@ -2,30 +2,24 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import sys
-import types
-import re
 import ast
 import copy
-
+import json
+import re
+import sys
+import types
 from collections import OrderedDict
 from collections.abc import MutableMapping
 
-import json
-
 import numpy as np
-
 import tomlkit
-from tomlkit import comment, document, nl, table, loads, dumps
-
 from astropy import units as u
+from tomlkit import comment, document, dumps, loads, nl, table
 
-from .utils import Environment, Logger
-
-from .instrument import Focalplane, Telescope
 from . import instrument
-
+from .instrument import Focalplane, Telescope
 from .traits import TraitConfig
+from .utils import Environment, Logger
 
 
 def build_config(objects):

--- a/src/toast/coordinates.py
+++ b/src/toast/coordinates.py
@@ -3,24 +3,18 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-
 from collections import OrderedDict
-
 from datetime import datetime, timezone
 
-import numpy as np
-
 import ephem
-
-from astropy import time as atime
+import numpy as np
 from astropy import coordinates as acoord
+from astropy import time as atime
 from astropy import units as u
 
-from .timing import function_timer
-
-from .healpix import ang2vec
-
 from . import qarray as qa
+from .healpix import ang2vec
+from .timing import function_timer
 
 
 def to_UTC(t):

--- a/src/toast/covariance.py
+++ b/src/toast/covariance.py
@@ -4,16 +4,14 @@
 
 import numpy as np
 
-from .timing import function_timer
-
 from ._libtoast import (
     AlignedF64,
-    cov_mult_diag,
     cov_apply_diag,
     cov_eigendecompose_diag,
+    cov_mult_diag,
 )
-
 from .pixels import PixelData
+from .timing import function_timer
 
 
 # These are just wrappers to time the libtoast calls

--- a/src/toast/data.py
+++ b/src/toast/data.py
@@ -2,16 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from collections.abc import MutableMapping
-
-from collections import OrderedDict
-
 import re
+from collections import OrderedDict
+from collections.abc import MutableMapping
 
 import numpy as np
 
 from .mpi import Comm
-
 from .utils import Logger
 
 

--- a/src/toast/dipole.py
+++ b/src/toast/dipole.py
@@ -2,18 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import healpy as hp
 import numpy as np
-
 import scipy.constants as constants
-
 from astropy import units as u
 
-import healpy as hp
-
-from .timing import function_timer
-
 from . import qarray as qa
-
+from .timing import function_timer
 from .utils import array_dot
 
 

--- a/src/toast/dist.py
+++ b/src/toast/dist.py
@@ -3,13 +3,11 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 from collections.abc import MutableMapping
-
 from typing import NamedTuple
 
 import numpy as np
 
 from .mpi import Comm
-
 from .timing import function_timer
 
 

--- a/src/toast/fft.py
+++ b/src/toast/fft.py
@@ -4,8 +4,7 @@
 
 import numpy as np
 
-from ._libtoast import FFTPlanType, FFTDirection, FFTPlanReal1D, FFTPlanReal1DStore
-
+from ._libtoast import FFTDirection, FFTPlanReal1D, FFTPlanReal1DStore, FFTPlanType
 from .utils import object_ndim
 
 

--- a/src/toast/healpix.py
+++ b/src/toast/healpix.py
@@ -2,26 +2,23 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import numpy as np
+
+from ._libtoast import (
+    HealpixPixels,
+    healpix_ang2vec,
+    healpix_vec2ang,
+    healpix_vecs2angpa,
+)
+from .timing import function_timer
 from .utils import (
-    Logger,
     AlignedF64,
     AlignedI64,
+    Logger,
     ensure_buffer_f64,
     ensure_buffer_i64,
     object_ndim,
 )
-
-from ._libtoast import (
-    healpix_ang2vec,
-    healpix_vec2ang,
-    healpix_vecs2angpa,
-    HealpixPixels,
-)
-
-
-import numpy as np
-
-from .timing import function_timer
 
 
 def ang2vec(theta, phi):

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -5,20 +5,13 @@
 import os
 import sys
 
-import numpy as np
-
-import h5py
-
-from astropy import units as u
-
-import astropy.time as astime
-
 import astropy.coordinates as coord
-
-from astropy.table import QTable, Column
-
-from astropy.io.misc.hdf5 import write_table_hdf5, read_table_hdf5
-
+import astropy.time as astime
+import h5py
+import numpy as np
+from astropy import units as u
+from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
+from astropy.table import Column, QTable
 from scipy.constants import h, k
 
 try:
@@ -28,22 +21,18 @@ except ImportError:
 
 import tomlkit
 
-from .timing import function_timer, Timer
-
+from . import qarray
 from . import qarray as qa
-
+from ._libtoast import integrate_simpson
 from .noise_sim import AnalyticNoise
+from .timing import Timer, function_timer
 from .utils import (
-    Logger,
     Environment,
+    Logger,
+    hdf5_use_serial,
     name_UID,
     table_write_parallel_hdf5,
-    hdf5_use_serial,
 )
-
-from . import qarray
-
-from ._libtoast import integrate_simpson
 
 # CMB temperature
 TCMB = 2.72548

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -3,15 +3,11 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 from astropy import units as u
-
-from astropy.table import QTable, Column
+from astropy.table import Column, QTable
 
 from . import qarray as qa
-
 from .instrument import Focalplane
-
 from .vis import set_matplotlib_backend
 
 

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -4,13 +4,6 @@
 
 # Namespace imports
 
-from .observation_hdf_save import save_hdf5
-
+from .hdf_utils import H5File, have_hdf5_parallel, hdf5_config, hdf5_open
 from .observation_hdf_load import load_hdf5
-
-from .hdf_utils import (
-    have_hdf5_parallel,
-    hdf5_config,
-    hdf5_open,
-    H5File,
-)
+from .observation_hdf_save import save_hdf5

--- a/src/toast/io/hdf_utils.py
+++ b/src/toast/io/hdf_utils.py
@@ -2,35 +2,27 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import datetime
+import json
 import os
 import re
-import datetime
-
-import numpy as np
-
-from astropy import units as u
 
 import h5py
+import numpy as np
+from astropy import units as u
 
-import json
-
+from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
+from ..mpi import MPI, use_mpi
+from ..observation import Observation
+from ..timing import GlobalTimers, Timer, function_timer
 from ..utils import (
     Environment,
     Logger,
-    import_from_name,
     dtype_to_aligned,
     have_hdf5_parallel,
+    import_from_name,
 )
-
-from ..mpi import MPI, use_mpi
-
-from ..timing import Timer, function_timer, GlobalTimers
-
-from ..instrument import GroundSite, SpaceSite, Focalplane, Telescope
-
 from ..weather import SimWeather
-
-from ..observation import Observation
 
 
 def check_dataset_buffer_size(msg, slices, dtype, parallel):

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -2,36 +2,22 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
-import numpy as np
-
-import re
 import datetime
-
-from astropy import units as u
+import json
+import os
+import re
 
 import h5py
+import numpy as np
+from astropy import units as u
 
-import json
-
-from ..utils import (
-    Environment,
-    Logger,
-    import_from_name,
-    dtype_to_aligned,
-)
-
+from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
 from ..mpi import MPI
-
-from ..timing import Timer, function_timer, GlobalTimers
-
-from ..instrument import GroundSite, SpaceSite, Focalplane, Telescope
-
-from ..weather import SimWeather
-
 from ..observation import Observation
-
-from .hdf_utils import check_dataset_buffer_size, hdf5_open, hdf5_config
+from ..timing import GlobalTimers, Timer, function_timer
+from ..utils import Environment, Logger, dtype_to_aligned, import_from_name
+from ..weather import SimWeather
+from .hdf_utils import check_dataset_buffer_size, hdf5_config, hdf5_open
 
 
 @function_timer

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -2,34 +2,26 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import json
 import os
-import numpy as np
 
+import h5py
+import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
-import h5py
-
-import json
-
+from ..instrument import GroundSite
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..observation_dist import global_interval_times
+from ..timing import GlobalTimers, Timer, function_timer
 from ..utils import (
     Environment,
     Logger,
-    object_fullname,
     dtype_to_aligned,
     hdf5_use_serial,
+    object_fullname,
 )
-
-from ..mpi import MPI
-
-from ..timing import Timer, function_timer, GlobalTimers
-
-from ..instrument import GroundSite
-
-from ..observation import default_values as defaults
-
-from ..observation_dist import global_interval_times
-
 from .hdf_utils import check_dataset_buffer_size, hdf5_open
 
 

--- a/src/toast/job.py
+++ b/src/toast/job.py
@@ -2,14 +2,11 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import psutil
-
 import numpy as np
-
+import psutil
 from astropy import units as u
 
 from .mpi import MPI
-
 from .utils import Logger
 
 

--- a/src/toast/mpi.py
+++ b/src/toast/mpi.py
@@ -5,12 +5,7 @@
 import os
 import time
 
-from ._libtoast import (
-    Logger,
-    Environment,
-    acc_enabled,
-    acc_get_num_devices,
-)
+from ._libtoast import Environment, Logger, acc_enabled, acc_get_num_devices
 
 use_mpi = None
 MPI = None
@@ -87,14 +82,13 @@ if use_mpi is None:
 
 # We put other imports and *after* the MPI check, since usually the MPI initialization # is time sensitive and may timeout the job if it does not happen quickly enough.
 
-import sys
 import itertools
-from contextlib import contextmanager
+import sys
 import traceback
+from contextlib import contextmanager
 
 import numpy as np
-
-from pshmem import MPIShared, MPILock
+from pshmem import MPILock, MPIShared
 
 from ._libtoast import Logger
 

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -3,18 +3,15 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-
-from typing import Type
 import re
-import numpy as np
-
-from astropy import units as u
+from typing import Type
 
 import h5py
+import numpy as np
+from astropy import units as u
 
+from .timing import Timer, function_timer
 from .utils import hdf5_use_serial
-
-from .timing import function_timer, Timer
 
 
 class Noise(object):

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -4,17 +4,13 @@
 
 import os
 
+import h5py
 import numpy as np
-
 from astropy import units as u
 
-import h5py
-
 from .noise import Noise
-
-from .utils import hdf5_use_serial
-
 from .timing import function_timer
+from .utils import hdf5_use_serial
 
 
 class AnalyticNoise(Noise):

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -2,49 +2,29 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import sys
-
-import types
-
 import copy
-
 import numbers
-
-from collections.abc import MutableMapping, Sequence, Mapping
+import sys
+import types
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import numpy as np
-
 from pshmem.utils import mpi_data_type
 
-from .mpi import MPI, comm_equal
-
-from .instrument import Telescope
-
 from .dist import distribute_samples
-
+from .instrument import Telescope
 from .intervals import IntervalList
-
-from .utils import (
-    Logger,
-    name_UID,
-)
-
-from .timing import function_timer
-
+from .mpi import MPI, comm_equal
 from .observation_data import (
-    DetectorData,
     DetDataManager,
-    SharedDataManager,
+    DetectorData,
     IntervalsManager,
+    SharedDataManager,
 )
-
-from .observation_view import DetDataView, SharedView, View, ViewManager, ViewInterface
-
-from .observation_dist import (
-    DistDetSamp,
-    redistribute_data,
-)
-
+from .observation_dist import DistDetSamp, redistribute_data
+from .observation_view import DetDataView, SharedView, View, ViewInterface, ViewManager
+from .timing import function_timer
+from .utils import Logger, name_UID
 
 default_values = None
 

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -3,43 +3,30 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import sys
-
-from collections.abc import MutableMapping, Mapping
-
+from collections.abc import Mapping, MutableMapping
 from typing import NamedTuple
 
 import numpy as np
-
 from astropy import units as u
-
 from pshmem import MPIShared
 
-from .mpi import MPI, comm_equivalent, comm_equal
-
+from ._libtoast import acc_copyin, acc_copyout, acc_enabled, acc_is_present
+from .intervals import IntervalList
+from .mpi import MPI, comm_equal, comm_equivalent
+from .timing import function_timer
 from .utils import (
-    Logger,
-    AlignedI8,
-    AlignedU8,
-    AlignedI16,
-    AlignedU16,
-    AlignedI32,
-    AlignedU32,
-    AlignedI64,
-    AlignedU64,
     AlignedF32,
     AlignedF64,
+    AlignedI8,
+    AlignedI16,
+    AlignedI32,
+    AlignedI64,
+    AlignedU8,
+    AlignedU16,
+    AlignedU32,
+    AlignedU64,
+    Logger,
     dtype_to_aligned,
-)
-
-from .intervals import IntervalList
-
-from .timing import function_timer
-
-from ._libtoast import (
-    acc_enabled,
-    acc_is_present,
-    acc_copyin,
-    acc_copyout,
 )
 
 

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -2,38 +2,25 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import sys
-
 import numbers
-
-from collections.abc import MutableMapping, Sequence, Mapping
+import sys
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import numpy as np
-
 from pshmem.utils import mpi_data_type
 
+from .dist import DistRange, distribute_samples
 from .mpi import MPI, comm_equal, comm_equivalent
-
-from .dist import distribute_samples, DistRange
-
-from .timing import function_timer
-
-from .utils import (
-    Logger,
-    name_UID,
-    dtype_to_aligned,
-    AlignedI32,
-)
-
 from .observation_data import (
-    DetectorData,
     DetDataManager,
-    SharedDataManager,
+    DetectorData,
     IntervalsManager,
+    SharedDataManager,
     SharedDataType,
 )
-
-from .observation_view import DetDataView, SharedView, View, ViewManager, ViewInterface
+from .observation_view import DetDataView, SharedView, View, ViewInterface, ViewManager
+from .timing import function_timer
+from .utils import AlignedI32, Logger, dtype_to_aligned, name_UID
 
 
 class DistDetSamp(object):

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -2,11 +2,9 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import sys
-
 import numbers
-
-from collections.abc import MutableMapping, Sequence, Mapping
+import sys
+from collections.abc import Mapping, MutableMapping, Sequence
 
 import numpy as np
 

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -4,106 +4,58 @@
 
 # Import Operators into our public API
 
-from .operator import Operator
-
-from .memory_counter import MemoryCounter
-
-from .delete import Delete
-
-from .copy import Copy
-
-from .reset import Reset
-
 from .arithmetic import Combine
-
-from .pipeline import Pipeline
-
-from .sim_satellite import SimSatellite
-
-from .sim_ground import SimGround
-
+from .cadence_map import CadenceMap
+from .conviqt import SimConviqt, SimTEBConviqt, SimWeightedConviqt
+from .copy import Copy
+from .crosslinking import CrossLinking
+from .delete import Delete
+from .demodulation import Demodulate, StokesWeightsDemod
 from .elevation_noise import ElevationNoise
-
-from .sim_tod_noise import SimNoise
-
-from .sim_tod_dipole import SimDipole
-
-from .sim_tod_atm import SimAtmosphere
-
-from .noise_model import DefaultNoiseModel
-
-from .noise_weight import NoiseWeight
-
-from .gainscrambler import GainScrambler
-
-from .pointing_detector import PointingDetectorSimple
-
-from .scan_map import ScanMap, ScanMask, ScanScale
-
-from .scan_healpix import ScanHealpixMap, ScanHealpixMask
-
-from .pointing import BuildPixelDistribution
-
+from .filterbin import FilterBin, combine_observation_matrix
 from .flag_intervals import FlagIntervals
-
+from .flag_sso import FlagSSO
+from .gainscrambler import GainScrambler
+from .groundfilter import GroundFilter
+from .load_hdf5 import LoadHDF5
+from .load_spt3g import LoadSpt3g
+from .madam import Madam, madam_params_from_mapmaker
+from .mapmaker import Calibrate, MapMaker
+from .mapmaker_binning import BinMap
+from .mapmaker_templates import SolveAmplitudes, TemplateMatrix
 from .mapmaker_utils import (
     BuildHitMap,
     BuildInverseCovariance,
     BuildNoiseWeighted,
     CovarianceAndHits,
 )
-
-from .mapmaker_binning import BinMap
-
-from .mapmaker_templates import TemplateMatrix, SolveAmplitudes
-
-from .mapmaker import MapMaker, Calibrate
-
-from .madam import Madam, madam_params_from_mapmaker
-
-from .conviqt import SimConviqt, SimWeightedConviqt, SimTEBConviqt
-
-from .sim_gaindrifts import GainDrifter
-from .sim_crosstalk import CrossTalk, MitigateCrossTalk
-
-from .sim_cosmic_rays import InjectCosmicRays
-
-from .totalconvolve import SimTotalconvolve
-
-from .polyfilter import PolyFilter, PolyFilter2D, CommonModeFilter
-
-from .groundfilter import GroundFilter
-
-from .statistics import Statistics
-
-from .time_constant import TimeConstant
-
-from .load_spt3g import LoadSpt3g
-
-from .save_spt3g import SaveSpt3g
-
-from .run_spt3g import RunSpt3g
-
-from .cadence_map import CadenceMap
-
-from .flag_sso import FlagSSO
-
-from .crosslinking import CrossLinking
-
-from .sss import SimScanSynchronousSignal
-
-from .demodulation import Demodulate, StokesWeightsDemod
-
-from .stokes_weights import StokesWeights
-
-from .pixels_healpix import PixelsHealpix
-
-from .filterbin import FilterBin, combine_observation_matrix
-
-from .save_hdf5 import SaveHDF5
-
-from .load_hdf5 import LoadHDF5
-
+from .memory_counter import MemoryCounter
 from .noise_estimation import NoiseEstim
-
+from .noise_model import DefaultNoiseModel
+from .noise_weight import NoiseWeight
+from .operator import Operator
+from .pipeline import Pipeline
+from .pixels_healpix import PixelsHealpix
+from .pointing import BuildPixelDistribution
+from .pointing_detector import PointingDetectorSimple
+from .polyfilter import CommonModeFilter, PolyFilter, PolyFilter2D
+from .reset import Reset
+from .run_spt3g import RunSpt3g
+from .save_hdf5 import SaveHDF5
+from .save_spt3g import SaveSpt3g
+from .scan_healpix import ScanHealpixMap, ScanHealpixMask
+from .scan_map import ScanMap, ScanMask, ScanScale
+from .sim_cosmic_rays import InjectCosmicRays
+from .sim_crosstalk import CrossTalk, MitigateCrossTalk
+from .sim_gaindrifts import GainDrifter
+from .sim_ground import SimGround
+from .sim_satellite import SimSatellite
+from .sim_tod_atm import SimAtmosphere
+from .sim_tod_dipole import SimDipole
+from .sim_tod_noise import SimNoise
+from .sss import SimScanSynchronousSignal
+from .statistics import Statistics
+from .stokes_weights import StokesWeights
+from .time_constant import TimeConstant
+from .totalconvolve import SimTotalconvolve
 from .yield_cut import YieldCut

--- a/src/toast/ops/arithmetic.py
+++ b/src/toast/ops/arithmetic.py
@@ -4,10 +4,10 @@
 
 import traitlets
 
-from ..utils import Logger
 from ..mpi import MPI
 from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, List
+from ..traits import Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/arithmetic.py
+++ b/src/toast/ops/arithmetic.py
@@ -5,13 +5,9 @@
 import traitlets
 
 from ..utils import Logger
-
 from ..mpi import MPI
-
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Unicode, List
-
 from .operator import Operator
 
 

--- a/src/toast/ops/cadence_map.py
+++ b/src/toast/ops/cadence_map.py
@@ -3,22 +3,22 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-from time import time
 import warnings
+from time import time
 
-from astropy import units as u
+import h5py
 import numpy as np
 import traitlets
-import h5py
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
 from .. import qarray as qa
-from ..data import Data
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
-from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
-from ..observation import default_values as defaults
 from ..coordinates import to_MJD
+from ..data import Data
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 from .pointing import BuildPixelDistribution
 

--- a/src/toast/ops/cadence_map.py
+++ b/src/toast/ops/cadence_map.py
@@ -2,7 +2,6 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import h5py
 import os
 from time import time
 import warnings
@@ -10,10 +9,9 @@ import warnings
 from astropy import units as u
 import numpy as np
 import traitlets
+import h5py
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-
-from .operator import Operator
 from .. import qarray as qa
 from ..data import Data
 from ..timing import function_timer
@@ -21,6 +19,7 @@ from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
 from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
 from ..observation import default_values as defaults
 from ..coordinates import to_MJD
+from .operator import Operator
 from .pointing import BuildPixelDistribution
 
 

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -10,14 +10,12 @@ import numpy as np
 import traitlets
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-
-from .operator import Operator
 from .. import qarray as qa
 from ..timing import function_timer
 from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
 from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 conviqt = None
@@ -57,16 +55,24 @@ class SimConviqt(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional shared flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     view = Unicode(
         None, allow_none=True, help="Use this view of the data in all observations"

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -5,18 +5,17 @@
 import os
 import warnings
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
 from .. import qarray as qa
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
-from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
-
 
 conviqt = None
 

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -5,13 +5,9 @@
 import traitlets
 
 from ..utils import Logger
-
 from ..mpi import MPI
-
 from ..traits import trait_docs, Int, Unicode, List
-
 from ..timing import function_timer
-
 from .operator import Operator
 
 

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -4,10 +4,10 @@
 
 import traitlets
 
-from ..utils import Logger
 from ..mpi import MPI
-from ..traits import trait_docs, Int, Unicode, List
 from ..timing import function_timer
+from ..traits import Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -5,37 +5,22 @@
 import os
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..mpi import MPI
-
 from .. import qarray as qa
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Float, Instance
-
 from ..timing import function_timer, Timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..pixels_io import write_healpix_fits
-
 from ..observation import default_values as defaults
-
 from .operator import Operator
-
 from .pipeline import Pipeline
-
 from .delete import Delete
-
 from .copy import Copy
-
 from .pointing import BuildPixelDistribution
-
 from .mapmaker_utils import BuildNoiseWeighted
 
 

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -4,24 +4,24 @@
 
 import os
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..mpi import MPI
 from .. import qarray as qa
 from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Float, Instance
-from ..timing import function_timer, Timer
-from ..pixels import PixelDistribution, PixelData
-from ..pixels_io import write_healpix_fits
+from ..mpi import MPI
 from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from .copy import Copy
+from .delete import Delete
+from .mapmaker_utils import BuildNoiseWeighted
 from .operator import Operator
 from .pipeline import Pipeline
-from .delete import Delete
-from .copy import Copy
 from .pointing import BuildPixelDistribution
-from .mapmaker_utils import BuildNoiseWeighted
 
 
 class UniformNoise:

--- a/src/toast/ops/delete.py
+++ b/src/toast/ops/delete.py
@@ -5,11 +5,8 @@
 import traitlets
 
 from ..utils import Logger
-
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Unicode, List
-
 from .operator import Operator
 
 

--- a/src/toast/ops/delete.py
+++ b/src/toast/ops/delete.py
@@ -4,9 +4,9 @@
 
 import traitlets
 
-from ..utils import Logger
 from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, List
+from ..traits import Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -5,17 +5,17 @@
 import copy
 
 import numpy as np
-from astropy import units as u
 import traitlets
+from astropy import units as u
 
-from ..utils import Environment, Logger
-from ..timing import function_timer, Timer
+from .. import qarray as qa
+from ..intervals import IntervalList
 from ..noise import Noise
 from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
 from ..observation import default_values as defaults
-from ..intervals import IntervalList
-from .. import qarray as qa
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -5,27 +5,17 @@
 import copy
 
 import numpy as np
-
 from astropy import units as u
-
 import traitlets
 
 from ..utils import Environment, Logger
-
 from ..timing import function_timer, Timer
-
 from ..noise import Noise
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-
 from ..observation import default_values as defaults
-
 from ..intervals import IntervalList
-
 from .. import qarray as qa
-
 from .operator import Operator
 
 

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -23,12 +23,12 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..pixels_io import (
-    read_healpix_fits,
-    write_healpix_fits,
-    read_healpix_hdf5,
-    write_healpix_hdf5,
     filename_is_fits,
     filename_is_hdf5,
+    read_healpix_fits,
+    read_healpix_hdf5,
+    write_healpix_fits,
+    write_healpix_hdf5,
 )
 from ..timing import Timer, function_timer
 from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -3,17 +3,13 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Environment, Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, List
-
 from ..timing import function_timer
-
 from .. import qarray as qa
-
+from ..observation import default_values as defaults
 from .operator import Operator
 
 
@@ -37,7 +33,9 @@ class FlagIntervals(Operator):
     )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for flags to modify"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
     shared_flag_bytes = Int(

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -2,14 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Environment, Logger
-from ..traits import trait_docs, Int, Unicode, Bool, List
-from ..timing import function_timer
 from .. import qarray as qa
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, List, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -4,20 +4,20 @@
 
 from time import time
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import ephem
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..mpi import MPI
-from ..timing import function_timer
 from .. import qarray as qa
-from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance, List
-from ..utils import Environment, Logger, Timer
-from ..observation import default_values as defaults
 from ..coordinates import to_DJD
+from ..data import Data
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, List, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, Timer
 from .operator import Operator
 from .pipeline import Pipeline
 

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -4,35 +4,22 @@
 
 from time import time
 
-from ..mpi import MPI
-
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import ephem
-
 import healpy as hp
 
+from ..mpi import MPI
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance, List
-
-from .operator import Operator
-
-from .pipeline import Pipeline
-
 from ..utils import Environment, Logger, Timer
-
 from ..observation import default_values as defaults
-
 from ..coordinates import to_DJD
+from .operator import Operator
+from .pipeline import Pipeline
 
 
 @trait_docs
@@ -57,6 +44,7 @@ class FlagSSO(Operator):
 
     det_flags = Unicode(
         defaults.det_flags,
+        allow_none=True,
         help="Observation detdata key for flags to use",
     )
 

--- a/src/toast/ops/gainscrambler.py
+++ b/src/toast/ops/gainscrambler.py
@@ -6,17 +6,12 @@ import re
 
 import traitlets
 
-from .operator import Operator
-
 from ..traits import trait_docs, Int, Float, Unicode
-
 from .. import rng
-
 from ..utils import Logger
-
 from ..timing import function_timer
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/gainscrambler.py
+++ b/src/toast/ops/gainscrambler.py
@@ -6,11 +6,11 @@ import re
 
 import traitlets
 
-from ..traits import trait_docs, Int, Float, Unicode
 from .. import rng
-from ..utils import Logger
-from ..timing import function_timer
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Float, Int, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -4,21 +4,20 @@
 
 from time import time
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..mpi import MPI
-from ..timing import function_timer
 from .. import qarray as qa
+from .._libtoast import add_templates, bin_invcov, bin_proj, legendre
 from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-from ..utils import Environment, Logger, Timer
-from .._libtoast import bin_proj, bin_invcov, add_templates, legendre
+from ..mpi import MPI
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, Timer
 from .operator import Operator
-
 
 # Wrappers for more precise timing
 

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -4,31 +4,20 @@
 
 from time import time
 
-from ..mpi import MPI
-
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import healpy as hp
 
+from ..mpi import MPI
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-
-from .operator import Operator
-
 from ..utils import Environment, Logger, Timer
-
 from .._libtoast import bin_proj, bin_invcov, add_templates, legendre
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 # Wrappers for more precise timing

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -2,19 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
 import glob
+import os
 
-import traitlets
-import numpy as np
 import h5py
+import numpy as np
+import traitlets
 
-from ..utils import Logger
 from ..dist import distribute_discrete
-from ..traits import trait_docs, Int, Unicode, List, Bool
-from ..timing import function_timer
-from ..observation import default_values as defaults
 from ..io import load_hdf5
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -2,28 +2,20 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
-
 import os
 import glob
 
+import traitlets
 import numpy as np
-
 import h5py
 
 from ..utils import Logger
-
 from ..dist import distribute_discrete
-
 from ..traits import trait_docs, Int, Unicode, List, Bool
-
 from ..timing import function_timer
-
-from .operator import Operator
-
 from ..observation import default_values as defaults
-
 from ..io import load_hdf5
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/load_spt3g.py
+++ b/src/toast/ops/load_spt3g.py
@@ -2,22 +2,22 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
 import glob
+import os
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
 from ..dist import distribute_discrete
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..timing import function_timer
 from ..spt3g import available
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
-
 
 if available:
     from spt3g import core as c3g
+
     from ..spt3g import frame_collector
 
 

--- a/src/toast/ops/load_spt3g.py
+++ b/src/toast/ops/load_spt3g.py
@@ -2,24 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
-
 import os
 import glob
 
+import traitlets
 import numpy as np
 
 from ..utils import Logger
-
 from ..dist import distribute_discrete
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..timing import function_timer
-
+from ..spt3g import available
 from .operator import Operator
 
-from ..spt3g import available
 
 if available:
     from spt3g import core as c3g

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -5,37 +5,22 @@
 import os
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..mpi import MPI
-
 from ..traits import trait_docs, Int, Unicode, Bool, Float, Instance
-
 from ..timing import function_timer, Timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..pixels_io import write_healpix_fits, write_healpix_hdf5
-
 from ..observation import default_values as defaults
-
 from .operator import Operator
-
 from .pipeline import Pipeline
-
 from .delete import Delete
-
 from .copy import Copy
-
 from .scan_map import ScanMap, ScanMask
-
 from .mapmaker_utils import CovarianceAndHits
-
 from .mapmaker_templates import SolveAmplitudes, ApplyAmplitudes
-
 from .memory_counter import MemoryCounter
 
 

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -4,24 +4,24 @@
 
 import os
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
 from ..mpi import MPI
-from ..traits import trait_docs, Int, Unicode, Bool, Float, Instance
-from ..timing import function_timer, Timer
-from ..pixels import PixelDistribution, PixelData
-from ..pixels_io import write_healpix_fits, write_healpix_hdf5
 from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits, write_healpix_hdf5
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from .copy import Copy
+from .delete import Delete
+from .mapmaker_templates import ApplyAmplitudes, SolveAmplitudes
+from .mapmaker_utils import CovarianceAndHits
+from .memory_counter import MemoryCounter
 from .operator import Operator
 from .pipeline import Pipeline
-from .delete import Delete
-from .copy import Copy
 from .scan_map import ScanMap, ScanMask
-from .mapmaker_utils import CovarianceAndHits
-from .mapmaker_templates import SolveAmplitudes, ApplyAmplitudes
-from .memory_counter import MemoryCounter
 
 
 @trait_docs

--- a/src/toast/ops/mapmaker_binning.py
+++ b/src/toast/ops/mapmaker_binning.py
@@ -2,19 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..timing import function_timer
-from ..pixels import PixelDistribution, PixelData
 from ..covariance import covariance_apply
 from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from .delete import Delete
+from .mapmaker_utils import BuildHitMap, BuildInverseCovariance, BuildNoiseWeighted
 from .operator import Operator
 from .pipeline import Pipeline
-from .delete import Delete
-from .mapmaker_utils import BuildHitMap, BuildNoiseWeighted, BuildInverseCovariance
 
 
 @trait_docs

--- a/src/toast/ops/mapmaker_binning.py
+++ b/src/toast/ops/mapmaker_binning.py
@@ -3,27 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..timing import function_timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..covariance import covariance_apply
-
 from ..observation import default_values as defaults
-
 from .operator import Operator
-
 from .pipeline import Pipeline
-
 from .delete import Delete
-
 from .mapmaker_utils import BuildHitMap, BuildNoiseWeighted, BuildInverseCovariance
 
 

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -3,31 +3,19 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..timing import function_timer, Timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..templates import AmplitudesMap
-
 from .operator import Operator
-
 from .pipeline import Pipeline
-
 from .delete import Delete
-
 from .copy import Copy
-
 from .reset import Reset
-
 from .scan_map import ScanMap
-
 from .noise_weight import NoiseWeight
 
 

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -2,21 +2,21 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..timing import function_timer, Timer
-from ..pixels import PixelDistribution, PixelData
+from ..pixels import PixelData, PixelDistribution
 from ..templates import AmplitudesMap
+from ..timing import Timer, function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from .copy import Copy
+from .delete import Delete
+from .noise_weight import NoiseWeight
 from .operator import Operator
 from .pipeline import Pipeline
-from .delete import Delete
-from .copy import Copy
 from .reset import Reset
 from .scan_map import ScanMap
-from .noise_weight import NoiseWeight
 
 
 @trait_docs

--- a/src/toast/ops/mapmaker_templates.py
+++ b/src/toast/ops/mapmaker_templates.py
@@ -4,25 +4,25 @@
 
 from collections import OrderedDict
 
-import traitlets
 import numpy as np
+import traitlets
 
 from ..mpi import MPI
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, List, Float, Instance
-from ..timing import function_timer, Timer
-from ..templates import Template, AmplitudesMap
 from ..observation import default_values as defaults
-from ..pixels import PixelDistribution, PixelData
+from ..pixels import PixelData, PixelDistribution
+from ..templates import AmplitudesMap, Template
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, List, Unicode, trait_docs
+from ..utils import Logger
+from .arithmetic import Combine
+from .copy import Copy
+from .delete import Delete
+from .mapmaker_solve import SolverLHS, SolverRHS, solve
+from .mapmaker_utils import CovarianceAndHits
+from .memory_counter import MemoryCounter
 from .operator import Operator
 from .pipeline import Pipeline
-from .delete import Delete
-from .copy import Copy
-from .arithmetic import Combine
 from .scan_map import ScanMap, ScanMask
-from .mapmaker_utils import CovarianceAndHits
-from .mapmaker_solve import solve, SolverRHS, SolverLHS
-from .memory_counter import MemoryCounter
 
 
 @trait_docs

--- a/src/toast/ops/mapmaker_templates.py
+++ b/src/toast/ops/mapmaker_templates.py
@@ -5,39 +5,23 @@
 from collections import OrderedDict
 
 import traitlets
-
 import numpy as np
 
 from ..mpi import MPI
-
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, List, Float, Instance
-
 from ..timing import function_timer, Timer
-
 from ..templates import Template, AmplitudesMap
-
 from ..observation import default_values as defaults
-
 from ..pixels import PixelDistribution, PixelData
-
 from .operator import Operator
-
 from .pipeline import Pipeline
-
 from .delete import Delete
-
 from .copy import Copy
-
 from .arithmetic import Combine
-
 from .scan_map import ScanMap, ScanMask
-
 from .mapmaker_utils import CovarianceAndHits
-
 from .mapmaker_solve import solve, SolverRHS, SolverLHS
-
 from .memory_counter import MemoryCounter
 
 
@@ -66,10 +50,14 @@ class TemplateMatrix(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for solver flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for solver flags")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     @traitlets.validate("templates")
     def _check_templates(self, proposal):

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -2,22 +2,18 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-from ..timing import function_timer
-from ..pixels import PixelDistribution, PixelData
+from .._libtoast import cov_accum_diag_hits, cov_accum_diag_invnpp, cov_accum_zmap
 from ..covariance import covariance_invert
 from ..observation import default_values as defaults
-from .._libtoast import (
-    cov_accum_zmap,
-    cov_accum_diag_hits,
-    cov_accum_diag_invnpp,
-)
-from .operator import Operator
+from ..pixels import PixelData, PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .delete import Delete
+from .operator import Operator
 from .pipeline import Pipeline
 from .pointing import BuildPixelDistribution
 

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -3,33 +3,22 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-
 from ..timing import function_timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..covariance import covariance_invert
-
 from ..observation import default_values as defaults
-
 from .._libtoast import (
     cov_accum_zmap,
     cov_accum_diag_hits,
     cov_accum_diag_invnpp,
 )
-
 from .operator import Operator
-
 from .delete import Delete
-
 from .pipeline import Pipeline
-
 from .pointing import BuildPixelDistribution
 
 
@@ -67,16 +56,24 @@ class BuildHitMap(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional telescope flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     pixels = Unicode(defaults.pixels, help="Observation detdata key for pixel indices")
 
@@ -254,16 +251,24 @@ class BuildInverseCovariance(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional telescope flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     pixels = Unicode("pixels", help="Observation detdata key for pixel indices")
 
@@ -503,7 +508,9 @@ class BuildNoiseWeighted(Operator):
         help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
         defaults.shared_flags,
@@ -511,7 +518,9 @@ class BuildNoiseWeighted(Operator):
         help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional telescope flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     pixels = Unicode("pixels", help="Observation detdata key for pixel indices")
 
@@ -768,16 +777,24 @@ class CovarianceAndHits(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional telescope flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     pixel_pointing = Instance(
         klass=Operator,

--- a/src/toast/ops/memory_counter.py
+++ b/src/toast/ops/memory_counter.py
@@ -3,17 +3,12 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import traitlets
 
 from ..utils import Environment, Logger, memreport
-
 from ..timing import function_timer, Timer
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Bool, Unicode
-
 from .operator import Operator
 
 

--- a/src/toast/ops/memory_counter.py
+++ b/src/toast/ops/memory_counter.py
@@ -5,10 +5,10 @@
 import numpy as np
 import traitlets
 
-from ..utils import Environment, Logger, memreport
-from ..timing import function_timer, Timer
 from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Bool, Unicode
+from ..timing import Timer, function_timer
+from ..traits import Bool, Int, Unicode, trait_docs
+from ..utils import Environment, Logger, memreport
 from .operator import Operator
 
 

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -16,10 +16,10 @@ from astropy import units as u
 
 from .. import qarray as qa
 from .._libtoast import filter_poly2D, filter_polynomial, subtract_mean, sum_detectors
+from ..intervals import Interval
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..intervals import Interval
 from ..traits import (
     Bool,
     Dict,
@@ -40,13 +40,13 @@ from ..utils import (
     Timer,
     dtype_to_aligned,
 )
+from .arithmetic import Combine
+from .copy import Copy
+from .delete import Delete
 from .noise_estimation_utils import autocov_psd, crosscov_psd, flagged_running_average
 from .operator import Operator
-from .scan_healpix import ScanHealpixMap, ScanHealpixMask
-from .copy import Copy
-from .arithmetic import Combine
 from .polyfilter import CommonModeFilter
-from .delete import Delete
+from .scan_healpix import ScanHealpixMap, ScanHealpixMask
 
 
 @trait_docs

--- a/src/toast/ops/noise_estimation_utils.py
+++ b/src/toast/ops/noise_estimation_utils.py
@@ -5,9 +5,9 @@
 import numpy as np
 from scipy.signal import fftconvolve
 
+from .._libtoast import fod_autosums, fod_crosssums
 from ..mpi import MPI
 from ..timing import function_timer
-from .._libtoast import fod_autosums, fod_crosssums
 
 
 @function_timer

--- a/src/toast/ops/noise_estimation_utils.py
+++ b/src/toast/ops/noise_estimation_utils.py
@@ -3,13 +3,10 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 from scipy.signal import fftconvolve
 
 from ..mpi import MPI
-
 from ..timing import function_timer
-
 from .._libtoast import fod_autosums, fod_crosssums
 
 

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -6,10 +6,10 @@ import numpy as np
 import traitlets
 from astropy import units as u
 
-from ..utils import Environment, Logger
-from ..timing import function_timer, Timer
 from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -3,19 +3,13 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import traitlets
-
 from astropy import units as u
 
 from ..utils import Environment, Logger
-
 from ..timing import function_timer, Timer
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-
 from .operator import Operator
 
 

--- a/src/toast/ops/noise_weight.py
+++ b/src/toast/ops/noise_weight.py
@@ -5,10 +5,10 @@
 import numpy as np
 import traitlets
 
-from ..utils import Environment, Logger
-from ..timing import function_timer, Timer
 from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/noise_weight.py
+++ b/src/toast/ops/noise_weight.py
@@ -3,17 +3,12 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import traitlets
 
 from ..utils import Environment, Logger
-
 from ..timing import function_timer, Timer
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-
 from .operator import Operator
 
 

--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -3,8 +3,8 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..timing import function_timer_stackskip
-from ..utils import Logger
 from ..traits import TraitConfig
+from ..utils import Logger
 
 
 class Operator(TraitConfig):

--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -2,10 +2,8 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-
 from ..timing import function_timer_stackskip
 from ..utils import Logger
-
 from ..traits import TraitConfig
 
 

--- a/src/toast/ops/pipeline.py
+++ b/src/toast/ops/pipeline.py
@@ -6,10 +6,10 @@ from collections import OrderedDict
 
 import traitlets
 
-from ..utils import Logger
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, List
 from ..data import Data
+from ..timing import function_timer
+from ..traits import Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/pipeline.py
+++ b/src/toast/ops/pipeline.py
@@ -7,16 +7,10 @@ from collections import OrderedDict
 import traitlets
 
 from ..utils import Logger
-
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Unicode, List
-
 from ..data import Data
-
 from .operator import Operator
-
-from .._libtoast import acc_enabled
 
 
 @trait_docs

--- a/src/toast/ops/pixels_healpix.py
+++ b/src/toast/ops/pixels_healpix.py
@@ -2,19 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Environment, Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..healpix import HealpixPixels
-from ..timing import function_timer
 from .. import qarray as qa
-from ..pixels import PixelDistribution
-from ..observation import default_values as defaults
 from .._libtoast import healpix_pixels
-from .operator import Operator
+from ..healpix import HealpixPixels
+from ..observation import default_values as defaults
+from ..pixels import PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .delete import Delete
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/pixels_healpix.py
+++ b/src/toast/ops/pixels_healpix.py
@@ -3,27 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Environment, Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..healpix import HealpixPixels
-
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..pixels import PixelDistribution
-
 from ..observation import default_values as defaults
-
 from .._libtoast import healpix_pixels
-
 from .operator import Operator
-
 from .delete import Delete
 
 

--- a/src/toast/ops/pointing.py
+++ b/src/toast/ops/pointing.py
@@ -2,16 +2,16 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-from ..timing import function_timer
-from ..pixels import PixelDistribution, PixelData
 from ..observation import default_values as defaults
-from .operator import Operator
+from ..pixels import PixelData, PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .delete import Delete
+from .operator import Operator
 from .pipeline import Pipeline
 
 

--- a/src/toast/ops/pointing.py
+++ b/src/toast/ops/pointing.py
@@ -3,21 +3,15 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-
 from ..timing import function_timer
-
 from ..pixels import PixelDistribution, PixelData
-
+from ..observation import default_values as defaults
 from .operator import Operator
-
 from .delete import Delete
-
 from .pipeline import Pipeline
 
 
@@ -47,10 +41,14 @@ class BuildPixelDistribution(Operator):
     )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional telescope flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     pixel_pointing = Instance(
         klass=Operator,

--- a/src/toast/ops/pointing_detector.py
+++ b/src/toast/ops/pointing_detector.py
@@ -3,19 +3,13 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Environment, Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool
-
 from ..timing import function_timer
-
 from ..observation import default_values as defaults
-
 from .. import qarray as qa
-
 from .operator import Operator
 
 

--- a/src/toast/ops/pointing_detector.py
+++ b/src/toast/ops/pointing_detector.py
@@ -2,14 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Environment, Logger
-from ..traits import trait_docs, Int, Unicode, Bool
-from ..timing import function_timer
-from ..observation import default_values as defaults
 from .. import qarray as qa
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -12,8 +12,6 @@ import numpy as np
 import traitlets
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-
-from .operator import Operator
 from .. import qarray as qa
 from ..timing import function_timer
 from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
@@ -27,8 +25,8 @@ from ..utils import (
     AlignedU8,
 )
 from ..observation import default_values as defaults
-
 from .._libtoast import filter_polynomial, filter_poly2D, sum_detectors, subtract_mean
+from .operator import Operator
 
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -4,30 +4,29 @@
 
 import os
 import re
-from time import time
 import warnings
+from time import time
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
 from .. import qarray as qa
+from .._libtoast import filter_poly2D, filter_polynomial, subtract_mean, sum_detectors
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
+from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
+from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
 from ..utils import (
-    Logger,
-    Environment,
-    Timer,
-    GlobalTimers,
-    dtype_to_aligned,
     AlignedF64,
     AlignedU8,
+    Environment,
+    GlobalTimers,
+    Logger,
+    Timer,
+    dtype_to_aligned,
 )
-from ..observation import default_values as defaults
-from .._libtoast import filter_polynomial, filter_poly2D, sum_detectors, subtract_mean
 from .operator import Operator
-
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/ops/reset.py
+++ b/src/toast/ops/reset.py
@@ -3,15 +3,11 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numbers
-
 import traitlets
 
 from ..utils import Logger
-
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Unicode, List
-
 from .operator import Operator
 
 

--- a/src/toast/ops/reset.py
+++ b/src/toast/ops/reset.py
@@ -3,11 +3,12 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numbers
+
 import traitlets
 
-from ..utils import Logger
 from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, List
+from ..traits import Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/run_spt3g.py
+++ b/src/toast/ops/run_spt3g.py
@@ -2,20 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, List
-from ..timing import function_timer
 from ..spt3g import available
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
-
 
 if available:
     from spt3g import core as c3g
-    from ..spt3g import frame_emitter
-    from ..spt3g import frame_collector
+
+    from ..spt3g import frame_collector, frame_emitter
 
 
 @trait_docs

--- a/src/toast/ops/run_spt3g.py
+++ b/src/toast/ops/run_spt3g.py
@@ -3,18 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance, List
-
 from ..timing import function_timer
-
+from ..spt3g import available
 from .operator import Operator
 
-from ..spt3g import available
 
 if available:
     from spt3g import core as c3g

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -5,20 +5,14 @@
 import os
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, List, Dict, Bool
-
 from ..timing import function_timer
-
-from .operator import Operator
-
 from ..observation import default_values as defaults
-
 from ..io import save_hdf5
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -4,14 +4,14 @@
 
 import os
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, List, Dict, Bool
-from ..timing import function_timer
-from ..observation import default_values as defaults
 from ..io import save_hdf5
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Int, List, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/save_spt3g.py
+++ b/src/toast/ops/save_spt3g.py
@@ -4,17 +4,18 @@
 
 import os
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-from ..timing import function_timer
 from ..spt3g import available
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
 
 if available:
     from spt3g import core as c3g
+
     from ..spt3g import frame_emitter
 
 

--- a/src/toast/ops/save_spt3g.py
+++ b/src/toast/ops/save_spt3g.py
@@ -5,18 +5,13 @@
 import os
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-
 from ..timing import function_timer
-
-from .operator import Operator
-
 from ..spt3g import available
+from .operator import Operator
 
 if available:
     from spt3g import core as c3g

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -3,32 +3,22 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..timing import function_timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..pixels_io import (
     read_healpix_fits,
     read_healpix_hdf5,
     filename_is_fits,
     filename_is_hdf5,
 )
-
 from ..observation import default_values as defaults
-
 from .operator import Operator
-
 from .scan_map import ScanMap, ScanMask
-
 from .pointing import BuildPixelDistribution
-
 from .pipeline import Pipeline
 
 
@@ -236,7 +226,9 @@ class ScanHealpixMask(Operator):
     file = Unicode(None, allow_none=True, help="Path to healpix FITS file")
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to set"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
     det_flags_value = Int(

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -2,24 +2,24 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..timing import function_timer
-from ..pixels import PixelDistribution, PixelData
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
 from ..pixels_io import (
-    read_healpix_fits,
-    read_healpix_hdf5,
     filename_is_fits,
     filename_is_hdf5,
+    read_healpix_fits,
+    read_healpix_hdf5,
 )
-from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .operator import Operator
-from .scan_map import ScanMap, ScanMask
-from .pointing import BuildPixelDistribution
 from .pipeline import Pipeline
+from .pointing import BuildPixelDistribution
+from .scan_map import ScanMap, ScanMask
 
 
 @trait_docs

--- a/src/toast/ops/scan_map.py
+++ b/src/toast/ops/scan_map.py
@@ -3,21 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Logger, AlignedF64
-
 from ..traits import trait_docs, Int, Unicode, Bool
-
 from ..timing import function_timer
-
 from ..pixels import PixelDistribution, PixelData
-
 from ..observation import default_values as defaults
-
 from .._libtoast import scan_map_float64, scan_map_float32
-
 from .operator import Operator
 
 
@@ -221,7 +214,9 @@ class ScanMask(Operator):
     API = Int(0, help="Internal interface version for this operator")
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to set"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
     det_flags_value = Int(

--- a/src/toast/ops/scan_map.py
+++ b/src/toast/ops/scan_map.py
@@ -2,15 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Logger, AlignedF64
-from ..traits import trait_docs, Int, Unicode, Bool
-from ..timing import function_timer
-from ..pixels import PixelDistribution, PixelData
+from .._libtoast import scan_map_float32, scan_map_float64
 from ..observation import default_values as defaults
-from .._libtoast import scan_map_float64, scan_map_float32
+from ..pixels import PixelData, PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Int, Unicode, trait_docs
+from ..utils import AlignedF64, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -3,21 +3,16 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 from scipy import interpolate, signal
-
-from ..timing import function_timer
-
-from ..traits import trait_docs, Int, Float, Unicode, Bool, Quantity, Callable
 from astropy import units as u
 
-from .operator import Operator
-
+from ..timing import function_timer
+from ..traits import trait_docs, Int, Float, Unicode, Bool, Quantity, Callable
 from ..utils import Environment, Logger
 from .. import rng
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 class InjectCosmicRays(Operator):

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -2,16 +2,16 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
-from scipy import interpolate, signal
+import traitlets
 from astropy import units as u
+from scipy import interpolate, signal
 
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Float, Unicode, Bool, Quantity, Callable
-from ..utils import Environment, Logger
 from .. import rng
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Callable, Float, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_crosstalk.py
+++ b/src/toast/ops/sim_crosstalk.py
@@ -5,12 +5,12 @@
 import numpy as np
 import traitlets
 
-from ..utils import Environment, Logger
-from ..timing import function_timer, Timer
-from ..noise_sim import AnalyticNoise
 from .. import rng
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
+from ..noise_sim import AnalyticNoise
 from ..observation import default_values as defaults
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_crosstalk.py
+++ b/src/toast/ops/sim_crosstalk.py
@@ -3,21 +3,15 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import traitlets
 
 from ..utils import Environment, Logger
-
 from ..timing import function_timer, Timer
-
 from ..noise_sim import AnalyticNoise
-
 from .. import rng
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-
-from .operator import Operator
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 @function_timer

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -3,19 +3,15 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 from astropy import units as u
+
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Float, Unicode, Bool, Quantity, Callable
-
 from ..observation import default_values as defaults
-
-from .operator import Operator
-
 from ..utils import Environment, Logger
 from .. import rng
+from .operator import Operator
 from .sim_tod_noise import sim_noise_timestream
 
 

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -2,15 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 from astropy import units as u
 
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Float, Unicode, Bool, Quantity, Callable
-from ..observation import default_values as defaults
-from ..utils import Environment, Logger
 from .. import rng
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Callable, Float, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 from .sim_tod_noise import sim_noise_timestream
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -3,22 +3,16 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import datetime
-
 import copy
 
 import traitlets
-
 import numpy as np
-
 from scipy.constants import degree
-
 import healpy as hp
-
 from astropy import units as u
-from toast.weather import SimWeather
 
+from ..weather import SimWeather
 from .. import qarray as qa
-
 from ..utils import (
     Environment,
     name_UID,
@@ -27,35 +21,20 @@ from ..utils import (
     astropy_control,
     memreport,
 )
-
 from ..dist import distribute_uniform, distribute_discrete
-
 from ..timing import function_timer, Timer, GlobalTimers
-
 from ..intervals import Interval, regular_intervals, IntervalList
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity, List
-
 from ..observation import Observation
-
 from ..instrument import Telescope
-
 from ..schedule import GroundSchedule
-
 from ..coordinates import azel_to_radec
-
 from ..healpix import ang2vec
-
 from ..observation import default_values as defaults
-
 from .operator import Operator
-
 from .sim_hwp import simulate_hwp_response
-
 from .flag_intervals import FlagIntervals
-
 from .sim_ground_utils import (
     simulate_elnod,
     simulate_ces_scan,

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -2,46 +2,46 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import datetime
 import copy
+import datetime
 
-import traitlets
-import numpy as np
-from scipy.constants import degree
 import healpy as hp
+import numpy as np
+import traitlets
 from astropy import units as u
+from scipy.constants import degree
 
-from ..weather import SimWeather
 from .. import qarray as qa
+from ..coordinates import azel_to_radec
+from ..dist import distribute_discrete, distribute_uniform
+from ..healpix import ang2vec
+from ..instrument import Telescope
+from ..intervals import Interval, IntervalList, regular_intervals
+from ..noise_sim import AnalyticNoise
+from ..observation import Observation
+from ..observation import default_values as defaults
+from ..schedule import GroundSchedule
+from ..timing import GlobalTimers, Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, List, Quantity, Unicode, trait_docs
 from ..utils import (
     Environment,
-    name_UID,
     Logger,
-    rate_from_times,
     astropy_control,
     memreport,
+    name_UID,
+    rate_from_times,
 )
-from ..dist import distribute_uniform, distribute_discrete
-from ..timing import function_timer, Timer, GlobalTimers
-from ..intervals import Interval, regular_intervals, IntervalList
-from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity, List
-from ..observation import Observation
-from ..instrument import Telescope
-from ..schedule import GroundSchedule
-from ..coordinates import azel_to_radec
-from ..healpix import ang2vec
-from ..observation import default_values as defaults
-from .operator import Operator
-from .sim_hwp import simulate_hwp_response
+from ..weather import SimWeather
 from .flag_intervals import FlagIntervals
+from .operator import Operator
 from .sim_ground_utils import (
-    simulate_elnod,
-    simulate_ces_scan,
     add_solar_intervals,
     oscillate_el,
+    simulate_ces_scan,
+    simulate_elnod,
     step_el,
 )
+from .sim_hwp import simulate_hwp_response
 
 
 @trait_docs

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -4,12 +4,12 @@
 
 import datetime
 
+import ephem
 import numpy as np
 from astropy import units as u
-import ephem
 
-from ..timing import function_timer, Timer
 from ..intervals import IntervalList
+from ..timing import Timer, function_timer
 
 
 @function_timer

--- a/src/toast/ops/sim_ground_utils.py
+++ b/src/toast/ops/sim_ground_utils.py
@@ -5,9 +5,7 @@
 import datetime
 
 import numpy as np
-
 from astropy import units as u
-
 import ephem
 
 from ..timing import function_timer, Timer

--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -5,7 +5,7 @@
 import numpy as np
 from astropy import units as u
 
-from ..timing import function_timer, Timer
+from ..timing import Timer, function_timer
 
 
 @function_timer

--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -3,7 +3,6 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 from astropy import units as u
 
 from ..timing import function_timer, Timer

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -2,23 +2,24 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
-import numpy as np
-from scipy.constants import degree
 import healpy as hp
+import numpy as np
+import traitlets
 from astropy import units as u
+from scipy.constants import degree
 
 from .. import qarray as qa
-from ..utils import Environment, name_UID, Logger, rate_from_times
 from ..dist import distribute_discrete
-from ..timing import function_timer, Timer
-from ..intervals import Interval
-from ..schedule import SatelliteSchedule
-from ..noise_sim import AnalyticNoise
-from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-from ..observation import Observation, default_values as defaults
-from ..instrument import Telescope
 from ..healpix import ang2vec
+from ..instrument import Telescope
+from ..intervals import Interval
+from ..noise_sim import AnalyticNoise
+from ..observation import Observation
+from ..observation import default_values as defaults
+from ..schedule import SatelliteSchedule
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, name_UID, rate_from_times
 from .operator import Operator
 from .sim_hwp import simulate_hwp_response
 

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -3,40 +3,23 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
-
 from scipy.constants import degree
-
 import healpy as hp
-
 from astropy import units as u
 
 from .. import qarray as qa
-
 from ..utils import Environment, name_UID, Logger, rate_from_times
-
 from ..dist import distribute_discrete
-
 from ..timing import function_timer, Timer
-
 from ..intervals import Interval
-
 from ..schedule import SatelliteSchedule
-
 from ..noise_sim import AnalyticNoise
-
 from ..traits import trait_docs, Int, Unicode, Float, Bool, Instance, Quantity
-
-from ..observation import Observation
-from ..observation import default_values as defaults
-
+from ..observation import Observation, default_values as defaults
 from ..instrument import Telescope
-
 from ..healpix import ang2vec
-
 from .operator import Operator
-
 from .sim_hwp import simulate_hwp_response
 
 

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -2,37 +2,24 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI
-
 import os
 
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import healpy as hp
 
+from ..mpi import MPI
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-
-from .operator import Operator
-
-from .pipeline import Pipeline
-
 from ..utils import Environment, Logger, Timer
-
 from ..atm import AtmSim, available_utils, available_atm
-
 from ..observation import default_values as defaults
-
 from .sim_tod_atm_utils import ObserveAtmosphere
+from .operator import Operator
+from .pipeline import Pipeline
 
 if available_atm:
     from ..atm import AtmSim
@@ -83,10 +70,14 @@ class SimAtmosphere(Operator):
     )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional shared flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     det_flags = Unicode(
         defaults.det_flags,

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -4,22 +4,22 @@
 
 import os
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..mpi import MPI
-from ..timing import function_timer
 from .. import qarray as qa
+from ..atm import AtmSim, available_atm, available_utils
 from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-from ..utils import Environment, Logger, Timer
-from ..atm import AtmSim, available_utils, available_atm
+from ..mpi import MPI
 from ..observation import default_values as defaults
-from .sim_tod_atm_utils import ObserveAtmosphere
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, Timer
 from .operator import Operator
 from .pipeline import Pipeline
+from .sim_tod_atm_utils import ObserveAtmosphere
 
 if available_atm:
     from ..atm import AtmSim
@@ -961,8 +961,9 @@ class SimAtmosphere(Operator):
         from ..vis import set_matplotlib_backend
 
         set_matplotlib_backend()
-        import matplotlib.pyplot as plt
         import pickle
+
+        import matplotlib.pyplot as plt
 
         azmin, azmax, elmin, elmax = scan_range
         azmin = azmin.to_value(u.radian)

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -4,28 +4,18 @@
 
 from numpy.core.fromnumeric import size
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import healpy as hp
-
 import scipy.interpolate
 
 from ..timing import function_timer, GlobalTimers
-
 from .. import qarray as qa
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-
-from .operator import Operator
-
 from ..utils import Environment, Logger
-
 from ..observation import default_values as defaults
-
 from ..atm import AtmSim
+from .operator import Operator
 
 
 @trait_docs
@@ -71,16 +61,24 @@ class ObserveAtmosphere(Operator):
     )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional shared flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     sim = Unicode("atmsim", help="The observation key for the list of AtmSim objects")
 

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -2,19 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from numpy.core.fromnumeric import size
-import traitlets
-import numpy as np
-from astropy import units as u
 import healpy as hp
+import numpy as np
 import scipy.interpolate
+import traitlets
+from astropy import units as u
+from numpy.core.fromnumeric import size
 
-from ..timing import function_timer, GlobalTimers
 from .. import qarray as qa
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-from ..utils import Environment, Logger
-from ..observation import default_values as defaults
 from ..atm import AtmSim
+from ..observation import default_values as defaults
+from ..timing import GlobalTimers, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_tod_dipole.py
+++ b/src/toast/ops/sim_tod_dipole.py
@@ -2,17 +2,17 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..timing import function_timer
 from .. import qarray as qa
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity
-from ..utils import Environment, Logger
-from ..observation import default_values as defaults
 from ..dipole import dipole
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_tod_dipole.py
+++ b/src/toast/ops/sim_tod_dipole.py
@@ -3,26 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import healpy as hp
 
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity
-
-from .operator import Operator
-
 from ..utils import Environment, Logger
-
 from ..observation import default_values as defaults
-
 from ..dipole import dipole
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -3,27 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
-
 from scipy import interpolate
-
 from astropy import units as u
 
 from .. import rng
-
 from ..timing import function_timer
-
 from ..traits import trait_docs, Int, Unicode, Quantity, Bool
-
 from ..fft import FFTPlanReal1DStore
-
 from ..utils import rate_from_times, Logger, AlignedF64
-
 from ..observation import default_values as defaults
-
 from .._libtoast import tod_sim_noise_timestream, tod_sim_noise_timestream_batch
-
 from .operator import Operator
 
 

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -2,18 +2,18 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
-from scipy import interpolate
+import traitlets
 from astropy import units as u
+from scipy import interpolate
 
 from .. import rng
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Quantity, Bool
-from ..fft import FFTPlanReal1DStore
-from ..utils import rate_from_times, Logger, AlignedF64
-from ..observation import default_values as defaults
 from .._libtoast import tod_sim_noise_timestream, tod_sim_noise_timestream_batch
+from ..fft import FFTPlanReal1DStore
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, Quantity, Unicode, trait_docs
+from ..utils import AlignedF64, Logger, rate_from_times
 from .operator import Operator
 
 

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -4,21 +4,21 @@
 
 from time import time
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import ephem
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..mpi import MPI
-from ..timing import function_timer
 from .. import qarray as qa
 from .. import rng
-from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance, List
-from ..utils import Environment, Logger, Timer
-from ..observation import default_values as defaults
 from ..coordinates import to_DJD
+from ..data import Data
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, List, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, Timer
 from .operator import Operator
 from .pipeline import Pipeline
 

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -4,37 +4,23 @@
 
 from time import time
 
-from ..mpi import MPI
-
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import ephem
-
 import healpy as hp
 
+from ..mpi import MPI
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from .. import rng
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance, List
-
-from .operator import Operator
-
-from .pipeline import Pipeline
-
 from ..utils import Environment, Logger, Timer
-
 from ..observation import default_values as defaults
-
 from ..coordinates import to_DJD
+from .operator import Operator
+from .pipeline import Pipeline
 
 
 @trait_docs

--- a/src/toast/ops/statistics.py
+++ b/src/toast/ops/statistics.py
@@ -4,20 +4,20 @@
 
 import os
 import re
-from time import time
 import warnings
+from time import time
 
-from astropy import units as u
 import h5py
 import numpy as np
 import traitlets
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
 from .. import qarray as qa
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
-from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 
 

--- a/src/toast/ops/statistics.py
+++ b/src/toast/ops/statistics.py
@@ -13,14 +13,12 @@ import numpy as np
 import traitlets
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-
-from .operator import Operator
 from .. import qarray as qa
 from ..timing import function_timer
 from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Instance
 from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/stokes_weights.py
+++ b/src/toast/ops/stokes_weights.py
@@ -2,19 +2,19 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import traitlets
 import numpy as np
+import traitlets
 
-from ..utils import Environment, Logger
-from ..traits import trait_docs, Int, Unicode, Bool, Instance
-from ..healpix import HealpixPixels
-from ..timing import function_timer
 from .. import qarray as qa
-from ..pixels import PixelDistribution
-from ..observation import default_values as defaults
 from .._libtoast import stokes_weights
-from .operator import Operator
+from ..healpix import HealpixPixels
+from ..observation import default_values as defaults
+from ..pixels import PixelDistribution
+from ..timing import function_timer
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..utils import Environment, Logger
 from .delete import Delete
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/stokes_weights.py
+++ b/src/toast/ops/stokes_weights.py
@@ -3,27 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import traitlets
-
 import numpy as np
 
 from ..utils import Environment, Logger
-
 from ..traits import trait_docs, Int, Unicode, Bool, Instance
-
 from ..healpix import HealpixPixels
-
 from ..timing import function_timer
-
 from .. import qarray as qa
-
 from ..pixels import PixelDistribution
-
 from ..observation import default_values as defaults
-
 from .._libtoast import stokes_weights
-
 from .operator import Operator
-
 from .delete import Delete
 
 

--- a/src/toast/ops/time_constant.py
+++ b/src/toast/ops/time_constant.py
@@ -2,18 +2,18 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-from ..fft import FFTPlanReal1DStore
 from .. import qarray as qa
 from .. import rng
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Float
-from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
+from ..fft import FFTPlanReal1DStore
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Float, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 
 

--- a/src/toast/ops/time_constant.py
+++ b/src/toast/ops/time_constant.py
@@ -7,15 +7,14 @@ import numpy as np
 import traitlets
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-
 from ..fft import FFTPlanReal1DStore
-from .operator import Operator
 from .. import qarray as qa
 from .. import rng
 from ..timing import function_timer
 from ..traits import trait_docs, Int, Unicode, Bool, Dict, Quantity, Float
 from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -5,19 +5,18 @@
 import os
 import warnings
 
-from astropy import units as u
+import healpy as hp
 import numpy as np
 import traitlets
-import healpy as hp
+from astropy import units as u
 
-from ..mpi import MPI, MPI_Comm, use_mpi, Comm
 from .. import qarray as qa
-from ..timing import function_timer
-from ..traits import trait_docs, Int, Float, Unicode, Bool, Dict, Quantity, Instance
-from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
+from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Dict, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
-
 
 totalconvolve = None
 

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -11,13 +11,12 @@ import traitlets
 import healpy as hp
 
 from ..mpi import MPI, MPI_Comm, use_mpi, Comm
-from .operator import Operator
 from .. import qarray as qa
 from ..timing import function_timer
 from ..traits import trait_docs, Int, Float, Unicode, Bool, Dict, Quantity, Instance
 from ..utils import Logger, Environment, Timer, GlobalTimers, dtype_to_aligned
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 totalconvolve = None
@@ -55,16 +54,24 @@ class SimTotalconvolve(Operator):
     )
 
     det_flags = Unicode(
-        None, allow_none=True, help="Observation detdata key for flags to use"
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
     )
 
-    det_flag_mask = Int(0, help="Bit mask value for optional detector flagging")
+    det_flag_mask = Int(
+        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+    )
 
     shared_flags = Unicode(
-        None, allow_none=True, help="Observation shared key for telescope flags to use"
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
     )
 
-    shared_flag_mask = Int(0, help="Bit mask value for optional shared flagging")
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for optional flagging"
+    )
 
     view = Unicode(
         None, allow_none=True, help="Use this view of the data in all observations"

--- a/src/toast/ops/yield_cut.py
+++ b/src/toast/ops/yield_cut.py
@@ -4,32 +4,21 @@
 
 from time import time
 
-from ..mpi import MPI
-
 import traitlets
-
 import numpy as np
-
 from astropy import units as u
-
 import healpy as hp
 
+from ..mpi import MPI
 from ..timing import function_timer
 from .. import rng
-
 from .. import qarray as qa
-
 from ..data import Data
-
 from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-
-from .operator import Operator
-
 from ..utils import Environment, Logger, Timer, name_UID
-
 from .._libtoast import bin_proj, bin_invcov, add_templates, legendre
-
 from ..observation import default_values as defaults
+from .operator import Operator
 
 
 @trait_docs

--- a/src/toast/ops/yield_cut.py
+++ b/src/toast/ops/yield_cut.py
@@ -4,20 +4,20 @@
 
 from time import time
 
-import traitlets
-import numpy as np
-from astropy import units as u
 import healpy as hp
+import numpy as np
+import traitlets
+from astropy import units as u
 
-from ..mpi import MPI
-from ..timing import function_timer
-from .. import rng
 from .. import qarray as qa
+from .. import rng
+from .._libtoast import add_templates, bin_invcov, bin_proj, legendre
 from ..data import Data
-from ..traits import trait_docs, Int, Unicode, Bool, Quantity, Float, Instance
-from ..utils import Environment, Logger, Timer, name_UID
-from .._libtoast import bin_proj, bin_invcov, add_templates, legendre
+from ..mpi import MPI
 from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, Timer, name_UID
 from .operator import Operator
 
 

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -5,36 +5,25 @@
 import os
 
 import numpy as np
-
-from .timing import function_timer, Timer, GlobalTimers
-
-from .dist import distribute_uniform
-
-from .mpi import MPI
-
 from pshmem.utils import mpi_data_type
 
+from ._libtoast import acc_copyin, acc_copyout, acc_enabled, acc_is_present
+from ._libtoast import global_to_local as libtoast_global_to_local
+from .dist import distribute_uniform
+from .mpi import MPI
+from .timing import GlobalTimers, Timer, function_timer
 from .utils import (
-    Logger,
-    AlignedI8,
-    AlignedU8,
-    AlignedI16,
-    AlignedU16,
-    AlignedI32,
-    AlignedU32,
-    AlignedI64,
-    AlignedU64,
     AlignedF32,
     AlignedF64,
-)
-
-from ._libtoast import global_to_local as libtoast_global_to_local
-
-from ._libtoast import (
-    acc_enabled,
-    acc_is_present,
-    acc_copyin,
-    acc_copyout,
+    AlignedI8,
+    AlignedI16,
+    AlignedI32,
+    AlignedI64,
+    AlignedU8,
+    AlignedU16,
+    AlignedU32,
+    AlignedU64,
+    Logger,
 )
 
 

--- a/src/toast/pixels_io.py
+++ b/src/toast/pixels_io.py
@@ -2,21 +2,16 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import h5py
-
 import os
 
+import h5py
+import healpy as hp
 import numpy as np
 
-from .timing import function_timer, Timer
-
-from .mpi import MPI, use_mpi
-
-import healpy as hp
-
-from .utils import Logger, memreport
-
 from .io import have_hdf5_parallel
+from .mpi import MPI, use_mpi
+from .timing import Timer, function_timer
+from .utils import Logger, memreport
 
 
 @function_timer

--- a/src/toast/qarray.py
+++ b/src/toast/qarray.py
@@ -6,29 +6,27 @@
 
 import numpy as np
 
-from .utils import Logger, AlignedF64, ensure_buffer_f64, object_ndim
-
 from ._libtoast import (
-    qa_inv,
     qa_amplitude,
-    qa_normalize,
-    qa_rotate,
-    qa_mult,
-    qa_slerp,
     qa_exp,
-    qa_ln,
-    qa_pow,
+    qa_from_angles,
     qa_from_axisangle,
-    qa_to_axisangle,
-    qa_to_rotmat,
+    qa_from_position,
     qa_from_rotmat,
     qa_from_vectors,
-    qa_from_angles,
+    qa_inv,
+    qa_ln,
+    qa_mult,
+    qa_normalize,
+    qa_pow,
+    qa_rotate,
+    qa_slerp,
     qa_to_angles,
+    qa_to_axisangle,
     qa_to_position,
-    qa_from_position,
+    qa_to_rotmat,
 )
-
+from .utils import AlignedF64, Logger, ensure_buffer_f64, object_ndim
 
 null_quat = np.array([0.0, 0.0, 0.0, 1.0])
 

--- a/src/toast/rng.py
+++ b/src/toast/rng.py
@@ -4,22 +4,19 @@
 
 import numpy as np
 
-from .utils import Logger, Environment, AlignedU64, AlignedF64
-
-from .dist import distribute_uniform
-
-from .timing import function_timer
-
 from ._libtoast import (
+    rng_dist_normal,
     rng_dist_uint64,
     rng_dist_uniform_01,
     rng_dist_uniform_11,
-    rng_dist_normal,
+    rng_multi_dist_normal,
     rng_multi_dist_uint64,
     rng_multi_dist_uniform_01,
     rng_multi_dist_uniform_11,
-    rng_multi_dist_normal,
 )
+from .dist import distribute_uniform
+from .timing import function_timer
+from .utils import AlignedF64, AlignedU64, Environment, Logger
 
 
 @function_timer

--- a/src/toast/schedule.py
+++ b/src/toast/schedule.py
@@ -4,20 +4,15 @@
 
 import os
 import sys
-
 from datetime import datetime
 
 import dateutil
-
 import numpy as np
-
 from astropy import units as u
+from astropy.table import Column, QTable
 
-from astropy.table import QTable, Column
-
-from .timing import function_timer, Timer
-
-from .utils import Logger, Environment
+from .timing import Timer, function_timer
+from .utils import Environment, Logger
 
 
 class Scan(object):

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -10,24 +10,22 @@ to toast_ground_sim.py
 """
 
 import argparse
-from datetime import datetime, timezone, timedelta
-import dateutil.parser
 import os
 import sys
 import traceback
+from datetime import datetime, timedelta, timezone
 
-import numpy as np
-from scipy.constants import degree
-from matplotlib import cm
-
+import dateutil.parser
 import ephem
 import healpy as hp
+import numpy as np
+from matplotlib import cm
+from scipy.constants import degree
 
-from .utils import Logger
 from . import qarray as qa
+from .coordinates import DJDtoUNIX, to_DJD, to_MJD, to_UTC
 from .timing import function_timer
-from .coordinates import to_DJD, to_MJD, to_UTC, DJDtoUNIX
-
+from .utils import Logger
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/schedule_sim_satellite.py
+++ b/src/toast/schedule_sim_satellite.py
@@ -7,12 +7,10 @@
 import datetime
 
 import numpy as np
-
 from astropy import units as u
 
-from .utils import Logger
-
 from .schedule import SatelliteScan, SatelliteSchedule
+from .utils import Logger
 
 
 def create_satellite_schedule(

--- a/src/toast/scripts/benchmarking_utilities.py
+++ b/src/toast/scripts/benchmarking_utilities.py
@@ -8,20 +8,23 @@ Functions common to all benchmarking scripts.
 total_sample = num_obs * obs_minutes * sample_rate * n_detector
 """
 
-import math
 import copy
-import healpy
+import math
 import os
 from datetime import datetime
-import numpy as np
+
+import healpy
 import matplotlib.pyplot as plt
+import numpy as np
 from astropy import units as u
 from astropy.table import QTable
+
 import toast
 import toast.ops
-from toast.job import job_size, get_node_mem
 from toast.instrument import Focalplane
 from toast.instrument_sim import fake_hexagon_focalplane
+from toast.job import get_node_mem, job_size
+
 from ..utils import Environment, Logger, Timer
 
 

--- a/src/toast/scripts/toast_benchmark_ground
+++ b/src/toast/scripts/toast_benchmark_ground
@@ -9,36 +9,31 @@ This script runs a simple ground simulation and makes a map.
 The workflow is tailored to the size of the communicator.
 """
 
-import os
-import sys
-import shutil
 import argparse
+import os
+import shutil
+import sys
 
 import numpy as np
-
 from astropy import units as u
 
 import toast
 import toast.ops
-
 from toast import spt3g as t3g
-
 from toast.schedule_sim_ground import run_scheduler
-
-from toast.timing import gather_timers, dump, function_timer
-
 from toast.scripts.benchmarking_utilities import (
-    get_mpi_settings,
-    select_case,
-    make_focalplane,
-    scan_map,
-    run_mapmaker,
-    run_madam,
     compute_science_metric,
-    estimate_memory_overhead,
-    python_startup_time,
     default_sim_atmosphere,
+    estimate_memory_overhead,
+    get_mpi_settings,
+    make_focalplane,
+    python_startup_time,
+    run_madam,
+    run_mapmaker,
+    scan_map,
+    select_case,
 )
+from toast.timing import dump, function_timer, gather_timers
 
 if t3g.available:
     from spt3g import core as c3g

--- a/src/toast/scripts/toast_benchmark_ground_setup
+++ b/src/toast/scripts/toast_benchmark_ground_setup
@@ -8,35 +8,27 @@
 This script sets up the input files needed by the toast_benchmark_ground workflow.
 """
 
-import os
-import sys
-import shutil
-
 import argparse
+import os
+import shutil
+import sys
+import warnings
 
 import numpy as np
-
 from astropy import units as u
-
 from erfa import ErfaWarning
 
 import toast
 import toast.ops
-
-from toast.schedule_sim_ground import run_scheduler
-
 from toast.instrument_sim import fake_hexagon_focalplane
-
-from toast.timing import gather_timers, dump, function_timer
-
+from toast.schedule_sim_ground import run_scheduler
 from toast.scripts.benchmarking_utilities import (
-    get_mpi_settings,
     create_input_maps,
-    python_startup_time,
     default_sim_atmosphere,
+    get_mpi_settings,
+    python_startup_time,
 )
-
-import warnings
+from toast.timing import dump, function_timer, gather_timers
 
 warnings.simplefilter("ignore", ErfaWarning)
 

--- a/src/toast/scripts/toast_benchmark_satellite
+++ b/src/toast/scripts/toast_benchmark_satellite
@@ -11,26 +11,28 @@ The workflow is tailored to the size of the communicator.
 total_sample = num_obs * obs_minutes * sample_rate * n_detector
 """
 
+import argparse
 import os
 import sys
-import argparse
 from datetime import datetime
+
 from astropy import units as u
+
 import toast
 import toast.ops
-from toast.timing import gather_timers, dump, function_timer
 from toast.schedule_sim_satellite import create_satellite_schedule
 from toast.scripts.benchmarking_utilities import (
-    get_mpi_settings,
-    select_case,
-    make_focalplane,
-    scan_map,
-    run_mapmaker,
-    run_madam,
     compute_science_metric,
     estimate_memory_overhead,
+    get_mpi_settings,
+    make_focalplane,
     python_startup_time,
+    run_madam,
+    run_mapmaker,
+    scan_map,
+    select_case,
 )
+from toast.timing import dump, function_timer, gather_timers
 
 
 def parse_arguments():

--- a/src/toast/scripts/toast_env
+++ b/src/toast/scripts/toast_env
@@ -7,14 +7,13 @@
 """This does some simple tests of the TOAST runtime environment.
 """
 
-import sys
 import argparse
+import sys
 import traceback
 
 import toast
-from toast.mpi import get_world, Comm
-
-from toast.utils import Logger, Environment, numba_threading_layer
+from toast.mpi import Comm, get_world
+from toast.utils import Environment, Logger, numba_threading_layer
 
 
 def main():

--- a/src/toast/scripts/toast_fake_focalplane
+++ b/src/toast/scripts/toast_fake_focalplane
@@ -7,20 +7,17 @@
 """Generate a focalplane file compatible with the example workflows.
 """
 
-import sys
 import argparse
+import sys
 
 import numpy as np
-
 from astropy import units as u
 
 import toast
+from toast.instrument_sim import fake_hexagon_focalplane, plot_focalplane
 from toast.io import H5File
 from toast.mpi import get_world
-
 from toast.utils import Logger
-
-from toast.instrument_sim import fake_hexagon_focalplane, plot_focalplane
 
 
 def main():

--- a/src/toast/scripts/toast_ground_schedule
+++ b/src/toast/scripts/toast_ground_schedule
@@ -14,8 +14,8 @@ import traceback
 
 import toast
 from toast.mpi import get_world
-from toast.timing import GlobalTimers
 from toast.schedule_sim_ground import run_scheduler
+from toast.timing import GlobalTimers
 
 
 def main():

--- a/src/toast/scripts/toast_hdf5_to_spt3g
+++ b/src/toast/scripts/toast_hdf5_to_spt3g
@@ -8,26 +8,21 @@
 This script loads HDF5 format data and exports to SPT3G format data.
 """
 
-import os
-import sys
-import shutil
-import re
-
 import argparse
+import os
+import re
+import shutil
+import sys
 
 import numpy as np
-
 from astropy import units as u
+from spt3g import core as c3g
 
 import toast
 import toast.ops
-
-from toast.timing import gather_timers, dump
-
 from toast import spt3g as t3g
-from spt3g import core as c3g
-
 from toast.observation import default_values as defaults
+from toast.timing import dump, gather_timers
 
 
 def parse_arguments():

--- a/src/toast/scripts/toast_healpix_coadd
+++ b/src/toast/scripts/toast_healpix_coadd
@@ -8,9 +8,9 @@
 minimum variance averages
 """
 
+import argparse
 import os
 import sys
-import argparse
 import traceback
 
 import h5py
@@ -18,9 +18,10 @@ import healpy as hp
 import numpy as np
 
 import toast
-from toast.mpi import get_world, Comm, MPI
-
-from toast.utils import Logger, Environment, Timer
+from toast import PixelData, PixelDistribution
+from toast._libtoast import cov_apply_diag, cov_eigendecompose_diag
+from toast.covariance import covariance_apply, covariance_invert
+from toast.mpi import MPI, Comm, get_world
 from toast.pixels_io import (
     filename_is_fits,
     filename_is_hdf5,
@@ -29,9 +30,7 @@ from toast.pixels_io import (
     write_healpix_fits,
     write_healpix_hdf5,
 )
-from toast._libtoast import cov_eigendecompose_diag, cov_apply_diag
-from toast import PixelDistribution, PixelData
-from toast.covariance import covariance_invert, covariance_apply
+from toast.utils import Environment, Logger, Timer
 
 
 def main():

--- a/src/toast/scripts/toast_healpix_convert
+++ b/src/toast/scripts/toast_healpix_convert
@@ -7,9 +7,9 @@
 """This script converts HEALPiX maps between FITS and HDF5
 """
 
+import argparse
 import os
 import sys
-import argparse
 import traceback
 
 import h5py
@@ -17,15 +17,14 @@ import healpy as hp
 import numpy as np
 
 import toast
-from toast.mpi import get_world, Comm
-
-from toast.utils import Logger, Environment, Timer
+from toast.mpi import Comm, get_world
 from toast.pixels_io import (
     filename_is_fits,
     filename_is_hdf5,
     read_healpix,
     write_healpix,
 )
+from toast.utils import Environment, Logger, Timer
 
 
 def main():

--- a/src/toast/scripts/toast_mini
+++ b/src/toast/scripts/toast_mini
@@ -11,29 +11,25 @@ The workflow is tailored to the size of the communicator.
 total_sample = num_obs * obs_minutes * sample_rate * n_detector
 """
 
+import argparse
 import os
 import sys
-import argparse
 from datetime import datetime
 
 from astropy import units as u
 
 import toast
-
 import toast.ops
-
-from toast.timing import gather_timers, dump, function_timer
-
 from toast.schedule_sim_satellite import create_satellite_schedule
-
 from toast.scripts.benchmarking_utilities import (
-    get_mpi_settings,
-    select_case,
-    make_focalplane,
-    estimate_memory_overhead,
-    python_startup_time,
     default_sim_atmosphere,
+    estimate_memory_overhead,
+    get_mpi_settings,
+    make_focalplane,
+    python_startup_time,
+    select_case,
 )
+from toast.timing import dump, function_timer, gather_timers
 
 
 def parse_arguments():

--- a/src/toast/scripts/toast_satellite_schedule
+++ b/src/toast/scripts/toast_satellite_schedule
@@ -8,20 +8,16 @@
 This script creates a schedule file compatible with the SatelliteSchedule class.
 """
 
-import sys
-
-from datetime import datetime
-
 import argparse
+import sys
+from datetime import datetime
 
 from astropy import units as u
 
 import toast
 from toast.mpi import get_world
-
-from toast.utils import Logger
-
 from toast.schedule_sim_satellite import create_satellite_schedule
+from toast.utils import Logger
 
 
 def main():

--- a/src/toast/scripts/toast_timing_plot
+++ b/src/toast/scripts/toast_timing_plot
@@ -7,18 +7,14 @@
 """Plot global timing results
 """
 
-import sys
 import argparse
-import re
-
 import csv
+import re
+import sys
 
 import numpy as np
-
 import pandas as pd
-
 import plotly.express as px
-
 import plotly.io as pio
 
 

--- a/src/toast/spt3g/__init__.py
+++ b/src/toast/spt3g/__init__.py
@@ -4,32 +4,22 @@
 
 # Import objects into our public API
 
+from .spt3g_export import export_obs, export_obs_data, export_obs_meta
+from .spt3g_import import import_obs, import_obs_data, import_obs_meta
 from .spt3g_utils import (
     available,
-    from_g3_unit,
-    to_g3_unit,
-    from_g3_time,
-    to_g3_time,
-    from_g3_scalar_type,
-    to_g3_scalar_type,
-    from_g3_array_type,
-    to_g3_array_type,
-    to_g3_map_array_type,
-    from_g3_quats,
-    to_g3_quats,
     compress_timestream,
     frame_collector,
     frame_emitter,
-)
-
-from .spt3g_export import (
-    export_obs_meta,
-    export_obs_data,
-    export_obs,
-)
-
-from .spt3g_import import (
-    import_obs_meta,
-    import_obs_data,
-    import_obs,
+    from_g3_array_type,
+    from_g3_quats,
+    from_g3_scalar_type,
+    from_g3_time,
+    from_g3_unit,
+    to_g3_array_type,
+    to_g3_map_array_type,
+    to_g3_quats,
+    to_g3_scalar_type,
+    to_g3_time,
+    to_g3_unit,
 )

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -2,32 +2,26 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
 import io
-
-import numpy as np
+import os
 
 import h5py
-
+import numpy as np
 from astropy import units as u
 
-from ..utils import Environment, Logger, object_fullname
-
-from ..timing import function_timer
-
-from ..intervals import IntervalList
-
 from ..instrument import GroundSite, SpaceSite
-
+from ..intervals import IntervalList
+from ..timing import function_timer
+from ..utils import Environment, Logger, object_fullname
 from .spt3g_utils import (
     available,
-    to_g3_scalar_type,
+    compress_timestream,
     to_g3_array_type,
     to_g3_map_array_type,
-    to_g3_unit,
-    to_g3_time,
     to_g3_quats,
-    compress_timestream,
+    to_g3_scalar_type,
+    to_g3_time,
+    to_g3_unit,
 )
 
 if available:

--- a/src/toast/spt3g/spt3g_import.py
+++ b/src/toast/spt3g/spt3g_import.py
@@ -2,37 +2,29 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
-import io
-import re
 import datetime
-
-import numpy as np
+import io
+import os
+import re
 
 import h5py
-
+import numpy as np
 from astropy import units as u
 
-from ..utils import Environment, Logger, import_from_name
-
-from ..timing import function_timer
-
 from ..instrument import Focalplane, GroundSite, SpaceSite
-
-from ..weather import SimWeather
-
-from ..observation import Observation
-
 from ..intervals import IntervalList
-
+from ..observation import Observation
+from ..timing import function_timer
+from ..utils import Environment, Logger, import_from_name
+from ..weather import SimWeather
 from .spt3g_utils import (
     available,
-    from_g3_array_type,
-    from_g3_scalar_type,
-    from_g3_unit,
-    from_g3_time,
-    from_g3_quats,
     decompress_timestream,
+    from_g3_array_type,
+    from_g3_quats,
+    from_g3_scalar_type,
+    from_g3_time,
+    from_g3_unit,
 )
 
 if available:

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -3,12 +3,11 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-import numpy as np
 
+import numpy as np
 from astropy import units as u
 
 from ..utils import Environment, Logger
-
 
 available = True
 try:

--- a/src/toast/templates/__init__.py
+++ b/src/toast/templates/__init__.py
@@ -4,14 +4,9 @@
 
 # Import Templates into our public API
 
-from .template import Template
-
 from .amplitudes import Amplitudes, AmplitudesMap
-
-from .offset import Offset
-
 from .fourier2d import Fourier2D
-
-from .subharmonic import SubHarmonic
-
 from .gaintemplate import GainTemplate
+from .offset import Offset
+from .subharmonic import SubHarmonic
+from .template import Template

--- a/src/toast/templates/amplitudes.py
+++ b/src/toast/templates/amplitudes.py
@@ -7,13 +7,12 @@ from collections.abc import MutableMapping
 import numpy as np
 
 from ..mpi import MPI
-
 from ..utils import (
-    Logger,
-    AlignedU8,
     AlignedF32,
     AlignedF64,
     AlignedI32,
+    AlignedU8,
+    Logger,
     dtype_to_aligned,
 )
 

--- a/src/toast/templates/fourier2d.py
+++ b/src/toast/templates/fourier2d.py
@@ -5,27 +5,18 @@
 from collections import OrderedDict
 
 import numpy as np
-
 import scipy
 import scipy.signal
-
+import traitlets
 from astropy import units as u
 
-import traitlets
-
-from ..mpi import MPI
-
-from ..utils import Logger, AlignedF64
-
 from .. import qarray as qa
-
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float, Quantity
-
 from ..data import Data
-
-from .template import Template
-
+from ..mpi import MPI
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import AlignedF64, Logger
 from .amplitudes import Amplitudes
+from .template import Template
 
 
 @trait_docs

--- a/src/toast/templates/gaintemplate.py
+++ b/src/toast/templates/gaintemplate.py
@@ -5,20 +5,14 @@
 from collections import OrderedDict
 
 import numpy as np
-
-from ..mpi import MPI
-
-from ..utils import Logger
-
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
+import scipy
 
 from ..data import Data
-
-from .template import Template
-
+from ..mpi import MPI
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .amplitudes import Amplitudes
-
-import scipy
+from .template import Template
 
 
 @trait_docs

--- a/src/toast/templates/offset.py
+++ b/src/toast/templates/offset.py
@@ -4,30 +4,20 @@
 
 from collections import OrderedDict
 
-import traitlets
-
 import numpy as np
-
 import scipy
 import scipy.signal
-
+import traitlets
 from astropy import units as u
 
-from ..utils import Logger, rate_from_times, AlignedF32
-
-from ..timing import function_timer
-
-from ..mpi import MPI
-
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float, Quantity
-
-from ..data import Data
-
-from .template import Template
-
-from .amplitudes import Amplitudes
-
 from .._libtoast import template_offset_add_to_signal, template_offset_project_signal
+from ..data import Data
+from ..mpi import MPI
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import AlignedF32, Logger, rate_from_times
+from .amplitudes import Amplitudes
+from .template import Template
 
 
 @trait_docs

--- a/src/toast/templates/subharmonic.py
+++ b/src/toast/templates/subharmonic.py
@@ -6,17 +6,12 @@ from collections import OrderedDict
 
 import numpy as np
 
-from ..mpi import MPI
-
-from ..utils import Logger
-
-from ..traits import trait_docs, Int, Unicode, Bool, Instance, Float
-
 from ..data import Data
-
-from .template import Template
-
+from ..mpi import MPI
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
 from .amplitudes import Amplitudes
+from .template import Template
 
 
 @trait_docs

--- a/src/toast/templates/template.py
+++ b/src/toast/templates/template.py
@@ -3,18 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import traitlets
 
 from toast.timing import function_timer_stackskip
 
-from ..utils import Logger
-
-from ..traits import TraitConfig, Instance, Unicode, Int
-
 from ..data import Data
-
 from ..observation import default_values as defaults
+from ..traits import Instance, Int, TraitConfig, Unicode
+from ..utils import Logger
 
 
 class Template(TraitConfig):

--- a/src/toast/tests/__init__.py
+++ b/src/toast/tests/__init__.py
@@ -6,5 +6,4 @@
 
 # If toast has not yet been imported, make sure we initialize MPI
 from ..mpi import MPI
-
 from .runner import test as run

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -3,43 +3,27 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-
+import shutil
+import tempfile
 from datetime import datetime
 
-import tempfile
-
-import shutil
-
-import numpy as np
-
 import healpy as hp
-
+import numpy as np
 from astropy import units as u
-
-from ..mpi import Comm
-
-from ..data import Data
-
-from .. import qarray as qa
-
-from ..instrument import Focalplane, Telescope, GroundSite, SpaceSite
-
-from ..instrument_sim import fake_hexagon_focalplane
-
-from ..schedule import GroundSchedule
-
-from ..schedule_sim_satellite import create_satellite_schedule
-
-from ..schedule_sim_ground import run_scheduler
-
-from ..observation import DetectorData, Observation
-from ..observation import default_values as defaults
-
-from ..pixels import PixelData
+from astropy.table import Column, QTable
 
 from .. import ops as ops
-
-from astropy.table import QTable, Column
+from .. import qarray as qa
+from ..data import Data
+from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
+from ..instrument_sim import fake_hexagon_focalplane
+from ..mpi import Comm
+from ..observation import DetectorData, Observation
+from ..observation import default_values as defaults
+from ..pixels import PixelData
+from ..schedule import GroundSchedule
+from ..schedule_sim_ground import run_scheduler
+from ..schedule_sim_satellite import create_satellite_schedule
 
 ZAXIS = np.array([0.0, 0.0, 1.0])
 

--- a/src/toast/tests/accelerator.py
+++ b/src/toast/tests/accelerator.py
@@ -8,31 +8,22 @@ import time
 import numpy as np
 import numpy.testing as nt
 
-from ..traits import (
-    trait_docs,
-    Int,
-    Unicode,
-)
-
 from .. import ops
-
-from .mpi import MPITestCase
-
 from .._libtoast import (
-    acc_enabled,
-    acc_is_present,
     acc_copyin,
     acc_copyout,
     acc_delete,
+    acc_enabled,
+    acc_is_present,
     acc_update_device,
     acc_update_self,
-    test_acc_op_buffer,
     test_acc_op_array,
+    test_acc_op_buffer,
 )
-
 from ..observation import default_values as defaults
-
-from ._helpers import create_outdir, create_comm, create_satellite_data
+from ..traits import Int, Unicode, trait_docs
+from ._helpers import create_comm, create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 @trait_docs

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -2,60 +2,45 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
-import os
-
-import copy
-
-import types
-
 import argparse
-
+import copy
+import os
+import types
 from datetime import datetime
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
-
-from tomlkit import comment, document, nl, table, dumps, loads
-
-from ..utils import Environment, Logger
-
-from ..traits import (
-    trait_docs,
-    Int,
-    Unicode,
-    Float,
-    Bool,
-    Instance,
-    Quantity,
-    Dict,
-    List,
-    Set,
-    Tuple,
-)
-
-from ..config import (
-    load_config,
-    dump_toml,
-    build_config,
-    create_from_config,
-    parse_config,
-)
-
-from ..instrument import Telescope, Focalplane
-
-from ..schedule_sim_satellite import create_satellite_schedule
+from tomlkit import comment, document, dumps, loads, nl, table
 
 from .. import ops
-
-from ..templates import Offset, SubHarmonic
-
+from ..config import (
+    build_config,
+    create_from_config,
+    dump_toml,
+    load_config,
+    parse_config,
+)
 from ..data import Data
-
-from ._helpers import create_outdir, create_comm, create_space_telescope
+from ..instrument import Focalplane, Telescope
+from ..schedule_sim_satellite import create_satellite_schedule
+from ..templates import Offset, SubHarmonic
+from ..traits import (
+    Bool,
+    Dict,
+    Float,
+    Instance,
+    Int,
+    List,
+    Quantity,
+    Set,
+    Tuple,
+    Unicode,
+    trait_docs,
+)
+from ..utils import Environment, Logger
+from ._helpers import create_comm, create_outdir, create_space_telescope
+from .mpi import MPITestCase
 
 
 class FakeClass:

--- a/src/toast/tests/covariance.py
+++ b/src/toast/tests/covariance.py
@@ -4,24 +4,17 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import MPI
-
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..covariance import covariance_invert, covariance_multiply, covariance_apply
-
+from ..covariance import covariance_apply, covariance_invert, covariance_multiply
+from ..mpi import MPI
+from ..pixels import PixelData, PixelDistribution
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class CovarianceTest(MPITestCase):

--- a/src/toast/tests/dist.py
+++ b/src/toast/tests/dist.py
@@ -2,28 +2,25 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import re
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from ..dist import distribute_uniform, distribute_discrete
 from ..data import Data
+from ..dist import distribute_discrete, distribute_uniform
+from ..mpi import MPI, Comm
 from ..observation import Observation
-from ..mpi import Comm, MPI
-
 from ._helpers import (
-    create_outdir,
-    create_satellite_empty,
     create_comm,
     create_ground_telescope,
+    create_outdir,
     create_satellite_data,
+    create_satellite_empty,
 )
+from .mpi import MPITestCase
 
 
 class DataTest(MPITestCase):

--- a/src/toast/tests/env.py
+++ b/src/toast/tests/env.py
@@ -7,13 +7,10 @@ import time
 import numpy as np
 import numpy.testing as nt
 
-from .mpi import MPITestCase
-
+from ..mpi import MPILock, MPIShared
 from ..utils import Environment
-
-from ..mpi import MPIShared, MPILock
-
 from ._helpers import create_comm
+from .mpi import MPITestCase
 
 
 class EnvTest(MPITestCase):

--- a/src/toast/tests/fft.py
+++ b/src/toast/tests/fft.py
@@ -2,16 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
+
 import numpy as np
 
-from ..fft import r1d_forward, r1d_backward
-
+from ..fft import r1d_backward, r1d_forward
 from ..rng import random
-
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class FFTTest(MPITestCase):

--- a/src/toast/tests/healpix.py
+++ b/src/toast/tests/healpix.py
@@ -2,18 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
-import numpy as np
 
 import healpy as hp
+import numpy as np
 
-from ..healpix import ang2vec, vec2ang, Pixels
-
+from ..healpix import Pixels, ang2vec, vec2ang
 from ..rng import random
-
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class HealpixTest(MPITestCase):

--- a/src/toast/tests/instrument.py
+++ b/src/toast/tests/instrument.py
@@ -5,22 +5,15 @@
 import os
 
 import numpy as np
-
-from .mpi import MPITestCase
-
 import numpy.testing as nt
-
 from astropy import units as u
-
-from astropy.table import QTable, Column
+from astropy.table import Column, QTable
 
 from ..instrument import Focalplane
-
 from ..instrument_sim import fake_hexagon_focalplane
-
 from ..io import H5File
-
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class InstrumentTest(MPITestCase):

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -3,12 +3,10 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
-from .mpi import MPITestCase
-
 import numpy.testing as nt
 
 from ..intervals import Interval, IntervalList
+from .mpi import MPITestCase
 
 # from ..tod.interval import intervals_to_chunklist
 #

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -6,24 +6,16 @@ import os
 import sys
 
 import numpy as np
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
-from ..mpi import MPI
-
-from ..data import Data
-
-from ..io import save_hdf5, load_hdf5
-
 from ..config import build_config
-
+from ..data import Data
+from ..io import load_hdf5, save_hdf5
+from ..mpi import MPI
 from ..observation_data import DetectorData
-
-from ._helpers import create_outdir, create_ground_data
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class IoHdf5Test(MPITestCase):

--- a/src/toast/tests/math_misc.py
+++ b/src/toast/tests/math_misc.py
@@ -7,15 +7,12 @@ try:
 except ImportError:
     from scipy.integrate import simps as simpson
 
-from .mpi import MPITestCase
-
-from ..utils import AlignedU64
-
-from ..rng import random, random_multi
-
 import numpy as np
 
 from .._libtoast import integrate_simpson
+from ..rng import random, random_multi
+from ..utils import AlignedU64
+from .mpi import MPITestCase
 
 
 class MathMiscTest(MPITestCase):

--- a/src/toast/tests/mpi.py
+++ b/src/toast/tests/mpi.py
@@ -2,19 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI, use_mpi
-
 import sys
 import time
 import traceback
-import time
-
 import warnings
-
+from unittest import TestCase, TestResult
 from unittest.signals import registerResult
 
-from unittest import TestCase
-from unittest import TestResult
+from ..mpi import MPI, use_mpi
 
 
 class MPITestCase(TestCase):

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -5,25 +5,17 @@
 import os
 import sys
 
-import numpy as np
-
 import h5py
-
-from .mpi import MPITestCase
-
+import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from ..noise import Noise
-
-from ..noise_sim import AnalyticNoise
-
 from ..instrument_sim import fake_hexagon_focalplane
-
 from ..io import H5File
-
+from ..noise import Noise
+from ..noise_sim import AnalyticNoise
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class InstrumentTest(MPITestCase):

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -2,31 +2,26 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import sys
 import traceback
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
-
 from pshmem import MPIShared
 
-from ..observation import DetectorData, Observation, set_default_values
-
+from ..mpi import MPI, Comm
+from ..observation import DetectorData, Observation
 from ..observation import default_values as defaults
-
-from ..mpi import Comm, MPI
-
+from ..observation import set_default_values
 from ._helpers import (
+    create_ground_data,
     create_outdir,
     create_satellite_empty,
-    create_ground_data,
     fake_flags,
 )
+from .mpi import MPITestCase
 
 
 class ObservationTest(MPITestCase):

--- a/src/toast/tests/ops_cadence_map.py
+++ b/src/toast/tests/ops_cadence_map.py
@@ -4,32 +4,21 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import MPI
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..pixels_io import write_healpix_fits
-
 from ..covariance import covariance_apply
-
+from ..mpi import MPI
+from ..noise import Noise
 from ..observation import default_values as defaults
-
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class CadenceMapTest(MPITestCase):

--- a/src/toast/tests/ops_crosslinking.py
+++ b/src/toast/tests/ops_crosslinking.py
@@ -4,28 +4,19 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import MPI
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
-from ..pixels import PixelDistribution, PixelData
-
+from ..mpi import MPI
+from ..noise import Noise
 from ..observation import default_values as defaults
-
+from ..pixels import PixelData, PixelDistribution
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class CrossLinkingTest(MPITestCase):

--- a/src/toast/tests/ops_elevation_noise.py
+++ b/src/toast/tests/ops_elevation_noise.py
@@ -6,18 +6,13 @@ import os
 import sys
 
 import numpy as np
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
-from ..mpi import MPI
-
 from ..data import Data
-
-from ._helpers import create_outdir, create_ground_data
+from ..mpi import MPI
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class ElevationNoiseTest(MPITestCase):

--- a/src/toast/tests/ops_flag_sso.py
+++ b/src/toast/tests/ops_flag_sso.py
@@ -4,25 +4,17 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
+from .. import qarray as qa
 from ..observation import default_values as defaults
-
 from ..pixels_io import write_healpix_fits
-
-from ._helpers import create_outdir, create_ground_data
+from ..vis import set_matplotlib_backend
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class FlagSSOTest(MPITestCase):

--- a/src/toast/tests/ops_gainscrambler.py
+++ b/src/toast/tests/ops_gainscrambler.py
@@ -2,15 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 
 import numpy as np
 
 from .. import ops
-
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class OpGainScramblerTest(MPITestCase):

--- a/src/toast/tests/ops_groundfilter.py
+++ b/src/toast/tests/ops_groundfilter.py
@@ -6,23 +6,16 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 from astropy.table import Column
 
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
 from .. import ops as ops
-
-from ..vis import set_matplotlib_backend
-
-from ..pixels import PixelDistribution, PixelData
-
+from ..noise import Noise
 from ..observation import default_values as defaults
-
-from ._helpers import create_outdir, create_ground_data, fake_flags
+from ..pixels import PixelData, PixelDistribution
+from ..vis import set_matplotlib_backend
+from ._helpers import create_ground_data, create_outdir, fake_flags
+from .mpi import MPITestCase
 
 
 class GroundFilterTest(MPITestCase):

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -4,30 +4,20 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
-from ..observation import default_values as defaults
-
 from .. import templates
-
-from ..pixels import PixelDistribution, PixelData
-
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
 from ..pixels_io import write_healpix_fits
-
-from ._helpers import create_outdir, create_satellite_data, create_fake_sky
+from ..vis import set_matplotlib_backend
+from ._helpers import create_fake_sky, create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class MapmakerTest(MPITestCase):

--- a/src/toast/tests/ops_mapmaker_binning.py
+++ b/src/toast/tests/ops_mapmaker_binning.py
@@ -4,32 +4,21 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import MPI
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..pixels_io import write_healpix_fits
-
 from ..covariance import covariance_apply
-
+from ..mpi import MPI
+from ..noise import Noise
 from ..observation import default_values as defaults
-
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class MapmakerBinningTest(MPITestCase):

--- a/src/toast/tests/ops_mapmaker_solve.py
+++ b/src/toast/tests/ops_mapmaker_solve.py
@@ -4,28 +4,19 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
+from ..noise import Noise
 from ..observation import default_values as defaults
-
-from ..templates import Offset, AmplitudesMap
-
-from ..ops.mapmaker_solve import SolverRHS, SolverLHS
-
+from ..ops.mapmaker_solve import SolverLHS, SolverRHS
+from ..templates import AmplitudesMap, Offset
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class MapmakerSolveTest(MPITestCase):

--- a/src/toast/tests/ops_mapmaker_utils.py
+++ b/src/toast/tests/ops_mapmaker_utils.py
@@ -6,22 +6,15 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from ..mpi import MPI
-
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
 from .. import ops as ops
-
+from ..mpi import MPI
+from ..noise import Noise
 from ..observation import default_values as defaults
-
-from ..pixels import PixelDistribution, PixelData
-
+from ..pixels import PixelData, PixelDistribution
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class MapmakerUtilsTest(MPITestCase):

--- a/src/toast/tests/ops_memory_counter.py
+++ b/src/toast/tests/ops_memory_counter.py
@@ -2,16 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
-import os
 import copy
+import os
 
 import numpy as np
 
 from .. import ops as ops
-
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class MemoryCounterTest(MPITestCase):

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -6,33 +6,24 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 from astropy.table import Column
 
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
 from .. import ops as ops
-
-from ..vis import set_matplotlib_backend
-
-from ..pixels import PixelDistribution, PixelData
-from ..pixels_io import write_healpix_fits
-
 from .. import qarray as qa
-
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
 from ._helpers import (
+    create_fake_sky,
+    create_ground_data,
     create_outdir,
     create_satellite_data,
-    create_ground_data,
-    create_fake_sky,
     fake_flags,
 )
-
-from ..observation import default_values as defaults
-
+from .mpi import MPITestCase
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 
@@ -119,8 +110,8 @@ class NoiseEstimTest(MPITestCase):
         estim.apply(data)
 
         if data.comm.world_rank == 0:
-            import matplotlib.pyplot as plt
             import astropy.io.fits as pf
+            import matplotlib.pyplot as plt
 
             obs = data.obs[0]
             det = obs.local_detectors[0]

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -6,32 +6,23 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 from astropy.table import Column
 
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
 from .. import ops as ops
-
-from ..vis import set_matplotlib_backend
-
-from ..pixels import PixelDistribution, PixelData
-
 from .. import qarray as qa
-
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..vis import set_matplotlib_backend
 from ._helpers import (
+    create_fake_sky,
+    create_ground_data,
     create_outdir,
     create_satellite_data,
-    create_ground_data,
-    create_fake_sky,
     fake_flags,
 )
-
-from ..observation import default_values as defaults
-
+from .mpi import MPITestCase
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/tests/ops_scan_healpix.py
+++ b/src/toast/tests/ops_scan_healpix.py
@@ -6,25 +6,19 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
 from ..observation import default_values as defaults
-
 from ..pixels import PixelData
-
 from ..pixels_io import write_healpix_fits, write_healpix_hdf5
-
 from ._helpers import (
+    create_fake_mask,
+    create_fake_sky,
     create_outdir,
     create_satellite_data,
-    create_fake_sky,
-    create_fake_mask,
 )
+from .mpi import MPITestCase
 
 
 class ScanHealpixTest(MPITestCase):

--- a/src/toast/tests/ops_scan_map.py
+++ b/src/toast/tests/ops_scan_map.py
@@ -6,18 +6,13 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
 from ..observation import default_values as defaults
-
 from ..pixels import PixelData
-
-from ._helpers import create_outdir, create_satellite_data, create_fake_sky
+from ._helpers import create_fake_sky, create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class ScanMapTest(MPITestCase):

--- a/src/toast/tests/ops_sim_cosmic_rays.py
+++ b/src/toast/tests/ops_sim_cosmic_rays.py
@@ -4,26 +4,22 @@
 
 import os
 
-import numpy as np
 import healpy as hp
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
+import numpy as np
 
 from .. import ops as ops
 from .. import rng
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..pixels_io import write_healpix_fits
-
 from ..covariance import covariance_apply
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
 from ._helpers import (
+    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    create_fake_sky,
 )
+from .mpi import MPITestCase
 
 
 class SimCosmicRayTest(MPITestCase):

--- a/src/toast/tests/ops_sim_crosstalk.py
+++ b/src/toast/tests/ops_sim_crosstalk.py
@@ -4,25 +4,21 @@
 
 import os
 
-import numpy as np
 import healpy as hp
-from .mpi import MPITestCase
-
+import numpy as np
 
 from .. import ops as ops
 from .. import rng
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..pixels_io import write_healpix_fits
-
 from ..covariance import covariance_apply
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
 from ._helpers import (
+    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    create_fake_sky,
 )
+from .mpi import MPITestCase
 
 
 class SimCrossTalkTest(MPITestCase):

--- a/src/toast/tests/ops_sim_gaindrifts.py
+++ b/src/toast/tests/ops_sim_gaindrifts.py
@@ -4,28 +4,23 @@
 
 import os
 
-import numpy as np
 import healpy as hp
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
+import numpy as np
 
 from .. import ops as ops
 from .. import rng
-
-from ..observation import default_values as defaults
-
-from ..pixels import PixelDistribution, PixelData
-
-from ..pixels_io import write_healpix_fits
-
 from ..covariance import covariance_apply
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
 from ._helpers import (
+    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    create_fake_sky,
 )
+from .mpi import MPITestCase
 
 
 class SimGainTest(MPITestCase):

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -2,42 +2,27 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
-
 from datetime import datetime
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import Comm, MPI
-
-from ..data import Data
-
-from ..observation import default_values as defaults
-
-from ..instrument import Focalplane, Telescope, GroundSite
-
-from ..instrument_sim import fake_hexagon_focalplane
-
-from ..schedule_sim_ground import run_scheduler
-
-from ..schedule import GroundSchedule
-
-from ..pixels_io import write_healpix_fits
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
-from ._helpers import create_outdir, create_comm
+from .. import qarray as qa
+from ..data import Data
+from ..instrument import Focalplane, GroundSite, Telescope
+from ..instrument_sim import fake_hexagon_focalplane
+from ..mpi import MPI, Comm
+from ..observation import default_values as defaults
+from ..pixels_io import write_healpix_fits
+from ..schedule import GroundSchedule
+from ..schedule_sim_ground import run_scheduler
+from ..vis import set_matplotlib_backend
+from ._helpers import create_comm, create_outdir
+from .mpi import MPITestCase
 
 
 class SimGroundTest(MPITestCase):

--- a/src/toast/tests/ops_sim_satellite.py
+++ b/src/toast/tests/ops_sim_satellite.py
@@ -2,40 +2,26 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
-
 from datetime import datetime
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-import healpy as hp
-
-from ..mpi import Comm, MPI
-
-from ..data import Data
-
-from ..observation import default_values as defaults
-
-from ..instrument import Focalplane, Telescope, SpaceSite
-
-from ..instrument_sim import fake_hexagon_focalplane
-
-from ..schedule_sim_satellite import create_satellite_schedule
-
-from ..pixels_io import write_healpix_fits
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
-from ._helpers import create_outdir, create_comm
+from .. import qarray as qa
+from ..data import Data
+from ..instrument import Focalplane, SpaceSite, Telescope
+from ..instrument_sim import fake_hexagon_focalplane
+from ..mpi import MPI, Comm
+from ..observation import default_values as defaults
+from ..pixels_io import write_healpix_fits
+from ..schedule_sim_satellite import create_satellite_schedule
+from ..vis import set_matplotlib_backend
+from ._helpers import create_comm, create_outdir
+from .mpi import MPITestCase
 
 
 class SimSatelliteTest(MPITestCase):

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -4,29 +4,19 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
-from ..observation import default_values as defaults
-
-from ..pixels_io import write_healpix_fits
-
-from ..dipole import dipole
-
-from ._helpers import create_outdir, create_ground_data
-
+from .. import qarray as qa
 from ..atm import available_atm, available_utils
+from ..dipole import dipole
+from ..observation import default_values as defaults
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class SimAtmTest(MPITestCase):

--- a/src/toast/tests/ops_sim_tod_conviqt.py
+++ b/src/toast/tests/ops_sim_tod_conviqt.py
@@ -4,30 +4,22 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
+from .. import qarray as qa
 from ..observation import default_values as defaults
-
 from ..pixels_io import write_healpix_fits
-
+from ..vis import set_matplotlib_backend
 from ._helpers import (
+    create_fake_beam_alm,
+    create_fake_sky_alm,
     create_outdir,
     create_satellite_data,
-    create_fake_sky_alm,
-    create_fake_beam_alm,
 )
+from .mpi import MPITestCase
 
 
 class SimConviqtTest(MPITestCase):
@@ -236,12 +228,11 @@ class SimConviqtTest(MPITestCase):
         fname2 = self.fname_beam.replace(".fits", "_bottom.fits")
 
         beam_file_dict = {}
-        for det in data.obs[0].local_detectors:
+        for det in data.obs[0].all_detectors:
             if det[-1] == "A":
                 beam_file_dict[det] = self.fname_beam
             else:
                 beam_file_dict[det] = fname2
-
         return beam_file_dict
 
     def test_sim_conviqt(self):

--- a/src/toast/tests/ops_sim_tod_dipole.py
+++ b/src/toast/tests/ops_sim_tod_dipole.py
@@ -4,25 +4,17 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
-from ..pixels_io import write_healpix_fits
-
+from .. import qarray as qa
 from ..dipole import dipole
-
-from ._helpers import create_outdir, create_healpix_ring_satellite
+from ..pixels_io import write_healpix_fits
+from ..vis import set_matplotlib_backend
+from ._helpers import create_healpix_ring_satellite, create_outdir
+from .mpi import MPITestCase
 
 
 class SimDipoleTest(MPITestCase):

--- a/src/toast/tests/ops_sim_tod_noise.py
+++ b/src/toast/tests/ops_sim_tod_noise.py
@@ -6,22 +6,15 @@ import os
 import sys
 
 import numpy as np
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import rng as rng
-
-from ..noise import Noise
-
 from .. import ops as ops
-
+from .. import rng as rng
+from ..noise import Noise
 from ..ops.sim_tod_noise import sim_noise_timestream
-
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class SimNoiseTest(MPITestCase):

--- a/src/toast/tests/ops_sim_tod_totalconvolve.py
+++ b/src/toast/tests/ops_sim_tod_totalconvolve.py
@@ -4,29 +4,22 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
+from .. import qarray as qa
 from ..pixels_io import write_healpix_fits
-
+from ..vis import set_matplotlib_backend
 from ._helpers import (
-    create_outdir,
-    create_healpix_ring_satellite,
-    create_satellite_data,
-    create_fake_sky_alm,
     create_fake_beam_alm,
+    create_fake_sky_alm,
+    create_healpix_ring_satellite,
+    create_outdir,
+    create_satellite_data,
 )
+from .mpi import MPITestCase
 
 
 class SimTotalconvolveTest(MPITestCase):
@@ -276,8 +269,9 @@ class SimTotalconvolveTest(MPITestCase):
                         rtol=1e-3,
                         atol=1e-3,
                     ):
-                        import matplotlib.pyplot as plt
                         import pdb
+
+                        import matplotlib.pyplot as plt
 
                         pdb.set_trace()
                         fail = True

--- a/src/toast/tests/ops_sss.py
+++ b/src/toast/tests/ops_sss.py
@@ -4,25 +4,17 @@
 
 import os
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
-from .. import qarray as qa
-
 from .. import ops as ops
-
+from .. import qarray as qa
 from ..observation import default_values as defaults
-
 from ..pixels_io import write_healpix_fits
-
-from ._helpers import create_outdir, create_ground_data
+from ..vis import set_matplotlib_backend
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class SSSTest(MPITestCase):

--- a/src/toast/tests/ops_statistics.py
+++ b/src/toast/tests/ops_statistics.py
@@ -7,18 +7,13 @@ import os
 import h5py
 import numpy as np
 import scipy.stats as stats
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
 from ..observation import default_values as defaults
-
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class StatisticsTest(MPITestCase):

--- a/src/toast/tests/ops_time_constant.py
+++ b/src/toast/tests/ops_time_constant.py
@@ -6,24 +6,16 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 from astropy.table import Column
 
-from .mpi import MPITestCase
-
-from ..noise import Noise
-
 from .. import ops as ops
-
-from ..vis import set_matplotlib_backend
-
-from ..pixels import PixelDistribution, PixelData
-
 from .. import qarray as qa
-
-from ._helpers import create_outdir, create_satellite_data, create_fake_sky, fake_flags
-
+from ..noise import Noise
+from ..pixels import PixelData, PixelDistribution
+from ..vis import set_matplotlib_backend
+from ._helpers import create_fake_sky, create_outdir, create_satellite_data, fake_flags
+from .mpi import MPITestCase
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/tests/ops_yield_cut.py
+++ b/src/toast/tests/ops_yield_cut.py
@@ -7,18 +7,13 @@ import os
 import h5py
 import numpy as np
 import scipy.stats as stats
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..vis import set_matplotlib_backend
-
 from .. import ops as ops
-
 from ..observation import default_values as defaults
-
-from ._helpers import create_outdir, create_ground_data
+from ..vis import set_matplotlib_backend
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 
 class YieldCutTest(MPITestCase):

--- a/src/toast/tests/pixels.py
+++ b/src/toast/tests/pixels.py
@@ -2,21 +2,16 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 
+import healpy as hp
 import numpy as np
-
 import numpy.testing as nt
 
-import healpy as hp
-
-from ..pixels import PixelDistribution, PixelData
-
 from .. import pixels_io as io
-
+from ..pixels import PixelData, PixelDistribution
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class PixelTest(MPITestCase):

--- a/src/toast/tests/qarray.py
+++ b/src/toast/tests/qarray.py
@@ -4,9 +4,8 @@
 
 import numpy as np
 
-from .mpi import MPITestCase
-
 from .. import qarray as qa
+from .mpi import MPITestCase
 
 
 class QarrayTest(MPITestCase):

--- a/src/toast/tests/rng.py
+++ b/src/toast/tests/rng.py
@@ -2,13 +2,11 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
-from ..utils import AlignedU64
+import numpy as np
 
 from ..rng import random, random_multi
-
-import numpy as np
+from ..utils import AlignedU64
+from .mpi import MPITestCase
 
 
 class RNGTest(MPITestCase):

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -2,89 +2,73 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI, use_mpi
-
 import os
-import sys
 import shutil
-
+import sys
 import unittest
 
-from .mpi import MPITestRunner
-
-from ..vis import set_matplotlib_backend
-
-from .._libtoast import libtoast_tests
-
 from .. import timing
-
+from .._libtoast import libtoast_tests
+from ..mpi import MPI, use_mpi
+from ..spt3g import available as spt3g_available
+from ..vis import set_matplotlib_backend
+from . import accelerator as test_accelerator
+from . import config as test_config
+from . import covariance as test_covariance
+from . import dist as test_dist
 from . import env as test_env
-from . import timing as test_timing
-from . import rng as test_rng
-from . import math_misc as test_math_misc
 from . import fft as test_fft
 from . import healpix as test_healpix
-from . import qarray as test_qarray
 from . import instrument as test_instrument
 from . import intervals as test_intervals
-from . import pixels as test_pixels
-from . import weather as test_weather
+from . import io_hdf5 as test_io_hdf5
+from . import math_misc as test_math_misc
 from . import noise as test_noise
-
 from . import observation as test_observation
-
-from . import dist as test_dist
-
-from . import config as test_config
-
-from . import ops_sim_satellite as test_ops_sim_satellite
-from . import ops_sim_ground as test_ops_sim_ground
-from . import ops_memory_counter as test_ops_memory_counter
-from . import ops_pointing_healpix as test_ops_pointing_healpix
-from . import ops_sim_tod_noise as test_ops_sim_tod_noise
-from . import ops_sim_tod_dipole as test_ops_sim_tod_dipole
-from . import ops_sim_tod_atm as test_ops_sim_tod_atm
-from . import ops_sim_tod_conviqt as test_ops_sim_tod_conviqt
-
-from . import ops_sim_tod_totalconvolve as test_ops_sim_tod_totalconvolve
-
-from . import ops_flag_sso as test_ops_flag_sso
-from . import ops_statistics as test_ops_statistics
-from . import ops_mapmaker_utils as test_ops_mapmaker_utils
-from . import ops_mapmaker_binning as test_ops_mapmaker_binning
-from . import ops_mapmaker_solve as test_ops_mapmaker_solve
-from . import ops_mapmaker as test_ops_mapmaker
-from . import ops_scan_map as test_ops_scan_map
-from . import ops_scan_healpix as test_ops_scan_healpix
-from . import ops_madam as test_ops_madam
-
-from . import ops_gainscrambler as test_ops_gainscrambler
-from . import ops_sim_gaindrifts as test_ops_sim_gaindrifts
-from . import ops_sim_crosstalk as test_ops_sim_crosstalk
-from . import ops_polyfilter as test_ops_polyfilter
-from . import ops_groundfilter as test_ops_groundfilter
-from . import ops_sim_cosmic_rays as test_ops_sim_cosmic_rays
-from . import ops_time_constant as test_ops_time_constant
 from . import ops_cadence_map as test_ops_cadence_map
 from . import ops_crosslinking as test_ops_crosslinking
-from . import ops_sss as test_ops_sss
 from . import ops_demodulate as test_ops_demodulate
-from . import ops_filterbin as test_ops_filterbin
-from . import ops_noise_estim as test_ops_noise_estim
-from . import ops_yield_cut as test_ops_yield_cut
 from . import ops_elevation_noise as test_ops_elevation_noise
-
-from . import covariance as test_covariance
-
+from . import ops_filterbin as test_ops_filterbin
+from . import ops_flag_sso as test_ops_flag_sso
+from . import ops_gainscrambler as test_ops_gainscrambler
+from . import ops_groundfilter as test_ops_groundfilter
+from . import ops_madam as test_ops_madam
+from . import ops_mapmaker as test_ops_mapmaker
+from . import ops_mapmaker_binning as test_ops_mapmaker_binning
+from . import ops_mapmaker_solve as test_ops_mapmaker_solve
+from . import ops_mapmaker_utils as test_ops_mapmaker_utils
+from . import ops_memory_counter as test_ops_memory_counter
+from . import ops_noise_estim as test_ops_noise_estim
+from . import ops_pointing_healpix as test_ops_pointing_healpix
+from . import ops_polyfilter as test_ops_polyfilter
+from . import ops_scan_healpix as test_ops_scan_healpix
+from . import ops_scan_map as test_ops_scan_map
+from . import ops_sim_cosmic_rays as test_ops_sim_cosmic_rays
+from . import ops_sim_crosstalk as test_ops_sim_crosstalk
+from . import ops_sim_gaindrifts as test_ops_sim_gaindrifts
+from . import ops_sim_ground as test_ops_sim_ground
+from . import ops_sim_satellite as test_ops_sim_satellite
+from . import ops_sim_tod_atm as test_ops_sim_tod_atm
+from . import ops_sim_tod_conviqt as test_ops_sim_tod_conviqt
+from . import ops_sim_tod_dipole as test_ops_sim_tod_dipole
+from . import ops_sim_tod_noise as test_ops_sim_tod_noise
+from . import ops_sim_tod_totalconvolve as test_ops_sim_tod_totalconvolve
+from . import ops_sss as test_ops_sss
+from . import ops_statistics as test_ops_statistics
+from . import ops_time_constant as test_ops_time_constant
+from . import ops_yield_cut as test_ops_yield_cut
+from . import pixels as test_pixels
+from . import qarray as test_qarray
+from . import rng as test_rng
 from . import template_amplitudes as test_template_amplitudes
-from . import template_offset as test_template_offset
 from . import template_fourier2d as test_template_fourier2d
-from . import template_subharmonic as test_template_subharmonic
 from . import template_gain as test_template_gain
-
-from . import io_hdf5 as test_io_hdf5
-
-from . import accelerator as test_accelerator
+from . import template_offset as test_template_offset
+from . import template_subharmonic as test_template_subharmonic
+from . import timing as test_timing
+from . import weather as test_weather
+from .mpi import MPITestRunner
 
 #
 # from . import psd_math as testpsdmath
@@ -117,7 +101,6 @@ from . import accelerator as test_accelerator
 # tidas_available = False
 #
 
-from ..spt3g import available as spt3g_available
 
 if spt3g_available:
     from . import spt3g as test_spt3g

--- a/src/toast/tests/spt3g.py
+++ b/src/toast/tests/spt3g.py
@@ -5,39 +5,33 @@
 import os
 
 import numpy as np
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
 from .. import ops as ops
-
-from ..mpi import MPI
-
 from ..data import Data
-
-from ._helpers import create_outdir, create_ground_data
-
+from ..mpi import MPI
 from ..spt3g import (
     available,
-    from_g3_unit,
-    to_g3_unit,
-    from_g3_time,
-    to_g3_time,
-    from_g3_scalar_type,
-    to_g3_scalar_type,
+    export_obs,
+    export_obs_data,
+    export_obs_meta,
     from_g3_array_type,
+    from_g3_quats,
+    from_g3_scalar_type,
+    from_g3_time,
+    from_g3_unit,
+    import_obs,
+    import_obs_data,
+    import_obs_meta,
     to_g3_array_type,
     to_g3_map_array_type,
-    from_g3_quats,
     to_g3_quats,
-    export_obs_meta,
-    export_obs_data,
-    export_obs,
-    import_obs_meta,
-    import_obs_data,
-    import_obs,
+    to_g3_scalar_type,
+    to_g3_time,
+    to_g3_unit,
 )
+from ._helpers import create_ground_data, create_outdir
+from .mpi import MPITestCase
 
 if available:
     from spt3g import core as c3g

--- a/src/toast/tests/template_amplitudes.py
+++ b/src/toast/tests/template_amplitudes.py
@@ -6,20 +6,14 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..utils import rate_from_times
-
-from ..dist import distribute_uniform
-
 from .. import ops
-
+from ..dist import distribute_uniform
 from ..templates import Amplitudes, AmplitudesMap
-
-from ._helpers import create_outdir, create_comm
+from ..utils import rate_from_times
+from ._helpers import create_comm, create_outdir
+from .mpi import MPITestCase
 
 
 class TemplateTest(MPITestCase):

--- a/src/toast/tests/template_fourier2d.py
+++ b/src/toast/tests/template_fourier2d.py
@@ -6,20 +6,14 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..utils import rate_from_times
-
 from .. import ops
-
 from ..observation import default_values as defaults
-
 from ..templates import Fourier2D
-
+from ..utils import rate_from_times
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class TemplateFourier2DTest(MPITestCase):

--- a/src/toast/tests/template_gain.py
+++ b/src/toast/tests/template_gain.py
@@ -6,18 +6,13 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..utils import rate_from_times
-
 from .. import ops
-
 from ..templates import GainTemplate
-
+from ..utils import rate_from_times
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class TemplateGainTest(MPITestCase):

--- a/src/toast/tests/template_offset.py
+++ b/src/toast/tests/template_offset.py
@@ -6,20 +6,14 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..utils import rate_from_times
-
 from .. import ops
-
 from ..observation import default_values as defaults
-
 from ..templates import Offset
-
+from ..utils import rate_from_times
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class TemplateOffsetTest(MPITestCase):

--- a/src/toast/tests/template_subharmonic.py
+++ b/src/toast/tests/template_subharmonic.py
@@ -6,20 +6,14 @@ import os
 
 import numpy as np
 import numpy.testing as nt
-
 from astropy import units as u
 
-from .mpi import MPITestCase
-
-from ..utils import rate_from_times
-
 from .. import ops
-
 from ..observation import default_values as defaults
-
 from ..templates import SubHarmonic
-
+from ..utils import rate_from_times
 from ._helpers import create_outdir, create_satellite_data
+from .mpi import MPITestCase
 
 
 class TemplateSubHarmonicTest(MPITestCase):

--- a/src/toast/tests/timing.py
+++ b/src/toast/tests/timing.py
@@ -3,17 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-import time
-
 import pickle
+import time
 
 import numpy as np
 
-from .mpi import MPITestCase
-
-from ..timing import Timer, GlobalTimers, function_timer, gather_timers, dump
-
+from ..timing import GlobalTimers, Timer, dump, function_timer, gather_timers
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 @function_timer

--- a/src/toast/tests/weather.py
+++ b/src/toast/tests/weather.py
@@ -4,15 +4,12 @@
 
 from datetime import datetime
 
-import numpy as np
-
 import astropy.units as u
-
-from .mpi import MPITestCase
-
+import numpy as np
 import numpy.testing as nt
 
-from ..weather import Weather, SimWeather
+from ..weather import SimWeather, Weather
+from .mpi import MPITestCase
 
 
 class WeatherTest(MPITestCase):

--- a/src/toast/timing.py
+++ b/src/toast/timing.py
@@ -2,23 +2,17 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import csv
+import inspect
 import os
 import re
-
-import inspect
-
-from functools import wraps
-
-import csv
-
 from collections import OrderedDict
+from functools import wraps
 
 import numpy as np
 
-from ._libtoast import Timer, GlobalTimers
-
+from ._libtoast import GlobalTimers, Timer
 from .utils import Environment
-
 
 stack_toast_file_pat = re.compile(r".*(toast.*)\.py")
 

--- a/src/toast/traits.py
+++ b/src/toast/traits.py
@@ -2,33 +2,30 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import re
 import copy
-
+import re
 from collections import OrderedDict
 
 import traitlets
-
+from astropy import units as u
 from traitlets import (
-    signature_has_traits,
-    HasTraits,
-    TraitError,
-    Undefined,
-    Unicode,
     Bool,
-    List,
-    Set,
+    Callable,
     Dict,
-    Tuple,
+    Float,
+    HasTraits,
     Instance,
     Int,
-    Float,
-    Callable,
+    List,
+    Set,
+    TraitError,
+    Tuple,
+    Undefined,
+    Unicode,
+    signature_has_traits,
 )
 
-from astropy import units as u
-
-from .utils import object_fullname, import_from_name
+from .utils import import_from_name, object_fullname
 
 
 class Quantity(Float):

--- a/src/toast/unported/cache.py
+++ b/src/toast/unported/cache.py
@@ -2,22 +2,23 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import re
 import ctypes
+import re
+
 import numpy as np
 
 from .utils import (
-    Logger,
-    AlignedI8,
-    AlignedU8,
-    AlignedI16,
-    AlignedU16,
-    AlignedI32,
-    AlignedU32,
-    AlignedI64,
-    AlignedU64,
     AlignedF32,
     AlignedF64,
+    AlignedI8,
+    AlignedI16,
+    AlignedI32,
+    AlignedI64,
+    AlignedU8,
+    AlignedU16,
+    AlignedU32,
+    AlignedU64,
+    Logger,
 )
 
 

--- a/src/toast/unported/fod/__init__.py
+++ b/src/toast/unported/fod/__init__.py
@@ -2,6 +2,5 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .psd_math import autocov_psd, crosscov_psd
-
 from .noise_estimation import OpNoiseEstim
+from .psd_math import autocov_psd, crosscov_psd

--- a/src/toast/unported/map/__init__.py
+++ b/src/toast/unported/map/__init__.py
@@ -4,11 +4,10 @@
 
 # import functions in our public API
 
-from .pixels import DistPixels
-
 from .cov import (
-    covariance_invert,
-    covariance_rcond,
-    covariance_multiply,
     covariance_apply,
+    covariance_invert,
+    covariance_multiply,
+    covariance_rcond,
 )
+from .pixels import DistPixels

--- a/src/toast/unported/map/cov.py
+++ b/src/toast/unported/map/cov.py
@@ -4,12 +4,9 @@
 
 import numpy as np
 
-from ..timing import function_timer
-
+from .._libtoast import cov_apply_diag, cov_eigendecompose_diag, cov_mult_diag
 from ..operator import Operator
-
-from .._libtoast import cov_mult_diag, cov_apply_diag, cov_eigendecompose_diag
-
+from ..timing import function_timer
 from .pixels import DistPixels
 
 

--- a/src/toast/unported/map/pixels.py
+++ b/src/toast/unported/map/pixels.py
@@ -4,19 +4,14 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 
-from ..timing import function_timer, Timer
-
-from ..mpi import MPI
-
-import healpy as hp
-
-from ..operator import Operator
-
-from ..cache import Cache
-
 from .._libtoast import global_to_local as libtoast_global_to_local
+from ..cache import Cache
+from ..mpi import MPI
+from ..operator import Operator
+from ..timing import Timer, function_timer
 
 
 class DistPixels(object):

--- a/src/toast/unported/pipeline_tools/__init__.py
+++ b/src/toast/unported/pipeline_tools/__init__.py
@@ -4,52 +4,51 @@
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
+from ..timing import Timer, function_timer
+from ..utils import Environment, Logger
 from .atm import (
     add_atmosphere_args,
-    simulate_atmosphere,
     scale_atmosphere_by_frequency,
+    simulate_atmosphere,
     update_atmospheric_noise_weights,
 )
-from .binning import add_binner_args, init_binner, apply_binner
+from .binning import add_binner_args, apply_binner, init_binner
 from .debug import add_debug_args
 from .dipole import add_dipole_args, simulate_dipole
 from .dist import add_dist_args, get_comm, get_time_communicators
-from .export import add_tidas_args, output_tidas, add_spt3g_args, output_spt3g
+from .export import add_spt3g_args, add_tidas_args, output_spt3g, output_tidas
 from .filters import (
-    add_polyfilter_args,
+    add_groundfilter_args,
     add_polyfilter2D_args,
+    add_polyfilter_args,
+    apply_groundfilter,
     apply_polyfilter,
     apply_polyfilter2D,
-    add_groundfilter_args,
-    apply_groundfilter,
 )
 from .gain import add_gainscrambler_args, scramble_gains
+from .madam import add_madam_args, apply_madam, setup_madam
 from .mapmaker import add_mapmaker_args, apply_mapmaker
-from .madam import add_madam_args, setup_madam, apply_madam
-from .noise import add_noise_args, simulate_noise, get_analytic_noise
+from .noise import add_noise_args, get_analytic_noise, simulate_noise
 from .pointing import add_pointing_args, expand_pointing
 from .sky_signal import (
-    add_sky_map_args,
-    add_pysm_args,
-    scan_sky_signal,
-    simulate_sky_signal,
     add_conviqt_args,
+    add_pysm_args,
+    add_sky_map_args,
     apply_conviqt,
     apply_weighted_conviqt,
+    scan_sky_signal,
+    simulate_sky_signal,
 )
 from .sss import add_sss_args, simulate_sss
 from .todground import (
-    add_todground_args,
-    get_elevation_noise,
-    get_breaks,
-    load_schedule,
-    load_weather,
-    Site,
     CES,
     Schedule,
+    Site,
+    add_todground_args,
+    get_breaks,
+    get_elevation_noise,
+    load_schedule,
+    load_weather,
 )
 from .todsatellite import add_todsatellite_args
 

--- a/src/toast/unported/pipeline_tools/atm.py
+++ b/src/toast/unported/pipeline_tools/atm.py
@@ -8,19 +8,17 @@ import os
 import numpy as np
 from scipy.constants import h, k
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
 from .. import qarray as qa
-
+from ..timing import Timer, function_timer
 from ..todmap import OpSimAtmosphere, atm_available_utils
+from ..utils import Environment, Logger
 
 if atm_available_utils:
     from ..todmap.atm import (
-        atm_atmospheric_loading,
-        atm_atmospheric_loading_vec,
         atm_absorption_coefficient,
         atm_absorption_coefficient_vec,
+        atm_atmospheric_loading,
+        atm_atmospheric_loading_vec,
     )
 
 

--- a/src/toast/unported/pipeline_tools/binning.py
+++ b/src/toast/unported/pipeline_tools/binning.py
@@ -8,10 +8,10 @@ import os
 import numpy as np
 from healpy import nside2npix
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-from ..map import covariance_apply, covariance_invert, DistPixels
-from ..todmap import OpSimDipole, OpAccumDiag
+from ..map import DistPixels, covariance_apply, covariance_invert
+from ..timing import Timer, function_timer
+from ..todmap import OpAccumDiag, OpSimDipole
+from ..utils import Environment, Logger
 
 
 def add_binner_args(parser):

--- a/src/toast/unported/pipeline_tools/classes.py
+++ b/src/toast/unported/pipeline_tools/classes.py
@@ -8,11 +8,10 @@ import sys
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..tod import AnalyticNoise
-from ..utils import Logger, Environment
 from .. import qarray
-
+from ..timing import Timer, function_timer
+from ..tod import AnalyticNoise
+from ..utils import Environment, Logger
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/unported/pipeline_tools/debug.py
+++ b/src/toast/unported/pipeline_tools/debug.py
@@ -5,8 +5,8 @@
 import argparse
 import os
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
+from ..timing import Timer, function_timer
+from ..utils import Environment, Logger
 
 
 def add_debug_args(parser):

--- a/src/toast/unported/pipeline_tools/dipole.py
+++ b/src/toast/unported/pipeline_tools/dipole.py
@@ -7,9 +7,9 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
+from ..timing import Timer, function_timer
 from ..todmap import OpSimDipole
-from ..utils import Logger, Environment
+from ..utils import Environment, Logger
 
 
 def add_dipole_args(parser):

--- a/src/toast/unported/pipeline_tools/dist.py
+++ b/src/toast/unported/pipeline_tools/dist.py
@@ -3,14 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import argparse
-from datetime import datetime
 import os
+from datetime import datetime
 
 import numpy as np
 
-from ..mpi import get_world, Comm
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
+from ..mpi import Comm, get_world
+from ..timing import Timer, function_timer
+from ..utils import Environment, Logger
 
 
 def add_dist_args(parser):

--- a/src/toast/unported/pipeline_tools/export.py
+++ b/src/toast/unported/pipeline_tools/export.py
@@ -7,10 +7,9 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
-from ..tod import tidas_available, spt3g_available
+from ..timing import Timer, function_timer
+from ..tod import spt3g_available, tidas_available
+from ..utils import Environment, Logger
 
 if tidas_available:
     from ..tod.tidas import OpTidasExport, TODTidas

--- a/src/toast/unported/pipeline_tools/filters.py
+++ b/src/toast/unported/pipeline_tools/filters.py
@@ -6,8 +6,8 @@ import argparse
 
 import numpy as np
 
-from toast.timing import function_timer, Timer
-from toast.utils import Logger, Environment
+from toast.timing import Timer, function_timer
+from toast.utils import Environment, Logger
 
 from ..tod import OpPolyFilter, OpPolyFilter2D
 from ..todmap import OpGroundFilter

--- a/src/toast/unported/pipeline_tools/gain.py
+++ b/src/toast/unported/pipeline_tools/gain.py
@@ -7,10 +7,9 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
+from ..timing import Timer, function_timer
 from ..tod import OpGainScrambler
+from ..utils import Environment, Logger
 
 
 def add_gainscrambler_args(parser):

--- a/src/toast/unported/pipeline_tools/madam.py
+++ b/src/toast/unported/pipeline_tools/madam.py
@@ -9,10 +9,9 @@ import re
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
+from ..timing import Timer, function_timer
 from ..todmap import OpMadam
+from ..utils import Environment, Logger
 
 
 def add_madam_args(parser):

--- a/src/toast/unported/pipeline_tools/mapmaker.py
+++ b/src/toast/unported/pipeline_tools/mapmaker.py
@@ -9,11 +9,10 @@ import re
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
-from ..todmap import OpMapMaker
+from ..timing import Timer, function_timer
 from ..tod import OpPolyFilter
+from ..todmap import OpMapMaker
+from ..utils import Environment, Logger
 
 
 def add_mapmaker_args(parser):

--- a/src/toast/unported/pipeline_tools/noise.py
+++ b/src/toast/unported/pipeline_tools/noise.py
@@ -7,10 +7,9 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
+from ..timing import Timer, function_timer
 from ..tod import AnalyticNoise, OpSimNoise
+from ..utils import Environment, Logger
 
 
 def add_noise_args(parser):

--- a/src/toast/unported/pipeline_tools/pointing.py
+++ b/src/toast/unported/pipeline_tools/pointing.py
@@ -7,11 +7,10 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
 from ..map import DistPixels
+from ..timing import Timer, function_timer
 from ..todmap import OpMadam, OpPointingHpix
+from ..utils import Environment, Logger
 
 
 def add_pointing_args(parser):

--- a/src/toast/unported/pipeline_tools/sky_signal.py
+++ b/src/toast/unported/pipeline_tools/sky_signal.py
@@ -7,11 +7,10 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
 from ..map import DistPixels
-from ..todmap import OpSimPySM, OpSimScan, OpMadam, OpSimConviqt, OpSimWeightedConviqt
+from ..timing import Timer, function_timer
+from ..todmap import OpMadam, OpSimConviqt, OpSimPySM, OpSimScan, OpSimWeightedConviqt
+from ..utils import Environment, Logger
 
 
 def add_sky_signal_args(parser):

--- a/src/toast/unported/pipeline_tools/sss.py
+++ b/src/toast/unported/pipeline_tools/sss.py
@@ -7,10 +7,9 @@ import os
 
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
-
+from ..timing import Timer, function_timer
 from ..todmap import OpSimScanSynchronousSignal
+from ..utils import Environment, Logger
 
 
 def add_sss_args(parser):

--- a/src/toast/unported/pipeline_tools/todground.py
+++ b/src/toast/unported/pipeline_tools/todground.py
@@ -3,18 +3,17 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import argparse
-import dateutil.parser
 import os
 
+import dateutil.parser
 import healpy as hp
 import numpy as np
 
 from .. import qarray
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
+from ..timing import Timer, function_timer
+from ..utils import Environment, Logger
 from ..weather import Weather
-
-from .classes import Telescope, Focalplane
+from .classes import Focalplane, Telescope
 from .debug import add_debug_args
 
 # Schedule, Site and CES are small helper classes for building

--- a/src/toast/unported/pipeline_tools/todsatellite.py
+++ b/src/toast/unported/pipeline_tools/todsatellite.py
@@ -3,14 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import argparse
-import dateutil.parser
 import os
 
+import dateutil.parser
 import healpy as hp
 import numpy as np
 
-from ..timing import function_timer, Timer
-from ..utils import Logger, Environment
+from ..timing import Timer, function_timer
+from ..utils import Environment, Logger
 
 # from ..tod import OpSimAtmosphere, atm_available_utils
 

--- a/src/toast/unported/pipelines/toast_benchmark.py
+++ b/src/toast/unported/pipelines/toast_benchmark.py
@@ -21,46 +21,32 @@ import time
 wait = random.uniform(0.0, startup_delay)
 time.sleep(wait)
 
-from toast.mpi import MPI
+import argparse
+import copy
 
 # Now import the remaining modules
 import os
-import sys
-import re
-import copy
-import argparse
-import traceback
 import pickle
-
+import re
+import sys
+import traceback
 from datetime import datetime
 
+import healpy as hp
+import numpy as np
 import psutil
 
-import numpy as np
-
-import healpy as hp
-
-from toast.mpi import get_world, Comm
-
-from toast.dist import distribute_uniform, Data, distribute_discrete
-
-from toast.utils import Logger, Environment, memreport
-
-from toast.timing import function_timer, GlobalTimers, Timer, gather_timers
-from toast.timing import dump as dump_timing
-
-from toast.todmap import TODGround
-
-from toast import pipeline_tools
-
-from toast import rng
-
+from toast import pipeline_tools, rng
+from toast.dist import Data, distribute_discrete, distribute_uniform
+from toast.mpi import MPI, Comm, get_world
 from toast.pipeline_tools import Focalplane
-
-from toast.tod.sim_focalplane import hex_pol_angles_qu, hex_layout, hex_nring
-
 from toast.schedule import run_scheduler
-
+from toast.timing import GlobalTimers, Timer
+from toast.timing import dump as dump_timing
+from toast.timing import function_timer, gather_timers
+from toast.tod.sim_focalplane import hex_layout, hex_nring, hex_pol_angles_qu
+from toast.todmap import TODGround
+from toast.utils import Environment, Logger, memreport
 
 # This function is part of the package in TOAST 3.0.  Remove this here when porting.
 

--- a/src/toast/unported/pipelines/toast_cache_test.py
+++ b/src/toast/unported/pipelines/toast_cache_test.py
@@ -18,18 +18,17 @@ Then it frees the buffers of a given type from all detectors and
 compares the resulting change to what is expected.
 
 """
+import argparse
 import os
 import re
 import sys
-import argparse
 import traceback
-import psutil
 
 import numpy as np
-
-from toast.utils import Logger
+import psutil
 
 from toast.cache import Cache
+from toast.utils import Logger
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_cov_invert.py
+++ b/src/toast/unported/pipelines/toast_cov_invert.py
@@ -6,23 +6,19 @@
 
 """Invert a block diagonal covariance matrix.
 """
+import argparse
 import os
 import re
 import sys
-import argparse
 import traceback
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from toast.mpi import get_world
-
-from toast.utils import Logger
-
 from toast.dist import distribute_uniform
-
 from toast.map import DistPixels, covariance_invert
+from toast.mpi import get_world
+from toast.utils import Logger
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_cov_rcond.py
+++ b/src/toast/unported/pipelines/toast_cov_rcond.py
@@ -6,23 +6,19 @@
 
 """Invert a block diagonal covariance matrix.
 """
+import argparse
 import os
 import re
 import sys
-import argparse
 import traceback
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from toast.mpi import get_world
-
-from toast.utils import Logger
-
 from toast.dist import distribute_uniform
-
 from toast.map import DistPixels, covariance_rcond
+from toast.mpi import get_world
+from toast.utils import Logger
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_env_test.py
+++ b/src/toast/unported/pipelines/toast_env_test.py
@@ -7,13 +7,12 @@
 """This does some simple tests of the TOAST runtime environment.
 """
 
-import sys
 import argparse
+import sys
 import traceback
 
-from toast.mpi import get_world, Comm
-
-from toast.utils import Logger, Environment, numba_threading_layer
+from toast.mpi import Comm, get_world
+from toast.utils import Environment, Logger, numba_threading_layer
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_fake_focalplane.py
+++ b/src/toast/unported/pipelines/toast_fake_focalplane.py
@@ -7,21 +7,17 @@
 """Generate a focalplane pickle file compatible with the example scripts.
 """
 
-import sys
 import argparse
+import pickle
+import sys
 import traceback
 
-import pickle
-
 import numpy as np
-
 from scipy.constants import degree
 
 from toast.mpi import get_world
-
+from toast.tod import hex_layout, hex_pol_angles_qu, plot_focalplane
 from toast.utils import Logger
-
-from toast.tod import hex_pol_angles_qu, hex_layout, plot_focalplane
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_future.py
+++ b/src/toast/unported/pipelines/toast_future.py
@@ -8,36 +8,25 @@
 Prototype of TOAST 3.0 interfaces
 """
 
+import argparse
 import os
 import sys
-
-import argparse
-
 import traceback
 
 import numpy as np
 
 import toast
-
-from toast import qarray as qa
-
 from toast import Telescope
-
-from toast.mpi import get_world, Comm
-
-from toast.data import Data
-
-from toast.utils import Logger, Environment
-
-from toast.timing import GlobalTimers, gather_timers
-
-from toast.timing import dump as dump_timing
-
-from toast.config import dump_toml, parse_config, create
-
 from toast import future_ops as ops
-
+from toast import qarray as qa
+from toast.config import create, dump_toml, parse_config
+from toast.data import Data
 from toast.future_ops.sim_focalplane import fake_hexagon_focalplane
+from toast.mpi import Comm, get_world
+from toast.timing import GlobalTimers
+from toast.timing import dump as dump_timing
+from toast.timing import gather_timers
+from toast.utils import Environment, Logger
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_ground_schedule.py
+++ b/src/toast/unported/pipelines/toast_ground_schedule.py
@@ -13,8 +13,8 @@ import sys
 import traceback
 
 from toast.mpi import get_world
-from toast.timing import GlobalTimers
 from toast.schedule_sim_ground import run_scheduler
+from toast.timing import GlobalTimers
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_ground_sim.py
+++ b/src/toast/unported/pipelines/toast_ground_sim.py
@@ -12,8 +12,9 @@ This script runs a ground simulation and makes a map.
 import os
 
 if "TOAST_STARTUP_DELAY" in os.environ:
-    import numpy as np
     import time
+
+    import numpy as np
 
     delay = np.float(os.environ["TOAST_STARTUP_DELAY"])
     wait = np.random.rand() * delay
@@ -21,26 +22,22 @@ if "TOAST_STARTUP_DELAY" in os.environ:
     #      flush=True)
     time.sleep(wait)
 
-import copy
-import sys
 import argparse
-import traceback
+import copy
 import pickle
+import sys
+import traceback
 
 import numpy as np
 
-from toast.mpi import get_world, Comm
-
-from toast.dist import distribute_uniform, Data
-
-from toast.utils import Logger, Environment, memreport
-
-from toast.timing import function_timer, GlobalTimers, Timer, gather_timers
-from toast.timing import dump as dump_timing
-
-from toast.todmap import TODGround
-
 from toast import pipeline_tools
+from toast.dist import Data, distribute_uniform
+from toast.mpi import Comm, get_world
+from toast.timing import GlobalTimers, Timer
+from toast.timing import dump as dump_timing
+from toast.timing import function_timer, gather_timers
+from toast.todmap import TODGround
+from toast.utils import Environment, Logger, memreport
 
 # import warnings
 # warnings.filterwarnings('error')

--- a/src/toast/unported/pipelines/toast_ground_sim_simple.py
+++ b/src/toast/unported/pipelines/toast_ground_sim_simple.py
@@ -9,64 +9,60 @@ Simpler version of the ground simulation script
 """
 
 import argparse
-import dateutil.parser
 import os
 import pickle
 import sys
 import traceback
 
+import dateutil.parser
 import numpy as np
 
-from toast.mpi import get_world, Comm
-
-from toast.dist import distribute_uniform, Data
-
-from toast.utils import Logger, Environment, memreport
-
-from toast.timing import function_timer, GlobalTimers, Timer, gather_timers
-from toast.timing import dump as dump_timing
-
 import toast.qarray as qa
-from toast.tod import OpCacheCopy, plot_focalplane, OpCacheClear
-from toast.todmap import TODGround
-
+from toast.dist import Data, distribute_uniform
+from toast.mpi import Comm, get_world
 from toast.pipeline_tools import (
-    add_dist_args,
-    add_debug_args,
-    get_time_communicators,
-    get_comm,
-    add_polyfilter_args,
-    apply_polyfilter,
-    add_groundfilter_args,
-    apply_groundfilter,
-    add_atmosphere_args,
-    add_noise_args,
-    simulate_noise,
-    add_gainscrambler_args,
-    scramble_gains,
-    add_pointing_args,
-    expand_pointing,
-    add_madam_args,
-    setup_madam,
-    apply_madam,
-    add_sky_map_args,
-    add_pysm_args,
-    scan_sky_signal,
-    simulate_sky_signal,
-    copy_signal,
-    add_tidas_args,
-    output_tidas,
-    add_spt3g_args,
-    output_spt3g,
-    add_todground_args,
-    get_breaks,
     Focalplane,
-    load_schedule,
-    add_mc_args,
+    add_atmosphere_args,
     add_binner_args,
-    init_binner,
+    add_debug_args,
+    add_dist_args,
+    add_gainscrambler_args,
+    add_groundfilter_args,
+    add_madam_args,
+    add_mc_args,
+    add_noise_args,
+    add_pointing_args,
+    add_polyfilter_args,
+    add_pysm_args,
+    add_sky_map_args,
+    add_spt3g_args,
+    add_tidas_args,
+    add_todground_args,
     apply_binner,
+    apply_groundfilter,
+    apply_madam,
+    apply_polyfilter,
+    copy_signal,
+    expand_pointing,
+    get_breaks,
+    get_comm,
+    get_time_communicators,
+    init_binner,
+    load_schedule,
+    output_spt3g,
+    output_tidas,
+    scan_sky_signal,
+    scramble_gains,
+    setup_madam,
+    simulate_noise,
+    simulate_sky_signal,
 )
+from toast.timing import GlobalTimers, Timer
+from toast.timing import dump as dump_timing
+from toast.timing import function_timer, gather_timers
+from toast.tod import OpCacheClear, OpCacheCopy, plot_focalplane
+from toast.todmap import TODGround
+from toast.utils import Environment, Logger, memreport
 
 
 def parse_arguments(comm):

--- a/src/toast/unported/pipelines/toast_map.py
+++ b/src/toast/unported/pipelines/toast_map.py
@@ -7,28 +7,23 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from toast.mpi import MPI, finalize
-
+import argparse
 import os
+import pickle
+import re
 import sys
 import time
-
-import re
-import argparse
 import traceback
-
-import pickle
 
 import numpy as np
 
 import toast
-import toast.tod as tt
 import toast.map as tm
-import toast.todmap as ttm
-
 import toast.qarray as qa
 import toast.timing as timing
-
+import toast.tod as tt
+import toast.todmap as ttm
+from toast.mpi import MPI, finalize
 from toast.vis import set_backend
 
 if tt.tidas_available:

--- a/src/toast/unported/pipelines/toast_pixel_comm.py
+++ b/src/toast/unported/pipelines/toast_pixel_comm.py
@@ -8,42 +8,28 @@
 Distributed map communication tests.
 """
 
+import argparse
 import os
 import sys
-
-import argparse
-
 import traceback
 
+import healpy as hp
 import numpy as np
-
 from astropy import units as u
 
-import healpy as hp
-
 import toast
-
-from toast.mpi import get_world, Comm
-
-from toast.data import Data
-
-from toast.utils import Logger, Environment
-
-from toast.timing import Timer, GlobalTimers, gather_timers
-
-from toast.timing import dump as dump_timing
-
-from toast.config import dump_toml, parse_config, create
-
-from toast.pixels import PixelDistribution, PixelData
-
-from toast.pixels_io import write_healpix_fits
-
 from toast import future_ops as ops
-
-from toast.instrument_sim import fake_hexagon_focalplane
-
+from toast.config import create, dump_toml, parse_config
+from toast.data import Data
 from toast.instrument import Telescope
+from toast.instrument_sim import fake_hexagon_focalplane
+from toast.mpi import Comm, get_world
+from toast.pixels import PixelData, PixelDistribution
+from toast.pixels_io import write_healpix_fits
+from toast.timing import GlobalTimers, Timer
+from toast.timing import dump as dump_timing
+from toast.timing import gather_timers
+from toast.utils import Environment, Logger
 
 
 def main():

--- a/src/toast/unported/pipelines/toast_satellite_sim.py
+++ b/src/toast/unported/pipelines/toast_satellite_sim.py
@@ -8,33 +8,26 @@
 This script runs a satellite simulation and makes a map.
 """
 
-import os
-import sys
-import re
 import argparse
+import os
+import pickle
+import re
+import sys
 import traceback
 
-import pickle
-
 import numpy as np
-
 from astropy.io import fits
 
-from toast.mpi import get_world, Comm
-
-from toast.dist import distribute_uniform, Data
-
-from toast.utils import Logger, Environment
-
-from toast.vis import set_backend
-
-from toast.timing import function_timer, GlobalTimers, Timer, gather_timers
-from toast.timing import dump as dump_timing
-
-from toast.tod import regular_intervals, plot_focalplane, OpApplyGain
-from toast.todmap import TODSatellite, slew_precession_axis
-
 from toast import pipeline_tools
+from toast.dist import Data, distribute_uniform
+from toast.mpi import Comm, get_world
+from toast.timing import GlobalTimers, Timer
+from toast.timing import dump as dump_timing
+from toast.timing import function_timer, gather_timers
+from toast.tod import OpApplyGain, plot_focalplane, regular_intervals
+from toast.todmap import TODSatellite, slew_precession_axis
+from toast.utils import Environment, Logger
+from toast.vis import set_backend
 
 
 def parse_arguments(comm, procs):

--- a/src/toast/unported/tests/binned.py
+++ b/src/toast/unported/tests/binned.py
@@ -2,27 +2,23 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
 
-import healpy as hp
-
-from ..tod import AnalyticNoise, OpSimNoise, regular_intervals, OpFlagGaps
-from ..todmap import TODSatellite, OpPointingHpix, OpMadam, OpAccumDiag
-
-from ..map import DistPixels, covariance_invert, covariance_apply
-
+from ..map import DistPixels, covariance_apply, covariance_invert
+from ..tod import AnalyticNoise, OpFlagGaps, OpSimNoise, regular_intervals
+from ..todmap import OpAccumDiag, OpMadam, OpPointingHpix, TODSatellite
 from ._helpers import (
-    create_outdir,
-    create_distdata,
     boresight_focalplane,
+    create_distdata,
+    create_outdir,
     uniform_chunks,
 )
+from .mpi import MPITestCase
 
 
 class BinnedTest(MPITestCase):

--- a/src/toast/unported/tests/cache.py
+++ b/src/toast/unported/tests/cache.py
@@ -2,17 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import ctypes
 import sys
 
 import numpy as np
 
-import ctypes
-
-from .mpi import MPITestCase
-
 from ..cache import Cache
-
 from ..utils import AlignedF64, memreport
+from .mpi import MPITestCase
 
 
 class CacheTest(MPITestCase):

--- a/src/toast/unported/tests/map_ground.py
+++ b/src/toast/unported/tests/map_ground.py
@@ -2,22 +2,18 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
 
-import healpy as hp
-
-from ..tod import AnalyticNoise, OpSimNoise
-from ..todmap import TODGround, OpPointingHpix, OpSimGradient, OpSimScan, OpMadam
-
 from ..map import DistPixels
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ..tod import AnalyticNoise, OpSimNoise
+from ..todmap import OpMadam, OpPointingHpix, OpSimGradient, OpSimScan, TODGround
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class MapGroundTest(MPITestCase):

--- a/src/toast/unported/tests/map_satellite.py
+++ b/src/toast/unported/tests/map_satellite.py
@@ -2,37 +2,32 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
 
-import healpy as hp
-
 from .. import qarray as qa
-
+from ..map import DistPixels
 from ..tod import AnalyticNoise, OpSimNoise
 from ..todmap import (
-    TODSatellite,
+    OpMadam,
     OpPointingHpix,
     OpSimGradient,
-    slew_precession_axis,
-    satellite_scanning,
     OpSimScan,
-    OpMadam,
+    TODSatellite,
+    satellite_scanning,
+    slew_precession_axis,
 )
-
-from ..map import DistPixels
-
 from ._helpers import (
-    create_outdir,
-    create_distdata,
     boresight_focalplane,
+    create_distdata,
+    create_outdir,
     uniform_chunks,
 )
+from .mpi import MPITestCase
 
 
 class MapSatelliteTest(MPITestCase):

--- a/src/toast/unported/tests/ops_applygain.py
+++ b/src/toast/unported/tests/ops_applygain.py
@@ -6,13 +6,10 @@ import os
 
 import numpy as np
 
-from .mpi import MPITestCase
-
-from ..tod.applygain import write_calibration_file, OpApplyGain
-
+from ..tod.applygain import OpApplyGain, write_calibration_file
 from ..tod.tod import TODCache
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class TestApplyGain(MPITestCase):

--- a/src/toast/unported/tests/ops_dipole.py
+++ b/src/toast/unported/tests/ops_dipole.py
@@ -2,28 +2,17 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 
+import healpy as hp
 import numpy as np
 import numpy.testing as nt
 
-import healpy as hp
-
 from .. import qarray as qa
-
-from ..todmap import (
-    TODHpixSpiral,
-    OpPointingHpix,
-    OpSimDipole,
-    dipole,
-    OpAccumDiag,
-)
-
-from ..map import DistPixels, covariance_invert, covariance_apply
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ..map import DistPixels, covariance_apply, covariance_invert
+from ..todmap import OpAccumDiag, OpPointingHpix, OpSimDipole, TODHpixSpiral, dipole
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class OpSimDipoleTest(MPITestCase):

--- a/src/toast/unported/tests/ops_madam.py
+++ b/src/toast/unported/tests/ops_madam.py
@@ -2,19 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
-
 import shutil
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from ..todmap import TODHpixSpiral, OpSimGradient, OpPointingHpix, OpMadam
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ..todmap import OpMadam, OpPointingHpix, OpSimGradient, TODHpixSpiral
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class OpMadamTest(MPITestCase):

--- a/src/toast/unported/tests/ops_mapmaker.py
+++ b/src/toast/unported/tests/ops_mapmaker.py
@@ -2,9 +2,6 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-# from .mpi import MPITestCase
-from toast.tests.mpi import MPITestCase
-
 import glob
 import os
 import shutil
@@ -12,22 +9,25 @@ import shutil
 import healpy as hp
 import numpy as np
 
-from ..timing import gather_timers, GlobalTimers
-from ..timing import dump as dump_timing
-from ..tod import AnalyticNoise, OpSimNoise, Interval, OpCacheCopy, OpCacheInit
+# from .mpi import MPITestCase
+from toast.tests.mpi import MPITestCase
+
+from .. import qarray as qa
 from ..map import DistPixels
+from ..timing import GlobalTimers
+from ..timing import dump as dump_timing
+from ..timing import gather_timers
+from ..tod import AnalyticNoise, Interval, OpCacheCopy, OpCacheInit, OpSimNoise
 from ..todmap import (
-    TODHpixSpiral,
-    OpSimGradient,
-    OpPointingHpix,
     OpMadam,
     OpMapMaker,
+    OpPointingHpix,
+    OpSimGradient,
     OpSimScan,
+    TODHpixSpiral,
 )
-from ..todmap.mapmaker import TemplateMatrix, OffsetTemplate, Signal
-from .. import qarray as qa
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ..todmap.mapmaker import OffsetTemplate, Signal, TemplateMatrix
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
 
 
 class OpMapMakerTest(MPITestCase):

--- a/src/toast/unported/tests/ops_polyfilter.py
+++ b/src/toast/unported/tests/ops_polyfilter.py
@@ -2,16 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 
 import numpy as np
 
-from ..tod import OpPolyFilter, AnalyticNoise, OpSimNoise, Interval
+from ..tod import AnalyticNoise, Interval, OpPolyFilter, OpSimNoise
 from ..todmap import TODHpixSpiral
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class OpPolyFilterTest(MPITestCase):

--- a/src/toast/unported/tests/ops_sim_atm.py
+++ b/src/toast/unported/tests/ops_sim_atm.py
@@ -2,8 +2,6 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
@@ -13,22 +11,21 @@ import numpy.testing as nt
 from ..mpi import MPI
 from ..tod import AnalyticNoise, OpSimNoise
 from ..todmap import (
-    TODGround,
     OpPointingHpix,
+    OpSimAtmosphere,
     OpSimGradient,
     OpSimScan,
-    OpSimAtmosphere,
+    TODGround,
     atm_available_utils,
 )
-
 from ..weather import Weather
-
 from ._helpers import (
-    create_outdir,
-    create_distdata,
     boresight_focalplane,
+    create_distdata,
+    create_outdir,
     create_weather,
 )
+from .mpi import MPITestCase
 
 
 class OpsSimAtmosphereTest(MPITestCase):

--- a/src/toast/unported/tests/ops_sim_pysm.py
+++ b/src/toast/unported/tests/ops_sim_pysm.py
@@ -6,11 +6,9 @@ import os
 
 import numpy as np
 
-from .mpi import MPITestCase
-
 from ..todmap import OpPointingHpix, TODHpixSpiral, pysm
-
-from ._helpers import create_outdir, create_distdata, uniform_chunks
+from ._helpers import create_distdata, create_outdir, uniform_chunks
+from .mpi import MPITestCase
 
 if pysm is not None:
     from ..todmap import PySMSky, OpSimPySM

--- a/src/toast/unported/tests/ops_sim_sss.py
+++ b/src/toast/unported/tests/ops_sim_sss.py
@@ -2,8 +2,6 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
@@ -12,23 +10,21 @@ import numpy.testing as nt
 
 from ..mpi import MPI
 from ..tod import AnalyticNoise, OpSimNoise
-
 from ..todmap import (
-    TODGround,
     OpPointingHpix,
     OpSimGradient,
     OpSimScan,
     OpSimScanSynchronousSignal,
+    TODGround,
 )
-
 from ..weather import Weather
-
 from ._helpers import (
-    create_outdir,
-    create_distdata,
     boresight_focalplane,
+    create_distdata,
+    create_outdir,
     create_weather,
 )
+from .mpi import MPITestCase
 
 
 class OpSimScanSynchronousSignalTest(MPITestCase):

--- a/src/toast/unported/tests/psd_math.py
+++ b/src/toast/unported/tests/psd_math.py
@@ -2,24 +2,20 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 
 import numpy as np
 
+from ..fod import autocov_psd
 from ..tod import AnalyticNoise, OpSimNoise
 from ..todmap import TODHpixSpiral
-
-from ..fod import autocov_psd
-
 from ._helpers import (
-    create_outdir,
-    create_distdata,
     boresight_focalplane,
+    create_distdata,
+    create_outdir,
     uniform_chunks,
 )
-
+from .mpi import MPITestCase
 
 # FIXME:  This seems like a useful generic function- maybe move it into
 # toast.fod.psd_math?

--- a/src/toast/unported/tests/tidas.py
+++ b/src/toast/unported/tests/tidas.py
@@ -2,25 +2,22 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from .mpi import MPITestCase
-
 import os
 import shutil
 
 import numpy as np
 import numpy.testing as nt
 
-from .. import qarray as qa
-
-from ..tod import regular_intervals, TODGround
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
-
 # This file will only be imported if TIDAS is already available
 import tidas as tds
 from tidas.mpi import MPIVolume
+
+from .. import qarray as qa
+from ..tod import TODGround, regular_intervals
 from ..tod import tidas as tt
 from ..tod import tidas_utils as ttutils
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class TidasTest(MPITestCase):

--- a/src/toast/unported/tests/tod.py
+++ b/src/toast/unported/tests/tod.py
@@ -6,11 +6,9 @@ import os
 
 import numpy as np
 
-from .mpi import MPITestCase
-
 from ..tod import TODCache
-
 from ._helpers import create_outdir
+from .mpi import MPITestCase
 
 
 class TODTest(MPITestCase):

--- a/src/toast/unported/tests/tod_satellite.py
+++ b/src/toast/unported/tests/tod_satellite.py
@@ -4,21 +4,15 @@
 
 import os
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from .mpi import MPITestCase
-
-from ..mpi import MPI
-
 from .. import healpix as hpx
-
 from .. import qarray as qa
-
-from ..todmap import slew_precession_axis, satellite_scanning, TODSatellite
-
-from ._helpers import create_outdir, create_distdata, boresight_focalplane
+from ..mpi import MPI
+from ..todmap import TODSatellite, satellite_scanning, slew_precession_axis
+from ._helpers import boresight_focalplane, create_distdata, create_outdir
+from .mpi import MPITestCase
 
 
 class TODSatelliteTest(MPITestCase):

--- a/src/toast/unported/tod/__init__.py
+++ b/src/toast/unported/tod/__init__.py
@@ -4,44 +4,32 @@
 
 # import functions into our public API
 
-from .tod import TOD, TODCache
-
+from .applygain import OpApplyGain, write_calibration_file
+from .gainscrambler import OpGainScrambler
 from .interval import Interval, OpFlagGaps
-
-from .tod_math import (
-    calibrate,
-    sim_noise_timestream,
-    OpCacheCopy,
-    OpCacheClear,
-    flagged_running_average,
-    OpCacheInit,
-    OpFlagsApply,
-)
-
-from .sim_noise import AnalyticNoise
-
-from .sim_interval import regular_intervals
-
+from .memorycounter import OpMemoryCounter
+from .noise import Noise
+from .polyfilter import OpPolyFilter, OpPolyFilter2D
 from .sim_det_noise import OpSimNoise
-
 from .sim_focalplane import (
     hex_layout,
-    rhombus_layout,
     hex_pol_angles_qu,
     hex_pol_angles_radial,
-    rhomb_pol_angles_qu,
     plot_focalplane,
+    rhomb_pol_angles_qu,
+    rhombus_layout,
 )
-
-from .noise import Noise
-
-from .polyfilter import OpPolyFilter, OpPolyFilter2D
-
-from .gainscrambler import OpGainScrambler
-from .applygain import OpApplyGain, write_calibration_file
-
-from .memorycounter import OpMemoryCounter
-
-from .tidas import available as tidas_available
-
+from .sim_interval import regular_intervals
+from .sim_noise import AnalyticNoise
 from .spt3g_utils import available as spt3g_available
+from .tidas import available as tidas_available
+from .tod import TOD, TODCache
+from .tod_math import (
+    OpCacheClear,
+    OpCacheCopy,
+    OpCacheInit,
+    OpFlagsApply,
+    calibrate,
+    flagged_running_average,
+    sim_noise_timestream,
+)

--- a/src/toast/unported/tod/applygain.py
+++ b/src/toast/unported/tod/applygain.py
@@ -3,16 +3,12 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 from astropy.io import fits
 
 from ..operator import Operator
-
 from ..timing import function_timer
-
-from .tod_math import calibrate
-
 from ..utils import Logger
+from .tod_math import calibrate
 
 
 def write_calibration_file(filename, gain):

--- a/src/toast/unported/tod/interval.py
+++ b/src/toast/unported/tod/interval.py
@@ -5,7 +5,6 @@
 import numpy as np
 
 from ..operator import Operator
-
 from ..timing import function_timer
 
 

--- a/src/toast/unported/tod/memorycounter.py
+++ b/src/toast/unported/tod/memorycounter.py
@@ -3,12 +3,9 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 from ..mpi import MPI
-
 from ..operator import Operator
-
-from ..utils import Logger
-
 from ..timing import function_timer
+from ..utils import Logger
 
 
 class OpMemoryCounter(Operator):

--- a/src/toast/unported/tod/sim_det_noise.py
+++ b/src/toast/unported/tod/sim_det_noise.py
@@ -4,13 +4,10 @@
 
 import numpy as np
 
-from ..timing import function_timer
-
 from ..fft import FFTPlanReal1DStore
-
-from .tod_math import sim_noise_timestream
-
 from ..operator import Operator
+from ..timing import function_timer
+from .tod_math import sim_noise_timestream
 
 
 class OpSimNoise(Operator):

--- a/src/toast/unported/tod/sim_focalplane.py
+++ b/src/toast/unported/tod/sim_focalplane.py
@@ -511,8 +511,9 @@ def plot_focalplane(
 
     """
     if outfile is not None:
-        import matplotlib
         import warnings
+
+        import matplotlib
 
         # Try to force matplotlib to not use any Xwindows backend.
         warnings.filterwarnings("ignore")

--- a/src/toast/unported/tod/sim_interval.py
+++ b/src/toast/unported/tod/sim_interval.py
@@ -5,7 +5,6 @@
 import numpy as np
 
 from ..timing import function_timer
-
 from .interval import Interval
 
 

--- a/src/toast/unported/tod/spt3g_utils.py
+++ b/src/toast/unported/tod/spt3g_utils.py
@@ -2,11 +2,11 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import sys
 import os
-import re
-import traceback
 import pickle
+import re
+import sys
+import traceback
 
 import numpy as np
 

--- a/src/toast/unported/tod/tidas.py
+++ b/src/toast/unported/tod/tidas.py
@@ -2,29 +2,26 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI
-
 import os
 import re
 
 import numpy as np
 
 from .. import qarray as qa
-
-from ..utils import Logger
-from ..timing import function_timer, Timer
-
-from ..dist import distribute_discrete
 from ..data import Data
+from ..dist import distribute_discrete
+from ..mpi import MPI
 from ..operator import Operator
-
-from .tod import TOD
+from ..timing import Timer, function_timer
+from ..utils import Logger
 from .interval import Interval, intervals_to_chunklist
+from .tod import TOD
 
 available = True
 try:
     import tidas as tds
     from tidas.mpi import MPIVolume
+
     from . import tidas_utils as tdsutils
 except ImportError:
     available = False

--- a/src/toast/unported/tod/tod.py
+++ b/src/toast/unported/tod/tod.py
@@ -2,18 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI
-
 import numpy as np
 
-from ..dist import distribute_samples
-
-from ..cache import Cache
-
 from .. import qarray as qa
-
+from ..cache import Cache
+from ..dist import distribute_samples
+from ..mpi import MPI
 from ..timing import function_timer
-
 from .interval import Interval
 
 

--- a/src/toast/unported/tod/tod_math.py
+++ b/src/toast/unported/tod/tod_math.py
@@ -3,19 +3,14 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 import scipy.interpolate as si
 from scipy.signal import fftconvolve
 
-from ..operator import Operator
-
-from ..timing import function_timer
-
-from ..utils import Logger, AlignedF64
-
 from .. import rng as rng
-
 from .._libtoast import tod_sim_noise_timestream
+from ..operator import Operator
+from ..timing import function_timer
+from ..utils import AlignedF64, Logger
 
 
 class OpCacheInit(Operator):

--- a/src/toast/unported/todmap/__init__.py
+++ b/src/toast/unported/todmap/__init__.py
@@ -9,41 +9,24 @@ from .pysm import pysm
 if pysm is not None:
     from .pysm import PySMSky
 
-from .todmap_math import (
-    OpAccumDiag,
-    OpScanScale,
-    OpScanMask,
-    dipole,
-)
-
-from .pointing import OpPointingHpix, OpMuellerPointingHpix
-
-from .sim_tod import (
-    satellite_scanning,
-    TODHpixSpiral,
-    TODSatellite,
-    slew_precession_axis,
-    TODGround,
-)
-
-from .sim_det_map import OpSimGradient, OpSimScan
-
-from .sim_det_dipole import OpSimDipole
-
-from .sim_det_pysm import OpSimPySM
-
-from .sim_det_atm import OpSimAtmosphere
-
-from .sss import OpSimScanSynchronousSignal
-
-from .groundfilter import OpGroundFilter
-
-from .pointing_math import aberrate
-
-from .conviqt import OpSimConviqt, OpSimWeightedConviqt
-
 from .atm import available_utils as atm_available_utils
-from .mapsampler import MapSampler
-
+from .conviqt import OpSimConviqt, OpSimWeightedConviqt
+from .groundfilter import OpGroundFilter
 from .madam import OpMadam
 from .mapmaker import OpMapMaker
+from .mapsampler import MapSampler
+from .pointing import OpMuellerPointingHpix, OpPointingHpix
+from .pointing_math import aberrate
+from .sim_det_atm import OpSimAtmosphere
+from .sim_det_dipole import OpSimDipole
+from .sim_det_map import OpSimGradient, OpSimScan
+from .sim_det_pysm import OpSimPySM
+from .sim_tod import (
+    TODGround,
+    TODHpixSpiral,
+    TODSatellite,
+    satellite_scanning,
+    slew_precession_axis,
+)
+from .sss import OpSimScanSynchronousSignal
+from .todmap_math import OpAccumDiag, OpScanMask, OpScanScale, dipole

--- a/src/toast/unported/todmap/atm.py
+++ b/src/toast/unported/todmap/atm.py
@@ -3,25 +3,21 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-import numpy as np
 
 import h5py
-
-from ..utils import Environment, Logger
-
-from ..timing import Timer, function_timer, GlobalTimers
-
-from ..rng import random as toast_rng
-
-from ..mpi import MPI, MPIShared
+import numpy as np
 
 from .._libtoast import (
-    atm_sim_compute_slice,
-    atm_sim_observe,
-    atm_sim_compress_flag_hits_rank,
     atm_sim_compress_flag_extend_rank,
+    atm_sim_compress_flag_hits_rank,
+    atm_sim_compute_slice,
     atm_sim_kolmogorov_init_rank,
+    atm_sim_observe,
 )
+from ..mpi import MPI, MPIShared
+from ..rng import random as toast_rng
+from ..timing import GlobalTimers, Timer, function_timer
+from ..utils import Environment, Logger
 
 available_utils = None
 if available_utils is None:

--- a/src/toast/unported/todmap/conviqt.py
+++ b/src/toast/unported/todmap/conviqt.py
@@ -4,15 +4,12 @@
 
 import warnings
 
-from ..mpi import use_mpi
-
 import numpy as np
 
 from .. import qarray as qa
-
+from ..mpi import use_mpi
 from ..operator import Operator
-
-from ..timing import function_timer, Timer
+from ..timing import Timer, function_timer
 
 conviqt = None
 

--- a/src/toast/unported/todmap/madam.py
+++ b/src/toast/unported/todmap/madam.py
@@ -2,16 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..mpi import MPI, use_mpi
-
 import os
 
 import healpy as hp
 import numpy as np
 
 from ..cache import Cache
+from ..mpi import MPI, use_mpi
 from ..operator import Operator
-from ..timing import function_timer, Timer
+from ..timing import Timer, function_timer
 from ..utils import Logger, memreport
 
 madam = None

--- a/src/toast/unported/todmap/mapmaker.py
+++ b/src/toast/unported/todmap/mapmaker.py
@@ -1,24 +1,21 @@
-from collections import OrderedDict
 import os
 import sys
+from collections import OrderedDict
 
 import numpy as np
 import scipy.linalg
 import scipy.signal
 
-from ..operator import Operator
-from ..mpi import MPI
-
-from ..timing import gather_timers, GlobalTimers, function_timer, Timer
-from ..utils import Logger, Environment
-from .sim_det_map import OpSimScan
-from .todmap_math import OpAccumDiag, OpScanScale, OpScanMask
-from ..tod import OpCacheClear, OpCacheCopy, OpCacheInit, OpFlagsApply, OpFlagGaps
-from ..map import covariance_apply, covariance_invert, DistPixels, covariance_rcond
 from .. import qarray as qa
-
 from .._libtoast import add_offsets_to_signal, project_signal_offsets
-
+from ..map import DistPixels, covariance_apply, covariance_invert, covariance_rcond
+from ..mpi import MPI
+from ..operator import Operator
+from ..timing import GlobalTimers, Timer, function_timer, gather_timers
+from ..tod import OpCacheClear, OpCacheCopy, OpCacheInit, OpFlagGaps, OpFlagsApply
+from ..utils import Environment, Logger
+from .sim_det_map import OpSimScan
+from .todmap_math import OpAccumDiag, OpScanMask, OpScanScale
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/unported/todmap/mapsampler.py
+++ b/src/toast/unported/todmap/mapsampler.py
@@ -4,17 +4,13 @@
 
 import warnings
 
+import healpy as hp
 import numpy as np
-
 from scipy.constants import arcmin
 
-import healpy as hp
-
-from ..mpi import MPIShared
-
-from ..timing import function_timer
-
 from .._libtoast import fast_scanning_float32
+from ..mpi import MPIShared
+from ..timing import function_timer
 
 DTYPE = np.float32
 

--- a/src/toast/unported/todmap/pointing.py
+++ b/src/toast/unported/todmap/pointing.py
@@ -2,21 +2,15 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from ..qarray import rotate
-
-from ..utils import Environment
-
-from ..healpix import HealpixPixels
-
-from ..operator import Operator
-
-from ..timing import function_timer
-
 from .._libtoast import pointing_matrix_healpix
+from ..healpix import HealpixPixels
+from ..operator import Operator
+from ..qarray import rotate
+from ..timing import function_timer
+from ..utils import Environment
 
 
 class OpPointingHpix(Operator):

--- a/src/toast/unported/todmap/pointing_math.py
+++ b/src/toast/unported/todmap/pointing_math.py
@@ -3,13 +3,10 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
-
 from scipy.constants import c
 
 from .. import qarray as qa
-
 from ..timing import function_timer
-
 
 cinv = 1e3 / c  # Inverse light speed in km / s ( the assumed unit for velocity )
 

--- a/src/toast/unported/todmap/pysm.py
+++ b/src/toast/unported/todmap/pysm.py
@@ -2,19 +2,17 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from ..utils import set_numba_threading
-
 from ..timing import function_timer
-
+from ..utils import set_numba_threading
 
 pysm = None
 try:
-    import pysm
-    import pysm.units as u
-
     # Disable PySM warnings generated when accessing local
     # data, since these fill the logs.
     import warnings
+
+    import pysm
+    import pysm.units as u
 
     warnings.filterwarnings("ignore", category=UserWarning, module="pysm")
 except ImportError:

--- a/src/toast/unported/todmap/sim_det_atm.py
+++ b/src/toast/unported/todmap/sim_det_atm.py
@@ -6,12 +6,9 @@ import os
 
 import numpy as np
 
-from ..utils import Logger, memreport
-
-from ..timing import function_timer, Timer
-
 from ..operator import Operator
-
+from ..timing import Timer, function_timer
+from ..utils import Logger, memreport
 from .atm import available_utils
 
 if available_utils:
@@ -22,11 +19,10 @@ if available_utils:
         atm_atmospheric_loading_vec,
     )
 
-from .atm import AtmSim
-
+import toast.qarray as qa
 from toast.mpi import MPI
 
-import toast.qarray as qa
+from .atm import AtmSim
 
 
 class OpSimAtmosphere(Operator):
@@ -381,8 +377,9 @@ class OpSimAtmosphere(Operator):
         from ..vis import set_backend
 
         set_backend()
-        import matplotlib.pyplot as plt
         import pickle
+
+        import matplotlib.pyplot as plt
 
         azmin, azmax, elmin, elmax = scan_range
 

--- a/src/toast/unported/todmap/sim_det_dipole.py
+++ b/src/toast/unported/todmap/sim_det_dipole.py
@@ -2,17 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
-from ..timing import function_timer
-
-from .todmap_math import dipole
-
 from ..operator import Operator
-
+from ..timing import function_timer
 from ..utils import Environment
+from .todmap_math import dipole
 
 
 class OpSimDipole(Operator):

--- a/src/toast/unported/todmap/sim_det_map.py
+++ b/src/toast/unported/todmap/sim_det_map.py
@@ -7,16 +7,13 @@ import os
 import healpy as hp
 import numpy as np
 
+from .. import qarray as qa
+from .._libtoast import scan_map_float32, scan_map_float64
 from ..map import DistPixels
 from ..mpi import MPI
-from ..timing import function_timer, GlobalTimers
-from ..utils import Logger, Environment
-
-from .. import qarray as qa
-
-from .._libtoast import scan_map_float64, scan_map_float32
-
 from ..operator import Operator
+from ..timing import GlobalTimers, function_timer
+from ..utils import Environment, Logger
 
 
 class OpSimGradient(Operator):

--- a/src/toast/unported/todmap/sim_det_pysm.py
+++ b/src/toast/unported/todmap/sim_det_pysm.py
@@ -2,18 +2,13 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import healpy as hp
 import numpy as np
 
-import healpy as hp
-
 from ..mpi import MPI
-
-from ..timing import function_timer
-
-from ..utils import Logger, Timer
-
 from ..operator import Operator
-
+from ..timing import function_timer
+from ..utils import Logger, Timer
 from .pysm import pysm
 
 if pysm is not None:
@@ -21,7 +16,6 @@ if pysm is not None:
     from .pysm import PySMSky
 
 from ..map import DistPixels
-
 from .sim_det_map import OpSimScan
 
 

--- a/src/toast/unported/todmap/sim_tod.py
+++ b/src/toast/unported/todmap/sim_tod.py
@@ -13,11 +13,10 @@ import numpy as np
 from scipy.constants import degree
 
 from .. import qarray as qa
-from ..timing import function_timer, Timer
-from ..tod import Interval, TOD
 from ..healpix import ang2vec
-from .pointing_math import quat_equ2ecl, quat_equ2gal, quat_ecl2gal
-
+from ..timing import Timer, function_timer
+from ..tod import TOD, Interval
+from .pointing_math import quat_ecl2gal, quat_equ2ecl, quat_equ2gal
 
 XAXIS, YAXIS, ZAXIS = np.eye(3)
 

--- a/src/toast/unported/todmap/todmap_math.py
+++ b/src/toast/unported/todmap/todmap_math.py
@@ -2,26 +2,22 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import scipy.constants as constants
 import numpy as np
-
-from ..timing import function_timer, GlobalTimers
-
-from ..operator import Operator
+import scipy.constants as constants
 
 from .. import qarray as qa
-
 from .._libtoast import (
+    apply_flags_to_pixels,
     cov_accum_diag,
-    cov_accum_zmap,
     cov_accum_diag_hits,
     cov_accum_diag_invnpp,
-    scan_map_float64,
+    cov_accum_zmap,
     scan_map_float32,
-    apply_flags_to_pixels,
+    scan_map_float64,
 )
-
 from ..map import DistPixels
+from ..operator import Operator
+from ..timing import GlobalTimers, function_timer
 
 
 class OpAccumDiag(Operator):

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -2,57 +2,54 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import os
+import datetime
 import gc
 import hashlib
-import warnings
-
 import importlib
-
-import datetime
-
+import os
+import warnings
 from tempfile import TemporaryDirectory
 
-import numpy as np
-
-import h5py
-
 import astropy.io.misc.hdf5 as aspy5
+import h5py
+import numpy as np
 from astropy.table import meta as aspymeta
 
-
-from ._libtoast import Environment, Timer, GlobalTimers, threading_state
-
 from ._libtoast import (
-    AlignedI8,
-    AlignedU8,
-    AlignedI16,
-    AlignedU16,
-    AlignedI32,
-    AlignedU32,
-    AlignedI64,
-    AlignedU64,
     AlignedF32,
     AlignedF64,
-)
-
-from ._libtoast import vsin, vcos, vsincos, vatan2, vsqrt, vrsqrt, vexp, vlog
-
-from ._libtoast import (
-    vfast_sin,
-    vfast_cos,
-    vfast_sincos,
+    AlignedI8,
+    AlignedI16,
+    AlignedI32,
+    AlignedI64,
+    AlignedU8,
+    AlignedU16,
+    AlignedU32,
+    AlignedU64,
+    Environment,
+    GlobalTimers,
+    Logger,
+    Timer,
+    threading_state,
+    vatan2,
+    vcos,
+    vexp,
     vfast_atan2,
-    vfast_sqrt,
-    vfast_rsqrt,
+    vfast_cos,
+    vfast_erfinv,
     vfast_exp,
     vfast_log,
-    vfast_erfinv,
+    vfast_rsqrt,
+    vfast_sin,
+    vfast_sincos,
+    vfast_sqrt,
+    vlog,
+    vrsqrt,
+    vsin,
+    vsincos,
+    vsqrt,
 )
-
 from .mpi import MPI, use_mpi
-
-from ._libtoast import Logger
 
 
 def _create_log_rank(level):
@@ -211,7 +208,7 @@ def set_numba_threading():
         threading = "tbb"
 
     try:
-        from numba import vectorize, config, threading_layer
+        from numba import config, threading_layer, vectorize
 
         # Set threading layer and number of threads.  Note that this still
         # does not always work.  The conf structure is repopulated from the

--- a/src/toast/weather.py
+++ b/src/toast/weather.py
@@ -2,22 +2,16 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import datetime
 import os
-
 from collections import OrderedDict
 
-import datetime
-
+import h5py
+import numpy as np
+from astropy import units as u
 from pkg_resources import resource_filename
 
-import numpy as np
-
-from astropy import units as u
-
-import h5py
-
 from . import rng as rng
-
 from .timing import function_timer
 
 

--- a/src/toast/widgets.py
+++ b/src/toast/widgets.py
@@ -2,20 +2,20 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from datetime import datetime, timezone, timedelta
-import re
 import copy
+import re
+from datetime import datetime, timedelta, timezone
 
-import numpy as np
 import ipywidgets as widgets
-from IPython.display import display, clear_output
+import numpy as np
 import plotly.graph_objects as go
+from IPython.display import clear_output, display
 from plotly_resampler import FigureResampler
 
+from .intervals import IntervalList
+from .noise import Noise
 from .observation import default_values as defaults
 from .pixels import PixelData
-from .noise import Noise
-from .intervals import IntervalList
 
 
 class ObservationWidget(object):

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -25,26 +25,23 @@ an interactive python session.
 
 """
 
-# Import toast first to avoid thread addinity issues with numpy and OpenBLAS
-import toast
-
+import argparse
+import datetime
 import os
 import pickle
 import sys
 import traceback
-import argparse
-import datetime
 
 import numpy as np
-
 from astropy import units as u
+
+# Import toast first to avoid thread addinity issues with numpy and OpenBLAS
+import toast
 
 # import toast
 import toast.ops
-
-from toast.mpi import MPI, Comm
-
 from toast import spt3g as t3g
+from toast.mpi import MPI, Comm
 
 if t3g.available:
     from spt3g import core as c3g

--- a/workflows/toast_sim_ground_simple.py
+++ b/workflows/toast_sim_ground_simple.py
@@ -13,17 +13,15 @@ useful starting point for interactively hacking on a specific use case or test.
 
 """
 
+import argparse
 import os
 import sys
 import traceback
-import argparse
 
 import numpy as np
-
 from astropy import units as u
 
 import toast
-
 from toast.mpi import MPI
 
 

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -25,18 +25,16 @@ an interactive python session.
 
 """
 
+import argparse
 import os
 import sys
 import traceback
-import argparse
 
 import numpy as np
-
 from astropy import units as u
 
 import toast
 import toast.ops
-
 from toast.mpi import MPI
 
 

--- a/workflows/toast_sim_satellite_simple.py
+++ b/workflows/toast_sim_satellite_simple.py
@@ -13,17 +13,15 @@ useful starting point for interactively hacking on a specific use case or test.
 
 """
 
+import argparse
 import os
 import sys
 import traceback
-import argparse
 
 import numpy as np
-
 from astropy import units as u
 
 import toast
-
 from toast.mpi import MPI
 from toast.ops import noise_model
 


### PR DESCRIPTION
This changes a few operators to consistently use the default names for flags and the default bit mask.  Most operators were already changed to use these.  This PR also includes running the `isort` tool on the python source files, which organizes the import statements in a way that agrees with PEP8.