### PR TITLE
SPT-3G export tune up

### DIFF
--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -796,7 +796,7 @@ class SimGround(Operator):
 
             if self.det_data is not None:
                 exists_data = ob.detdata.ensure(
-                    self.det_data, dtype=np.float64, detectors=dets
+                    self.det_data, dtype=np.float64, detectors=dets, units=u.Kelvin
                 )
 
             if self.det_flags is not None:

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -277,7 +277,7 @@ class SimNoise(Operator):
             # detectors within the observation...
 
             # Make sure correct output exists
-            exists = ob.detdata.ensure(self.det_data, detectors=dets)
+            exists = ob.detdata.ensure(self.det_data, detectors=dets, units=u.Kelvin)
 
             # Get the sample rate from the data.  We also have nominal sample rates
             # from the noise model and also from the focalplane.  Perhaps we should add

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -2222,8 +2222,6 @@ def build_schedule(args, start_timestamp, stop_timestamp, patches, observer, sun
                 fout_fmt,
                 ods,
                 boresight_angle,
-                last_successful,
-                last_el,
             )
 
         if args.operational_days and len(ods) > args.operational_days:

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -2222,6 +2222,8 @@ def build_schedule(args, start_timestamp, stop_timestamp, patches, observer, sun
                 fout_fmt,
                 ods,
                 boresight_angle,
+                last_successful,
+                last_el,
             )
 
         if args.operational_days and len(ods) > args.operational_days:

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -111,47 +111,47 @@ def to_g3_unit(aunit):
         scale = 1.0 * aunit
         # Try to convert the units to the various types of quantities
         try:
-            scale = scale.to(u.volt)
+            scale = scale.to(u.volt)*c3g.G3Units.volt
             return (c3g.G3TimestreamUnits.Voltage, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.watt)
+            scale = scale.to(u.watt)*c3g.G3Units.watt
             return (c3g.G3TimestreamUnits.Power, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.ohm)
+            scale = scale.to(u.ohm)*(c3g.G3Units.volt/c3g.G3Units.amp)
             return (c3g.G3TimestreamUnits.Resistance, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.ampere)
+            scale = scale.to(u.ampere)*c3g.G3Units.ampere
             return (c3g.G3TimestreamUnits.Current, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.meter)
+            scale = scale.to(u.meter)*c3g.G3Units.meter
             return (c3g.G3TimestreamUnits.Distance, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.pascal)
+            scale = scale.to(u.bar)*c3g.G3Units.bar
             return (c3g.G3TimestreamUnits.Pressure, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.radian)
+            scale = scale.to(u.radian)*c3g.G3Units.radian
             return (c3g.G3TimestreamUnits.Angle, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.Jy)
+            scale = scale.to(u.Jy)*c3g.G3Units.Jy
             return (c3g.G3TimestreamUnits.FluxDensity, scale.value)
         except Exception:
             pass
         try:
-            scale = scale.to(u.Kelvin)
+            scale = scale.to(u.Kelvin)*c3g.G3Units.kelvin
             return (c3g.G3TimestreamUnits.Tcmb, scale.value)
         except Exception:
             pass

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -162,7 +162,7 @@ def to_g3_unit(aunit):
 def from_g3_unit(gunit):
     """Convert G3 timestream unit to astropy.
 
-    This function assumes that the quantities are in SI units.
+    This function assumes that the quantities are in SPT-3G units.
 
     Args:
         gunit (G3TimestreamUnit):  The input units.
@@ -174,23 +174,23 @@ def from_g3_unit(gunit):
     if gunit == c3g.G3TimestreamUnits.Counts:
         return u.dimensionless_unscaled
     elif gunit == c3g.G3TimestreamUnits.Voltage:
-        return u.volt
+        return u.def_unit('SPT_Voltage', u.volt/c3g.G3Units.volt)
     elif gunit == c3g.G3TimestreamUnits.Power:
-        return u.watt
+        return u.def_unit('SPT_Power', u.watt/c3g.G3Units.watt)
     elif gunit == c3g.G3TimestreamUnits.Resistance:
-        return u.ohm
+        return u.def_unit('SPT_Resistance', u.ohm/(c3g.G3Units.volt/c3g.G3Units.amp))
     elif gunit == c3g.G3TimestreamUnits.Current:
-        return u.ampere
+        return u.def_unit('SPT_Current', u.ampere/c3g.G3Units.ampere)
     elif gunit == c3g.G3TimestreamUnits.Distance:
-        return u.meter
+        return u.def_unit('SPT_Distance', u.meter/c3g.G3Units.meter)
     elif gunit == c3g.G3TimestreamUnits.Pressure:
-        return u.pascal
+        return u.def_unit('SPT_Pressure', u.bar/c3g.G3Units.bar)
     elif gunit == c3g.G3TimestreamUnits.Angle:
-        return u.radian
+        return u.def_unit('SPT_Angle', u.radian/c3g.G3Units.radian)
     elif gunit == c3g.G3TimestreamUnits.FluxDensity:
-        return u.Jy
+        return u.def_unit('SPT_FluxDensity', u.Jy/c3g.G3Units.Jy)
     elif gunit == c3g.G3TimestreamUnits.Tcmb:
-        return u.Kelvin
+        return u.def_unit('SPT_Tcmb', u.Kelvin/c3g.G3Units.kelvin)
     else:
         return u.dimensionless_unscaled
 

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -95,8 +95,9 @@ def to_g3_map_array_type(dt):
 def to_g3_unit(aunit):
     """Convert astropy unit to G3 timestream unit.
 
-    We convert our input units to SI base units (no milli-, micro-, etc prefix).
-    We also return the scale factor needed to transform to this unit.
+    We convert our input units to SPT-3G base units.
+    We also return the scale factor needed to transform to this unit,
+    defined as the ratio between definitions of the fundmental SI units.
 
     Args:
         aunit (astropy.unit):  The input unit.

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -628,23 +628,24 @@ def dump_spt3g(job, args, data):
         det_names=[
             (
                 ops.sim_noise.det_data,
-                ops.sim_noise.det_data,
+                "CalTimestreams",
                 c3g.G3TimestreamMap,
             ),
             # ("flags", "detector_flags", c3g.G3TimestreamMap),
         ],
-        interval_names=[
-            (ops.sim_ground.scan_leftright_interval, "intervals_scan_leftright"),
-            (ops.sim_ground.turn_leftright_interval, "intervals_turn_leftright"),
-            (ops.sim_ground.scan_rightleft_interval, "intervals_scan_rightleft"),
-            (ops.sim_ground.turn_rightleft_interval, "intervals_turn_rightleft"),
-            (ops.sim_ground.elnod_interval, "intervals_elnod"),
-            (ops.sim_ground.scanning_interval, "intervals_scanning"),
-            (ops.sim_ground.turnaround_interval, "intervals_turnaround"),
-            (ops.sim_ground.sun_up_interval, "intervals_sun_up"),
-            (ops.sim_ground.sun_close_interval, "intervals_sun_close"),
+        # split data into frames where it is covered by these intervals
+        split_interval_names=[
+            ops.sim_ground.scan_leftright_interval,
+            ops.sim_ground.turn_leftright_interval,
+            ops.sim_ground.scan_rightleft_interval,
+            ops.sim_ground.turn_rightleft_interval,
+            ops.sim_ground.elnod_interval
         ],
-        compress=True,
+        # export information about these intervals into frames
+        interval_names=[
+            (ops.sim_ground.turnaround_interval, "intervals_turnaround"),
+        ],
+        compress=False, # Compression must be off for data to be intelligible to spt3g_software
     )
     exporter = t3g.export_obs(
         meta_export=meta_exporter,


### PR DESCRIPTION
This set of changes encompasses my fixes to make data exported by TOAST readable by spt3g_software to a point such that a skymap can be produced from simulated detector data. As my focus was on the export case, some new functionality isn't mirrored for importing, although some of the more fundamental parts are. 

The main changes are:
- Exporting focal plane geometry using SPT-3G datastructures
- Setting units on the detector data and correcting how units are translated
- Accounting for a coordinate system convention difference when translating directions
- Splitting data into `G3Frame`s in a manner more typical for experimental data

There is also some optimization of `IntervalList` intersections, as this was a bottleneck for exporting data. 