### PR TITLE
Aoa tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -307,6 +307,7 @@ conf["entry_points"] = {
         "toast_healpix_coadd = toast.scripts.toast_healpix_coadd:main",
         "toast_hdf5_to_spt3g = toast.scripts.toast_hdf5_to_spt3g:main",
         "toast_timing_plot = toast.scripts.toast_timing_plot:main",
+        "toast_obsmatrix_combine = toast.scripts.toast_obsmatrix_combine:main",
     ]
 }
 conf["cmdclass"] = {"build_ext": CMakeBuild}

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -430,10 +430,6 @@ class Focalplane(object):
             etc.  Will be calculated from the detector offsets by default.
         sample_rate (Quantity):  The common (nominal) sample rate for all detectors.
         thinfp (int):  Only sample the detectors in the file.
-        fmin (float):  Override noise model fmin.
-        fknee (float):  Override noise model fknee.
-        alpha (float):  Override noise model alpha.
-        NET (float):  Override noise model NET.
 
     """
 
@@ -446,18 +442,10 @@ class Focalplane(object):
         field_of_view=None,
         sample_rate=None,
         thinfp=None,
-        fmin=None,
-        fknee=None,
-        alpha=None,
-        NET=None,
     ):
         self.detector_data = detector_data
         self.field_of_view = field_of_view
         self.sample_rate = sample_rate
-        self.fmin = fmin
-        self.fknee = fknee
-        self.alpha = alpha
-        self.NET = NET
         self.thinfp = thinfp
         if detector_data is not None and len(detector_data) > 0:
             # We have some dets
@@ -466,20 +454,6 @@ class Focalplane(object):
     @function_timer
     def _initialize(self):
         log = Logger.get()
-
-        self.detector_data = self.detector_data.copy()
-        if self.fmin is not None:
-            self.detector_data["psd_fmin"] = self.fmin
-        if self.fknee is not None:
-            self.detector_data["psd_fknee"] = self.fknee
-            # Noise simulation has a requirement fmin < fknee
-            bad = self.detector_data["psd_fknee"] <= self.detector_data["psd_fmin"]
-            self.detector_data["psd_fmin"][bad] \
-                = self.detector_data["psd_fknee"][bad] / 10
-        if self.alpha is not None:
-            self.detector_data["psd_alpha"] = self.alpha
-        if self.NET is not None:
-            self.detector_data["psd_net"] = self.NET
 
         if self.thinfp is not None:
             # Pick only every `thinfp` pixel on the focal plane

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -430,6 +430,10 @@ class Focalplane(object):
             etc.  Will be calculated from the detector offsets by default.
         sample_rate (Quantity):  The common (nominal) sample rate for all detectors.
         thinfp (int):  Only sample the detectors in the file.
+        fmin (float):  Override noise model fmin.
+        fknee (float):  Override noise model fknee.
+        alpha (float):  Override noise model alpha.
+        NET (float):  Override noise model NET.
 
     """
 
@@ -442,10 +446,18 @@ class Focalplane(object):
         field_of_view=None,
         sample_rate=None,
         thinfp=None,
+        fmin=None,
+        fknee=None,
+        alpha=None,
+        NET=None,
     ):
         self.detector_data = detector_data
         self.field_of_view = field_of_view
         self.sample_rate = sample_rate
+        self.fmin = fmin
+        self.fknee = fknee
+        self.alpha = alpha
+        self.NET = NET
         self.thinfp = thinfp
         if detector_data is not None and len(detector_data) > 0:
             # We have some dets
@@ -454,6 +466,20 @@ class Focalplane(object):
     @function_timer
     def _initialize(self):
         log = Logger.get()
+
+        self.detector_data = self.detector_data.copy()
+        if self.fmin is not None:
+            self.detector_data["psd_fmin"] = self.fmin
+        if self.fknee is not None:
+            self.detector_data["psd_fknee"] = self.fknee
+            # Noise simulation has a requirement fmin < fknee
+            bad = self.detector_data["psd_fknee"] <= self.detector_data["psd_fmin"]
+            self.detector_data["psd_fmin"][bad] \
+                = self.detector_data["psd_fknee"][bad] / 10
+        if self.alpha is not None:
+            self.detector_data["psd_alpha"] = self.alpha
+        if self.NET is not None:
+            self.detector_data["psd_net"] = self.NET
 
         if self.thinfp is not None:
             # Pick only every `thinfp` pixel on the focal plane

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -207,7 +207,7 @@ class Noise(object):
                 first = np.searchsorted(freq, rate * 0.2, side="left")
                 last = np.searchsorted(freq, rate * 0.4, side="right")
                 noisevar = np.median(psd[first:last].to_value(u.K**2 * u.second))
-                invvar = 1.0 / noisevar
+                invvar = 1.0 / noisevar / rate.to_value(u.Hz)
                 for det in self._dets_for_keys[k]:
                     self._detweights[det] += mix[det][k] * invvar
         return self._detweights[det]

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -204,8 +204,24 @@ class Noise(object):
                 freq = self.freq(k)
                 psd = self.psd(k)
                 rate = self.rate(k)
-                first = np.searchsorted(freq, rate * 0.2, side="left")
-                last = np.searchsorted(freq, rate * 0.4, side="right")
+                # Noise in the middle of the PSD
+                first = np.searchsorted(freq, rate * 0.225, side="left")
+                last = np.searchsorted(freq, rate * 0.275, side="right")
+                noisevar_mid = np.median(psd[first:last].to_value(u.K**2 * u.second))
+                # Noise in the end of the PSD
+                first = np.searchsorted(freq, rate * 0.45, side="left")
+                last = np.searchsorted(freq, rate * 0.50, side="right")
+                noisevar_end = np.median(psd[first:last].to_value(u.K**2 * u.second))
+                if noisevar_end / noisevar_mid < 0.5:
+                    # There is a transfer function roll-off.  Measure the
+                    # white noise plateau value
+                    first = np.searchsorted(freq, rate * 0.2, side="left")
+                    last = np.searchsorted(freq, rate * 0.4, side="right")
+                else:
+                    # No significant roll-off.  Use the last PSD bins for
+                    # the noise variance
+                    first = np.searchsorted(freq, rate * 0.45, side="left")
+                    last = np.searchsorted(freq, rate * 0.50, side="right")
                 noisevar = np.median(psd[first:last].to_value(u.K**2 * u.second))
                 invvar = 1.0 / noisevar / rate.to_value(u.Hz)
                 for det in self._dets_for_keys[k]:

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -207,10 +207,16 @@ class Noise(object):
                 # Noise in the middle of the PSD
                 first = np.searchsorted(freq, rate * 0.225, side="left")
                 last = np.searchsorted(freq, rate * 0.275, side="right")
+                if first == last:
+                    first = max(0, first - 1)
+                    last = min(freq.size - 1, last + 1)
                 noisevar_mid = np.median(psd[first:last].to_value(u.K**2 * u.second))
                 # Noise in the end of the PSD
                 first = np.searchsorted(freq, rate * 0.45, side="left")
                 last = np.searchsorted(freq, rate * 0.50, side="right")
+                if first == last:
+                    first = max(0, first - 1)
+                    last = min(freq.size - 1, last + 1)
                 noisevar_end = np.median(psd[first:last].to_value(u.K**2 * u.second))
                 if noisevar_end / noisevar_mid < 0.5:
                     # There is a transfer function roll-off.  Measure the
@@ -222,6 +228,9 @@ class Noise(object):
                     # the noise variance
                     first = np.searchsorted(freq, rate * 0.45, side="left")
                     last = np.searchsorted(freq, rate * 0.50, side="right")
+                if first == last:
+                    first = max(0, first - 1)
+                    last = min(freq.size - 1, last + 1)
                 noisevar = np.median(psd[first:last].to_value(u.K**2 * u.second))
                 invvar = 1.0 / noisevar / rate.to_value(u.Hz)
                 for det in self._dets_for_keys[k]:

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -135,7 +135,8 @@ class AnalyticNoise(Noise):
         return self._NET[det]
 
     def _detector_weight(self, det):
-        return 1.0 / (self._NET[det] ** 2).to_value(u.K**2 * u.second)
+        return 1.0 / (self._NET[det] ** 2).to_value(u.K**2 * u.second) \
+            / self._rate[det].to_value(u.Hz)
 
     def _save_hdf5(self, handle, comm, **kwargs):
         """Internal method which can be overridden by derived classes."""

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -112,9 +112,11 @@ class Demodulate(Operator):
         help="Observation key containing the noise model",
     )
 
-    wkernel = Int(None, allow_none=True, help="kernel size of filter")
+    wkernel = Int(None, allow_none=True, help="Override automatic filter kernel size")
 
-    fmax = Quantity(None, allow_none=True, help="Maximum frequency for lowpass")
+    fmax = Quantity(
+        None, allow_none=True, help="Override automatic lowpass cut-off frequency"
+    )
 
     nskip = Int(3, help="Downsampling factor")
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -295,7 +295,9 @@ class ElevationNoise(Operator):
                 # Scale the PSD
 
                 net_factor = noise_a / np.sin(el) + noise_c
+
                 self.net_factors.append(net_factor)
+                self.rates.append(focalplane.sample_rate.to_value(u.Hz))
 
                 if modulate_pwv:
                     pwv = obs.telescope.site.weather.pwv.to_value(u.mm)
@@ -314,7 +316,6 @@ class ElevationNoise(Operator):
             for det in dets:
                 self.weights_in.append(noise.detector_weight(det))
                 self.weights_out.append(out_noise.detector_weight(det))
-                self.rates.append(focalplane.sample_rate.to_value(u.Hz))
 
             if self.out_model is None or self.noise_model == self.out_model:
                 # We are replacing the input
@@ -345,7 +346,7 @@ class ElevationNoise(Operator):
                 weights_in = np.hstack(weights_in)
                 weights_out = np.hstack(weights_out)
                 rates = np.hstack(rates)
-        if comm is None or comm.rank == 0 and len(net_factors) > 0:
+        if (comm is None or comm.rank == 0) and len(net_factors) > 0:
             net = net_factors
             tot = total_factors
             net1 = np.sqrt(1 / weights_in / rates) * 1e6

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -330,8 +330,8 @@ class ElevationNoise(Operator):
         comm = data.comm.comm_world
         net_factors = np.array(self.net_factors)
         total_factors = np.array(self.total_factors)
-        weighsts_in = np.array(self.weights_in)
-        weighsts_out = np.array(self.weights_out)
+        weights_in = np.array(self.weights_in)
+        weights_out = np.array(self.weights_out)
         rates = np.array(self.rates)
         if comm is not None:
             net_factors = comm.gather(self.net_factors)

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -306,7 +306,6 @@ class ElevationNoise(Operator):
 
                 out_noise.psd(det)[:] *= net_factor**2
                 self.total_factors.append(net_factor)
-                self.rates.append(focalplane.sample_rate.to_value(u.Hz))
 
             self.detector_pointing.view = detector_pointing_view
 
@@ -315,6 +314,7 @@ class ElevationNoise(Operator):
             for det in dets:
                 self.weights_in.append(noise.detector_weight(det))
                 self.weights_out.append(out_noise.detector_weight(det))
+                self.rates.append(focalplane.sample_rate.to_value(u.Hz))
 
             if self.out_model is None or self.noise_model == self.out_model:
                 # We are replacing the input

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -338,7 +338,7 @@ class ElevationNoise(Operator):
                 net_factors = np.hstack(net_factors)
                 total_factors = np.hstack(total_factors)
                 weight_ratios = np.hstack(weight_ratios)
-        if comm is None or comm.rank == 0:
+        if comm is None or comm.rank == 0 and len(net_factors) > 0:
             net = net_factors
             tot = total_factors
             ratio = np.sqrt(weight_ratios)

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -334,11 +334,11 @@ class ElevationNoise(Operator):
         weights_out = np.array(self.weights_out)
         rates = np.array(self.rates)
         if comm is not None:
-            net_factors = comm.gather(self.net_factors)
-            total_factors = comm.gather(self.total_factors)
-            weights_in = comm.gather(self.weights_in)
-            weights_out = comm.gather(self.weights_out)
-            rates = comm.gather(self.rates)
+            net_factors = comm.gather(net_factors)
+            total_factors = comm.gather(total_factors)
+            weights_in = comm.gather(weights_in)
+            weights_out = comm.gather(weights_out)
+            rates = comm.gather(rates)
             if comm.rank == 0:
                 net_factors = np.hstack(net_factors)
                 total_factors = np.hstack(total_factors)

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -498,6 +498,7 @@ class FilterBin(Operator):
             template_covariance = None
 
             for idet, det in enumerate(dets):
+                t1 = time()
                 if self.grank == 0:
                     log.debug(
                         f"{self.group:4} : FilterBin:   Processing detector "

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -943,9 +943,9 @@ class FilterBin(Operator):
                     log.debug(
                         f"{self.group:4} : FilterBin:     Caching to {fname_cache}*",
                     )
-                np.save(fname_cache + ".data", local_obs_matrix)
-                np.save(fname_cache + ".indices", local_obs_matrix)
-                np.save(fname_cache + ".indptr", local_obs_matrix)
+                np.save(fname_cache + ".data", local_obs_matrix.data)
+                np.save(fname_cache + ".indices", local_obs_matrix.indices)
+                np.save(fname_cache + ".indptr", local_obs_matrix.indptr)
                 if self.grank == 0:
                     log.debug(
                         f"{self.group:4} : FilterBin:     cached in {time() - t1:.2f} s",

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -438,6 +438,11 @@ class FilterBin(Operator):
         if self.maskfile is not None:
             raise RuntimeError("Filtering mask not yet implemented")
 
+        log.debug_rank(
+            f"FilterBin:  Running with self.cache_dir = {self.cache_dir}",
+            comm=data.comm.comm_world,
+        )
+
         self._initialize_comm(data)
 
         # Filter data
@@ -893,6 +898,11 @@ class FilterBin(Operator):
                     t1 = time()
             except:
                 local_obs_matrix = None
+        else:
+            if self.grank == 0:
+                log.debug(
+                    f"{self.group:4} : FilterBin:     cache_dir = {self.cache_dir}"
+                )
 
         if local_obs_matrix is None:
             templates = templates.T.copy()
@@ -951,6 +961,11 @@ class FilterBin(Operator):
                         f"{self.group:4} : FilterBin:     cached in {time() - t1:.2f} s",
                     )
                     t1 = time()
+            else:
+                if self.grank == 0:
+                    log.debug(
+                        f"{self.group:4} : FilterBin:     NOT caching detector matrix",
+                    )
 
         if self.grank == 0:
             log.debug(f"{self.group:4} : FilterBin:     Adding to global")

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -62,7 +62,7 @@ class GroundFilter(Operator):
 
     det_data = Unicode(
         defaults.det_data,
-        help="Observation detdata key for accumulating atmosphere timestreams",
+        help="Observation detdata key",
     )
 
     view = Unicode(

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -1244,6 +1244,7 @@ def scan_patch(
             els,
             rising,
             tstop,
+            to_cross,
         )
         if has_extent:
             scan_started = True
@@ -1507,7 +1508,7 @@ def current_extent_pole(
 
 @function_timer
 def current_extent(
-    azmins, azmaxs, aztimes, corners, fp_radius, el, azs, els, rising, t
+        azmins, azmaxs, aztimes, corners, fp_radius, el, azs, els, rising, t, to_cross
 ):
     """Get the azimuthal extent of the patch along elevation el.
 
@@ -1519,6 +1520,9 @@ def current_extent(
     azs_cross = []
     for i in range(len(corners)):
         j = (i + 1) % len(corners)
+        if not to_cross[i] and not to_cross[j]:
+            # Both of the corners already crossed the elevation line
+            continue
         for el0 in [el - fp_radius, el, el + fp_radius]:
             if (els[i] - el0) * (els[j] - el0) < 0:
                 # The corners are on opposite sides of the elevation line
@@ -1528,6 +1532,10 @@ def current_extent(
                 el2 = els[j] - el0
                 az2 = unwind_angle(az1, az2)
                 az_cross = (az1 + el1 * (az2 - az1) / (el1 - el2)) % (2 * np.pi)
+                if rising and az_cross > np.pi:
+                    continue
+                if not rising and az_cross < np.pi:
+                    continue
                 azs_cross.append(az_cross)
             if fp_radius == 0:
                 break
@@ -2866,7 +2874,6 @@ def add_side(corner1, corner2, corners_temp, coordconv):
     Add one side of a rectangle with enough interpolation points.
     """
     step = np.radians(1)
-    corners_temp.append(ephem.Equatorial(corner1))
     lon1 = corner1.ra
     lon2 = corner2.ra
     lat1 = corner1.dec
@@ -2889,6 +2896,7 @@ def add_side(corner1, corner2, corners_temp, coordconv):
             corners_temp.append(ephem.Equatorial(coordconv(lon, lat, epoch="2000")))
     else:
         raise RuntimeError("add_side: both latitude and longitude change")
+    corners_temp.append(ephem.Equatorial(corner2))
     return
 
 

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -2192,8 +2192,10 @@ def build_schedule(args, start_timestamp, stop_timestamp, patches, observer, sun
                 fout_fmt,
                 ods,
                 boresight_angle,
-                last_successful,
-                last_el,
+                # Pole scheduling does not (yet) implement
+                # elevation change penalty
+                # last_successful,
+                # last_el,
             )
         else:
             success, t, el = attempt_scan(

--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -14,6 +14,7 @@ set(ENTRY_POINTS
     toast_healpix_coadd.py
     toast_hdf5_to_spt3g.py
     toast_mini.py
+    toast_obsmatrix_combine.py
 )
 
 foreach(pyscript ${ENTRY_POINTS})

--- a/src/toast/scripts/toast_obsmatrix_combine.py
+++ b/src/toast/scripts/toast_obsmatrix_combine.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""This script converts HEALPiX maps between FITS and HDF5
+"""
+
+import argparse
+import os
+import sys
+import traceback
+
+import h5py
+import healpy as hp
+import numpy as np
+
+import toast
+from toast.mpi import Comm, get_world
+from toast.ops import combine_observation_matrix
+from toast.utils import Environment, Logger, Timer
+
+
+def main():
+    env = Environment.get()
+    log = Logger.get()
+    comm, procs, rank = get_world()
+    timer0 = Timer()
+    timer = Timer()
+    timer0.start()
+    timer.start()
+
+    parser = argparse.ArgumentParser(
+        description="Convert HEALPiX maps between FITS and HDF5"
+    )
+
+    parser.add_argument(
+        "rootname",
+        help="Root name of the observation matrix slices",
+    )
+
+    args = parser.parse_args()
+
+    if rank == 0:
+        fname_matrix = combine_observation_matrix(args.rootname)
+
+    log.info_rank(f"Wrote combined matrix to {fname_matrix} in", timer=timer0, comm=comm)
+
+    return
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -107,7 +107,7 @@ class DemodulateTest(MPITestCase):
 
         # Demodulate
 
-        demod = ops.Demodulate(stokes_weights=weights)
+        demod = ops.Demodulate(stokes_weights=weights, purge=True)
         demod_data = demod.apply(data)
 
         # ops.Delete(detdata=[defaults.weights]).apply(demod_data)

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -149,7 +149,7 @@ class FilterBinTest(MPITestCase):
             return
 
         # Create a fake ground data set for testing
-        data = create_ground_data(self.comm, sample_rate=1 * u.Hz)
+        data = create_ground_data(self.comm, sample_rate=1 * u.Hz, pixel_per_process=4)
 
         # Create some detector pointing matrices
         detpointing = ops.PointingDetectorSimple()

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -274,146 +274,7 @@ class FilterBinTest(MPITestCase):
                 print(f"rms1 = {rms1}, rms2 = {rms2}, rms2/rms1 = {rms2 / rms1}")
                 if rms2 > 1e-5 * rms1:
                     print(f"rms2 = {rms2}, rms1 = {rms1}")
-                    print("WARNING:  Fix and re-enable filterbin unit tests")
-                # assert rms2 < 1e-5 * rms1
-        return
-
-    def test_filterbin_obsmatrix_pypointing(self):
-        if sys.platform.lower() == "darwin":
-            print(f"WARNING:  Skipping test_filterbin_pypointing on MacOS")
-            return
-
-        # Create a fake ground data set for testing
-        data = create_ground_data(self.comm, sample_rate=1 * u.Hz)
-
-        # Create some detector pointing matrices
-        detpointing = ops.PointingDetectorSimple(use_python=True)
-        pixels = ops.PixelsHealpix(
-            nside=self.nside,
-            create_dist="pixel_dist",
-            detector_pointing=detpointing,
-            use_python=True,
-        )
-        pixels.apply(data)
-
-        weights = ops.StokesWeights(
-            mode="IQU",
-            hwp_angle=defaults.hwp_angle,
-            detector_pointing=detpointing,
-            use_python=True,
-        )
-        weights.apply(data)
-
-        # Create an uncorrelated noise model from focalplane detector properties
-        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
-        default_model.apply(data)
-
-        input_map_file = os.path.join(self.outdir, "input_map.fits")
-        if not os.path.exists(input_map_file):
-            if data.comm.world_rank == 0:
-                lmax = 3 * self.nside
-                cls = np.ones(4 * (lmax + 1)).reshape(4, -1)
-                fwhm = np.radians(10)
-                input_map = hp.synfast(
-                    cls, self.nside, lmax=lmax, fwhm=fwhm, verbose=False
-                )
-                if pixels.nest:
-                    input_map = hp.reorder(input_map, r2n=True)
-                hp.write_map(input_map_file, input_map, nest=pixels.nest)
-
-        if data.comm.comm_world is not None:
-            data.comm.comm_world.Barrier()
-
-        # Scan map into timestreams
-        scan_hpix = ops.ScanHealpixMap(
-            file=input_map_file,
-            det_data=defaults.det_data,
-            pixel_pointing=pixels,
-            stokes_weights=weights,
-        )
-        scan_hpix.apply(data)
-
-        # Configure and apply the filterbin operator
-        binning = ops.BinMap(
-            pixel_dist="pixel_dist",
-            covariance="covariance",
-            det_data=defaults.det_data,
-            pixel_pointing=pixels,
-            stokes_weights=weights,
-            noise_model=default_model.noise_model,
-            sync_type="allreduce",
-            shared_flags=defaults.shared_flags,
-            shared_flag_mask=1,
-            det_flags=defaults.det_flags,
-            det_flag_mask=255,
-        )
-
-        filterbin = ops.FilterBin(
-            name="filterbin_pypointing",
-            det_data=defaults.det_data,
-            det_flags=defaults.det_flags,
-            det_flag_mask=255,
-            shared_flags=defaults.shared_flags,
-            shared_flag_mask=1,
-            binning=binning,
-            ground_filter_order=5,
-            split_ground_template=True,
-            poly_filter_order=2,
-            output_dir=self.outdir,
-            write_obs_matrix=True,
-        )
-        filterbin.apply(data)
-
-        if data.comm.world_rank == 0:
-            import matplotlib.pyplot as plt
-
-            rot = [42, -42]
-            reso = 4
-            fig = plt.figure(figsize=[18, 12])
-            cmap = "coolwarm"
-            nest = pixels.nest
-
-            rootname = os.path.join(self.outdir, f"{filterbin.name}_obs_matrix")
-            fname_matrix = ops.combine_observation_matrix(rootname)
-
-            obs_matrix = scipy.sparse.load_npz(fname_matrix)
-
-            input_map = hp.read_map(input_map_file, None, nest=nest)
-
-            fname_filtered = os.path.join(
-                self.outdir, f"{filterbin.name}_filtered_map.fits"
-            )
-            filtered = hp.read_map(fname_filtered, None, nest=nest)
-
-            test_map = obs_matrix.dot(input_map.ravel()).reshape([3, -1])
-
-            good = filtered[0] != 0
-
-            nrow, ncol = 2, 2
-            args = {"rot": rot, "reso": reso, "cmap": cmap, "nest": nest}
-
-            diffmap = test_map - filtered
-            diffmap[filtered == 0] = hp.UNSEEN
-            filtered[filtered == 0] = hp.UNSEEN
-            test_map[test_map == 0] = hp.UNSEEN
-            hp.gnomview(filtered[0], sub=[nrow, ncol, 1], title="Filtered map", **args)
-            hp.gnomview(
-                test_map[0], sub=[nrow, ncol, 2], title="Input x obs.matrix", **args
-            )
-            hp.gnomview(input_map[0], sub=[nrow, ncol, 3], title="Input map", **args)
-            hp.gnomview(diffmap[0], sub=[nrow, ncol, 4], title="Difference", **args)
-            fname = os.path.join(self.outdir, "obs_matrix_test.png")
-            fig.savefig(fname)
-
-            for i in range(3):
-                rms1 = np.std(filtered[i][good])
-                rms2 = np.std((filtered - test_map)[i][good])
-                print(
-                    f"pypoint rms1 = {rms1}, rms2 = {rms2}, rms2/rms1 = {rms2 / rms1}"
-                )
-                if rms2 > 1e-5 * rms1:
-                    print("WARNING:  Fix and re-enable filterbin unit tests")
-                # assert rms2 < 1e-5 * rms1
+                assert rms2 < 1e-5 * rms1
         return
 
     def test_filterbin_obsmatrix_flags(self):
@@ -566,8 +427,7 @@ class FilterBinTest(MPITestCase):
                 rms2 = np.std((filtered - test_map)[i][good])
                 if rms2 > 1e-5 * rms1:
                     print(f"rms2 = {rms2}, rms1 = {rms1}")
-                    print("WARNING:  Fix and re-enable filterbin unit tests")
-                # assert rms2 < 1e-5 * rms1
+                assert rms2 < 1e-5 * rms1
 
         return
 
@@ -742,7 +602,6 @@ class FilterBinTest(MPITestCase):
                     rms2 = np.std((filtered - test_map)[i][good])
                     if rms2 > 1e-5 * rms1:
                         print(f"rms2 = {rms2}, rms1 = {rms1}")
-                        print("WARNING:  Fix and re-enable filterbin unit tests")
-                    # assert rms2 < 1e-5 * rms1
+                    assert rms2 < 1e-5 * rms1
 
         return

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -191,6 +191,7 @@ def load_instrument_and_schedule(args, comm):
         if comm is None or comm.rank == 0:
             pickle.dump(focalplane, open(fname_pickle, "wb"))
     log.info_rank("Loaded focalplane in", comm=comm, timer=timer)
+    log.info_rank(f"Focalplane: {str(focalplane)}", comm=comm)
     mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)
     log.info_rank(f"After loading focalplane:  {mem}", comm)
 

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -172,7 +172,8 @@ def load_instrument_and_schedule(args, comm):
     if os.path.isfile(fname_pickle):
         log.info_rank(f"Loading focalplane from {fname_pickle}", comm=comm)
         if comm is None or comm.rank == 0:
-            focalplane = pickle.load(open(fname_pickle, "rb"))
+            with open(fname_pickle, "rb") as handle:
+                focalplane = pickle.load(handle)
         else:
             focalplane = None
         if comm is not None:
@@ -183,13 +184,14 @@ def load_instrument_and_schedule(args, comm):
         else:
             fknee = args.fknee * u.Hz
         focalplane = toast.instrument.Focalplane(
-            sample_rate=sample_rate, thinfp=args.thinfp, fknee=fknee,
+            sample_rate=sample_rate, thinfp=args.thinfp, fknee=fknee
         )
         with toast.io.H5File(args.focalplane, "r", comm=comm, force_serial=True) as f:
             focalplane.load_hdf5(f.handle, comm=comm)
         log.info_rank(f"Saving focalplane to {fname_pickle}", comm=comm)
         if comm is None or comm.rank == 0:
-            pickle.dump(focalplane, open(fname_pickle, "wb"))
+            with open(fname_pickle, "wb") as handle:
+                pickle.dump(focalplane, handle)
     log.info_rank("Loaded focalplane in", comm=comm, timer=timer)
     log.info_rank(f"Focalplane: {str(focalplane)}", comm=comm)
     mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -110,13 +110,6 @@ def parse_config(operators, templates, comm):
     )
 
     parser.add_argument(
-        "--fknee",
-        required=False,
-        type=float,
-        help="Override noise model knee frequency [Hz]",
-    )
-
-    parser.add_argument(
         "--pwv_limit",
         required=False,
         type=float,
@@ -167,7 +160,7 @@ def load_instrument_and_schedule(args, comm):
 
     fname_pickle = (
         f"{os.path.basename(args.focalplane)}_"
-        f"thinfp={args.thinfp}_fsample={args.sample_rate}_fknee={args.fknee}.pck"
+        f"thinfp={args.thinfp}_fsample={args.sample_rate}.pck"
     )
     if os.path.isfile(fname_pickle):
         log.info_rank(f"Loading focalplane from {fname_pickle}", comm=comm)

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -31,7 +31,9 @@ import os
 import pickle
 import sys
 import traceback
+import warnings
 
+import erfa
 import numpy as np
 from astropy import units as u
 
@@ -46,6 +48,9 @@ from toast.mpi import MPI, Comm
 if t3g.available:
     from spt3g import core as c3g
 
+
+warnings.simplefilter("error")
+warnings.simplefilter("ignore", erfa.core.ErfaWarning)
 
 def parse_config(operators, templates, comm):
     """Parse command line arguments and load any config files.


### PR DESCRIPTION
Tweaks coming from CMB-S4 AoA work.

* Fixes a bug in the scheduler that intermittently caused it to add mixed rising/setting scans when the patch was observed close to Az=180 degrees.
* Add a command line tool for combining observation matrices. It is just an interface around existing Python facilities.
* Fix a bug in caching elements of the observation matrix to speed up future calculations
* Re-enable observation matrix unit tests that were disabled during recent refactor work
* Fix the detector noise weights to be defined as 1 / sigma^2, where sigma^2 is the noise variance per detector sample. Without this, the noise matrices generated by the mapmaker cannot be translated into depth maps.