### PR TITLE
Pointing model updates

### DIFF
--- a/platforms/conda.sh
+++ b/platforms/conda.sh
@@ -28,10 +28,9 @@ else
     CMAKE_BUILD_TYPE=Release
 fi
 
-CMAKE_PLATFORM_FLAGS=""
 shext="so"
 if [[ ${CONDA_TOOLCHAIN_HOST} =~ .*darwin.* ]]; then
-    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}")
+    export TOAST_BUILD_CMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}"
     shext="dylib"
 fi
 

--- a/platforms/conda_dev.sh
+++ b/platforms/conda_dev.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# This configures toast using cmake directly (not pip), but uses the
+# conda compilers and other dependencies provided by conda.  It is
+# useful for building toast in parallel repeatedly for debugging
+# in situations where clean un-install is not a concern.
+
 set -e
 
 if [ "x${CONDA_PREFIX}" = "x" ]; then
@@ -35,22 +40,19 @@ if [[ ${CONDA_TOOLCHAIN_HOST} =~ .*darwin.* ]]; then
     shext="dylib"
 fi
 
-export TOAST_BUILD_CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-export TOAST_BUILD_CMAKE_PLATFORM_FLAGS=${CMAKE_PLATFORM_FLAGS}
-export TOAST_BUILD_CMAKE_C_COMPILER="${CC}"
-export TOAST_BUILD_CMAKE_CXX_COMPILER="${CXX}"
-export TOAST_BUILD_CMAKE_C_FLAGS="-O3 -g -fPIC"
-export TOAST_BUILD_CMAKE_CXX_FLAGS="-O3 -g -fPIC"
-export TOAST_BUILD_CMAKE_VERBOSE_MAKEFILE=1
-export TOAST_BUILD_CMAKE_INSTALL_PREFIX="${PREFIX}"
-export TOAST_BUILD_CMAKE_PREFIX_PATH="${PREFIX}"
-export TOAST_BUILD_FFTW_ROOT="${PREFIX}"
-export TOAST_BUILD_AATM_ROOT="${PREFIX}"
-export TOAST_BUILD_BLAS_LIBRARIES="${LIBDIR}/libblas.${shext}"
-export TOAST_BUILD_LAPACK_LIBRARIES="${LIBDIR}/liblapack.${shext}"
-export TOAST_BUILD_SUITESPARSE_INCLUDE_DIR_HINTS="${PREFIX}/include"
-export TOAST_BUILD_SUITESPARSE_LIBRARY_DIR_HINTS="${LIBDIR}"
-
-python setup.py build_ext --inplace
-
-conda develop "${topdir}/src"
+cmake \
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" ${CMAKE_PLATFORM_FLAGS} \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_C_FLAGS="-O3 -g -fPIC" \
+    -DCMAKE_CXX_FLAGS="-O3 -g -fPIC" \
+    -DCMAKE_VERBOSE_MAKEFILE=1 \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DFFTW_ROOT="${PREFIX}" \
+    -DAATM_ROOT="${PREFIX}" \
+    -DBLAS_LIBRARIES="${LIBDIR}/libblas.${shext}" \
+    -DLAPACK_LIBRARIES="${LIBDIR}/liblapack.${shext}" \
+    -DSUITESPARSE_INCLUDE_DIR_HINTS="${PREFIX}/include" \
+    -DSUITESPARSE_LIBRARY_DIR_HINTS="${LIBDIR}" \
+    ..

--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -121,6 +121,7 @@ install(FILES
     intervals.py
     instrument.py
     instrument_sim.py
+    instrument_coords.py
     coordinates.py
     noise.py
     atm.py

--- a/src/toast/instrument_coords.py
+++ b/src/toast/instrument_coords.py
@@ -111,7 +111,7 @@ def xieta_to_quat(xi, eta, gamma):
 
     """
     theta, phi, psi = xieta_to_iso(xi, eta, gamma)
-    return qa.from_iso(theta, phi, psi)
+    return qa.from_iso_angles(theta, phi, psi)
 
 
 def quat_to_xieta(quats):
@@ -127,5 +127,5 @@ def quat_to_xieta(quats):
         (tuple):  Tuple of xi, eta, gamma values in radians
 
     """
-    theta, phi, psi = qa.to_iso(quats)
+    theta, phi, psi = qa.to_iso_angles(quats)
     return iso_to_xieta(theta, phi, psi)

--- a/src/toast/instrument_coords.py
+++ b/src/toast/instrument_coords.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2015-2022 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import numpy as np
+
+from . import qarray as qa
+
+
+def xieta_to_iso(xi, eta, gamma):
+    """Convert xi, eta, gamma coordinates to ISO theta, phi, psi.
+
+    The xi, eta, gamma coordinate system is a 2D projection useful for focalplane
+    visualization and comparison.
+
+    Args:
+        xi (array):  Array or scalar xi values in radians
+        eta (array):  Array or scalar eta values in radians
+        gamma (array):  Array or scalar gamma values in radians
+
+    Returns:
+        (tuple):  Tuple of theta, phi, psi values
+
+    """
+    eps = 1.0e-12
+    theta = np.arcsin(np.sqrt(xi**2 + eta**2))
+    try:
+        lt = len(theta)
+        # Handle special values
+        theta_zero = theta < eps
+        theta_pi = np.pi - theta < eps
+        theta_extreme = np.logical_or(theta_zero, theta_pi)
+        theta_normal = np.logical_not(theta_extreme)
+
+        theta[theta_zero] = 0.0
+        theta[theta_pi] = np.pi
+
+        phi = np.zeros_like(theta)
+        phi[theta_normal] = np.arctan2(-xi[theta_normal], -eta[theta_normal])
+        psi = gamma - phi
+    except TypeError:
+        # Scalar values
+        if theta < eps:
+            theta = 0.0
+            phi = 0.0
+        elif np.pi - theta < eps:
+            theta = np.pi
+            phi = 0.0
+        else:
+            phi = np.arctan2(-xi, -eta)
+        psi = gamma - phi
+    return (theta, phi, psi)
+
+
+def iso_to_xieta(theta, phi, psi):
+    """Convert ISO theta, phi, psi coordinates to xi, eta, gamma coordinates.
+
+    The xi, eta, gamma coordinate system is a 2D projection useful for focalplane
+    visualization and comparison.
+
+    Args:
+        theta (array):  Array or scalar theta values in radians
+        phi (array):  Array or scalar phi values in radians
+        psi (array):  Array or scalar psi values in radians
+
+    Returns:
+        (tuple):  Tuple of xi, eta, gamma values
+
+    """
+    eps = 1.0e-12
+    stheta = np.sin(theta)
+    try:
+        lt = len(theta)
+        # Handle special values
+        theta_normal = np.logical_and(theta > eps, np.pi - theta > eps)
+
+        xi = np.zeros_like(theta)
+        xi[theta_normal] = -stheta[theta_normal] * np.sin(phi[theta_normal])
+
+        eta = np.zeros_like(theta)
+        eta[theta_normal] = -stheta[theta_normal] * np.cos(phi[theta_normal])
+
+        gamma = psi + phi
+    except TypeError:
+        # Scalar values
+        if (theta > eps) and (np.pi - theta > eps):
+            # Not extremes
+            xi = -stheta * np.sin(phi)
+            eta = -stheta * np.cos(phi)
+        else:
+            # special values
+            xi = 0.0
+            eta = 0.0
+        gamma = psi + phi
+    return (xi, eta, gamma)
+
+
+def xieta_to_quat(xi, eta, gamma):
+    """Convert xi, eta, gamma coordinates to quaternions.
+
+    The xi, eta, gamma coordinate system is a 2D projection useful for focalplane
+    visualization and comparison.
+
+    Args:
+        xi (array):  Array or scalar xi values in radians
+        eta (array):  Array or scalar eta values in radians
+        gamma (array):  Array or scalar gamma values in radians
+
+    Returns:
+        (array):  Array of one or more quaternions
+
+    """
+    theta, phi, psi = xieta_to_iso(xi, eta, gamma)
+    return qa.from_iso(theta, phi, psi)
+
+
+def quat_to_xieta(quats):
+    """Convert quaternions to xi, eta, gamma coordinates.
+
+    The xi, eta, gamma coordinate system is a 2D projection useful for focalplane
+    visualization and comparison.
+
+    Args:
+        quats (array):  Array of one or more quaternions
+
+    Returns:
+        (tuple):  Tuple of xi, eta, gamma values in radians
+
+    """
+    theta, phi, psi = qa.to_iso(quats)
+    return iso_to_xieta(theta, phi, psi)

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -8,37 +8,8 @@ from astropy.table import Column, QTable
 
 from . import qarray as qa
 from .instrument import Focalplane
+from .instrument_coords import quat_to_xieta, xieta_to_quat
 from .vis import set_matplotlib_backend
-
-
-def cartesian_to_quat(offsets):
-    """Convert cartesian angle offsets and rotation into quaternions.
-
-    Focalplane geometries are often described in terms of wafer locations or
-    separations given in simple X/Y angle offsets from a center point.
-    this helper function converts such parameters into a quaternion describing
-    the rotation.
-
-    Args:
-        offsets (list of arrays):  each item of the list has 3 elements for
-            the X / Y angle offsets in degrees and the rotation in degrees
-            about the Z axis.
-
-    Returns:
-        (list): list of quaternions for each item in the input list.
-
-    """
-    centers = list()
-    zaxis = np.array([0, 0, 1], dtype=np.float64)
-    for off in offsets:
-        angrot = qa.rotation(zaxis, off[2] * np.pi / 180.0)
-        wx = off[0] * np.pi / 180.0
-        wy = off[1] * np.pi / 180.0
-        wz = np.sqrt(1.0 - (wx * wx + wy * wy))
-        wdir = np.array([wx, wy, wz])
-        posrot = qa.from_vectors(zaxis, wdir)
-        centers.append(qa.mult(posrot, angrot))
-    return centers
 
 
 def hex_nring(npix):
@@ -66,13 +37,24 @@ def hex_nring(npix):
     return nrings
 
 
-def hex_row_col(npix, pix):
-    """Return the location of a given position.
+def hex_xieta_row_col(npos, pos):
+    """Return the location of a given hexagon position.
 
-    For a hexagonal layout, indexed in a "spiral" scheme (see hex_layout),
-    this function returnes the "row" and "column" of a single position.
-    The row is zero along the main vertex-vertex axis, and is positive
-    or negative above / below this line of positions.
+    This function is used when laying out polarization angles that need to alternate
+    in a particular way.  The "row" is zero along the main vertex-vertex direction
+    and can be positive or negative.  The "column" is always >= 0 and increments from
+    left to right in Xi / Eta plane.  For example, the (row, col) values for npos=19
+    would be:
+
+                                    ( 2, 0)   ( 2, 1)   ( 2, 2)
+        Eta ^
+            |                   ( 1, 0)   ( 1, 1)   ( 1, 2)   ( 1, 3)
+            |
+            +--> Xi         ( 0, 0)  ( 0, 1)  ( 0, 2)  ( 0, 3)  ( 0, 4)
+
+                                (-1, 0)   (-1, 1)   (-1, 2)   (-1, 3)
+
+                                     (-2, 0)   (-2, 1)   (-2, 2)
 
     Args:
         npos (int): The number of positions.
@@ -82,18 +64,18 @@ def hex_row_col(npix, pix):
         (tuple): The (row, column) location of the position.
 
     """
-    if pix >= npix:
-        raise ValueError("pixel value out of range")
-    test = npix - 1
+    if pos >= npos:
+        raise ValueError("position value out of range")
+    test = npos - 1
     nrings = 1
     while (test - 6 * nrings) >= 0:
         test -= 6 * nrings
         nrings += 1
-    if pix == 0:
+    if pos == 0:
         row = 0
         col = nrings - 1
     else:
-        test = pix - 1
+        test = pos - 1
         ring = 1
         while (test - 6 * ring) >= 0:
             test -= 6 * ring
@@ -122,11 +104,12 @@ def hex_row_col(npix, pix):
     return (row, col)
 
 
-def hex_pol_angles_qu(npix, offset=0.0):
+def hex_gamma_angles_qu(npix, offset=u.Quantity(0.0, u.degree)):
     """Generates a vector of detector polarization angles.
 
     The returned angles can be used to construct a hexagonal detector layout.
-    This scheme alternates pixels between 0/90 and +/- 45 degrees.
+    This scheme alternates pixels between 0/90 and +/- 45 degrees.  The angles
+    specify the "gamma" rotation angle in the xi, eta, gamma coordinate system.
 
     Args:
         npix (int): the number of pixels locations in the hexagon.
@@ -139,24 +122,25 @@ def hex_pol_angles_qu(npix, offset=0.0):
     pol = np.zeros(npix, dtype=np.float64)
     for pix in range(npix):
         # get the row / col of the pixel
-        row, col = hex_row_col(npix, pix)
+        row, col = hex_xieta_row_col(npix, pix)
         if np.mod(col, 2) == 0:
-            pol[pix] = 0.0 + offset
+            pol[pix] = 0.0 + offset.to_value(u.degree)
         else:
-            pol[pix] = 45.0 + offset
-    return pol
+            pol[pix] = 45.0 + offset.to_value(u.degree)
+    return u.Quantity(pol, u.degree)
 
 
-def hex_pol_angles_radial(npix, offset=0.0):
+def hex_gamma_angles_radial(npix, offset=u.Quantity(0.0, u.degree)):
     """Generates a vector of detector polarization angles.
 
     The returned angles can be used to construct a hexagonal detector layout.
     This scheme orients the bolometer along the radial direction of the
-    hexagon.
+    hexagon.  The angles specify the "gamma" rotation angle in the xi, eta, gamma
+    coordinate system.
 
     Args:
         npix (int): the number of pixels locations in the hexagon.
-        offset (float): the constant angle offset in degrees to apply.
+        offset (Quantity): the constant angle offset to apply.
 
     Returns:
         (array):  The detector polarization angles.
@@ -178,44 +162,61 @@ def hex_pol_angles_radial(npix, offset=0.0):
         midline = 0.5 * np.sqrt(3) * float(ring)
         edgedist = float(sectorsteps) - 0.5 * float(ring)
         relang = np.arctan2(edgedist, midline)
-        pol[pix] = (sectors * sixty + thirty + relang) * 180.0 / np.pi + offset
-    return pol
+
+        # Note:  this is the counter-clockwise (right-handed) angle in the xi/eta
+        # plane starting at the positive xi axis.
+        pixang = sectors * sixty + thirty + relang
+
+        # Convert to the gamma angle, which is zero at the X (-eta) axis and
+        # increasing in a right-handed sense from that axis in the X/Y plane.
+        pol[pix] = (1.5 * np.pi - pixang) * 180.0 / np.pi + offset.to_value(u.degree)
+    return u.Quantity(pol, u.degree)
 
 
-def hex_layout(
-    npix, angwidth, prefix, suffix, pol, center=np.array([0, 0, 0, 1], dtype=np.float64)
-):
-    """Return detectors in a hexagon layout.
+def hex_layout(npos, angwidth, prefix, suffix, pol, center=None, pos_offset=0):
+    """Construct a hexagonal layout of positions.
 
-    This maps the physical posititions of spots into angular positions
-    from the hexagon center.  The X axis in the hexagon frame is along
-    the vertex-to-opposite-vertex direction.  The Y axis is along
-    flat-to-opposite-flat direction.  The origin is at the center.
-    For example::
+    This function first creates a hexagon of positions using the Xi / Eta / Gamma
+    projected coordinate system.  The array of "pol" angles specify the gamma
+    rotation angle clockwise from the Eta axis.  It then converts each of these
+    positions into a quaternion that describes the rotation from the hexagon
+    X / Y / Z coordinate frame into the detector frame with the Z axis along the line
+    of sight and the X axis along the polarization sensitive direction.
 
-        Y ^             O O O
-        |              O O O O
-        |             O O + O O
-        +--> X         O O O O
-                        O O O
+    For example with 19 positions:
 
-    Each pixel is numbered 1..npix and each detector is named by the
+                           11    10    09           Eta
+                                                    ^
+                        12    03    02    08        |
+                                                    |
+        Y <---+     13     04    00    01     07    +---> Xi
+              |
+              |         14    05    06    18
+              V
+                           15    16    17
+              X
+
+    Each pixel is numbered 0...npos-1 and each detector is named by the
     prefix, the pixel number, and the suffix.  The first pixel is at
     the center, and then the pixels are numbered moving outward in rings.
 
     The extent of the hexagon is directly specified by the angwidth
-    parameter.  These, along with the npix parameter, constrain the packing
+    parameter.  These, along with the npos parameter, constrain the packing
     locations of the pixel centers.
 
+    If the "center" argument is specified, then each quaternion is additionally
+    multiplied by this in order to shift all positions to be relative to a new
+    center.
+
     Args:
-        npix (int): number of pixels packed onto wafer.
-        angwidth (float): the angle (in degrees) subtended by the width.
+        npos (int): number of pixels packed onto wafer.
+        angwidth (Quantity): the angle subtended by the width.
         prefix (str): the detector name prefix.
         suffix (str): the detector name suffix.
-        pol (ndarray): 1D array of detector polarization angles.  The
-            rotation is applied to the hexagon center prior to rotation
-            to the pixel location.
-        center (ndarray): quaternion offset of the center of the layout.
+        pol (ndarray): 1D array of detector polarization angles.  These are the
+            "gamma" angle in the xi / eta / gamma coordinate system.
+        center (ndarray): quaternion offset of the center of the layout (or None).
+        pos_offset (int): starting index of position numbers.
 
     Returns:
         (dict) A dictionary keyed on detector name, with each value itself a
@@ -229,26 +230,21 @@ def hex_layout(
     rtthree = np.sqrt(3.0)
     rtthreebytwo = 0.5 * rtthree
 
-    angwidth = angwidth * np.pi / 180.0
-
     # compute the diameter (vertex to vertex width)
-    angdiameter = angwidth / np.cos(thirty)
+    angdiameter = angwidth.to_value(u.radian) / np.cos(thirty)
 
     # find the angular packing size of one detector
-    test = npix - 1
+    test = npos - 1
     nrings = 1
     while (test - 6 * nrings) >= 0:
         test -= 6 * nrings
         nrings += 1
     pixdiam = angdiameter / (2 * nrings - 1)
 
-    # convert pol vector to radians
-    pol *= np.pi / 180.0
-
     # number of digits for pixel indexing
 
     ndigit = 0
-    test = npix
+    test = npos
     while test > 0:
         test = test // 10
         ndigit += 1
@@ -259,13 +255,12 @@ def hex_layout(
 
     dets = {}
 
-    for pix in range(npix):
-        dname = nameformat.format(prefix, pix, suffix)
+    for pix in range(npos):
+        dname = nameformat.format(prefix, pix + pos_offset, suffix)
 
-        polrot = qa.rotation(zaxis, pol[pix])
-
-        # center pixel has no offset
-        pixrot = nullquat
+        xi = 0
+        eta = 0
+        gamma = pol[pix].to_value(u.radian)
 
         if pix != 0:
             # Not at the center, find ring for this pix
@@ -309,25 +304,21 @@ def hex_layout(
 
             pixdist = rtthreebytwo * pixdiam * float(ring) / np.cos(relang)
 
-            pixx = np.sin(pixdist) * np.cos(pixang)
-            pixy = np.sin(pixdist) * np.sin(pixang)
-            pixz = np.cos(pixdist)
-            pixdir = np.array([pixx, pixy, pixz], dtype=np.float64)
-            norm = np.sqrt(np.dot(pixdir, pixdir))
-            pixdir /= norm
-
-            pixrot = qa.from_vectors(zaxis, pixdir)
+            xi = np.sin(pixdist) * np.cos(pixang)
+            eta = np.sin(pixdist) * np.sin(pixang)
 
         dprops = {}
-        dprops["quat"] = qa.mult(center, qa.mult(pixrot, polrot))
-        dprops["polangle_deg"] = pol[pix]
+        if center is None:
+            dprops["quat"] = xieta_to_quat(xi, eta, gamma)
+        else:
+            dprops["quat"] = qa.mult(center, xieta_to_quat(xi, eta, gamma))
 
         dets[dname] = dprops
 
     return dets
 
 
-def rhomb_dim(npix):
+def rhomb_dim(npos):
     """Compute the dimensions of a rhombus.
 
     For a rhombus with the specified number of positions, return the dimension
@@ -340,18 +331,33 @@ def rhomb_dim(npix):
         (int): The dimension of one side.
 
     """
-    dim = int(np.sqrt(float(npix)))
-    if dim**2 != npix:
-        raise ValueError("number of pixels for a rhombus wafer must be square")
+    dim = int(np.sqrt(float(npos)))
+    if dim**2 != npos:
+        raise ValueError("number of positions for a rhombus layout must be square")
     return dim
 
 
-def rhomb_row_col(npix, pix):
+def rhomb_xieta_row_col(npos, pos):
     """Return the location of a given position.
 
-    For a rhombus layout, indexed from top to bottom (see rhombus_layout),
-    this function returnes the "row" and "column" of a position.  The column
-    starts at zero on the left hand side of a row.
+    For a rhombus layout, this function returnes the "row" and "column" of a
+    position.  The column starts at zero on the left hand side of a row.
+    For example, the (row, col) values for npos=16 would be:
+
+                                          (0, 0)
+        Eta ^
+            |                         (1, 0)  (1, 1)
+            |
+            +--> Xi               (2, 0)  (2, 1)  (2, 2)
+
+                              (3, 0)  (3, 1)  (3, 2)  (3, 3)
+
+                                  (4, 0)  (4, 1)  (4, 2)
+
+                                      (5, 0)  (5, 1)
+
+                                          (6, 0)
+
 
     Args:
         npos (int): The number of positions.
@@ -361,10 +367,10 @@ def rhomb_row_col(npix, pix):
         (tuple): The (row, column) location of the position.
 
     """
-    if pix >= npix:
+    if pos >= npos:
         raise ValueError("pixel value out of range")
-    dim = rhomb_dim(npix)
-    col = pix
+    dim = rhomb_dim(npos)
+    col = pos
     rowcnt = 1
     row = 0
     while (col - rowcnt) >= 0:
@@ -377,7 +383,7 @@ def rhomb_row_col(npix, pix):
     return (row, col)
 
 
-def rhomb_pol_angles_qu(npix, offset=0.0):
+def rhomb_gamma_angles_qu(npix, offset=u.Quantity(0.0, u.degree)):
     """Generates a vector of detector polarization angles.
 
     The returned angles can be used to construct a rhombus detector layout.
@@ -385,7 +391,7 @@ def rhomb_pol_angles_qu(npix, offset=0.0):
 
     Args:
         npix (int): the number of pixels locations in the rhombus.
-        offset (float): the constant angle offset in degrees to apply.
+        offset (Quantity): the constant angle offset to apply.
 
     Returns:
         (array): The detector polarization angles.
@@ -394,61 +400,61 @@ def rhomb_pol_angles_qu(npix, offset=0.0):
     pol = np.zeros(npix, dtype=np.float64)
     for pix in range(npix):
         # get the row / col of the pixel
-        row, col = rhomb_row_col(npix, pix)
+        row, col = rhomb_xieta_row_col(npix, pix)
         if np.mod(col, 2) == 0:
-            pol[pix] = 45.0 + offset
+            pol[pix] = 45.0 + offset.to_value(u.degree)
         else:
-            pol[pix] = 0.0 + offset
-    return pol
+            pol[pix] = 0.0 + offset.to_value(u.degree)
+    return u.Quantity(pol, u.degree)
 
 
-def rhombus_layout(
-    npix,
-    angwidth,
-    prefix,
-    suffix,
-    polang,
-    center=np.array([0, 0, 0, 1], dtype=np.float64),
-):
-    """Return detectors in a rhombus layout.
+def rhombus_layout(npos, angwidth, prefix, suffix, pol, center=None, pos_offset=0):
+    """Return positions in a rhombus layout.
 
-    This particular rhombus geometry is essentially a third of a
-    hexagon.  In other words the aspect ratio of the rhombus is
-    constrained to have the long dimension be sqrt(3) times the short
-    dimension.
+    This particular rhombus geometry is essentially a third of a hexagon.  In other
+    words the aspect ratio of the rhombus is constrained to have the long dimension
+    be sqrt(3) times the short dimension.
 
-    This function maps the physical positions of pixels into angular
-    positions from the rhombus center.  The X axis is along the short
-    direction.  The Y axis is along longer direction.  The origin is
-    at the center of the rhombus.  For example::
+    This function first creates a rhombus of positions using the Xi / Eta / Gamma
+    projected coordinate system.  The array of "pol" angles specify the gamma
+    rotation angle clockwise from the Eta axis.  It then converts each of these
+    positions into a quaternion that describes the rotation from the rhombus
+    X / Y / Z coordinate frame into the detector frame with the Z axis along the line
+    of sight and the X axis along the polarization sensitive direction.
 
-                          O
-        Y ^              O O
-        |               O O O
-        |              O O O O
-        +--> X          O O O
-                         O O
-                          O
+    For example with 16 positions:
 
-    Each pixel is numbered 1..npix and each detector is named by the
-    prefix, the pixel number, and the suffix.  The first pixel is at the
-    "top", and then the pixels are numbered moving downward and left to
-    right.
+                              00
+
+                           01    02         Eta
+                                             ^
+                        03    04    05       |
+                                             |
+        Y <---+     06     07    08    09    +---> Xi
+              |
+              |         10    11    12
+              V
+                           13    14
+              X
+                              15
+
+    Each pixel is numbered 0...npos-1 and each detector is named by the prefix, the
+    pixel number, and the suffix.  The first pixel is at the "top", and then the
+    pixels are numbered moving downward and left to right.
 
     The extent of the rhombus is directly specified by the angwidth parameter.
-    This, along with the npix parameter, constrain the packing locations of
+    This, along with the npos parameter, constrain the packing locations of
     the pixel centers.
 
     Args:
-        npix (int): number of pixels packed onto wafer.
-        angwidth (float): the angle (in degrees) subtended by the short
-            dimension.
+        npos (int): number of pixels packed onto wafer.
+        angwidth (Quantity): the angle subtended by the short dimension.
         prefix (str): the detector name prefix.
         suffix (str): the detector name suffix.
-        polang (ndarray): 1D array of detector polarization angles.  The
-            rotation is applied to the hexagon center prior to rotation
-            to the pixel location.
+        pol (Quantity): 1D array of detector polarization angles.  These are the
+            "gamma" angle in the xi / eta / gamma coordinate system.
         center (ndarray): quaternion offset of the center of the layout.
+        pos_offset (int): starting index of position numbers.
 
     Returns:
         (dict):  A dictionary keyed on detector name, with each value itself a
@@ -459,22 +465,18 @@ def rhombus_layout(
     nullquat = np.array([0, 0, 0, 1], dtype=np.float64)
     rtthree = np.sqrt(3.0)
 
-    angwidth = angwidth * np.pi / 180.0
-    dim = rhomb_dim(npix)
+    dim = rhomb_dim(npos)
 
     # compute the height
-    angheight = rtthree * angwidth
+    angheight = rtthree * angwidth.to_value(u.radian)
 
     # find the angular packing size of one detector
-    pixdiam = angwidth / dim
-
-    # convert pol vector to radians
-    pol = polang * np.pi / 180.0
+    pixdiam = angwidth.to_value(u.radian) / dim
 
     # number of digits for pixel indexing
 
     ndigit = 0
-    test = npix
+    test = npos
     while test > 0:
         test = test // 10
         ndigit += 1
@@ -485,28 +487,29 @@ def rhombus_layout(
 
     dets = {}
 
-    for pix in range(npix):
-        dname = nameformat.format(prefix, pix, suffix)
+    for pix in range(npos):
+        dname = nameformat.format(prefix, pix + pos_offset, suffix)
 
-        polrot = qa.rotation(zaxis, pol[pix])
+        xi = 0
+        eta = 0
+        gamma = pol[pix].to_value(u.radian)
 
-        pixrow, pixcol = rhomb_row_col(npix, pix)
+        pixrow, pixcol = rhomb_xieta_row_col(npos, pix)
 
         rowang = 0.5 * rtthree * ((dim - 1) - pixrow) * pixdiam
         relrow = pixrow
         if pixrow >= dim:
             relrow = (2 * dim - 2) - pixrow
         colang = (float(pixcol) - float(relrow) / 2.0) * pixdiam
-        distang = np.sqrt(rowang**2 + colang**2)
-        zang = np.cos(distang)
-        pixdir = np.array([colang, rowang, zang], dtype=np.float64)
-        norm = np.sqrt(np.dot(pixdir, pixdir))
-        pixdir /= norm
 
-        pixrot = qa.from_vectors(zaxis, pixdir)
+        xi = colang
+        eta = rowang
 
         dprops = {}
-        dprops["quat"] = qa.mult(center, qa.mult(pixrot, polrot))
+        if center is None:
+            dprops["quat"] = xieta_to_quat(xi, eta, gamma)
+        else:
+            dprops["quat"] = qa.mult(center, xieta_to_quat(xi, eta, gamma))
 
         dets[dname] = dprops
 
@@ -563,14 +566,16 @@ def fake_hexagon_focalplane(
         (Focalplane):  The fake focalplane.
 
     """
-    width_deg = width.to_value(u.degree)
+    zaxis = np.array([0.0, 0.0, 1.0])
+    center = None
+
     # When laying out the hexagonal pixels, the angular "width" is the distance
     # between the flat sides.
-    width_flats = np.cos(np.pi / 6) * width_deg
-    pol_A = hex_pol_angles_qu(n_pix, offset=0.0)
-    pol_B = hex_pol_angles_qu(n_pix, offset=90.0)
-    quat_A = hex_layout(n_pix, width_flats, "D", "A", pol_A)
-    quat_B = hex_layout(n_pix, width_flats, "D", "B", pol_B)
+    width_flats = np.cos(np.pi / 6) * width
+    pol_A = hex_gamma_angles_qu(n_pix, offset=0.0 * u.degree)
+    pol_B = hex_gamma_angles_qu(n_pix, offset=90.0 * u.degree)
+    quat_A = hex_layout(n_pix, width_flats, "D", "A", pol_A, center=center)
+    quat_B = hex_layout(n_pix, width_flats, "D", "B", pol_B, center=center)
 
     temp_data = dict(quat_A)
     temp_data.update(quat_B)
@@ -607,6 +612,164 @@ def fake_hexagon_focalplane(
         det_table[idet]["name"] = det
         det_table[idet]["quat"] = det_data[det]["quat"]
         det_table[idet]["pol_leakage"] = epsilon
+        # psi_pol is the rotation from the PXX beam frame to the polarization
+        # sensitive direction.
+        if det.endswith("A"):
+            det_table[idet]["psi_pol"] = 0 * u.rad
+        else:
+            det_table[idet]["psi_pol"] = np.pi / 2 * u.rad
+        det_table[idet]["fwhm"] = fwhm * (
+            1 + np.random.randn() * fwhm_sigma.to_value(fwhm.unit)
+        )
+        det_table[idet]["bandcenter"] = bandcenter * (
+            1 + np.random.randn() * bandcenter_sigma.to_value(bandcenter.unit)
+        )
+        det_table[idet]["bandwidth"] = bandwidth * (
+            1 + np.random.randn() * bandcenter_sigma.to_value(bandcenter.unit)
+        )
+        det_table[idet]["psd_fmin"] = psd_fmin
+        det_table[idet]["psd_fknee"] = psd_fknee
+        det_table[idet]["psd_alpha"] = psd_alpha
+        det_table[idet]["psd_net"] = psd_net
+
+    return Focalplane(
+        detector_data=det_table,
+        sample_rate=sample_rate,
+        field_of_view=1.1 * (width + 2 * fwhm),
+    )
+
+
+def fake_rhombihex_focalplane(
+    n_pix_rhombus=4,
+    width=5.0 * u.degree,
+    sample_rate=1.0 * u.Hz,
+    epsilon=0.0,
+    fwhm=10.0 * u.arcmin,
+    bandcenter=150 * u.GHz,
+    bandwidth=20 * u.GHz,
+    psd_net=0.1 * u.K * np.sqrt(1 * u.second),
+    psd_fmin=0.0 * u.Hz,
+    psd_alpha=1.0,
+    psd_fknee=0.05 * u.Hz,
+    fwhm_sigma=0.0 * u.arcmin,
+    bandcenter_sigma=0 * u.GHz,
+    bandwidth_sigma=0 * u.GHz,
+    random_seed=123456,
+):
+    """Create a simple focalplane model for testing.
+
+    This function constructs a hexagonal layout using 3 rhombi.  Each pixel has two
+    orthogonal detectors.  It is intended for unit tests, benchmarking, etc where
+    a Focalplane is needed but the details are less important.  In addition to nominal
+    detector properties, this function adds other simulation-specific parameters to
+    the metadata.
+
+    Args:
+        n_pix_rhombus (int):  The (square) number of pixels in each of the 3 rhombi.
+        width (Quantity):  The angular width of the focalplane field of view on the sky.
+        sample_rate (Quantity):  The sample rate for all detectors.
+        epsilon (float):  The cross-polar response for all detectors.
+        fwhm (Quantity):  The beam FWHM
+        bandcenter (Quantity):  The detector band center.
+        bandwidth (Quantity):  The detector band width.
+        psd_net (Quantity):  The Noise Equivalent Temperature of each detector.
+        psd_fmin (Quantity):  The frequency below which to roll off the 1/f spectrum.
+        psd_alpha (float):  The spectral slope.
+        psd_fknee (Quantity):  The 1/f knee frequency.
+        fwhm_sigma (Quantity):  Draw random detector FWHM values from a normal
+            distribution with this width.
+        bandcenter_sigma (Quantity):  Draw random bandcenter values from a normal
+            distribution with this width.
+        bandwidth_sigma (Quantity):  Draw random bandwidth values from a normal
+            distribution with this width.
+        random_seed (int):  The seed to use for numpy random.
+
+    Returns:
+        (Focalplane):  The fake focalplane.
+
+    """
+    xaxis, yaxis, zaxis = np.eye(3)
+
+    # Gap between rhombi as a fraction of the total width
+    gap = 0.1 * width
+    gap_rad = gap.to_value(u.radian)
+
+    # The full width is twice the short dimension of one rhombus.
+    rhomb_width = 0.5 * (width - gap)
+    rhomb_width_rad = rhomb_width.to_value(u.radian)
+
+    # Quaternion offsets of the 3 rhombi
+    centers = [
+        xieta_to_quat(0.5 * rhomb_width_rad + gap_rad / np.sqrt(3), 0.0, 0.0),
+        xieta_to_quat(
+            -0.25 * rhomb_width_rad - 0.5 * gap_rad / np.sqrt(3),
+            0.25 * np.sqrt(3) * rhomb_width_rad + 0.5 * gap_rad,
+            -2 * np.pi / 3,
+        ),
+        xieta_to_quat(
+            -0.25 * rhomb_width_rad - 0.5 * gap_rad / np.sqrt(3),
+            -0.25 * np.sqrt(3) * rhomb_width_rad - 0.5 * gap_rad,
+            2 * np.pi / 3,
+        ),
+    ]
+
+    full_fp = dict()
+    for irhomb, cent in enumerate(centers):
+        pol_A = rhomb_gamma_angles_qu(n_pix_rhombus, offset=0.0 * u.degree)
+        pol_B = rhomb_gamma_angles_qu(n_pix_rhombus, offset=90.0 * u.degree)
+        quat_A = rhombus_layout(
+            n_pix_rhombus,
+            rhomb_width,
+            "D",
+            "A",
+            pol_A,
+            center=cent,
+            pos_offset=irhomb * n_pix_rhombus,
+        )
+        quat_B = rhombus_layout(
+            n_pix_rhombus,
+            rhomb_width,
+            "D",
+            "B",
+            pol_B,
+            center=cent,
+            pos_offset=irhomb * n_pix_rhombus,
+        )
+        full_fp.update(quat_A)
+        full_fp.update(quat_B)
+
+    # Sort by detector name so that detector pairs are together
+    det_data = {x: full_fp[x] for x in sorted(full_fp.keys())}
+
+    n_det = len(det_data)
+
+    det_table = QTable(
+        [
+            Column(name="name", data=[x for x in det_data.keys()]),
+            Column(name="quat", data=[det_data[x]["quat"] for x in det_data.keys()]),
+            Column(name="pol_leakage", length=n_det, unit=None),
+            Column(name="psi_pol", length=n_det, unit=u.rad),
+            Column(name="fwhm", length=n_det, unit=u.arcmin),
+            Column(name="psd_fmin", length=n_det, unit=u.Hz),
+            Column(name="psd_fknee", length=n_det, unit=u.Hz),
+            Column(name="psd_alpha", length=n_det, unit=None),
+            Column(name="psd_net", length=n_det, unit=(u.K * np.sqrt(1.0 * u.second))),
+            Column(name="bandcenter", length=n_det, unit=u.GHz),
+            Column(name="bandwidth", length=n_det, unit=u.GHz),
+            Column(
+                name="pixel", data=[x.rstrip("A").rstrip("B") for x in det_data.keys()]
+            ),
+        ]
+    )
+
+    np.random.seed(random_seed)
+
+    for idet, det in enumerate(det_data.keys()):
+        det_table[idet]["name"] = det
+        det_table[idet]["quat"] = det_data[det]["quat"]
+        det_table[idet]["pol_leakage"] = epsilon
+        # psi_pol is the rotation from the PXX beam frame to the polarization
+        # sensitive direction.
         if det.endswith("A"):
             det_table[idet]["psi_pol"] = 0 * u.rad
         else:
@@ -640,10 +803,14 @@ def plot_focalplane(
     show_labels=False,
     face_color=None,
     pol_color=None,
+    xieta=False,
 ):
     """Visualize a projected Focalplane.
 
     This makes a simple plot of the detector positions on the projected focalplane.
+    By default, this plots the focalplane in the boresight X / Y / Z frame, as seen
+    by incoming photons.  If `xieta` is set to True, the focalplane is plotted in
+    Xi / Eta / Gamma coordinates as seen from the observer looking out at the sky.
 
     To avoid python overhead in large MPI jobs, we place the matplotlib import inside
     this function, so that it is only imported when the function is actually called.
@@ -659,6 +826,8 @@ def plot_focalplane(
             detector circle.
         pol_color (dict): dictionary of color values for the polarization
             arrows.
+        xieta (bool):  Plot in observer xi/eta/gamma coordinates rather than
+            boresight X/Y/Z.
 
     Returns:
         None
@@ -694,8 +863,12 @@ def plot_focalplane(
 
     half_width = 0.6 * width_deg
     half_height = 0.6 * height_deg
-    ax.set_xlabel("Degrees", fontsize="medium")
-    ax.set_ylabel("Degrees", fontsize="medium")
+    if xieta:
+        ax.set_xlabel(r"Boresight $\xi$ Degrees", fontsize="medium")
+        ax.set_ylabel(r"Boresight $\eta$ Degrees", fontsize="medium")
+    else:
+        ax.set_xlabel("Boresight X Degrees", fontsize="medium")
+        ax.set_ylabel("Boresight Y Degrees", fontsize="medium")
     ax.set_xlim([-half_width, half_width])
     ax.set_ylim([-half_height, half_height])
 
@@ -712,16 +885,21 @@ def plot_focalplane(
         if fwhm is not None:
             detradius = 0.5 * fwhm / 60.0
 
-        # rotation from boresight
-        rdir = qa.rotate(quat, zaxis).flatten()
-        ang = np.arctan2(rdir[1], rdir[0])
-
-        orient = qa.rotate(quat, xaxis).flatten()
-        polang = np.arctan2(orient[1], orient[0])
-
-        mag = np.arccos(rdir[2]) * 180.0 / np.pi
-        xpos = mag * np.cos(ang)
-        ypos = mag * np.sin(ang)
+        if xieta:
+            xi, eta, gamma = quat_to_xieta(quat)
+            xpos = xi * 180.0 / np.pi
+            ypos = eta * 180.0 / np.pi
+            # Polang is plotted relative to visualization x/y coords
+            polang = 1.5 * np.pi - gamma
+        else:
+            # rotation from boresight
+            rdir = qa.rotate(quat, zaxis).flatten()
+            mag = np.arccos(rdir[2]) * 180.0 / np.pi
+            ang = np.arctan2(rdir[1], rdir[0])
+            orient = qa.rotate(quat, xaxis).flatten()
+            polang = np.arctan2(orient[1], orient[0])
+            xpos = mag * np.cos(ang)
+            ypos = mag * np.sin(ang)
 
         detface = "none"
         if face_color is not None:
@@ -769,6 +947,61 @@ def plot_focalplane(
             ec=detcolor,
             length_includes_head=True,
         )
+
+    # Draw a "mini" coordinate axes for reference
+    xmini = -0.8 * half_width
+    ymini = -0.8 * half_height
+    xlen = 0.1 * half_width
+    ylen = 0.1 * half_height
+    mini_width = 0.005 * half_width
+    mini_head_width = 3 * mini_width
+    mini_head_len = 3 * mini_width
+    if xieta:
+        aprops = [
+            (xlen, 0, "-", r"$\xi$"),
+            (0, ylen, "-", r"$\eta$"),
+            (-xlen, 0, "--", "Y"),
+            (0, -ylen, "--", "X"),
+        ]
+    else:
+        aprops = [
+            (xlen, 0, "-", "X"),
+            (0, ylen, "-", "Y"),
+            (-xlen, 0, "--", r"$\eta$"),
+            (0, -ylen, "--", r"$\xi$"),
+        ]
+    for ap in aprops:
+        lx = xmini + 1.5 * ap[0]
+        ly = ymini + 1.5 * ap[1]
+        lw = figdpi / 200.0
+        ax.arrow(
+            xmini,
+            ymini,
+            ap[0],
+            ap[1],
+            width=mini_width,
+            head_width=mini_head_width,
+            head_length=mini_head_len,
+            fc="k",
+            ec="k",
+            linestyle=ap[2],
+            linewidth=lw,
+            length_includes_head=True,
+        )
+        ax.text(
+            lx,
+            ly,
+            ap[3],
+            color="k",
+            fontsize=int(figdpi / 10),
+            horizontalalignment="center",
+            verticalalignment="center",
+        )
+
+    st = "Focalplane Looking Towards Observer"
+    if xieta:
+        st = "Focalplane on Sky From Observer"
+    fig.suptitle(st)
 
     if outfile is None:
         plt.show()

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -242,9 +242,7 @@ def hex_layout(npos, angwidth, prefix, suffix, pol, center=None, pos_offset=0):
     pixdiam = angdiameter / (2 * nrings - 1)
 
     # number of digits for pixel indexing
-    ndigit = 1
-    if test > 0:
-        ndigit = int(np.log10(np.abs(test))) + 1
+    ndigit = int(np.log10(npos)) + 1
     nameformat = "{{}}{{:0{}d}}{{}}".format(ndigit)
 
     # compute positions of all detectors
@@ -470,13 +468,7 @@ def rhombus_layout(npos, angwidth, prefix, suffix, pol, center=None, pos_offset=
     pixdiam = angwidth.to_value(u.radian) / dim
 
     # number of digits for pixel indexing
-
-    ndigit = 0
-    test = npos
-    while test > 0:
-        test = test // 10
-        ndigit += 1
-
+    ndigit = int(np.log10(npos)) + 1
     nameformat = "{{}}{{:0{}d}}{{}}".format(ndigit)
 
     # compute positions of all detectors

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -242,13 +242,9 @@ def hex_layout(npos, angwidth, prefix, suffix, pol, center=None, pos_offset=0):
     pixdiam = angdiameter / (2 * nrings - 1)
 
     # number of digits for pixel indexing
-
-    ndigit = 0
-    test = npos
-    while test > 0:
-        test = test // 10
-        ndigit += 1
-
+    ndigit = 1
+    if test > 0:
+        ndigit = int(np.log10(np.abs(test))) + 1
     nameformat = "{{}}{{:0{}d}}{{}}".format(ndigit)
 
     # compute positions of all detectors

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -335,6 +335,11 @@ def save_hdf5_intervals(obs, hgrp, fields, log_prefix):
             log.warning_rank(msg, comm=comm)
             continue
 
+        if field == obs.intervals.all_name:
+            # This is the internal fake interval for all samples.  We don't
+            # save this because it is re-created on demand.
+            continue
+
         # Get the list of start / stop tuples on the rank zero process
         ilist = global_interval_times(obs.dist, obs.intervals, field, join=False)
 

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -437,7 +437,7 @@ class SimConviqt(Operator):
                     if verbose:
                         timer.report_clear(f"initialize flags for detector {det}")
 
-                theta, phi, psi = qa.to_iso(quats)
+                theta, phi, psi = qa.to_iso_angles(quats)
                 # Polarization angle in the Pxx basis
                 psi_pol = self._get_psi_pol(focalplane, det)
                 if self.dxx:

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -437,7 +437,7 @@ class SimConviqt(Operator):
                     if verbose:
                         timer.report_clear(f"initialize flags for detector {det}")
 
-                theta, phi, psi = qa.to_angles(quats)
+                theta, phi, psi = qa.to_iso(quats)
                 # Polarization angle in the Pxx basis
                 psi_pol = self._get_psi_pol(focalplane, det)
                 if self.dxx:

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -120,7 +120,7 @@ class CrossLinking(Operator):
         self.pixel_pointing.detector_pointing.apply(obs_data, detectors=[det])
         quat = obs.detdata[self.pixel_pointing.detector_pointing.quats][det]
         # measure the scan direction wrt the local meridian for each sample
-        theta, phi, _ = qa.to_iso(quat)
+        theta, phi, _ = qa.to_iso_angles(quat)
         theta = np.pi / 2 - theta
         # scan direction across the reference sample
         dphi = np.roll(phi, -1) - np.roll(phi, 1)

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -120,7 +120,7 @@ class CrossLinking(Operator):
         self.pixel_pointing.detector_pointing.apply(obs_data, detectors=[det])
         quat = obs.detdata[self.pixel_pointing.detector_pointing.quats][det]
         # measure the scan direction wrt the local meridian for each sample
-        theta, phi = qa.to_position(quat)
+        theta, phi, _ = qa.to_iso(quat)
         theta = np.pi / 2 - theta
         # scan direction across the reference sample
         dphi = np.roll(phi, -1) - np.roll(phi, 1)

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -279,7 +279,7 @@ class ElevationNoise(Operator):
                 el_view = list()
                 for vw in range(len(views)):
                     # Detector elevation
-                    theta, _, _ = qa.to_iso(
+                    theta, _, _ = qa.to_iso_angles(
                         views.detdata[self.detector_pointing.quats][vw][det]
                     )
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -279,7 +279,7 @@ class ElevationNoise(Operator):
                 el_view = list()
                 for vw in range(len(views)):
                     # Detector elevation
-                    theta, _, _ = qa.to_angles(
+                    theta, _, _ = qa.to_iso(
                         views.detdata[self.detector_pointing.quats][vw][det]
                     )
 

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -988,7 +988,7 @@ class FilterBin(Operator):
                 az = obs.shared[self.azimuth]
             else:
                 quats = obs.shared[self.boresight_azel]
-                theta, phi = qa.to_position(quats)
+                theta, phi, _ = qa.to_iso(quats)
                 az = 2 * np.pi - phi
         except Exception as e:
             msg = (

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -988,7 +988,7 @@ class FilterBin(Operator):
                 az = obs.shared[self.azimuth]
             else:
                 quats = obs.shared[self.boresight_azel]
-                theta, phi, _ = qa.to_iso(quats)
+                theta, phi, _ = qa.to_iso_angles(quats)
                 az = 2 * np.pi - phi
         except Exception as e:
             msg = (

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -195,7 +195,7 @@ class FlagSSO(Operator):
                 quats = obs.detdata[self.detector_pointing.quats][det]
 
             # Convert Az/El quaternion of the detector into angles
-            theta, phi = qa.to_position(quats)
+            theta, phi, _ = qa.to_iso(quats)
 
             # Azimuth is measured in the opposite direction
             # than longitude

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -195,7 +195,7 @@ class FlagSSO(Operator):
                 quats = obs.detdata[self.detector_pointing.quats][det]
 
             # Convert Az/El quaternion of the detector into angles
-            theta, phi, _ = qa.to_iso(quats)
+            theta, phi, _ = qa.to_iso_angles(quats)
 
             # Azimuth is measured in the opposite direction
             # than longitude

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -188,7 +188,7 @@ class GroundFilter(Operator):
                 az = obs.shared[self.azimuth]
             else:
                 quats = obs.shared[self.boresight_azel]
-                theta, phi = qa.to_position(quats)
+                theta, phi, _ = qa.to_iso(quats)
                 az = 2 * np.pi - phi
         except Exception as e:
             msg = (

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -188,7 +188,7 @@ class GroundFilter(Operator):
                 az = obs.shared[self.azimuth]
             else:
                 quats = obs.shared[self.boresight_azel]
-                theta, phi, _ = qa.to_iso(quats)
+                theta, phi, _ = qa.to_iso_angles(quats)
                 az = 2 * np.pi - phi
         except Exception as e:
             msg = (

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -730,8 +730,11 @@ class BuildNoiseWeighted(Operator):
                 data[self.zmap].accel_update_device()
 
             zmap_good = data[self.zmap].data[:, :, 0] != 0.0
-            zmap_min = np.amin(data[self.zmap].data[zmap_good, :], axis=0)
-            zmap_max = np.amax(data[self.zmap].data[zmap_good, :], axis=0)
+            zmap_min = np.zeros((data[self.zmap].n_value), dtype=np.float64)
+            zmap_max = np.zeros((data[self.zmap].n_value), dtype=np.float64)
+            if np.count_nonzero(zmap_good) > 0:
+                zmap_min[:] = np.amin(data[self.zmap].data[zmap_good, :], axis=0)
+                zmap_max[:] = np.amax(data[self.zmap].data[zmap_good, :], axis=0)
             all_zmap_min = np.zeros_like(zmap_min)
             all_zmap_max = np.zeros_like(zmap_max)
             if data.comm.comm_world is not None:
@@ -1062,8 +1065,11 @@ class CovarianceAndHits(Operator):
         )
 
         rcond_good = rcond.data[:, :, 0] > 0.0
-        rcond_min = np.amin(rcond.data[rcond_good, 0])
-        rcond_max = np.amax(rcond.data[rcond_good, 0])
+        rcond_min = 0.0
+        rcond_max = 0.0
+        if np.count_nonzero(rcond_good) > 0:
+            rcond_min = np.amin(rcond.data[rcond_good, 0])
+            rcond_max = np.amax(rcond.data[rcond_good, 0])
         if data.comm.comm_world is not None:
             rcond_min = data.comm.comm_world.reduce(rcond_min, root=0, op=MPI.MIN)
             rcond_max = data.comm.comm_world.reduce(rcond_max, root=0, op=MPI.MAX)

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -12,6 +12,7 @@ from .._libtoast import (
     cov_accum_zmap,
 )
 from ..covariance import covariance_invert
+from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..timing import function_timer
@@ -709,9 +710,9 @@ class BuildNoiseWeighted(Operator):
 
     def _finalize(self, data, use_acc=False, **kwargs):
         if self.zmap in data:
+            log = Logger.get()
             # We have called exec() at least once
             if use_acc:
-                log = Logger.get()
                 log.verbose_rank(
                     f"Operator {self.name} finalize calling zmap update self",
                     comm=data.comm.comm_group,
@@ -722,12 +723,25 @@ class BuildNoiseWeighted(Operator):
             else:
                 data[self.zmap].sync_allreduce()
             if use_acc:
-                log = Logger.get()
                 log.verbose_rank(
                     f"Operator {self.name} finalize calling zmap update device",
                     comm=data.comm.comm_group,
                 )
                 data[self.zmap].accel_update_device()
+
+            zmap_good = data[self.zmap].data[:, :, 0] != 0.0
+            zmap_min = np.amin(data[self.zmap].data[zmap_good, :], axis=0)
+            zmap_max = np.amax(data[self.zmap].data[zmap_good, :], axis=0)
+            all_zmap_min = np.zeros_like(zmap_min)
+            all_zmap_max = np.zeros_like(zmap_max)
+            if data.comm.comm_world is not None:
+                data.comm.comm_world.Reduce(zmap_min, all_zmap_min, op=MPI.MIN, root=0)
+                data.comm.comm_world.Reduce(zmap_max, all_zmap_max, op=MPI.MAX, root=0)
+            if data.comm.world_rank == 0:
+                msg = f"  Noise-weighted map pixel value range:\n"
+                for m in range(data[self.zmap].n_value):
+                    msg += f"    map {m} {zmap_min[m]:1.3e} ... {zmap_max[m]:1.3e}"
+                log.debug(msg)
         return
 
     def _requires(self):
@@ -1046,6 +1060,17 @@ class CovarianceAndHits(Operator):
             rcond=rcond,
             use_alltoallv=(self.sync_type == "alltoallv"),
         )
+
+        rcond_good = rcond.data[:, :, 0] > 0.0
+        rcond_min = np.amin(rcond.data[rcond_good, 0])
+        rcond_max = np.amax(rcond.data[rcond_good, 0])
+        if data.comm.comm_world is not None:
+            rcond_min = data.comm.comm_world.reduce(rcond_min, root=0, op=MPI.MIN)
+            rcond_max = data.comm.comm_world.reduce(rcond_max, root=0, op=MPI.MAX)
+        if data.comm.world_rank == 0:
+            msg = f"  Pixel covariance condition number range = "
+            msg += f"{rcond_min:1.3e} ... {rcond_max:1.3e}"
+            log.debug(msg)
 
         # Store rcond
         data[self.rcond] = rcond

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -290,9 +290,17 @@ class FitNoiseModel(Operator):
         fknee = x[0]
         alpha = x[1]
         current = self._evaluate_log_model(freqs, fmin, net, fknee, alpha)
-        weights = np.ones_like(current) * freqs[-1]
-        weights -= freqs[-1] / (1.0 + freqs**2)
+
+        # Weight the difference so that low frequencies do not impact the fit.  This is
+        # basically a high-pass butterworth.
+        n_freq = len(freqs)
+        hp = np.arange(n_freq, dtype=np.float64)
+        hp *= 2.0 / n_freq
+        weights = 0.1 + 2.0 / np.sqrt(1.0 + np.power(hp, -4))
         resid = np.multiply(weights, current - logdata)
+        # print(
+        #     f"      current-data = {current - logdata}, weights = {weights}, resid = {resid}"
+        # )
         return resid
 
     def _fit_log_jac(self, x, *args, **kwargs):
@@ -387,9 +395,10 @@ class FitNoiseModel(Operator):
             x_0,
             jac=self._fit_log_jac,
             bounds=bounds,
-            xtol=1.0e-12,
-            gtol=1.0e-12,
-            ftol=1.0e-12,
+            xtol=1.0e-10,
+            gtol=1.0e-10,
+            ftol=1.0e-10,
+            max_nfev=500,
             kwargs={
                 "freqs": input_freqs,
                 "logdata": input_log_data,

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -439,7 +439,7 @@ class PixelsWCS(Operator):
                     # print(f"WCS det {det}, quats = {quats}")
 
                     view_samples = len(quats)
-                    theta, phi, _ = qa.to_iso(quats)
+                    theta, phi, _ = qa.to_iso_angles(quats)
                     # print(f"WCS det {det}, theta rad = {theta}, phi rad = {phi}")
                     to_deg = 180.0 / np.pi
                     theta *= to_deg
@@ -521,7 +521,7 @@ class PixelsWCS(Operator):
             rank_good = flags[rank::ntask] == 0
 
         for idet, detquat in enumerate(detquats):
-            theta, phi, _ = qa.to_iso(qa.mult(quats, detquat))
+            theta, phi, _ = qa.to_iso_angles(qa.mult(quats, detquat))
             if center_lonlat is None:
                 lon.append(phi[rank_good])
                 lat.append(np.pi / 2 - theta[rank_good])

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -302,7 +302,7 @@ class PixelsWCS(Operator):
         if self.auto_bounds and not self._done_auto:
             # Pass through the boresight pointing for every observation and build
             # the maximum extent of the detector field of view.
-            lonmax = 0 * u.radian
+            lonmax = -2 * np.pi * u.radian
             lonmin = 2 * np.pi * u.radian
             latmax = (-np.pi / 2) * u.radian
             latmin = (np.pi / 2) * u.radian
@@ -334,11 +334,15 @@ class PixelsWCS(Operator):
                 (lonmax.to(u.degree), latmin.to(u.degree)),
                 (lonmin.to(u.degree), latmax.to(u.degree)),
             )
+            # print(
+            #     f"WCS auto now set to lon: {lonmin.to(u.degree)} .. {lonmax.to(u.degree)}, lat: {latmin.to(u.degree)} .. {latmax.to(u.degree)}"
+            # )
             log.verbose(f"PixelsWCS auto_bounds set to {new_bounds}")
             self.bounds = new_bounds
             self._done_auto = True
 
         if self._local_submaps is None and self.create_dist is not None:
+            # print("WCS reset _local_submaps to zeros")
             self._local_submaps = np.zeros(self.submaps, dtype=np.bool)
 
         # Expand detector pointing
@@ -414,9 +418,14 @@ class PixelsWCS(Operator):
             flags = None
             if self.detector_pointing.shared_flags is not None:
                 flags = np.array(ob.shared[self.detector_pointing.shared_flags])
+                fvals, fcounts = np.unique(flags, return_counts=True)
+                # print(f"WCS flag counts = {fvals}, {fcounts}")
                 flags &= self.detector_pointing.shared_flag_mask
                 n_good = np.sum(flags == 0)
                 n_bad = np.sum(flags != 0)
+                # print(
+                #     f"WCS flag mask {int(self.detector_pointing.shared_flag_mask)} has {n_good} good and {n_bad} bad samples"
+                # )
 
             center_lonlat = None
             if self.center_offset is not None:
@@ -427,34 +436,35 @@ class PixelsWCS(Operator):
                 for vslice in view_slices:
                     # Timestream of detector quaternions
                     quats = ob.detdata[quats_name][det][vslice]
+                    # print(f"WCS det {det}, quats = {quats}")
+
                     view_samples = len(quats)
-
-                    # print(f"det {det} quats = {quats}")
-                    theta, phi = qa.to_position(quats)
-                    # print(f"det {det} rad theta, phi = {theta}, {phi}")
-
+                    theta, phi, _ = qa.to_iso(quats)
+                    # print(f"WCS det {det}, theta rad = {theta}, phi rad = {phi}")
                     to_deg = 180.0 / np.pi
                     theta *= to_deg
                     phi *= to_deg
-                    # print(f"det {det} deg theta, phi = {theta}, {phi}")
+
+                    # print(f"WCS det {det}, theta deg = {theta}, phi deg = {phi}")
 
                     world_in = np.column_stack([phi, 90.0 - theta])
+                    # print(f"WCS det {det}, world_in = {world_in}")
 
                     if center_lonlat is not None:
-                        # print(f"orig = {world_in}")
-                        # print(f"center_lonlat = {center_lonlat}")
                         world_in[:, 0] -= center_lonlat[vslice, 0]
                         world_in[:, 1] -= center_lonlat[vslice, 1]
-                        # print(f"final = {world_in}")
 
-                    # print(f"det {det} world_in = {world_in}")
+                    # print(f"WCS det {det}, world_in after center = {world_in}")
+
                     rdpix = self.wcs.wcs_world2pix(world_in, 0)
+                    # print(
+                    #     f"WCS det {det}, {view_samples} samps, {np.count_nonzero(rdpix >= 0)} pix >= 0, {np.count_nonzero(rdpix > 0)} pix > 0"
+                    # )
                     if flags is not None:
                         # Set bad pointing to pixel -1
                         bad_pointing = flags[vslice] != 0
                         rdpix[bad_pointing] = -1
                     rdpix = np.array(np.around(rdpix), dtype=np.int64)
-                    # print(f"det {det} rdpix = {rdpix}")
 
                     ob.detdata[self.pixels][det][vslice] = (
                         rdpix[:, 0] * self.pix_dec + rdpix[:, 1]
@@ -462,8 +472,6 @@ class PixelsWCS(Operator):
 
                     if self.create_dist is not None:
                         good = ob.detdata[self.pixels][det][vslice] >= 0
-                        # print(f"det {det} has {np.sum(good)} good pixels")
-                        # print((ob.detdata[self.pixels][det][vslice])[good])
                         self._local_submaps[
                             (ob.detdata[self.pixels][det][vslice])[good]
                             // self._n_pix_submap
@@ -475,6 +483,13 @@ class PixelsWCS(Operator):
         # extract this into a more general helper routine somewhere.
         fov = obs.telescope.focalplane.field_of_view
         fp_radius = 0.5 * fov.to_value(u.radian)
+
+        # Get the flags if needed.  Use the same flags as
+        # detector pointing.
+        flags = None
+        if self.detector_pointing.shared_flags is not None:
+            flags = np.array(obs.shared[self.detector_pointing.shared_flags])
+            flags &= self.detector_pointing.shared_flag_mask
 
         # work in parallel
         rank = obs.comm.group_rank
@@ -501,14 +516,21 @@ class PixelsWCS(Operator):
         lon = []
         lat = []
         quats = obs.shared[self.detector_pointing.boresight][rank::ntask].copy()
+        rank_good = slice(None)
+        if self.detector_pointing.shared_flags is not None:
+            rank_good = flags[rank::ntask] == 0
+
         for idet, detquat in enumerate(detquats):
-            theta, phi = qa.to_position(qa.mult(quats, detquat))
+            theta, phi, _ = qa.to_iso(qa.mult(quats, detquat))
             if center_lonlat is None:
-                lon.append(phi)
-                lat.append(np.pi / 2 - theta)
+                lon.append(phi[rank_good])
+                lat.append(np.pi / 2 - theta[rank_good])
             else:
-                lon.append(phi - center_lonlat[rank::ntask, 0])
-                lat.append((np.pi / 2 - theta) - center_lonlat[rank::ntask, 1])
+                lon.append(phi[rank_good] - center_lonlat[rank::ntask, 0][rank_good])
+                lat.append(
+                    (np.pi / 2 - theta[rank_good])
+                    - center_lonlat[rank::ntask, 1][rank_good]
+                )
         lon = np.unwrap(np.hstack(lon))
         lat = np.hstack(lat)
 
@@ -551,7 +573,6 @@ class PixelsWCS(Operator):
                     self._local_submaps == 1
                 ]
 
-            # print(f"create WCS pixdist {self._n_pix}, {self.submaps}, {submaps}")
             data[self.create_dist] = PixelDistribution(
                 n_pix=self._n_pix,
                 n_submap=self.submaps,

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -830,7 +830,9 @@ class SimGround(Operator):
                 # measured clockwise and the longitude counter-clockwise.  We define
                 # the focalplane coordinate X-axis to be pointed in the direction
                 # of decreasing elevation.
-                bore_azel = qa.from_lonlat(-(az_data), el_data, np.zeros_like(el_data))
+                bore_azel = qa.from_lonlat_angles(
+                    -(az_data), el_data, np.zeros_like(el_data)
+                )
 
                 if scan.boresight_angle.to_value(u.radian) != 0:
                     zaxis = np.array([0, 0, 1.0])

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -3,7 +3,7 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import copy
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
 import numpy as np
 import traitlets
@@ -14,7 +14,7 @@ from .. import qarray as qa
 from ..coordinates import azel_to_radec
 from ..dist import distribute_discrete, distribute_uniform
 from ..healpix import ang2vec
-from ..instrument import Telescope, Session
+from ..instrument import Session, Telescope
 from ..intervals import IntervalList, regular_intervals
 from ..noise_sim import AnalyticNoise
 from ..observation import Observation
@@ -826,15 +826,12 @@ class SimGround(Operator):
                 ]
                 # Get the motion of the site for these times.
                 position, velocity = site.position_velocity(stamps)
-                # Convert Az / El to quaternions.
-                # Remember that the azimuth is measured clockwise and the
-                # longitude counter-clockwise.
-                bore_azel = qa.from_angles(
-                    np.pi / 2 - el_data,
-                    -(az_data),
-                    np.zeros_like(el_data),
-                    IAU=False,
-                )
+                # Convert Az / El to quaternions.  Remember that the azimuth is
+                # measured clockwise and the longitude counter-clockwise.  We define
+                # the focalplane coordinate X-axis to be pointed in the direction
+                # of decreasing elevation.
+                bore_azel = qa.from_lonlat(-(az_data), el_data, np.zeros_like(el_data))
+
                 if scan.boresight_angle.to_value(u.radian) != 0:
                     zaxis = np.array([0, 0, 1.0])
                     rot = qa.rotation(zaxis, scan.boresight_angle.to_value(u.radian))

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -2,16 +2,17 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+from datetime import datetime, timedelta, timezone
+
 import numpy as np
 import traitlets
 from astropy import units as u
-from datetime import datetime, timezone, timedelta
 from scipy.constants import degree
 
 from .. import qarray as qa
 from ..dist import distribute_discrete
 from ..healpix import ang2vec
-from ..instrument import Telescope, Session
+from ..instrument import Session, Telescope
 from ..noise_sim import AnalyticNoise
 from ..observation import Observation
 from ..observation import default_values as defaults
@@ -29,39 +30,50 @@ def satellite_scanning(
     ob_key,
     sample_offset=0,
     q_prec=None,
-    spin_period_m=1.0,
-    spin_angle_deg=85.0,
-    prec_period_m=0.0,
-    prec_angle_deg=0.0,
+    spin_period=1.0 * u.minute,
+    spin_angle=85.0 * u.degree,
+    prec_period=0.0 * u.minute,
+    prec_angle=0.0 * u.degree,
 ):
     """Generate boresight quaternions for a generic satellite.
 
-    Given scan strategy parameters and the relevant angles
-    and rates, generate an array of quaternions representing
-    the rotation of the ecliptic coordinate axes to the
+    Given scan strategy parameters and the relevant angles and rates, generate an array
+    of quaternions representing the rotation of the ecliptic coordinate axes to the
     boresight.
+
+    The boresight / focalplane frame has the Z-axis pointed along the line of sight
+    and has the Y-axis oriented to be parallel to the scan direction.
+
+    In terms of relative rotations, this function:
+
+    - Rotates the ecliptic Z-axis to precession axis
+
+    - Rotates about the precession axis
+
+    - Rotates by the opening angle to the spin axis
+
+    - Rotates about the spin axis
+
+    - Rotates by the opening angle to the boresight line-of-sight
+
+    - Rotates by PI/2 about the line of sight to match the focalplane conventions
+      used internally in TOAST.
 
     Args:
         ob (Observation): The observation to populate.
         ob_key (str): The observation shared key to create.
-        sample_offset (int): The global offset in samples from the start
-            of the mission.
-        q_prec (ndarray): If None (the default), then the
-            precession axis will be fixed along the
-            X axis.  If a 1D array of size 4 is given,
-            This will be the fixed quaternion used
-            to rotate the Z coordinate axis to the
-            precession axis.  If a 2D array of shape
-            (nsim, 4) is given, this is the time-varying
-            rotation of the Z axis to the precession axis.
-        spin_period_m (float): The period (in minutes) of the
-            rotation about the spin axis.
-        spin_angle_deg (float): The opening angle (in degrees)
-            of the boresight from the spin axis.
-        prec_period_m (float): The period (in minutes) of the
-            rotation about the precession axis.
-        prec_angle_deg (float): The opening angle (in degrees)
-            of the spin axis from the precession axis.
+        sample_offset (int): The global offset in samples from the start of the
+            mission.
+        q_prec (ndarray): If None (the default), then the precession axis will be fixed
+            along the ecliptic X-axis.  If a 1D array of size 4 is given, This will be
+            the fixed quaternion used to rotate the ecliptic Z-axis to the precession
+            axis.  If a 2D array of shape (n_samp, 4) is given, this is the
+            time-varying rotation of the ecliptic Z-axis to the precession axis.
+        spin_period (Quantity): The period of the rotation about the spin axis.
+        spin_angle (Quantity): The opening angle of the boresight from the spin axis.
+        prec_period (Quantity): The period of the rotation about the precession axis.
+        prec_angle (Quantity): The opening angle of the spin axis from the precession
+            axis.
 
     """
     env = Environment.get()
@@ -82,19 +94,11 @@ def satellite_scanning(
         # Compute effective sample rate
         (sample_rate, dt, _, _, _) = rate_from_times(ob.shared["times"])
 
-        spin_rate = None
-        if spin_period_m > 0.0:
-            spin_rate = 1.0 / (60.0 * spin_period_m)
-        else:
-            spin_rate = 0.0
-        spin_angle = spin_angle_deg * np.pi / 180.0
+        spin_rate = 1.0 / spin_period.to_value(u.second)
+        spin_angle_rad = spin_angle.to_value(u.radian)
 
-        prec_rate = None
-        if prec_period_m > 0.0:
-            prec_rate = 1.0 / (60.0 * prec_period_m)
-        else:
-            prec_rate = 0.0
-        prec_angle = prec_angle_deg * np.pi / 180.0
+        prec_rate = 1.0 / prec_period.to_value(u.second)
+        prec_angle_rad = prec_angle.to_value(u.radian)
 
         xaxis = np.array([1, 0, 0], dtype=np.float64)
         yaxis = np.array([0, 1, 0], dtype=np.float64)
@@ -111,13 +115,15 @@ def satellite_scanning(
                 buf_n = n_samp - buf_off
             bslice = slice(buf_off, buf_off + buf_n)
 
+            # Rotation of the Ecliptic coordinate axis to the precession axis
+
             satrot = np.empty((buf_n, 4), np.float64)
             if q_prec is None:
                 # in this case, we just have a fixed precession axis, pointing
                 # along the ecliptic X axis.
-                satrot[:, :] = np.tile(
-                    qa.rotation(np.array([0.0, 1.0, 0.0]), np.pi / 2), buf_n
-                ).reshape(-1, 4)
+                satrot[:, :] = np.tile(qa.rotation(yaxis, np.pi / 2), buf_n).reshape(
+                    -1, 4
+                )
             elif q_prec.flatten().shape[0] == 4:
                 # we have a fixed precession axis.
                 satrot[:, :] = np.tile(q_prec.flatten(), buf_n).reshape(-1, 4)
@@ -125,57 +131,47 @@ def satellite_scanning(
                 # we have full vector of quaternions
                 satrot[:, :] = q_prec[bslice, :]
 
-            # Time-varying rotation about precession axis.
-            # Increment per sample is
+            # Time-varying rotation about precession axis.  Increment per sample is
             # (2pi radians) X (precrate) / (samplerate)
-            # Construct quaternion from axis / angle form.
-
-            # print("satrot = ", satrot[-1])
 
             precang = np.arange(buf_n, dtype=np.float64)
             precang += float(buf_off + first_samp + sample_offset)
             precang *= prec_rate / sample_rate
             precang = 2.0 * np.pi * (precang - np.floor(precang))
 
-            cang = np.cos(0.5 * precang)
-            sang = np.sin(0.5 * precang)
-
-            precaxis = np.multiply(
-                sang.reshape(-1, 1), np.tile(zaxis, buf_n).reshape(-1, 3)
-            )
-
-            precrot = np.concatenate((precaxis, cang.reshape(-1, 1)), axis=1)
+            precrot = qa.rotation(zaxis, precang)
 
             # Rotation which performs the precession opening angle
-            precopen = qa.rotation(np.array([1.0, 0.0, 0.0]), prec_angle)
 
-            # Time-varying rotation about spin axis.  Increment
-            # per sample is
+            precopen = qa.rotation(xaxis, prec_angle_rad)
+
+            # Time-varying rotation about spin axis.  Increment per sample is
             # (2pi radians) X (spinrate) / (samplerate)
-            # Construct quaternion from axis / angle form.
 
             spinang = np.arange(buf_n, dtype=np.float64)
             spinang += float(buf_off + first_samp + sample_offset)
             spinang *= spin_rate / sample_rate
             spinang = 2.0 * np.pi * (spinang - np.floor(spinang))
 
-            cang = np.cos(0.5 * spinang)
-            sang = np.sin(0.5 * spinang)
-
-            spinaxis = np.multiply(
-                sang.reshape(-1, 1), np.tile(zaxis, buf_n).reshape(-1, 3)
-            )
-
-            spinrot = np.concatenate((spinaxis, cang.reshape(-1, 1)), axis=1)
+            spinrot = qa.rotation(zaxis, spinang)
 
             # Rotation which performs the spin axis opening angle
 
-            spinopen = qa.rotation(np.array([1.0, 0.0, 0.0]), spin_angle)
+            spinopen = qa.rotation(xaxis, spin_angle_rad)
 
-            # compose final rotation
+            # Rotation of focalplane by PI/2
+
+            fprot = qa.rotation(zaxis, 0.5 * np.pi)
+
+            # Compose the final rotation.  These are relative rotations, so note
+            # the order.
 
             boresight[bslice, :] = qa.mult(
-                satrot, qa.mult(precrot, qa.mult(precopen, qa.mult(spinrot, spinopen)))
+                satrot,
+                qa.mult(
+                    precrot,
+                    qa.mult(precopen, qa.mult(spinrot, qa.mult(spinopen, fprot))),
+                ),
             )
             buf_off += buf_n
 
@@ -529,10 +525,10 @@ class SimSatellite(Operator):
                 self.boresight,
                 sample_offset=scan_offsets[obindx],
                 q_prec=q_prec,
-                spin_period_m=scan.spin_period.to_value(u.minute),
-                spin_angle_deg=self.spin_angle.to_value(u.degree),
-                prec_period_m=scan.prec_period.to_value(u.minute),
-                prec_angle_deg=self.prec_angle.to_value(u.degree),
+                spin_period=scan.spin_period,
+                spin_angle=self.spin_angle,
+                prec_period=scan.prec_period,
+                prec_angle=self.prec_angle,
             )
 
             # Set HWP angle

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -225,7 +225,7 @@ class ObserveAtmosphere(Operator):
 
                     # Convert Az/El quaternion of the detector back into
                     # angles from the simulation.
-                    theta, phi, _ = qa.to_iso(azel_quat)
+                    theta, phi, _ = qa.to_iso_angles(azel_quat)
 
                     # Stokes weights for observing polarized atmosphere
                     if self.weights is None:

--- a/src/toast/ops/sim_tod_atm_utils.py
+++ b/src/toast/ops/sim_tod_atm_utils.py
@@ -225,7 +225,7 @@ class ObserveAtmosphere(Operator):
 
                     # Convert Az/El quaternion of the detector back into
                     # angles from the simulation.
-                    theta, phi = qa.to_position(azel_quat)
+                    theta, phi, _ = qa.to_iso(azel_quat)
 
                     # Stokes weights for observing polarized atmosphere
                     if self.weights is None:

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -201,7 +201,7 @@ class SimScanSynchronousSignal(Operator):
                 quats = obs.detdata[self.detector_pointing.quats][det]
 
             # Convert Az/El quaternion of the detector into angles
-            theta, phi, _ = qa.to_iso(quats)
+            theta, phi, _ = qa.to_iso_angles(quats)
 
             signal = obs.detdata[self.det_data][det]
 

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -201,7 +201,7 @@ class SimScanSynchronousSignal(Operator):
                 quats = obs.detdata[self.detector_pointing.quats][det]
 
             # Convert Az/El quaternion of the detector into angles
-            theta, phi = qa.to_position(quats)
+            theta, phi, _ = qa.to_iso(quats)
 
             signal = obs.detdata[self.det_data][det]
 

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -496,7 +496,7 @@ class SimTotalconvolve(Operator):
                     if verbose:
                         timer.report_clear(f"initialize flags for detector {det}")
 
-                theta, phi, psi = qa.to_angles(quats)
+                theta, phi, psi = qa.to_iso(quats)
                 # Polarization angle in the Pxx basis
                 psi_pol = self._get_psi_pol(focalplane, det)
                 if self.dxx:

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -496,7 +496,7 @@ class SimTotalconvolve(Operator):
                     if verbose:
                         timer.report_clear(f"initialize flags for detector {det}")
 
-                theta, phi, psi = qa.to_iso(quats)
+                theta, phi, psi = qa.to_iso_angles(quats)
                 # Polarization angle in the Pxx basis
                 psi_pol = self._get_psi_pol(focalplane, det)
                 if self.dxx:

--- a/src/toast/qarray.py
+++ b/src/toast/qarray.py
@@ -414,7 +414,7 @@ def from_vectors(v1, v2):
         return out.array().reshape((-1, 4))
 
 
-def from_iso(theta, phi, psi):
+def from_iso_angles(theta, phi, psi):
     """Create quaternions from ISO theta, phi, psi spherical coordinates.
 
     The input angles describe the ZYZ rotations used to build the quaternion.
@@ -447,7 +447,7 @@ def from_iso(theta, phi, psi):
         return out.array().reshape((-1, 4))
 
 
-def from_lonlat(lon, lat, psi):
+def from_lonlat_angles(lon, lat, psi):
     """Create quaternions from longitude, latitude, and psi spherical coordinates.
 
     Args:
@@ -480,7 +480,7 @@ def from_lonlat(lon, lat, psi):
         return out.array().reshape((-1, 4))
 
 
-def to_iso(q):
+def to_iso_angles(q):
     """Convert quaternions to ISO theta, phi, psi spherical coordinates.
 
     Args:
@@ -504,7 +504,7 @@ def to_iso(q):
     return (theta.array(), phi.array(), psi.array())
 
 
-def to_lonlat(q):
+def to_lonlat_angles(q):
     """Convert quaternions to longitude, latitude, and psi spherical coordinates.
 
     Args:
@@ -549,7 +549,9 @@ def from_angles(theta, phi, pa, IAU=False):
 
     """
     log = Logger.get()
-    log.warning("from_angles() is deprecated, Use from_iso() or from_lonlat() instead")
+    log.warning(
+        "from_angles() is deprecated, Use from_iso_angles() or from_lonlat_angles() instead"
+    )
     thetain = ensure_buffer_f64(theta)
     phiin = ensure_buffer_f64(phi)
     pain = ensure_buffer_f64(pa)
@@ -586,7 +588,9 @@ def to_angles(q, IAU=False):
 
     """
     log = Logger.get()
-    log.warning("to_angles() is deprecated, Use to_iso() or to_lonlat() instead")
+    log.warning(
+        "to_angles() is deprecated, Use to_iso_angles() or to_lonlat_angles() instead"
+    )
     qin = ensure_buffer_f64(q)
     lq = len(qin) // 4
     theta = AlignedF64(lq)
@@ -617,7 +621,7 @@ def from_position(theta, phi):
     """
     log = Logger.get()
     log.warning(
-        "from_position() is deprecated, Use from_iso() or from_lonlat() instead"
+        "from_position() is deprecated, Use from_iso_angles() or from_lonlat_angles() instead"
     )
     thetain = ensure_buffer_f64(theta)
     phiin = ensure_buffer_f64(phi)
@@ -647,7 +651,9 @@ def to_position(q):
 
     """
     log = Logger.get()
-    log.warning("to_position() is deprecated, Use to_iso() or to_lonlat() instead")
+    log.warning(
+        "to_position() is deprecated, Use to_iso_angles() or to_lonlat_angles() instead"
+    )
     qin = ensure_buffer_f64(q)
     lq = len(qin) // 4
     theta = AlignedF64(lq)

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -778,7 +778,7 @@ def plot_projected_quats(outfile, qbore=None, qdet=None, valid=slice(None), scal
     qbang = None
     if qbore is not None:
         qbang = np.zeros((3, qbore.shape[0]), dtype=np.float64)
-        qbang[0], qbang[1], qbang[2] = qa.to_lonlat(qbore)
+        qbang[0], qbang[1], qbang[2] = qa.to_lonlat_angles(qbore)
         qbang[0] *= 180.0 / np.pi
         qbang[1] *= 180.0 / np.pi
         lon_min = np.amin(qbang[0])
@@ -790,7 +790,7 @@ def plot_projected_quats(outfile, qbore=None, qdet=None, valid=slice(None), scal
     if qdet is not None:
         qdang = np.zeros((qdet.shape[0], 3, qdet.shape[1]), dtype=np.float64)
         for det in range(qdet.shape[0]):
-            qdang[det, 0], qdang[det, 1], qdang[det, 2] = qa.to_lonlat(qdet[det])
+            qdang[det, 0], qdang[det, 1], qdang[det, 2] = qa.to_lonlat_angles(qdet[det])
             qdang[det, 0] *= 180.0 / np.pi
             qdang[det, 1] *= 180.0 / np.pi
         lon_min = np.amin(qdang[:, 0])

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -24,6 +24,7 @@ from ..pixels import PixelData
 from ..schedule import GroundSchedule
 from ..schedule_sim_ground import run_scheduler
 from ..schedule_sim_satellite import create_satellite_schedule
+from ..vis import set_matplotlib_backend
 
 ZAXIS = np.array([0.0, 0.0, 1.0])
 
@@ -764,3 +765,128 @@ def create_ground_data(
     sim_ground.apply(data)
 
     return data
+
+
+def plot_projected_quats(outfile, qbore=None, qdet=None, valid=slice(None), scale=1.0):
+    """Plot a list of quaternion arrays in longitude / latitude."""
+
+    set_matplotlib_backend()
+    import matplotlib.pyplot as plt
+
+    # Convert boresight and detector quaternions to angles
+
+    qbang = None
+    if qbore is not None:
+        qbang = np.zeros((3, qbore.shape[0]), dtype=np.float64)
+        qbang[0], qbang[1], qbang[2] = qa.to_lonlat(qbore)
+        qbang[0] *= 180.0 / np.pi
+        qbang[1] *= 180.0 / np.pi
+        lon_min = np.amin(qbang[0])
+        lon_max = np.amax(qbang[0])
+        lat_min = np.amin(qbang[1])
+        lat_max = np.amax(qbang[1])
+
+    qdang = None
+    if qdet is not None:
+        qdang = np.zeros((qdet.shape[0], 3, qdet.shape[1]), dtype=np.float64)
+        for det in range(qdet.shape[0]):
+            qdang[det, 0], qdang[det, 1], qdang[det, 2] = qa.to_lonlat(qdet[det])
+            qdang[det, 0] *= 180.0 / np.pi
+            qdang[det, 1] *= 180.0 / np.pi
+        lon_min = np.amin(qdang[:, 0])
+        lon_max = np.amax(qdang[:, 0])
+        lat_min = np.amin(qdang[:, 1])
+        lat_max = np.amax(qdang[:, 1])
+
+    # Set the sizes of shapes based on the plot range
+
+    span_lon = lon_max - lon_min
+    span_lat = lat_max - lat_min
+    span = min(span_lon, span_lat)
+    bmag = 0.05 * span * scale
+    dmag = 0.02 * span * scale
+
+    if span_lat > span_lon:
+        fig_y = 10
+        fig_x = fig_y * (span_lon / span_lat)
+        if fig_x < 4:
+            fig_x = 4
+    else:
+        fig_x = 10
+        fig_y = fig_x * (span_lat / span_lon)
+        if fig_y < 4:
+            fig_y = 4
+
+    figdpi = 100
+
+    fig = plt.figure(figsize=(fig_x, fig_y), dpi=figdpi)
+    ax = fig.add_subplot(1, 1, 1, aspect="equal")
+
+    # Compute the font size to use for detector labels
+    fontpix = 0.1 * figdpi
+    fontpt = int(0.75 * fontpix)
+
+    # Plot boresight if we have it
+
+    if qbang is not None:
+        ax.scatter(qbang[0][valid], qbang[1][valid], color="black", marker="x")
+        for ln, lt, ps in np.transpose(qbang)[valid]:
+            wd = 0.05 * bmag
+            dx = bmag * np.sin(ps)
+            dy = -bmag * np.cos(ps)
+            ax.arrow(
+                ln,
+                lt,
+                dx,
+                dy,
+                width=wd,
+                head_width=4.0 * wd,
+                head_length=0.2 * bmag,
+                length_includes_head=True,
+                ec="red",
+                fc="red",
+            )
+
+    # Plot detectors if we have them
+
+    if qdang is not None:
+        for idet, dang in enumerate(qdang):
+            ax.scatter(dang[0][valid], dang[1][valid], color="blue", marker=".")
+            for ln, lt, ps in np.transpose(dang)[valid]:
+                wd = 0.05 * dmag
+                dx = dmag * np.sin(ps)
+                dy = -dmag * np.cos(ps)
+                ax.arrow(
+                    ln,
+                    lt,
+                    dx,
+                    dy,
+                    width=wd,
+                    head_width=4.0 * wd,
+                    head_length=0.2 * dmag,
+                    length_includes_head=True,
+                    ec="blue",
+                    fc="blue",
+                )
+            ax.text(
+                dang[0][valid][0] + (idet % 2) * 1.5 * dmag,
+                dang[1][valid][0] + 1.0 * dmag,
+                f"{idet:02d}",
+                color="k",
+                fontsize=fontpt,
+                horizontalalignment="center",
+                verticalalignment="center",
+                bbox=dict(fc="w", ec="none", pad=1, alpha=0.0),
+            )
+
+    # Invert x axis so that longitude reflects what we would see from
+    # inside the celestial sphere
+    plt.gca().invert_xaxis()
+
+    ax.set_xlabel("Longitude Degrees", fontsize="medium")
+    ax.set_ylabel("Latitude Degrees", fontsize="medium")
+
+    fig.suptitle("Projected Pointing and Polarization on Sky")
+
+    plt.savefig(outfile)
+    plt.close()

--- a/src/toast/tests/instrument.py
+++ b/src/toast/tests/instrument.py
@@ -10,7 +10,14 @@ from astropy import units as u
 from astropy.table import Column, QTable
 
 from ..instrument import Focalplane
-from ..instrument_sim import fake_hexagon_focalplane
+from ..instrument_coords import iso_to_xieta, quat_to_xieta, xieta_to_iso, xieta_to_quat
+from ..instrument_sim import (
+    fake_hexagon_focalplane,
+    fake_rhombihex_focalplane,
+    hex_gamma_angles_qu,
+    hex_gamma_angles_radial,
+    hex_layout,
+)
 from ..io import H5File
 from ._helpers import create_outdir
 from .mpi import MPITestCase
@@ -20,6 +27,169 @@ class InstrumentTest(MPITestCase):
     def setUp(self):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
         self.outdir = create_outdir(self.comm, fixture_name)
+        self.xieta_space = np.pi / 6
+
+    def plot_positions(self, outfile, theta, phi, psi):
+        import matplotlib.pyplot as plt
+
+        space_deg = self.xieta_space * 180.0 / np.pi
+        fwhm = 0.3 * space_deg
+        detradius = 0.5 * fwhm
+        size_deg = 3 * space_deg
+        xfigsize = int(size_deg) + 1
+        yfigsize = int(size_deg) + 1
+        figdpi = 75
+
+        # Compute the font size to use for detector labels
+        fontpix = 0.5 * figdpi
+        fontpt = int(0.75 * fontpix)
+
+        fig = plt.figure(figsize=(xfigsize, yfigsize), dpi=figdpi)
+        ax = fig.add_subplot(1, 1, 1)
+
+        half_width = 0.6 * size_deg
+        half_height = 0.6 * size_deg
+        ax.set_xlabel("Boresight Xi Degrees", fontsize="medium")
+        ax.set_ylabel("Boresight Eta Degrees", fontsize="medium")
+        ax.set_xlim([-half_width, half_width])
+        ax.set_ylim([-half_height, half_height])
+
+        for th, ph, ps in zip(theta, phi, psi):
+            xi, eta, gamma = iso_to_xieta(th, ph, ps)
+            th_deg = th * 180.0 / np.pi
+            ph_deg = ph * 180.0 / np.pi
+            ps_deg = ps * 180.0 / np.pi
+
+            xpos = xi * 180.0 / np.pi
+            ypos = eta * 180.0 / np.pi
+            # Polang is plotted relative to visualization x/y coords
+            polang = 1.5 * np.pi - gamma
+
+            detface = "none"
+            circ = plt.Circle((xpos, ypos), radius=detradius, fc=detface, ec="k")
+            ax.add_artist(circ)
+
+            ascale = 2.0
+
+            xtail = xpos - ascale * detradius * np.cos(polang)
+            ytail = ypos - ascale * detradius * np.sin(polang)
+            dx = ascale * 2.0 * detradius * np.cos(polang)
+            dy = ascale * 2.0 * detradius * np.sin(polang)
+
+            detcolor = "black"
+            ax.arrow(
+                xtail,
+                ytail,
+                dx,
+                dy,
+                width=0.1 * detradius,
+                head_width=0.3 * detradius,
+                head_length=0.3 * detradius,
+                fc=detcolor,
+                ec=detcolor,
+                length_includes_head=True,
+            )
+        fig.suptitle("Focalplane on Sky Seen by Observer")
+        plt.savefig(outfile, dpi=figdpi, bbox_inches="tight", format="pdf")
+        plt.close()
+
+    def check_xieta(self, actual, desired):
+        """Check that input / output angles are the same."""
+        check_xi = np.array(actual[0])
+        check_eta = np.array(actual[1])
+        check_gamma = np.array(actual[2])
+        xi = np.array(desired[0])
+        eta = np.array(desired[1])
+        gamma = np.array(desired[2])
+        # Convert the gamma angles to +/- PI
+        try:
+            lt = len(gamma)
+            for ang in gamma, check_gamma:
+                high = ang > np.pi
+                low = ang < -np.pi
+                ang[high] -= 2 * np.pi
+                ang[low] += 2 * np.pi
+        except TypeError:
+            # scalar values
+            for ang in gamma, check_gamma:
+                if ang > np.pi:
+                    ang -= 2 * np.pi
+                if ang < -np.pi:
+                    ang += 2 * np.pi
+        if not np.allclose(check_xi, xi, rtol=1.0e-7, atol=1.0e-6):
+            print(f"XiEta xi check failed:")
+            print(f"{np.transpose((check_xi, xi))}")
+            print(f" = {np.transpose((check_xi*180/np.pi, xi*180/np.pi))}")
+            raise ValueError("Xi values not equal")
+        if not np.allclose(check_eta, eta, rtol=1.0e-7, atol=1.0e-6):
+            print(f"XiEta Eta check failed:")
+            print(f"{np.transpose((check_eta, eta))}")
+            print(f" = {np.transpose((check_eta*180/np.pi, eta*180/np.pi))}")
+            raise ValueError("Eta values not equal")
+        if not np.allclose(check_gamma, gamma, rtol=1.0e-7, atol=1.0e-6):
+            print(f"XiEta gamma check failed:")
+            print(f"{np.transpose((check_gamma, gamma))}")
+            print(f" = {np.transpose((check_gamma*180/np.pi, gamma*180/np.pi))}")
+            raise ValueError("Gamma values not equal")
+
+    def test_coords(self):
+        xi = np.tile(np.array([-self.xieta_space, 0.0, self.xieta_space]), 3)
+        eta = np.repeat(np.array([-self.xieta_space, 0.0, self.xieta_space]), 3)
+        gamma = np.array(
+            [
+                1 * np.pi / 4,
+                0 * np.pi / 4,
+                7 * np.pi / 4,
+                2 * np.pi / 4,
+                0 * np.pi / 4,
+                6 * np.pi / 4,
+                3 * np.pi / 4,
+                4 * np.pi / 4,
+                5 * np.pi / 4,
+            ]
+        )
+        theta, phi, psi = xieta_to_iso(xi, eta, gamma)
+        if self.comm is None or self.comm.rank == 0:
+            self.plot_positions(
+                os.path.join(self.outdir, "test_coords.pdf"), theta, phi, psi
+            )
+        check_xi, check_eta, check_gamma = iso_to_xieta(theta, phi, psi)
+        self.check_xieta((check_xi, check_eta, check_gamma), (xi, eta, gamma))
+
+        # Test that the gamma angle is recovered correctly at the origin
+        xi[:] = 0.0
+        eta[:] = 0.0
+        qt = xieta_to_quat(xi, eta, gamma)
+        check_xi, check_eta, check_gamma = quat_to_xieta(qt)
+        self.check_xieta((check_xi, check_eta, check_gamma), (xi, eta, gamma))
+
+    def test_hex_radial_layout(self):
+        npix = 7
+        pol = hex_gamma_angles_radial(npix)
+        space_deg = self.xieta_space * 180.0 / np.pi
+        fwhm = 0.3 * space_deg
+        fp = hex_layout(npix, space_deg * u.degree, "", "", pol)
+        quat = np.array([fp[f"{p}"]["quat"] for p in range(npix)])
+        xi, eta, gamma = quat_to_xieta(quat)
+        theta, phi, psi = xieta_to_iso(xi, eta, gamma)
+        if self.comm is None or self.comm.rank == 0:
+            self.plot_positions(
+                os.path.join(self.outdir, "hex_radial_layout.pdf"), theta, phi, psi
+            )
+
+    def test_hex_qu_layout(self):
+        npix = 7
+        pol = hex_gamma_angles_qu(npix)
+        space_deg = self.xieta_space * 180.0 / np.pi
+        fwhm = 0.3 * space_deg
+        fp = hex_layout(npix, space_deg * u.degree, "", "", pol)
+        quat = np.array([fp[f"{p}"]["quat"] for p in range(npix)])
+        xi, eta, gamma = quat_to_xieta(quat)
+        theta, phi, psi = xieta_to_iso(xi, eta, gamma)
+        if self.comm is None or self.comm.rank == 0:
+            self.plot_positions(
+                os.path.join(self.outdir, "hex_qu_layout.pdf"), theta, phi, psi
+            )
 
     def test_focalplane(self):
         names = ["det_01a", "det_01b", "det_02a", "det_02b"]
@@ -109,10 +279,10 @@ class InstrumentTest(MPITestCase):
         if self.comm is not None:
             self.comm.barrier()
 
-    def test_sim_focalplane(self):
+    def test_sim_focalplane_hex(self):
         fp = fake_hexagon_focalplane(
             n_pix=7,
-            width=5.0 * u.degree,
+            width=2.0 * u.degree,
             sample_rate=100.0 * u.Hz,
             epsilon=0.05,
             fwhm=10.0 * u.arcmin,
@@ -123,10 +293,76 @@ class InstrumentTest(MPITestCase):
             psd_alpha=1.2,
             psd_fknee=0.05 * u.Hz,
         )
-        fake_file = os.path.join(self.outdir, "fake_hex.h5")
 
+        fake_file = os.path.join(self.outdir, "fake_hex.h5")
         with H5File(fake_file, "w", comm=self.comm) as f:
             fp.save_hdf5(f.handle, comm=self.comm)
+
+        if self.comm is None or self.comm.rank == 0:
+            from ..instrument_sim import plot_focalplane
+
+            pltfile = os.path.join(self.outdir, "fake_hex_xyz.pdf")
+            fig = plot_focalplane(
+                fp,
+                width=3.0 * u.degree,
+                height=3.0 * u.degree,
+                outfile=pltfile,
+                show_labels=True,
+            )
+            pltfile = os.path.join(self.outdir, "fake_hex_xieta.pdf")
+            fig = plot_focalplane(
+                fp,
+                width=3.0 * u.degree,
+                height=3.0 * u.degree,
+                outfile=pltfile,
+                show_labels=True,
+                xieta=True,
+            )
+            del fig
+
+        if self.comm is not None:
+            self.comm.barrier()
+
+    def test_sim_focalplane_rhombihex(self):
+        fp = fake_rhombihex_focalplane(
+            n_pix_rhombus=4,
+            width=2.0 * u.degree,
+            sample_rate=100.0 * u.Hz,
+            epsilon=0.05,
+            fwhm=10.0 * u.arcmin,
+            bandcenter=150 * u.Hz,
+            bandwidth=20 * u.Hz,
+            psd_net=0.05 * u.K * np.sqrt(1 * u.second),
+            psd_fmin=1.0e-5 * u.Hz,
+            psd_alpha=1.2,
+            psd_fknee=0.05 * u.Hz,
+        )
+
+        fake_file = os.path.join(self.outdir, "fake_rhombihex.h5")
+        with H5File(fake_file, "w", comm=self.comm) as f:
+            fp.save_hdf5(f.handle, comm=self.comm)
+
+        if self.comm is None or self.comm.rank == 0:
+            from ..instrument_sim import plot_focalplane
+
+            pltfile = os.path.join(self.outdir, "fake_rhombihex_xyz.pdf")
+            fig = plot_focalplane(
+                fp,
+                width=3.0 * u.degree,
+                height=3.0 * u.degree,
+                outfile=pltfile,
+                show_labels=True,
+            )
+            pltfile = os.path.join(self.outdir, "fake_rhombihex_xieta.pdf")
+            fig = plot_focalplane(
+                fp,
+                width=3.0 * u.degree,
+                height=3.0 * u.degree,
+                outfile=pltfile,
+                show_labels=True,
+                xieta=True,
+            )
+            del fig
 
         if self.comm is not None:
             self.comm.barrier()

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -17,6 +17,7 @@ from ..noise import Noise
 from ..noise_sim import AnalyticNoise
 from ._helpers import create_outdir, create_satellite_data
 from .mpi import MPITestCase
+from .ops_noise_estim import plot_noise_estim_compare
 
 
 class InstrumentTest(MPITestCase):
@@ -193,4 +194,19 @@ class InstrumentTest(MPITestCase):
             for det in ob.local_detectors:
                 in_psd = in_model.psd(det)
                 fit_psd = out_model.psd(det)
-                np.testing.assert_array_almost_equal(in_psd.value, fit_psd.value)
+
+                fname = os.path.join(self.outdir, f"fit_{ob.name}_{det}.png")
+                plot_noise_estim_compare(
+                    fname,
+                    in_model.NET(det),
+                    in_model.freq(det),
+                    in_model.psd(det),
+                    in_model.freq(det),
+                    in_model.psd(det),
+                    fit_freq=out_model.freq(det),
+                    fit_psd=out_model.psd(det),
+                )
+
+                np.testing.assert_array_almost_equal(
+                    in_psd.value, fit_psd.value, decimal=2
+                )

--- a/src/toast/tests/ops_pointing_healpix.py
+++ b/src/toast/tests/ops_pointing_healpix.py
@@ -45,7 +45,7 @@ class PointingHealpixTest(MPITestCase):
         xaxis, yaxis, zaxis = np.eye(3)
         for phi in phivec:
             phirot = qa.rotation(zaxis, phi)
-            quats.append(qa.from_iso(theta, phi, psi))
+            quats.append(qa.from_iso_angles(theta, phi, psi))
         quats = np.vstack(quats)
         healpix_pixels(
             hpix,
@@ -112,7 +112,7 @@ class PointingHealpixTest(MPITestCase):
         )
         weights_ref = []
         for quat in quats:
-            theta, phi, psi = qa.to_iso(quat)
+            theta, phi, psi = qa.to_iso_angles(quat)
             weights_ref.append(np.array([1, np.cos(2 * psi), np.sin(2 * psi)]))
         weights_ref = np.vstack(weights_ref)
         failed = False

--- a/src/toast/tests/ops_pointing_healpix.py
+++ b/src/toast/tests/ops_pointing_healpix.py
@@ -45,7 +45,7 @@ class PointingHealpixTest(MPITestCase):
         xaxis, yaxis, zaxis = np.eye(3)
         for phi in phivec:
             phirot = qa.rotation(zaxis, phi)
-            quats.append(qa.from_angles(theta, phi, psi))
+            quats.append(qa.from_iso(theta, phi, psi))
         quats = np.vstack(quats)
         healpix_pixels(
             hpix,
@@ -112,7 +112,7 @@ class PointingHealpixTest(MPITestCase):
         )
         weights_ref = []
         for quat in quats:
-            theta, phi, psi = qa.to_angles(quat)
+            theta, phi, psi = qa.to_iso(quat)
             weights_ref.append(np.array([1, np.cos(2 * psi), np.sin(2 * psi)]))
         weights_ref = np.vstack(weights_ref)
         failed = False

--- a/src/toast/tests/ops_pointing_wcs.py
+++ b/src/toast/tests/ops_pointing_wcs.py
@@ -64,7 +64,7 @@ class PointingWCSTest(MPITestCase):
         phi = np.array(coord[:, 0], dtype=np.float64)
         half_pi = np.pi / 2
         theta = np.array(half_pi - coord[:, 1], dtype=np.float64)
-        bore = qa.from_iso(theta, phi, np.zeros_like(theta))
+        bore = qa.from_iso_angles(theta, phi, np.zeros_like(theta))
 
         nsamp = npix_ra * npix_dec
         data.obs.append(Observation(toastcomm, tele, n_samples=nsamp))
@@ -440,7 +440,7 @@ class PointingWCSTest(MPITestCase):
             zaxis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
             sphi = ob.shared["source"].data[:, 0] * np.pi / 180.0
             stheta = (90.0 - ob.shared["source"].data[:, 1]) * np.pi / 180.0
-            spos = qa.from_iso(stheta, sphi, np.zeros_like(stheta))
+            spos = qa.from_iso_angles(stheta, sphi, np.zeros_like(stheta))
             sdir = qa.rotate(spos, zaxis)
             for det in ob.local_detectors:
                 fwhm = 2 * ob.telescope.focalplane[det]["fwhm"].to_value(u.arcmin)

--- a/src/toast/tests/ops_pointing_wcs.py
+++ b/src/toast/tests/ops_pointing_wcs.py
@@ -64,7 +64,7 @@ class PointingWCSTest(MPITestCase):
         phi = np.array(coord[:, 0], dtype=np.float64)
         half_pi = np.pi / 2
         theta = np.array(half_pi - coord[:, 1], dtype=np.float64)
-        bore = qa.from_position(theta, phi)
+        bore = qa.from_iso(theta, phi, np.zeros_like(theta))
 
         nsamp = npix_ra * npix_dec
         data.obs.append(Observation(toastcomm, tele, n_samples=nsamp))
@@ -440,7 +440,7 @@ class PointingWCSTest(MPITestCase):
             zaxis = np.array([0.0, 0.0, 1.0], dtype=np.float64)
             sphi = ob.shared["source"].data[:, 0] * np.pi / 180.0
             stheta = (90.0 - ob.shared["source"].data[:, 1]) * np.pi / 180.0
-            spos = qa.from_position(stheta, sphi)
+            spos = qa.from_iso(stheta, sphi, np.zeros_like(stheta))
             sdir = qa.rotate(spos, zaxis)
             for det in ob.local_detectors:
                 fwhm = 2 * ob.telescope.focalplane[det]["fwhm"].to_value(u.arcmin)

--- a/src/toast/tests/ops_sim_satellite.py
+++ b/src/toast/tests/ops_sim_satellite.py
@@ -20,7 +20,7 @@ from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..schedule_sim_satellite import create_satellite_schedule
 from ..vis import set_matplotlib_backend
-from ._helpers import create_comm, create_outdir
+from ._helpers import create_comm, create_outdir, plot_projected_quats
 from .mpi import MPITestCase
 
 
@@ -33,7 +33,7 @@ class SimSatelliteTest(MPITestCase):
 
         npix = 1
         ring = 1
-        while 2 * npix <= self.toastcomm.group_size:
+        while npix <= self.toastcomm.group_size:
             npix += 6 * ring
             ring += 1
         self.npix = npix
@@ -43,7 +43,7 @@ class SimSatelliteTest(MPITestCase):
         # Slow sampling
         fp = fake_hexagon_focalplane(
             n_pix=self.npix,
-            sample_rate=(1.0 / 60.0) * u.Hz,
+            sample_rate=(5.0 / 60.0) * u.Hz,
         )
         site = SpaceSite("L2")
 
@@ -73,6 +73,24 @@ class SimSatelliteTest(MPITestCase):
             prec_angle=65.0 * u.degree,
         )
         sim_sat.apply(data)
+
+        # Plot some pointing
+        plotdetpointing = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            quats="pquats",
+        )
+        plotdetpointing.apply(data)
+        if data.comm.world_rank == 0:
+            n_debug = 10
+            bquat = np.array(data.obs[0].shared[defaults.boresight_radec][0:n_debug, :])
+            dquat = data.obs[0].detdata["pquats"][:, 0:n_debug, :]
+            invalid = np.array(data.obs[0].shared[defaults.shared_flags][0:n_debug])
+            invalid &= defaults.shared_mask_invalid
+            valid = np.logical_not(invalid)
+            outfile = os.path.join(self.outdir, "pointing.pdf")
+            plot_projected_quats(
+                outfile, qbore=bquat, qdet=dquat, valid=valid, scale=1.0
+            )
 
         # Expand pointing and make a hit map.
         detpointing = ops.PointingDetectorSimple()

--- a/src/toast/tests/qarray.py
+++ b/src/toast/tests/qarray.py
@@ -89,7 +89,7 @@ class QarrayTest(MPITestCase):
         phi = (10.0 / (2.0 * np.pi)) * np.arange(nsamp, dtype=np.float64)
         pa = np.zeros(nsamp, dtype=np.float64)
 
-        quats = qa.from_iso(theta, phi, pa)
+        quats = qa.from_iso_angles(theta, phi, pa)
 
         check = np.zeros((nsamp, 3), dtype=np.float64)
         for i in range(nsamp):
@@ -374,13 +374,13 @@ class QarrayTest(MPITestCase):
             np.array([-1.0, 0.0, 0.0]),
         ]
         for theta, phi, psi, vz, vx in zip(all_theta, all_phi, all_psi, all_z, all_x):
-            quat = qa.from_iso(theta, phi, psi)
+            quat = qa.from_iso_angles(theta, phi, psi)
             zrot = qa.rotate(quat, zaxis)
             xrot = qa.rotate(quat, xaxis)
             # print(f"{(zrot, xrot)} {(vz, vx)}")
             self.check_zx((zrot, xrot), (vz, vx))
 
-            check_theta, check_phi, check_psi = qa.to_iso(quat)
+            check_theta, check_phi, check_psi = qa.to_iso_angles(quat)
             # print(f"  {(check_theta, check_phi, check_psi)} {(theta, phi, psi)}")
             self.check_iso((check_theta, check_phi, check_psi), (theta, phi, psi))
 
@@ -402,12 +402,12 @@ class QarrayTest(MPITestCase):
                     phi[toff + poff + k] = j * 2.0 * np.pi / float(nphi)
                     psi[toff + poff + k] = k * 2.0 * np.pi / float(npsi)
         # print(f"Input {np.transpose((theta, phi, psi))}")
-        quat = qa.from_iso(theta, phi, psi)
+        quat = qa.from_iso_angles(theta, phi, psi)
         dir = qa.rotate(quat, np.tile(zaxis, n).reshape((n, 3)))
         orient = qa.rotate(quat, np.tile(xaxis, n).reshape((n, 3)))
         # print(f"Vec {np.transpose((dir, orient), axes=(1, 0, 2))}")
 
-        check_theta, check_phi, check_psi = qa.to_iso(quat)
+        check_theta, check_phi, check_psi = qa.to_iso_angles(quat)
         # print(f"Check {np.transpose((check_theta, check_phi, check_psi))}")
         self.check_iso((check_theta, check_phi, check_psi), (theta, phi, psi))
 
@@ -429,8 +429,8 @@ class QarrayTest(MPITestCase):
         psi *= np.pi / 180.0
         theta = np.zeros_like(psi)
         phi = np.zeros_like(psi)
-        quat = qa.from_iso(theta, phi, psi)
-        check_theta, check_phi, check_psi = qa.to_iso(quat)
+        quat = qa.from_iso_angles(theta, phi, psi)
+        check_theta, check_phi, check_psi = qa.to_iso_angles(quat)
         self.check_iso((check_theta, check_phi, check_psi), (theta, phi, psi))
 
     def test_depths(self):
@@ -483,12 +483,12 @@ class QarrayTest(MPITestCase):
         np.testing.assert_equal(ret2[0].shape, (1, 3))
         np.testing.assert_equal(np.shape(ret2[1]), (1,))
 
-        np.testing.assert_equal(np.shape(qa.from_iso(0, 0, 0)), (4,))
-        np.testing.assert_equal(np.shape(qa.from_iso([0], 0, 0)), (1, 4))
-        np.testing.assert_equal(np.shape(qa.from_iso([0], [0], [0])), (1, 4))
+        np.testing.assert_equal(np.shape(qa.from_iso_angles(0, 0, 0)), (4,))
+        np.testing.assert_equal(np.shape(qa.from_iso_angles([0], 0, 0)), (1, 4))
+        np.testing.assert_equal(np.shape(qa.from_iso_angles([0], [0], [0])), (1, 4))
 
-        ret1 = qa.to_iso(self.q1)
-        ret2 = qa.to_iso(np.atleast_2d(self.q1))
+        ret1 = qa.to_iso_angles(self.q1)
+        ret2 = qa.to_iso_angles(np.atleast_2d(self.q1))
         np.testing.assert_equal(np.shape(ret1[0]), ())
         np.testing.assert_equal(np.shape(ret1[1]), ())
         np.testing.assert_equal(np.shape(ret1[2]), ())

--- a/src/toast/widgets.py
+++ b/src/toast/widgets.py
@@ -274,7 +274,7 @@ class ObservationWidget(object):
             )
             with w_plot:
                 clear_output(wait=True)
-                fig.show_dash(mode="inline")
+                fig.show_dash(mode="inline", host="localhost")
 
         response(None)
         w_times.observe(response, names="value")


### PR DESCRIPTION
The generic simulated focalplane functions have poorly documented conventions, and this leads to confusion when building toast compatible focalplane models.  This work in progress first lays out the simulated focalplanes in the Xi / Eta / Gamma 2D conventions adopted by Simons Observatory, which is convenient for looking at focalplaned projected on the sky from the observer.  It then converts that model to individual detector quaternion rotations from the boresight, where the detector X axis is defined to be the polarization sensitive direction.  Still some changes needed here, and will add docs to a markdown file that will integrate into the updated jupyter book docs.

Examples of plots in both coordinate systems (we would typically be scanning parallel to the Y / Xi axis in this case):
![fake_hex_xieta](https://user-images.githubusercontent.com/84221/184669071-b03538a3-5870-435b-b5c0-2398a34c437c.png)
![fake_hex_xyz](https://user-images.githubusercontent.com/84221/184669268-29a87a1b-6427-4af0-9511-c1086942a9ea.png)
