### PR TITLE
Add small sandbox test for OMP offload in a python extension.

### DIFF
--- a/etc/pyomptarget/Makefile
+++ b/etc/pyomptarget/Makefile
@@ -1,0 +1,27 @@
+
+# GCC 12.1.0 with offload support
+CXX := g++-12
+CXXFLAGS := -O0 -g -fPIC -pthread -std=c++11 -fcf-protection=none -fno-stack-protector
+CXX_OMP_FLAGS := -fopenmp -foffload=nvptx-none='-Wa,-m,sm_80 -misa=sm_80 -fPIC -lm -latomic'
+
+# NVHPC
+# CXX = nvc++
+# CXXFLAGS = -O0 -g -fPIC -pthread -std=c++11
+# CXX_OMP_FLAGS = -mp=gpu -Minfo=mp -gpu=cc86
+
+
+pybind := ../../src/toast/pybind11
+modext := $(shell python3-config --extension-suffix)
+pyincl := $(shell python3-config --includes)
+
+
+pyomptarget$(modext) : module.o
+	$(CXX) -shared -o pyomptarget$(modext) module.o $(CXX_OMP_FLAGS)
+
+module.o : module.cpp
+	$(CXX) $(CXXFLAGS) $(CXX_OMP_FLAGS) -I. -I$(pybind)/include $(pyincl) -c -o module.o module.cpp
+
+
+clean :
+	rm -f *.so *.o
+

--- a/etc/pyomptarget/module.cpp
+++ b/etc/pyomptarget/module.cpp
@@ -1,0 +1,466 @@
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstring>
+#include <algorithm>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <limits>
+
+#include <omp.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+#include <pybind11/numpy.h>
+#include <pybind11/buffer_info.h>
+
+#include <pybind11/stl_bind.h>
+
+namespace py = pybind11;
+
+using size_container = py::detail::any_container <ssize_t>;
+
+
+// Device code
+
+#pragma omp declare target
+
+struct Interval {
+    double start;
+    double stop;
+    int64_t first;
+    int64_t last;
+};
+
+void qa_mult(double const * p, double const * q, double * r) {
+    r[0] =  p[0] * q[3] + p[1] * q[2] -
+           p[2] * q[1] + p[3] * q[0];
+    r[1] = -p[0] * q[2] + p[1] * q[3] +
+           p[2] * q[0] + p[3] * q[1];
+    r[2] =  p[0] * q[1] - p[1] * q[0] +
+           p[2] * q[3] + p[3] * q[2];
+    r[3] = -p[0] * q[0] - p[1] * q[1] -
+           p[2] * q[2] + p[3] * q[3];
+    return;
+}
+
+void pointing_detector_inner(
+    int32_t const * q_index,
+    uint8_t const * flags,
+    double const * boresight,
+    double const * fp,
+    double * quats,
+    int64_t isamp,
+    int64_t n_samp,
+    int64_t idet
+) {
+    int32_t qidx = q_index[idet];
+    double temp_bore[4];
+    uint8_t check = flags[isamp] & 255;
+    if (check == 0) {
+        temp_bore[0] = boresight[4 * isamp];
+        temp_bore[1] = boresight[4 * isamp + 1];
+        temp_bore[2] = boresight[4 * isamp + 2];
+        temp_bore[3] = boresight[4 * isamp + 3];
+    } else {
+        temp_bore[0] = 0.0;
+        temp_bore[1] = 0.0;
+        temp_bore[2] = 0.0;
+        temp_bore[3] = 1.0;
+    }
+    qa_mult(
+        temp_bore,
+        &(fp[4 * idet]),
+        &(quats[(qidx * 4 * n_samp) + 4 * isamp])
+    );
+    return;
+}
+
+#pragma omp end declare target
+
+template <typename T>
+void host_to_device(
+    std::unordered_map <void *, void *> & mem,
+    int64_t n_elem,
+    T * data,
+    std::string const & name
+) {
+    int target = omp_get_num_devices() - 1;
+    int host = omp_get_initial_device();
+
+    void * vdata = (void*)(&data[0]);
+
+    size_t n_bytes = n_elem * sizeof(T);
+    std::cerr << name << ": Allocating " << n_bytes << " device bytes (" << n_elem << " x " << sizeof(T) << ")" << std::endl;
+    void * buffer = omp_target_alloc(n_bytes, target);
+
+    std::cerr << name << ": Associating host pointer " << vdata << std::endl;
+    int failed = omp_target_associate_ptr(vdata, buffer, n_bytes, 0, target);
+    if (failed != 0) {
+        std::cerr << "Failed to associate dev pointer" << std::endl;
+    }
+
+    failed = omp_target_memcpy(buffer, vdata, n_bytes, 0, 0, target, host);
+    if (failed != 0) {
+        std::cerr << "Failed to copy " << name << " host to device" << std::endl;
+    }
+    std::cerr << name << ": map host " << vdata << " --> " << buffer << std::endl;
+    mem[vdata] = buffer;
+    return;
+}
+
+template <typename T>
+void device_to_host(
+    std::unordered_map <void *, void *> & mem,
+    int64_t n_elem,
+    T * data,
+    std::string const & name
+) {
+    int target = omp_get_num_devices() - 1;
+    int host = omp_get_initial_device();
+
+    void * vdata = (void*)(&data[0]);
+
+    size_t n_bytes = n_elem * sizeof(T);
+
+    void * buffer = mem.at(vdata);
+
+    int failed = omp_target_memcpy(vdata, buffer, n_bytes, 0, 0, host, target);
+    if (failed != 0) {
+        std::cerr << "Failed to copy " << name << " device to host" << std::endl;
+    }
+    return;
+}
+
+
+std::string get_format(std::string const & input) {
+    // Machine endianness
+    int32_t test = 1;
+    bool little_endian = (*(int8_t *)&test == 1);
+
+    std::string format = input;
+
+    // Remove leading caret, if present.
+    if (format.substr(0, 1) == "^") {
+        format = input.substr(1, input.length() - 1);
+    }
+
+    std::string fmt = format;
+    if (format.length() > 1) {
+        // The format string includes endianness information or
+        // is a compound type.
+        std::string endianness = format.substr(0, 1);
+        if (
+            ((endianness == ">") &&  !little_endian)  ||
+            ((endianness == "<") &&  little_endian)  ||
+            (endianness == "=")
+        ) {
+            fmt = format.substr(1, format.length() - 1);
+        } else if (
+            ((endianness == ">") &&  little_endian)  ||
+            ((endianness == "<") &&  !little_endian)
+        ) {
+            std::ostringstream o;
+            o << "Object has different endianness than system- cannot use";
+            throw std::runtime_error(o.str().c_str());
+        }
+    }
+    return fmt;
+}
+
+template <typename T>
+T * extract_buffer(
+    py::buffer data,
+    char const * name,
+    size_t assert_dims,
+    std::vector <int64_t> & shape,
+    std::vector <int64_t> assert_shape
+) {
+    // Get buffer info structure
+    auto info = data.request();
+
+    // Extract the format character for the target type
+    std::string target_format = get_format(py::format_descriptor <T>::format());
+
+    // Extract the format for the input buffer
+    std::string buffer_format = get_format(info.format);
+
+    // Verify format string
+    if (buffer_format != target_format) {
+        // On 64bit linux, numpy is internally inconsistent with the
+        // format codes for int64_t and long long:
+        //   https://github.com/numpy/numpy/issues/12264
+        // Here we treat them as equivalent.
+        if (((buffer_format == "q") || (buffer_format == "l"))
+            && ((target_format == "q") || (target_format == "l"))) {
+            // What could possibly go wrong...
+        } else {
+            std::ostringstream o;
+            o << "Object " << name << " has format \"" << buffer_format
+              << "\" instead of \"" << target_format << "\"";
+            throw std::runtime_error(o.str().c_str());
+        }
+    }
+
+    // Verify itemsize
+    if (info.itemsize != sizeof(T)) {
+        std::ostringstream o;
+        o << "Object " << name << " has item size of "
+          << info.itemsize << " instead of " << sizeof(T);
+        throw std::runtime_error(o.str().c_str());
+    }
+
+    // Verify number of dimensions
+    if (info.ndim != assert_dims) {
+        std::ostringstream o;
+        o << "Object " << name << " has " << info.ndim
+          << " dimensions instead of " << assert_dims;
+        throw std::runtime_error(o.str().c_str());
+    }
+
+    // Get array dimensions
+    for (py::ssize_t d = 0; d < info.ndim; d++) {
+        shape[d] = info.shape[d];
+    }
+
+    // Check strides and verify that memory is contiguous
+    size_t stride = info.itemsize;
+    for (int d = info.ndim - 1; d >= 0; d--) {
+        if (info.strides[d] != stride) {
+            std::ostringstream o;
+            o << "Object " << name
+              << ": python buffers must be contiguous in memory.";
+            throw std::runtime_error(o.str().c_str());
+        }
+        stride *= info.shape[d];
+    }
+
+    // If the user wants to verify any of the dimensions, do that
+    for (py::ssize_t d = 0; d < info.ndim; d++) {
+        if (assert_shape[d] >= 0) {
+            // We are checking this dimension
+            if (assert_shape[d] != shape[d]) {
+                std::ostringstream o;
+                o << "Object " << name << " dimension " << d
+                  << " has length " << shape[d]
+                  << " instead of " << assert_shape[d];
+                throw std::runtime_error(o.str().c_str());
+            }
+        }
+    }
+
+    return static_cast <T *> (info.ptr);
+}
+
+
+PYBIND11_MODULE(pyomptarget, m) {
+    m.doc() = R"(
+    Compiled extension using OpenMP target offload.
+
+    )";
+
+    py::class_ <Interval> (
+        m, "Interval",
+        R"(
+        Numpy dtype for an interval
+        )")
+    .def(py::init([]() {
+                      return Interval();
+                  }))
+    .def_readwrite("start", &Interval::start)
+    .def_readwrite("stop", &Interval::stop)
+    .def_readwrite("first", &Interval::first)
+    .def_readwrite("last", &Interval::last)
+    .def("astuple",
+         [](const Interval & self) {
+             return py::make_tuple(self.start, self.stop, self.first, self.last);
+         })
+    .def_static("fromtuple", [](const py::tuple & tup) {
+                    if (py::len(tup) != 4) {
+                        throw py::cast_error("Invalid size");
+                    }
+                    return Interval{tup[0].cast <double>(),
+                                    tup[1].cast <double>(),
+                                    tup[2].cast <int64_t>(),
+                                    tup[3].cast <int64_t>()};
+                });
+
+
+    PYBIND11_NUMPY_DTYPE(Interval, start, stop, first, last);
+
+    m.def(
+        "stage_data", [](
+            py::buffer boresight,
+            py::buffer quats,
+            py::buffer intervals,
+            py::buffer shared_flags
+        ) {
+            int target = omp_get_num_devices() - 1;
+            int host = omp_get_initial_device();
+            int defdev = omp_get_default_device();
+            std::cout << "OMP initial host device = " << host << std::endl;
+            std::cout << "OMP target device = " << target << std::endl;
+            std::cout << "OMP default device = " << defdev << std::endl;
+
+            std::unordered_map <void *, void *> mem;
+
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            double * raw_boresight = extract_buffer <double> (
+                boresight, "boresight", 2, temp_shape, {-1, 4}
+            );
+            int64_t n_samp = temp_shape[0];
+
+            uint8_t * raw_flags = extract_buffer <uint8_t> (
+                shared_flags, "flags", 1, temp_shape, {n_samp}
+            );
+
+            double * raw_quats = extract_buffer <double> (
+                quats, "quats", 3, temp_shape, {-1, n_samp, 4}
+            );
+            int64_t n_det = temp_shape[0];
+
+            Interval * raw_intervals = extract_buffer <Interval> (
+                intervals, "intervals", 1, temp_shape, {-1}
+            );
+            int64_t n_view = temp_shape[0];
+
+            host_to_device(mem, 4 * n_samp, raw_boresight, "boresight");
+
+            host_to_device(mem, n_samp, raw_flags, "flags");
+
+            host_to_device(mem, n_view, raw_intervals, "intervals");
+
+            host_to_device(mem, n_samp * n_det * 4, raw_quats, "quats");
+
+            return mem;
+        });
+
+    m.def(
+        "unstage_data", [](
+            std::unordered_map <void *, void *> mem,
+            py::buffer quats
+        ) {
+            std::vector <int64_t> temp_shape(3);
+            double * raw_quats = extract_buffer <double> (
+                quats, "quats", 3, temp_shape, {-1, -1, 4}
+            );
+            int64_t n_det = temp_shape[0];
+            int64_t n_samp = temp_shape[1];
+            device_to_host(mem, n_samp * n_det * 4, raw_quats, "quats");
+
+            int target = omp_get_num_devices() - 1;
+            for(auto & p : mem) {
+                std::cerr << "Disassociate host pointer " << p.first << std::endl;
+                int fail = omp_target_disassociate_ptr(p.first, target);
+                if (fail != 0) {
+                    std::cerr << "Failed to disassociate host pointer " << p.first << std::endl;
+                }
+                omp_target_free(p.second, target);
+            }
+        });
+
+    m.def(
+        "pointing_detector", [](
+            std::unordered_map <void *, void *> mem,
+            py::buffer focalplane,
+            py::buffer boresight,
+            py::buffer quat_index,
+            py::buffer quats,
+            py::buffer intervals,
+            py::buffer shared_flags
+        ) {
+            // What if quats has more dets than we are considering in quat_index?
+
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            int32_t * raw_quat_index = extract_buffer <int32_t> (
+                quat_index, "quat_index", 1, temp_shape, {-1}
+            );
+            int64_t n_det = temp_shape[0];
+
+            double * raw_focalplane = extract_buffer <double> (
+                focalplane, "focalplane", 2, temp_shape, {n_det, 4}
+            );
+
+            double * raw_boresight = extract_buffer <double> (
+                boresight, "boresight", 2, temp_shape, {-1, 4}
+            );
+            int64_t n_samp = temp_shape[0];
+            double * dev_boresight = (double*)mem.at(raw_boresight);
+
+            double * raw_quats = extract_buffer <double> (
+                quats, "quats", 3, temp_shape, {-1, n_samp, 4}
+            );
+            double * dev_quats = (double*)mem.at(raw_quats);
+
+            Interval * raw_intervals = extract_buffer <Interval> (
+                intervals, "intervals", 1, temp_shape, {-1}
+            );
+            Interval * dev_intervals = (Interval*)mem.at(raw_intervals);
+            int64_t n_view = temp_shape[0];
+            std::cerr << "interval 0 = " << raw_intervals[0].first << ", " << raw_intervals[0].last << std::endl;
+
+            uint8_t * raw_flags = extract_buffer <uint8_t> (
+                shared_flags, "flags", 1, temp_shape, {n_samp}
+            );
+            uint8_t * dev_flags = (uint8_t*)mem.at(raw_flags);
+
+            int present = omp_target_is_present(raw_boresight, 0);
+            std::cerr << "target present boresight = " << present << std::endl;
+            present = omp_target_is_present(raw_quats, 0);
+            std::cerr << "target present quats = " << present << std::endl;
+            present = omp_target_is_present(raw_intervals, 0);
+            std::cerr << "target present intervals = " << present << std::endl;
+            present = omp_target_is_present(raw_flags, 0);
+            std::cerr << "target present flags = " << present << std::endl;
+
+            # pragma omp target data           \
+                device(0)                      \
+                map(to:                        \
+                    raw_focalplane[0:4*n_det], \
+                    raw_quat_index[0:n_det],   \
+                    n_view,                    \
+                    n_det,                     \
+                    n_samp                     \
+                )
+            {
+                # pragma omp target teams distribute collapse(2) \
+                    is_device_ptr(                 \
+                        dev_boresight,             \
+                        dev_quats,                 \
+                        dev_intervals,             \
+                        dev_flags                  \
+                    )
+                for (int64_t idet = 0; idet < n_det; idet++) {
+                    for (int64_t iview = 0; iview < n_view; iview++) {
+                        # pragma omp parallel for default(shared)
+                        for (
+                            int64_t isamp = raw_intervals[iview].first;
+                            isamp <= raw_intervals[iview].last;
+                            isamp++
+                        ) {
+                            pointing_detector_inner(
+                                raw_quat_index,
+                                dev_flags,
+                                dev_boresight,
+                                raw_focalplane,
+                                dev_quats,
+                                isamp,
+                                n_samp,
+                                idet
+                            );
+                        }
+                    }
+                }
+            }
+
+            return;
+        });
+
+}

--- a/etc/pyomptarget/module.cpp
+++ b/etc/pyomptarget/module.cpp
@@ -298,7 +298,9 @@ PYBIND11_MODULE(pyomptarget, m) {
             py::buffer intervals,
             py::buffer shared_flags
         ) {
-            int target = omp_get_num_devices() - 1;
+            int ndev = omp_get_num_devices();
+            std::cout << "OMP found " << ndev << " available target offload devices" << std::endl;
+            int target = ndev - 1;
             int host = omp_get_initial_device();
             int defdev = omp_get_default_device();
             std::cout << "OMP initial host device = " << host << std::endl;

--- a/etc/pyomptarget/run.py
+++ b/etc/pyomptarget/run.py
@@ -1,0 +1,85 @@
+
+import os
+import sys
+
+sys.path.append(os.getcwd())
+import pyomptarget
+
+# Import this **AFTER** the custom module above, since both will
+# dlopen libgomp.
+import numpy as np
+
+
+def build_interval_dtype():
+    dtdbl = np.dtype("double")
+    dtll = np.dtype("longlong")
+    fmts = [dtdbl.char, dtdbl.char, dtll.char, dtll.char]
+    offs = [
+        0,
+        dtdbl.alignment,
+        2 * dtdbl.alignment,
+        2 * dtdbl.alignment + dtll.alignment,
+    ]
+    return np.dtype(
+        {
+            "names": ["start", "stop", "first", "last"],
+            "formats": fmts,
+            "offsets": offs,
+        }
+    )
+
+
+def main():
+    interval_dtype = build_interval_dtype()
+    ndet = 2
+    nsamp = 100
+
+    focalplane = np.tile(
+        np.array(
+            [0.0, 0.0, 0.0, 1.0],
+            dtype=np.float64,
+        ),
+        ndet,
+    ).reshape((-1, 4))
+
+    boresight = np.tile(
+        np.array(
+            [0.0, 0.0, 0.0, 1.0],
+            dtype=np.float64,
+        ),
+        nsamp,
+    ).reshape((-1, 4))
+
+    quat_index = np.arange(ndet, dtype=np.int32)
+
+    shared_flags = np.zeros(nsamp, dtype=np.uint8)
+
+    nview = 1
+    print(interval_dtype)
+    intervals = np.zeros(nview, dtype=interval_dtype).view(np.recarray)
+    intervals[0].first = 0
+    intervals[0].last = nsamp - 1
+    intervals[0].start = -1.0
+    intervals[0].stop = -1.0
+
+    quats = np.zeros((ndet, nsamp, 4), dtype=np.float64)
+
+    mem = pyomptarget.stage_data(boresight, quats, intervals, shared_flags)
+
+    pyomptarget.pointing_detector(
+        mem,
+        focalplane,
+        boresight,
+        quat_index,
+        quats,
+        intervals,
+        shared_flags,
+    )
+
+    pyomptarget.unstage_data(mem, quats)
+
+    # print(quats)
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/pyomptarget/run.py
+++ b/etc/pyomptarget/run.py
@@ -1,6 +1,7 @@
 
 import os
 import sys
+import time
 
 sys.path.append(os.getcwd())
 import pyomptarget
@@ -32,7 +33,7 @@ def build_interval_dtype():
 def main():
     interval_dtype = build_interval_dtype()
     ndet = 2
-    nsamp = 100
+    nsamp = 1000000
 
     focalplane = np.tile(
         np.array(
@@ -65,6 +66,8 @@ def main():
     quats = np.zeros((ndet, nsamp, 4), dtype=np.float64)
 
     mem = pyomptarget.stage_data(boresight, quats, intervals, shared_flags)
+
+    # time.sleep(5)
 
     pyomptarget.pointing_detector(
         mem,

--- a/platforms/conda_gpu.sh
+++ b/platforms/conda_gpu.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This is similar to the "conda_dev.sh" script, but uses a target-offload version of
+# gcc.  However, it also requires a manual hack- replacing the libgomp library in the
+# conda env with a symlink to the nvptx enabled version that comes with the custom gcc.
+
+set -e
+
+if [ "x${CONDA_PREFIX}" = "x" ]; then
+    echo "You must activate a conda environment before using this script."
+    exit 1
+fi
+
+# if [ "x${CONDA_TOOLCHAIN_HOST}" = "x" ]; then
+#     echo "Your conda environment does not contain compilers.  Run conda_dev_setup.sh first."
+#     exit 1
+# fi
+
+# Location of this script
+pushd $(dirname $0) >/dev/null 2>&1
+scriptdir=$(pwd)
+popd >/dev/null 2>&1
+topdir=$(dirname "${scriptdir}")
+
+PREFIX="${CONDA_PREFIX}"
+PYTHON="${PREFIX}/bin/python"
+LIBDIR="${PREFIX}/lib"
+
+if [ "x${DEBUG}" = "x1" ]; then
+    CMAKE_BUILD_TYPE=Debug
+else
+    CMAKE_BUILD_TYPE=Release
+fi
+
+CMAKE_PLATFORM_FLAGS=""
+shext="so"
+if [[ ${CONDA_TOOLCHAIN_HOST} =~ .*darwin.* ]]; then
+    CMAKE_PLATFORM_FLAGS+=(-DCMAKE_OSX_SYSROOT="${CONDA_BUILD_SYSROOT}")
+    shext="dylib"
+fi
+
+cmake \
+    -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" ${CMAKE_PLATFORM_FLAGS} \
+    -DCMAKE_C_COMPILER="gcc-12" \
+    -DCMAKE_CXX_COMPILER="g++-12" \
+    -DCMAKE_C_FLAGS="-O3 -g -fPIC" \
+    -DCMAKE_CXX_FLAGS="-O3 -g -fPIC -pthread -std=c++11 -fcf-protection=none -fno-stack-protector" \
+    -DUSE_OPENMP_TARGET=TRUE \
+    -DOPENMP_TARGET_FLAGS="-foffload=nvptx-none -foffload-options=-Wa,-m,sm_80 -foffload-options=-misa=sm_80 -foffload-options=-fPIC -foffload-options=-lm -foffload-options=-latomic" \
+    -DCMAKE_VERBOSE_MAKEFILE=1 \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_PREFIX_PATH="${PREFIX}" \
+    -DFFTW_ROOT="${PREFIX}" \
+    -DAATM_ROOT="${PREFIX}" \
+    -DBLAS_LIBRARIES="${LIBDIR}/libblas.${shext}" \
+    -DLAPACK_LIBRARIES="${LIBDIR}/liblapack.${shext}" \
+    -DSUITESPARSE_INCLUDE_DIR_HINTS="${PREFIX}/include" \
+    -DSUITESPARSE_LIBRARY_DIR_HINTS="${LIBDIR}" \
+    ..

--- a/src/toast/_libtoast/accelerator.cpp
+++ b/src/toast/_libtoast/accelerator.cpp
@@ -352,38 +352,6 @@ int OmpManager::present(void * buffer, size_t nbytes) {
     #endif // ifdef HAVE_OPENMP_TARGET
 }
 
-void * OmpManager::device_ptr(void * buffer) {
-    auto log = toast::Logger::get();
-    std::ostringstream o;
-
-    // If the device is the host device, return
-    if (device_is_host()) {
-        return buffer;
-    }
-
-    #ifdef HAVE_OPENMP_TARGET
-
-    size_t n = mem_.count(buffer);
-    if (n == 0) {
-        o.str("");
-        o << "OmpManager:  host ptr " << buffer
-          << " is not present- cannot get device pointer";
-        log.error(o.str().c_str());
-        throw std::runtime_error(o.str().c_str());
-    }
-    return mem_.at(buffer);
-
-    #else // ifdef HAVE_OPENMP_TARGET
-
-    o << "OmpManager:  OpenMP target support disabled";
-    log.error(o.str().c_str());
-    throw std::runtime_error(o.str().c_str());
-
-    return NULL;
-
-    #endif // ifdef HAVE_OPENMP_TARGET
-}
-
 void OmpManager::dump() {
     #ifdef HAVE_OPENMP_TARGET
     for (auto & p : mem_size_) {

--- a/src/toast/_libtoast/accelerator.hpp
+++ b/src/toast/_libtoast/accelerator.hpp
@@ -42,7 +42,7 @@ class OmpManager {
         void * null;
 
         template <typename T>
-        T * OmpManager::device_ptr(T * buffer) const {
+        T * device_ptr(T * buffer) {
             auto log = toast::Logger::get();
             std::ostringstream o;
             // If the device is the host device, return
@@ -59,7 +59,7 @@ class OmpManager {
                 log.error(o.str().c_str());
                 throw std::runtime_error(o.str().c_str());
             }
-            return static_cast <typename T *> (mem_.at(vbuffer));
+            return static_cast <T *> (mem_.at(vbuffer));
             #else // ifdef HAVE_OPENMP_TARGET
             o << "OmpManager:  OpenMP target support disabled";
             log.error(o.str().c_str());

--- a/src/toast/_libtoast/accelerator.hpp
+++ b/src/toast/_libtoast/accelerator.hpp
@@ -35,13 +35,38 @@ class OmpManager {
 
         int present(void * buffer, size_t nbytes);
 
-        void * device_ptr(void * buffer);
-
         void dump();
 
         ~OmpManager();
 
         void * null;
+
+        template <typename T>
+        T * OmpManager::device_ptr(T * buffer) const {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            // If the device is the host device, return
+            if (device_is_host()) {
+                return buffer;
+            }
+            #ifdef HAVE_OPENMP_TARGET
+            void * vbuffer = static_cast <void *> (buffer);
+            size_t n = mem_.count(vbuffer);
+            if (n == 0) {
+                o.str("");
+                o << "OmpManager:  host ptr " << buffer
+                << " is not present- cannot get device pointer";
+                log.error(o.str().c_str());
+                throw std::runtime_error(o.str().c_str());
+            }
+            return static_cast <typename T *> (mem_.at(vbuffer));
+            #else // ifdef HAVE_OPENMP_TARGET
+            o << "OmpManager:  OpenMP target support disabled";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+            return NULL;
+            #endif // ifdef HAVE_OPENMP_TARGET
+        }
 
     private:
 

--- a/src/toast/_libtoast/ops_mapmaker_utils.cpp
+++ b/src/toast/_libtoast/ops_mapmaker_utils.cpp
@@ -113,6 +113,10 @@ void init_ops_mapmaker_utils(py::module & m) {
             uint8_t shared_flag_mask,
             bool use_accel
         ) {
+            auto & omgr = OmpManager::get();
+            int dev = omgr.get_device();
+            bool offload = (!omgr.device_is_host()) && use_accel;
+
             // This is used to return the actual shape of each buffer
             std::vector <int64_t> temp_shape(3);
 
@@ -165,12 +169,6 @@ void init_ops_mapmaker_utils(py::module & m) {
             int64_t n_local_submap = temp_shape[0];
             int64_t n_pix_submap = temp_shape[1];
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
-
-            // int64_t n_zmap = n_local_submap * n_pix_submap * nnz;
-
             // Optionally use flags
 
             bool use_shared_flags = true;
@@ -194,6 +192,14 @@ void init_ops_mapmaker_utils(py::module & m) {
             if (offload) {
                 #ifdef HAVE_OPENMP_TARGET
 
+                int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
+                double * dev_weights = omgr.device_ptr(raw_weights);
+                double * dev_det_data = omgr.device_ptr(raw_det_data);
+                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                double * dev_zmap = omgr.device_ptr(raw_zmap);
+                uint8_t * dev_shared_flags = omgr.device_ptr(raw_shared_flags);
+                uint8_t * dev_det_flags = omgr.device_ptr(raw_det_flags);
+
                 # pragma omp target data             \
                 device(dev)                          \
                 map(to:                              \
@@ -214,13 +220,6 @@ void init_ops_mapmaker_utils(py::module & m) {
                 use_det_flags                        \
                 )                                    \
                 use_device_ptr(                      \
-                raw_pixels,                          \
-                raw_weights,                         \
-                raw_det_data,                        \
-                raw_det_flags,                       \
-                raw_intervals,                       \
-                raw_shared_flags,                    \
-                raw_zmap,                            \
                 raw_weight_index,                    \
                 raw_pixel_index,                     \
                 raw_flag_index,                      \
@@ -229,13 +228,22 @@ void init_ops_mapmaker_utils(py::module & m) {
                 raw_global2local                     \
                 )
                 {
-                    # pragma omp target teams distribute collapse(2)
+                    # pragma omp target teams distribute collapse(2) \
+                        is_device_ptr( \
+                            dev_pixels,                          \
+                            dev_weights,                         \
+                            dev_det_data,                        \
+                            dev_det_flags,                       \
+                            dev_intervals,                       \
+                            dev_shared_flags,                    \
+                            dev_zmap, \
+                        )
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
                             # pragma omp parallel for default(shared)
                             for (
-                                int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                int64_t isamp = dev_intervals[iview].first;
+                                isamp <= dev_intervals[iview].last;
                                 isamp++
                             ) {
                                 double zmap_val[nnz];
@@ -246,11 +254,11 @@ void init_ops_mapmaker_utils(py::module & m) {
                                     raw_flag_index,
                                     raw_data_index,
                                     raw_global2local,
-                                    raw_det_data,
-                                    raw_det_flags,
-                                    raw_shared_flags,
-                                    raw_pixels,
-                                    raw_weights,
+                                    dev_det_data,
+                                    dev_det_flags,
+                                    dev_shared_flags,
+                                    dev_pixels,
+                                    dev_weights,
                                     raw_det_scale,
                                     zmap_val,
                                     &zoff,
@@ -266,7 +274,7 @@ void init_ops_mapmaker_utils(py::module & m) {
                                 );
                                 for (int64_t iw = 0; iw < nnz; iw++) {
                                     # pragma omp atomic
-                                    raw_zmap[zoff + iw] += zmap_val[iw];
+                                    dev_zmap[zoff + iw] += zmap_val[iw];
                                 }
                             }
                         }

--- a/src/toast/_libtoast/ops_mapmaker_utils.cpp
+++ b/src/toast/_libtoast/ops_mapmaker_utils.cpp
@@ -236,7 +236,7 @@ void init_ops_mapmaker_utils(py::module & m) {
                             dev_det_flags,                       \
                             dev_intervals,                       \
                             dev_shared_flags,                    \
-                            dev_zmap, \
+                            dev_zmap \
                         )
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -393,7 +393,7 @@ void init_ops_pixels_healpix(py::module & m) {
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                uint8_t * dev_shared_flags = omgr.device_ptr(raw_shared_flags);
+                uint8_t * dev_flags = omgr.device_ptr(raw_flags);
 
                 # pragma omp target data  \
                 device(dev)               \

--- a/src/toast/_libtoast/ops_pointing_detector.cpp
+++ b/src/toast/_libtoast/ops_pointing_detector.cpp
@@ -133,7 +133,7 @@ void init_ops_pointing_detector(py::module & m) {
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 double * dev_boresight = omgr.device_ptr(raw_boresight);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                uint8_t * dev_shared_flags = omgr.device_ptr(raw_shared_flags);
+                uint8_t * dev_flags = omgr.device_ptr(raw_flags);
 
                 # pragma omp target data   \
                 device(dev)                \

--- a/src/toast/_libtoast/ops_pointing_detector.cpp
+++ b/src/toast/_libtoast/ops_pointing_detector.cpp
@@ -86,6 +86,9 @@ void init_ops_pointing_detector(py::module & m) {
             uint8_t shared_flag_mask,
             bool use_accel
         ) {
+            auto & omgr = OmpManager::get();
+            int dev = omgr.get_device();
+            bool offload = (!omgr.device_is_host()) && use_accel;
             // What if quats has more dets than we are considering in quat_index?
 
             // This is used to return the actual shape of each buffer
@@ -114,10 +117,6 @@ void init_ops_pointing_detector(py::module & m) {
             );
             int64_t n_view = temp_shape[0];
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
-
             // Optionally use flags
             bool use_flags = true;
             uint8_t * raw_flags = extract_buffer <uint8_t> (
@@ -131,6 +130,11 @@ void init_ops_pointing_detector(py::module & m) {
             if (offload) {
                 #ifdef HAVE_OPENMP_TARGET
 
+                double * dev_quats = omgr.device_ptr(raw_quats);
+                double * dev_boresight = omgr.device_ptr(raw_boresight);
+                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                uint8_t * dev_shared_flags = omgr.device_ptr(raw_shared_flags);
+
                 # pragma omp target data   \
                 device(dev)                \
                 map(to:                    \
@@ -143,29 +147,31 @@ void init_ops_pointing_detector(py::module & m) {
                 use_flags                  \
                 )                          \
                 use_device_ptr(            \
-                raw_boresight,             \
-                raw_quats,                 \
-                raw_intervals,             \
-                raw_flags,                 \
                 raw_focalplane,            \
                 raw_quat_index             \
                 )
                 {
-                    # pragma omp target teams distribute collapse(2)
+                    # pragma omp target teams distribute collapse(2) \
+                        is_device_ptr( \
+                            dev_boresight, \
+                            dev_quats, \
+                            dev_flags, \
+                            dev_intervals \
+                        )
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
                             # pragma omp parallel for default(shared)
                             for (
-                                int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                int64_t isamp = dev_intervals[iview].first;
+                                isamp <= dev_intervals[iview].last;
                                 isamp++
                             ) {
                                 pointing_detector_inner(
                                     raw_quat_index,
-                                    raw_flags,
-                                    raw_boresight,
+                                    dev_flags,
+                                    dev_boresight,
                                     raw_focalplane,
-                                    raw_quats,
+                                    dev_quats,
                                     isamp,
                                     n_samp,
                                     idet,

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -288,15 +288,18 @@ void init_template_offset(py::module & m) {
                 n_amp                    \
                 )
                 {
-                    # pragma omp parallel for default(shared) \
+                    # pragma omp target \
                         is_device_ptr( \
                             dev_amp_in,              \
                             dev_amp_out,             \
                             dev_offset_var           \
                         )
-                    for (int64_t iamp = 0; iamp < n_amp; iamp++) {
-                        dev_amp_out[iamp] = dev_amp_in[iamp];
-                        dev_amp_out[iamp] *= dev_offset_var[iamp];
+                    {
+                        # pragma omp parallel for default(shared)
+                        for (int64_t iamp = 0; iamp < n_amp; iamp++) {
+                            dev_amp_out[iamp] = dev_amp_in[iamp];
+                            dev_amp_out[iamp] *= dev_offset_var[iamp];
+                        }
                     }
                 }
 

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -24,6 +24,10 @@ void init_template_offset(py::module & m) {
             py::buffer intervals,
             bool use_accel
         ) {
+            auto & omgr = OmpManager::get();
+            int dev = omgr.get_device();
+            bool offload = (!omgr.device_is_host()) && use_accel;
+
             // This is used to return the actual shape of each buffer
             std::vector <int64_t> temp_shape(3);
 
@@ -47,12 +51,12 @@ void init_template_offset(py::module & m) {
                 n_amp_views, "n_amp_views", 1, temp_shape, {n_view}
             );
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
-
             if (offload) {
                 #ifdef HAVE_OPENMP_TARGET
+
+                double * dev_det_data = omgr.device_ptr(raw_det_data);
+                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
 
                 # pragma omp target data \
                 device(dev)              \
@@ -63,25 +67,25 @@ void init_template_offset(py::module & m) {
                 step_length,             \
                 amp_offset,              \
                 raw_n_amp_views          \
-                )                        \
-                use_device_ptr(          \
-                raw_amplitudes,          \
-                raw_det_data,            \
-                raw_intervals            \
                 )
                 {
                     int64_t offset = amp_offset;
-                    # pragma omp target teams distribute firstprivate(offset)
+                    # pragma omp target teams distribute firstprivate(offset) \
+                        is_device_ptr( \
+                            dev_amplitudes, \
+                            dev_det_data, \
+                            dev_intervals \
+                        )
                     for (int64_t iview = 0; iview < n_view; iview++) {
                         # pragma omp parallel for default(shared)
                         for (
-                            int64_t isamp = raw_intervals[iview].first;
-                            isamp <= raw_intervals[iview].last;
+                            int64_t isamp = dev_intervals[iview].first;
+                            isamp <= dev_intervals[iview].last;
                             isamp++
                         ) {
                             int64_t d = data_index * n_samp + isamp;
                             int64_t amp = offset + (int64_t)(isamp / step_length);
-                            raw_det_data[d] += raw_amplitudes[amp];
+                            dev_det_data[d] += dev_amplitudes[amp];
                         }
                         offset += raw_n_amp_views[iview];
                     }
@@ -121,6 +125,10 @@ void init_template_offset(py::module & m) {
             py::buffer intervals,
             bool use_accel
         ) {
+            auto & omgr = OmpManager::get();
+            int dev = omgr.get_device();
+            bool offload = (!omgr.device_is_host()) && use_accel;
+
             // This is used to return the actual shape of each buffer
             std::vector <int64_t> temp_shape(3);
 
@@ -144,10 +152,6 @@ void init_template_offset(py::module & m) {
                 n_amp_views, "n_amp_views", 1, temp_shape, {n_view}
             );
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
-
             // Optionally use flags
             bool use_flags = false;
             uint8_t * raw_det_flags = (uint8_t *)omgr.null;
@@ -161,6 +165,11 @@ void init_template_offset(py::module & m) {
             if (offload) {
                 #ifdef HAVE_OPENMP_TARGET
 
+                double * dev_det_data = omgr.device_ptr(raw_det_data);
+                uint8_t * dev_det_flags = omgr.device_ptr(raw_det_flags);
+                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
+
                 # pragma omp target data \
                 device(dev)              \
                 map(to:                  \
@@ -172,21 +181,21 @@ void init_template_offset(py::module & m) {
                 amp_offset,              \
                 raw_n_amp_views,         \
                 use_flags                \
-                )                        \
-                use_device_ptr(          \
-                raw_amplitudes,          \
-                raw_det_data,            \
-                raw_det_flags,           \
-                raw_intervals            \
                 )
                 {
                     int64_t offset = amp_offset;
-                    # pragma omp target teams distribute firstprivate(offset)
+                    # pragma omp target teams distribute firstprivate(offset) \
+                        is_device_ptr( \
+                            dev_amplitudes, \
+                            dev_det_data, \
+                            dev_det_flags, \
+                            dev_intervals \
+                        )
                     for (int64_t iview = 0; iview < n_view; iview++) {
                         # pragma omp parallel for default(shared)
                         for (
-                            int64_t isamp = raw_intervals[iview].first;
-                            isamp <= raw_intervals[iview].last;
+                            int64_t isamp = dev_intervals[iview].first;
+                            isamp <= dev_intervals[iview].last;
                             isamp++
                         ) {
                             int64_t d = data_index * n_samp + isamp;
@@ -194,15 +203,15 @@ void init_template_offset(py::module & m) {
                             double contrib = 0.0;
                             if (use_flags) {
                                 int64_t f = flag_index * n_samp + isamp;
-                                uint8_t check = raw_det_flags[f] & flag_mask;
+                                uint8_t check = dev_det_flags[f] & flag_mask;
                                 if (check == 0) {
-                                    contrib = raw_det_data[d];
+                                    contrib = dev_det_data[d];
                                 }
                             } else {
                                 contrib = raw_det_data[d];
                             }
                             # pragma omp atomic
-                            raw_amplitudes[amp] += contrib;
+                            dev_amplitudes[amp] += contrib;
                         }
                         offset += raw_n_amp_views[iview];
                     }
@@ -246,6 +255,10 @@ void init_template_offset(py::module & m) {
             py::buffer amplitudes_out,
             bool use_accel
         ) {
+            auto & omgr = OmpManager::get();
+            int dev = omgr.get_device();
+            bool offload = (!omgr.device_is_host()) && use_accel;
+
             // This is used to return the actual shape of each buffer
             std::vector <int64_t> temp_shape(3);
 
@@ -262,28 +275,28 @@ void init_template_offset(py::module & m) {
                 offset_var, "offset_var", 1, temp_shape, {n_amp}
             );
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
-
             if (offload) {
                 #ifdef HAVE_OPENMP_TARGET
+
+                double * dev_amp_in = omgr.device_ptr(raw_amp_in);
+                double * dev_amp_out = omgr.device_ptr(raw_amp_out);
+                double * dev_offset_var = omgr.device_ptr(raw_offset_var);
 
                 # pragma omp target data \
                 device(dev)              \
                 map(to:                  \
                 n_amp                    \
-                )                        \
-                use_device_ptr(          \
-                raw_amp_in,              \
-                raw_amp_out,             \
-                raw_offset_var           \
                 )
                 {
-                    # pragma omp parallel for default(shared)
+                    # pragma omp parallel for default(shared) \
+                        is_device_ptr( \
+                            dev_amp_in,              \
+                            dev_amp_out,             \
+                            dev_offset_var           \
+                        )
                     for (int64_t iamp = 0; iamp < n_amp; iamp++) {
-                        raw_amp_out[iamp] = raw_amp_in[iamp];
-                        raw_amp_out[iamp] *= raw_offset_var[iamp];
+                        dev_amp_out[iamp] = dev_amp_in[iamp];
+                        dev_amp_out[iamp] *= dev_offset_var[iamp];
                     }
                 }
 


### PR DESCRIPTION
This adds a small standalone test of making a compiled extension that includes openmp target offload code.  Tested with the `gcc-12-offload-nvptx` compiler package from the `ubuntu-toolchain-r` repo.  This was combined with a minimal conda env that had libomp replaced with the libgomp shipped with the above compiler.  Obviously not a long term solution.  This is just to confirm the correct syntax of the omp pragmas.  One strange thing is that this code seems to only work passing the device pointers (found with manual lookup) to the `target is_device_ptr()` clause, rather than using the internal OMP memory mapping table and passing the host pointers on entering the data region with `target data use_device_ptr()`.  Still investigating why, but this demonstrates that it is possible (at least with this compiler) to have OpenMP target offload code inside a dynamically loaded python extension.