### PR TITLE
Processing mask

### DIFF
--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -68,6 +68,7 @@ def set_default_values(values=None):
         "shared_mask_irregular": 4,
         "det_mask_invalid": 1,
         "det_mask_sso": 1 + 2,
+        "det_mask_processing": 2,
         #
         # ground-specific flag masks
         #

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -233,7 +233,8 @@ class FilterBin(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging"
     )
 
     shared_flags = Unicode(

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -86,7 +86,8 @@ class GroundFilter(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging"
     )
 
     ground_flag_mask = Int(

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -292,12 +292,11 @@ class GroundFilter(Operator):
         if self.detrend:
             trend = np.zeros_like(ref)
             add_templates(trend, legendre_trend, coeff[: self.trend_order])
-            ref[good] -= trend[good]
+            ref -= trend
         # Ground template
         grtemplate = np.zeros_like(ref)
         add_templates(grtemplate, legendre_filter, coeff[self.trend_order :])
-        ref[good] -= grtemplate[good]
-        ref[np.logical_not(good)] = 0
+        ref -= grtemplate
         return
 
     @function_timer

--- a/src/toast/ops/hwpfilter.py
+++ b/src/toast/ops/hwpfilter.py
@@ -233,12 +233,11 @@ class HWPFilter(Operator):
         if self.detrend:
             trend = np.zeros_like(ref)
             add_templates(trend, legendre_trend, coeff[: self.trend_order + 1])
-            ref[good] -= trend[good]
+            ref -= trend
         # HWP template
         hwptemplate = np.zeros_like(ref)
         add_templates(hwptemplate, fourier_filter, coeff[self.trend_order + 1 :])
-        ref[good] -= hwptemplate[good]
-        ref[np.logical_not(good)] = 0
+        ref -= hwptemplate
         return
 
     @function_timer

--- a/src/toast/ops/hwpfilter.py
+++ b/src/toast/ops/hwpfilter.py
@@ -81,7 +81,8 @@ class HWPFilter(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging",
     )
 
     hwp_flag_mask = Int(

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -899,7 +899,7 @@ class Madam(Operator):
                     for psdstart, psd, detw in psdlist:
                         psdstarts.append(psdstart)
                         psdvals.append(psd)
-                    detweights[idet] = psdlist[0][2].to_value(1 / u.K**2)
+                    detweights[idet] = psdlist[0][2]
                 npsdtot = np.sum(npsd)
                 psdstarts = np.array(psdstarts, dtype=np.float64)
                 psdvals = np.hstack(psdvals).astype(madam.PSD_TYPE)

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -899,7 +899,7 @@ class Madam(Operator):
                     for psdstart, psd, detw in psdlist:
                         psdstarts.append(psdstart)
                         psdvals.append(psd)
-                    detweights[idet] = psdlist[0][2]
+                    detweights[idet] = psdlist[0][2].to_value(1 / u.K**2)
                 npsdtot = np.sum(npsd)
                 psdstarts = np.array(psdstarts, dtype=np.float64)
                 psdvals = np.hstack(psdvals).astype(madam.PSD_TYPE)

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -63,7 +63,8 @@ class PolyFilter2D(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging",
     )
 
     poly_flag_mask = Int(1, help="Bit mask value for intervals that fail to filter")
@@ -452,7 +453,8 @@ class PolyFilter(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging",
     )
 
     poly_flag_mask = Int(
@@ -626,7 +628,8 @@ class CommonModeFilter(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_invalid, help="Bit mask value for optional detector flagging"
+        defaults.det_mask_invalid | defaults.det_mask_processing,
+        help="Bit mask value for optional detector flagging"
     )
 
     shared_flags = Unicode(

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -242,7 +242,8 @@ class ScanHealpixMask(Operator):
     )
 
     det_flags_value = Int(
-        1, help="The detector flag value to set where the mask result is non-zero"
+        defaults.det_mask_processing,
+        help="The detector flag value to set where the mask result is non-zero",
     )
 
     mask_bits = Int(

--- a/src/toast/ops/scan_healpix.py
+++ b/src/toast/ops/scan_healpix.py
@@ -286,7 +286,7 @@ class ScanHealpixMask(Operator):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.mask_name = "{}_mask".format(self.name)
+        self.mask_name = f"{self.name}_mask"
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):

--- a/src/toast/ops/scan_wcs.py
+++ b/src/toast/ops/scan_wcs.py
@@ -227,7 +227,8 @@ class ScanWCSMask(Operator):
     )
 
     det_flags_value = Int(
-        1, help="The detector flag value to set where the mask result is non-zero"
+        defaults.det_mask_processing,
+        help="The detector flag value to set where the mask result is non-zero",
     )
 
     mask_bits = Int(

--- a/src/toast/ops/scan_wcs.py
+++ b/src/toast/ops/scan_wcs.py
@@ -271,7 +271,7 @@ class ScanWCSMask(Operator):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.mask_name = "{}_mask".format(self.name)
+        self.mask_name = f"{self.name}_mask"
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):

--- a/src/toast/tests/ops_scan_healpix.py
+++ b/src/toast/tests/ops_scan_healpix.py
@@ -125,7 +125,7 @@ class ScanHealpixTest(MPITestCase):
         scan_hpix = ops.ScanHealpixMask(
             file=hpix_file,
             det_flags="test_flags",
-            det_flags_mask=defaults.det_mask_invalid,
+            det_flags_value=defaults.det_mask_invalid,
             pixel_pointing=pixels,
         )
         scan_hpix.apply(data)

--- a/src/toast/tests/ops_scan_wcs.py
+++ b/src/toast/tests/ops_scan_wcs.py
@@ -141,7 +141,7 @@ class ScanWCSTest(MPITestCase):
         scan_wcs = ops.ScanWCSMask(
             file=input_file,
             det_flags="test_flags",
-            det_flags_mask=defaults.det_mask_invalid,
+            det_flags_value=defaults.det_mask_invalid,
             pixel_pointing=pixels,
         )
         scan_wcs.apply(data)

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -531,6 +531,13 @@ def reduce_data(job, args, data):
     timer = toast.timing.Timer()
     timer.start()
 
+    # Load and apply processing mask
+
+    ops.processing_mask.pixel_pointing = ops.pixels_radec_final
+    ops.processing_mask.pixel_dist = ops.binner_final.pixel_dist
+    ops.processing_mask.apply(data)
+    log.info_rank("  Raised processing flags in", comm=world_comm, timer=timer)
+
     # Flag Sun, Moon and the planets
 
     ops.flag_sso.detector_pointing = ops.det_pointing_azel
@@ -825,6 +832,7 @@ def main():
         ),
         toast.ops.StokesWeights(name="weights_radec", mode="IQU"),
         toast.ops.YieldCut(name="yield_cut", enabled=False),
+        toast.ops.ScanHealpixMask(name="processing_mask", enabled=False)
         toast.ops.FlagSSO(name="flag_sso", enabled=False),
         toast.ops.CadenceMap(name="cadence_map", enabled=False),
         toast.ops.CrossLinking(name="crosslinking", enabled=False),

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -533,8 +533,8 @@ def reduce_data(job, args, data):
 
     # Load and apply processing mask
 
-    ops.processing_mask.pixel_pointing = ops.pixels_radec_final
-    ops.processing_mask.pixel_dist = ops.binner_final.pixel_dist
+    ops.processing_mask.pixel_pointing = ops.pixels_radec
+    ops.processing_mask.pixel_dist = ops.binner.pixel_dist
     ops.processing_mask.apply(data)
     log.info_rank("  Raised processing flags in", comm=world_comm, timer=timer)
 
@@ -832,7 +832,7 @@ def main():
         ),
         toast.ops.StokesWeights(name="weights_radec", mode="IQU"),
         toast.ops.YieldCut(name="yield_cut", enabled=False),
-        toast.ops.ScanHealpixMask(name="processing_mask", enabled=False)
+        toast.ops.ScanHealpixMask(name="processing_mask", enabled=False),
         toast.ops.FlagSSO(name="flag_sso", enabled=False),
         toast.ops.CadenceMap(name="cadence_map", enabled=False),
         toast.ops.CrossLinking(name="crosslinking", enabled=False),


### PR DESCRIPTION
Support a processing mask in the filtering operators.

It also fixes an issue with the filters setting flagged samples to zero. Flagged samples are not considered when fitting templates, but templates are subtracted from flagged samples.