### PR TITLE
Add a scheduler parameter for disabling SSO avoidance below horizon

### DIFF
--- a/src/toast/pixels_io_healpix.py
+++ b/src/toast/pixels_io_healpix.py
@@ -556,6 +556,8 @@ def filename_is_hdf5(filename):
 def read_healpix(filename, *args, **kwargs):
     """Read a FITS or HDF5 map serially"""
 
+    filename = filename.strip()
+
     if filename_is_fits(filename):
 
         # Load a FITS map with healpy
@@ -614,6 +616,9 @@ def read_healpix(filename, *args, **kwargs):
             result = mapdata, header
         else:
             result = mapdata
+    else:
+        msg = f"Could not ascertain file type for '{fname}'"
+        raise RuntimeError(msg)
 
     return result
 


### PR DESCRIPTION
This PR adds scheduler options to disable Solar and Lunar avoidance when the avoided object is below a user-specified elevation.