### PR TITLE
Changes to the Noise class to store only local detectors.

### DIFF
--- a/src/libtoast/src/toast_atm_utils.cpp
+++ b/src/libtoast/src/toast_atm_utils.cpp
@@ -71,10 +71,8 @@ atm::SkyStatus get_sky_status_vec(double altitude, double temperature,
     double freqstep = 0;
     if (nfreq > 1) freqstep = (freqmax - freqmin) / (nfreq - 1);
 
-    // aatm SpectralGrid seems to have a bug.  The first grid point is
-    // a whole grid step after the reference frequency.
     atm::SpectralGrid grid(nfreq, 0,
-                           atm::Frequency(freqmin - freqstep, "GHz"),
+                           atm::Frequency(freqmin, "GHz"),
                            atm::Frequency(freqstep, "GHz"));
     atm::RefractiveIndexProfile rip(grid, atmo);
     atm::SkyStatus ss(rip);

--- a/src/toast/config.py
+++ b/src/toast/config.py
@@ -18,7 +18,7 @@ from tomlkit import comment, document, dumps, loads, nl, table
 
 from . import instrument
 from .instrument import Focalplane, Telescope
-from .traits import TraitConfig, trait_string_to_scalar, trait_scalar_to_string
+from .traits import TraitConfig, trait_scalar_to_string, trait_string_to_scalar
 from .utils import Environment, Logger
 
 

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -477,56 +477,7 @@ class Focalplane(object):
             self._compute_fov()
         self._get_pol_angles()
         self._get_pol_efficiency()
-        self._get_noise()
         self._get_bandpass()
-
-    @function_timer
-    def _get_noise(self):
-        """Use the noise parameters to instantiate an analytical noise model.
-
-        The detector "indices" in the noise model are set to the 32bit detector
-        UID integers.  This allows reproducibility of noise simulations if the
-        same detector appears in multiple noise models.
-
-        """
-
-        model_available = False
-        noise_keys = "psd_fmin", "psd_fknee", "psd_alpha", "psd_net"
-        for key in noise_keys:
-            if key not in self.detector_data.colnames:
-                break
-        else:
-            model_available = True
-        if model_available:
-            dets = []
-            fmin = {}
-            fknee = {}
-            alpha = {}
-            NET = {}
-            rates = {}
-            indices = {}
-            for row in self.detector_data:
-                name = row["name"]
-                dets.append(name)
-                rates[name] = self.sample_rate
-                fmin[name] = row["psd_fmin"]
-                fknee[name] = row["psd_fknee"]
-                alpha[name] = row["psd_alpha"]
-                NET[name] = row["psd_net"]
-                indices[name] = row["uid"]
-
-            self.noise = AnalyticNoise(
-                rate=rates,
-                fmin=fmin,
-                detectors=dets,
-                fknee=fknee,
-                alpha=alpha,
-                NET=NET,
-                indices=indices,
-            )
-        else:
-            self.noise = None
-        return
 
     @function_timer
     def _get_bandpass(self):

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -161,7 +161,11 @@ class GroundSite(Site):
             return False
         if self.uid != other.uid:
             return False
-        if self.earthloc != other.earthloc:
+        if not np.isclose(other.earthloc.lon, self.earthloc.lon):
+            return False
+        if not np.isclose(other.earthloc.lat, self.earthloc.lat):
+            return False
+        if not np.isclose(other.earthloc.height, self.earthloc.height):
             return False
         if self.weather != other.weather:
             return False

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -406,7 +406,9 @@ def load_hdf5(
                 weather_realization = int(inst_group.attrs["site_weather_realization"])
                 weather_max_pwv = None
                 if inst_group.attrs["site_weather_max_pwv"] != "NONE":
-                    weather_max_pwv = float(inst_group.attrs["site_weather_max_pwv"])
+                    weather_max_pwv = u.Quantity(
+                        float(inst_group.attrs["site_weather_max_pwv"]), u.mm
+                    )
                 weather_time = datetime.fromtimestamp(
                     float(inst_group.attrs["site_weather_time"]), tz=timezone.utc
                 )

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -502,13 +502,18 @@ def save_hdf5(
                     if site.weather.max_pwv is None:
                         inst_group.attrs["site_weather_max_pwv"] = "NONE"
                     else:
-                        inst_group.attrs["site_weather_max_pwv"] = site.weather.max_pwv
+                        inst_group.attrs[
+                            "site_weather_max_pwv"
+                        ] = site.weather.max_pwv.to_value(u.mm)
                     inst_group.attrs[
                         "site_weather_time"
                     ] = site.weather.time.timestamp()
                     inst_group.attrs[
                         "site_weather_median"
                     ] = site.weather.median_weather
+                else:
+                    msg = "HDF5 saving currently only supports SimWeather instances"
+                    raise NotImplementedError(msg)
         session = obs.session
         if session is not None:
             inst_group.attrs["session_name"] = session.name

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -555,7 +555,7 @@ def save_hdf5(
             if meta_group is not None:
                 kgroup = meta_group.create_group(k)
                 kgroup.attrs["class"] = object_fullname(v.__class__)
-            v.save_hdf5(kgroup, comm=comm)
+            v.save_hdf5(kgroup, obs)
             del kgroup
         elif isinstance(v, u.Quantity):
             if isinstance(v.value, np.ndarray):

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy import units as u
 
 from .timing import Timer, function_timer
-from .utils import hdf5_use_serial, name_UID, Logger
+from .utils import Logger, hdf5_use_serial, name_UID
 
 
 class Noise(object):

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -11,13 +11,13 @@ import numpy as np
 from astropy import units as u
 
 from .timing import Timer, function_timer
-from .utils import hdf5_use_serial
+from .utils import hdf5_use_serial, name_UID
 
 
 class Noise(object):
     """Noise objects act as containers for noise PSDs.
 
-    Noise is a base class for an object that describes the noise properties of all
+    Noise is a base class for an object that describes the noise properties of local
     detectors for a single observation.  The PSDs in the input dictionary should be
     arrays with units (Quantities).
 
@@ -67,25 +67,15 @@ class Noise(object):
             self._mixmatrix = {d: {d: 1.0} for d in self._dets}
         else:
             # Assemble the list of keys needed for the specified detectors
-            keys = set()
             self._mixmatrix = dict()
-            self._keys_for_dets = dict()
-            self._dets_for_keys = dict()
             for det in self._dets:
-                self._keys_for_dets[det] = list()
                 self._mixmatrix[det] = dict()
                 for key, weight in mixmatrix[det].items():
-                    keys.add(key)
-                    if key not in self._dets_for_keys:
-                        self._dets_for_keys[key] = list()
                     self._mixmatrix[det][key] = weight
-                    if weight != 0:
-                        self._keys_for_dets[det].append(key)
-                        self._dets_for_keys[key].append(det)
-            self._keys = list(sorted(keys))
+            self._init_lookup()
 
         if indices is None:
-            self._indices = {x: i for i, x in enumerate(self._keys)}
+            self._indices = {x: name_UID(x) for x in self._keys}
         else:
             self._indices = dict(indices)
         self._freqs = {}
@@ -115,6 +105,22 @@ class Noise(object):
             self._rates[key] = 2.0 * self._freqs[key][-1]
 
         self._detweights = detweights
+
+    def _init_lookup(self):
+        # Initialize the detector / stream mapping structures
+        keys = set()
+        self._keys_for_dets = dict()
+        self._dets_for_keys = dict()
+        for det in self._dets:
+            self._keys_for_dets[det] = list()
+            for key, weight in self._mixmatrix[det].items():
+                keys.add(key)
+                if key not in self._dets_for_keys:
+                    self._dets_for_keys[key] = list()
+                if weight != 0:
+                    self._keys_for_dets[det].append(key)
+                    self._dets_for_keys[key].append(det)
+        self._keys = list(sorted(keys))
 
     @property
     def detectors(self):
@@ -266,35 +272,315 @@ class Noise(object):
         return self._detector_weight(det)
 
     @function_timer
-    def _save_base_hdf5(self, hf, comm):
-        """Write internal data to an open HDF5 group."""
-        # First store the mixing matrix as a separate dataset, and find the maximum
-        # string length used for the keys.
+    def _gather_base(self, comm):
+        out = None
 
+        # Detector weights might be customized by derived classes.  Get the list
+        # of weights locally before gathering.
+        local_weights = {d: self.detector_weight(d) for d in self._dets}
+
+        if comm is None or comm.size == 1:
+            out = {
+                "dets": self._dets,
+                "freqs": self._freqs,
+                "psds": self._psds,
+                "mix": self._mixmatrix,
+                "indices": self._indices,
+                "weights": local_weights,
+            }
+            return out
+
+        # First gather the stream properties and remove duplicates.  Each stream
+        # index should be globally unique and streams with the same index on different
+        # processes must have identical PSDs.
+
+        all_indices = comm.gather(self._indices, root=0)
+        all_freqs = comm.gather(self._freqs, root=0)
+        all_psds = comm.gather(self._psds, root=0)
+
+        if comm.rank == 0:
+            out = dict()
+            out["indices"] = dict()
+            out["freqs"] = dict()
+            out["psds"] = dict()
+            for pind, pfreq, ppsd in zip(all_indices, all_freqs, all_psds):
+                for k, v in pind.items():
+                    if k not in out["indices"]:
+                        out["indices"][k] = v
+                        out["freqs"][k] = pfreq[k]
+                        out["psds"][k] = ppsd[k]
+
+        del all_indices
+        del all_freqs
+        del all_psds
+
+        # Build full detector list and mixing matrix
+
+        all_dets = comm.gather(self._dets, root=0)
+        all_mix = comm.gather(self._mixmatrix, root=0)
+
+        if comm.rank == 0:
+            gdets = set()
+            out["mix"] = dict()
+            for pdets, pmix in zip(all_dets, all_mix):
+                for det in pdets:
+                    if det in gdets:
+                        msg = f"Multiple processes have detector '{det}'.  "
+                        msg += f"Are you using the grid column communicator?"
+                        raise RuntimeError(msg)
+                    gdets.add(det)
+                    out["mix"][det] = dict()
+                    for k, v in pmix[det].items():
+                        out["mix"][det][k] = v
+            out["dets"] = list(sorted(gdets))
+
+        del all_dets
+        del all_mix
+
+        # Detector weights
+
+        all_weights = comm.gather(local_weights, root=0)
+
+        if comm.rank == 0:
+            out["weights"] = dict()
+            for pweight in all_weights:
+                for k, v in pweight.items():
+                    out["weights"][k] = v
+
+        del all_weights
+        return out
+
+    def _gather(self, comm):
+        return self._gather_base(comm)
+
+    @function_timer
+    def gather(self, comm):
+        """Gather local pieces of the noise model to one process.
+
+        Every process has the noise model for its local detectors.  For doing I/O,
+        we need to combine these pieces into a single model on one process.  The
+        MPI communicator would typically be just the first process grid column.
+
+        Args:
+            comm (MPI.Comm):  The communicator used to gather the pieces.
+
+        Returns:
+            (dict):  The properties of the full noise model on the rank zero
+                process and None on other processes.
+
+        """
+        return self._gather(comm)
+
+    @function_timer
+    def _scatter_base(
+        self,
+        comm,
+        local_dets,
+        props,
+    ):
+        if comm is None or comm.size == 1:
+            self._dets = local_dets
+            self._freqs = props["freqs"]
+            self._psds = props["psds"]
+            self._indices = props["indices"]
+            self._mixmatrix = props["mix"]
+            self._detweights = props["weights"]
+            self._rates = {d: 2.0 * x[-1] for d, x in props["freqs"].items()}
+        else:
+            # Local detectors
+            self._dets = local_dets
+
+            # Get local detector weights
+            if comm.rank == 0:
+                all_weights = comm.bcast(props["weights"], root=0)
+            else:
+                all_weights = comm.bcast(None, root=0)
+            self._detweights = dict()
+            for d in self._dets:
+                self._detweights[d] = all_weights[d]
+            del all_weights
+
+            # Local mixing matrix
+            if comm.rank == 0:
+                all_mix = comm.bcast(props["mix"], root=0)
+            else:
+                all_mix = comm.bcast(None, root=0)
+            local_streams = set()
+            self._mixmatrix = dict()
+            for d in self._dets:
+                self._mixmatrix[d] = dict()
+                for k, v in all_mix[d].items():
+                    local_streams.add(k)
+                    self._mixmatrix[d][k] = v
+            del all_mix
+
+            # Local streams
+            if comm.rank == 0:
+                all_freqs = comm.bcast(props["freqs"], root=0)
+                all_psds = comm.bcast(props["psds"], root=0)
+                all_indices = comm.bcast(props["indices"], root=0)
+            else:
+                all_freqs = comm.bcast(None, root=0)
+                all_psds = comm.bcast(None, root=0)
+                all_indices = comm.bcast(None, root=0)
+            self._freqs = dict()
+            self._psds = dict()
+            self._indices = dict()
+            self._rates = dict()
+            for ls in local_streams:
+                self._freqs[ls] = all_freqs[ls]
+                self._psds[ls] = all_psds[ls]
+                self._indices[ls] = all_indices[ls]
+                self._rates[ls] = 2.0 * self._freqs[ls][-1]
+            del all_freqs
+            del all_psds
+            del all_indices
+        self._init_lookup()
+
+    def _scatter(self, comm, local_dets, props):
+        self._scatter_base(comm, local_dets, props)
+
+    @function_timer
+    def scatter(
+        self,
+        comm,
+        local_dets,
+        props,
+    ):
+        """Distribute noise model properties.
+
+        Given the global set of properties for all detectors, distribute this
+        so that every process has only the information needed for its local
+        detectors.  The internal data is replaced.
+
+        Args:
+            comm (MPI.Comm):  The communicator over which to distribute the pieces.
+            local_dets (list):  The list of local detectors on this process.
+            props (dict):  The dictionary of all properties for all streams.
+
+        Returns:
+            None
+
+        """
+        self._scatter(comm, local_dets, props)
+
+    def _redistribute(self, old_dist, new_dist):
+        # Every column of the process grid has the same information.  We
+        # gather the full noise model to rank zero.
+        props = None
+        if old_dist.comm_row_rank == 0:
+            props = self._gather(old_dist.comm_col)
+
+        # Broadcast this full noise model along the first process row of the
+        # new distribution.
+        if new_dist.comm_col_rank == 0 and new_dist.comm_row_size > 1:
+            props = new_dist.comm_row.bcast(props, root=0)
+
+        # Scatter noise model down each process column.
+        self._scatter(
+            new_dist.comm_col,
+            new_dist.dets[new_dist.comm.group_rank],
+            props,
+        )
+
+    def redistribute(self, old_dist, new_dist):
+        """Redistribute noise model.
+
+        Args:
+            old_dist (DistDetSamp):  The current distribution.
+            new_dist (DistDetSamp):  The new distribution.
+
+        Returns:
+            None
+
+        """
+        self._redistribute(old_dist, new_dist)
+
+    @function_timer
+    def _save_base_hdf5(self, hf, obs):
+        """Write internal data to an open HDF5 group.
+
+        This is collective, since each process has a local subset of detectors.
+        We communicate the contents to one process which writes them to the
+        open HDF5 group.
+
+        Args:
+            hf (Group):  The HDF5 group in which to write the datasets
+            obs (Observation):  The parent observation
+
+        Returns:
+            None
+
+        """
+        gcomm = obs.comm.comm_group
         rank = 0
         nproc = 1
-        if comm is not None:
-            rank = comm.rank
-            nproc = comm.size
+        if gcomm is not None:
+            rank = gcomm.rank
+            nproc = gcomm.size
 
-        mixdata = list()
+        # Gather data to the rank zero of the first grid column
+        props = None
+        if obs.comm_row_rank == 0:
+            props = self._gather_base(obs.comm_col)
+
+        # First store the mixing matrix as a separate dataset, and find the maximum
+        # string length used for the keys.  Also write the detector weights.
+
+        n_mix = 0
+        n_det = 0
         maxstr = 0
-        for det, streams in self._mixmatrix.items():
-            maxstr = max(maxstr, len(det))
-            for strm, weight in streams.items():
-                maxstr = max(maxstr, len(strm))
-                mixdata.append((det, strm, weight))
-        maxstr += 1
-        mixdtype = np.dtype(f"a{maxstr}, a{maxstr}, f4")
+        mixdtype = None
+        wtdtype = None
+        wtunit = None
+        if rank == 0:
+            mixdata = list()
+            maxstr = 0
+            for det, streams in props["mix"].items():
+                maxstr = max(maxstr, len(det))
+                for strm, weight in streams.items():
+                    maxstr = max(maxstr, len(strm))
+                    mixdata.append((det, strm, weight))
+            maxstr += 1
+            mixdtype = np.dtype(f"a{maxstr}, a{maxstr}, f4")
+            wtdtype = np.dtype(f"a{maxstr}, f4")
+            n_mix = len(mixdata)
+            n_det = len(props["dets"])
+            wtunit = props["weights"][props["dets"][0]].unit
+
+        if gcomm is not None:
+            mixdtype = gcomm.bcast(mixdtype, root=0)
+            wtdtype = gcomm.bcast(wtdtype, root=0)
+            n_mix = gcomm.bcast(n_mix, root=0)
+            n_det = gcomm.bcast(n_det, root=0)
+            wtunit = gcomm.bcast(wtunit, root=0)
+            maxstr = gcomm.bcast(maxstr, root=0)
+
+        wds = None
+        mds = None
 
         if hf is not None:
             # This process is participating
-            mds = hf.create_dataset("mixing_matrix", (len(mixdata),), dtype=mixdtype)
-            if rank == 0:
-                # Only one process needs to write
-                packed = np.array(mixdata, dtype=mixdtype)
-                mds.write_direct(packed)
-            del mds
+            wds = hf.create_dataset("detector_weights", (n_det,), dtype=wtdtype)
+            wds.attrs["unit"] = str(wtunit)
+            mds = hf.create_dataset("mixing_matrix", (n_mix,), dtype=mixdtype)
+
+        # Rank zero does the writing, and is guaranteed to always be
+        # participating in the write.
+        if rank == 0:
+            wtdata = list()
+            for d in props["dets"]:
+                wtdata.append((d, props["weights"][d].value))
+            packed = np.array(wtdata, dtype=wtdtype)
+            wds.write_direct(packed)
+            packed = np.array(mixdata, dtype=mixdtype)
+            mds.write_direct(packed)
+            del packed
+
+        if gcomm is not None:
+            gcomm.barrier()
+        del wds
+        del mds
 
         # Each stream psd can potentially have a unique set of frequencies, but in
         # practice we usually have a just one or a few.  To reduce the number of
@@ -309,144 +595,175 @@ class Noise(object):
         psd_group = dict()
         if rank == 0:
             # Compute the frequency hash on one process
-            for k in self.keys:
-                freq = self.freq(k)
+            for k, v in props["freqs"].items():
                 fhash = (
-                    hash(freq[2] * 1000 + freq[-2] + freq[-1])
+                    hash(v[2] * 1000 + v[-2] + v[-1])
                     .to_bytes(8, "big", signed=True)
                     .hex()
                 )
                 psd_group[k] = fhash
-        if comm is not None:
-            psd_group = comm.bcast(psd_group)
+        if gcomm is not None:
+            psd_group = gcomm.bcast(psd_group)
 
         # Organize the PSD information in groups according to the frequency arrays.
         # Also verify that all PSD units match.
-        psd_sets = dict()
-        psd_units = None
-        for k in self.keys:
-            freq = self.freq(k)
-            fhash = psd_group[k]
-            if fhash not in psd_sets:
-                psd_sets[fhash] = {
-                    "freq": freq,
-                    "indices": list(),
-                    "psds": list(),
-                    "keys": list(),
-                }
-            if psd_units is None:
-                psd_units = self.psd(k).unit
-            else:
-                if psd_units != self.psd(k).unit:
-                    raise RuntimeError(
-                        "All PSD units in a Noise object must be the same"
-                    )
-            psd_sets[fhash]["psds"].append(self.psd(k))
-            psd_sets[fhash]["indices"].append(self.index(k))
-            psd_sets[fhash]["keys"].append(k)
+        psd_set_meta = dict()
+        if rank == 0:
+            psd_sets = dict()
+            for k, v in props["freqs"].items():
+                fhash = psd_group[k]
+                if fhash not in psd_sets:
+                    psd_sets[fhash] = {
+                        "freq": v,
+                        "indices": list(),
+                        "psds": list(),
+                        "keys": list(),
+                    }
+                    psd_set_meta[fhash] = {
+                        "n_freq": len(v),
+                        "n_psd": 0,
+                        "units": None,
+                    }
+                if psd_set_meta[fhash]["units"] is None:
+                    psd_set_meta[fhash]["units"] = props["psds"][k].unit
+                else:
+                    if psd_set_meta[fhash]["units"] != props["psds"][k].unit:
+                        raise RuntimeError(
+                            "All PSD units in a Noise object must be the same"
+                        )
+                psd_set_meta[fhash]["n_psd"] += 1
+                psd_sets[fhash]["psds"].append(props["psds"][k])
+                psd_sets[fhash]["indices"].append(props["indices"][k])
+                psd_sets[fhash]["keys"].append(k)
+        if gcomm is not None:
+            psd_set_meta = gcomm.bcast(psd_set_meta, root=0)
 
         # Add an attribute for the units
         if hf is not None:
-            hf.attrs["psd_units"] = str(psd_units)
+            first_hash = list(psd_set_meta.keys())[0]
+            ustr = str(psd_set_meta[first_hash]["units"])
+            hf.attrs["psd_units"] = ustr
 
         # Create a dataset for each set of PSDs.  Also create separate datasets
         # for the name and index of each PSD.
-        for fhash, props in psd_sets.items():
-            freq = props["freq"]
-            psds = props["psds"]
-            indx = props["indices"]
-            keys = props["keys"]
-            nrows = 1 + len(psds)
-            ncols = len(freq)
+        for fhash, meta in psd_set_meta.items():
+            if rank == 0:
+                setprops = psd_sets[fhash]
+                freq = setprops["freq"]
+                psds = setprops["psds"]
+                indx = setprops["indices"]
+                keys = setprops["keys"]
+            nrows = 1 + meta["n_psd"]
+            ncols = meta["n_freq"]
+
+            pds = None
+            inds = None
+            kds = None
             if hf is not None:
                 # This process is participating
                 pds = hf.create_dataset(fhash, (nrows, ncols), dtype=np.float32)
-                if rank == 0:
-                    packed = np.zeros((nrows, ncols), dtype=np.float32)
-                    packed[0] = freq
-                    packed[1:] = np.array(psds, dtype=np.float32)
-                    pds.write_direct(packed)
-                del pds
-                ids = hf.create_dataset(
-                    f"{fhash}_indices", (len(psds),), dtype=np.int32
+                inds = hf.create_dataset(
+                    f"{fhash}_indices", (meta["n_psd"],), dtype=np.uint32
                 )
-                if rank == 0:
-                    packed = np.array(indx, dtype=np.int32)
-                    ids.write_direct(packed)
-                del ids
                 keytype = np.dtype(f"a{maxstr}")
-                kds = hf.create_dataset(f"{fhash}_keys", (len(psds),), dtype=keytype)
-                if rank == 0:
-                    packed = np.array(keys, dtype=keytype)
-                    kds.write_direct(packed)
-                del kds
+                kds = hf.create_dataset(
+                    f"{fhash}_keys", (meta["n_psd"],), dtype=keytype
+                )
 
-    def _save_hdf5(self, handle, comm, **kwargs):
+            # Rank zero does the writing, and is guaranteed to always be
+            # participating in the write.
+            if rank == 0:
+                packed = np.zeros((nrows, ncols), dtype=np.float32)
+                packed[0] = freq
+                packed[1:] = np.array(psds, dtype=np.float32)
+                pds.write_direct(packed)
+
+                packed = np.array(indx, dtype=np.uint32)
+                inds.write_direct(packed)
+
+                packed = np.array(keys, dtype=keytype)
+                kds.write_direct(packed)
+                del packed
+
+            # Wait for writing to complete
+            if gcomm is not None:
+                gcomm.barrier()
+
+            # Close datasets
+            del pds
+            del inds
+            del kds
+
+    def _save_hdf5(self, handle, obs, **kwargs):
         """Internal method which can be overridden by derived classes."""
-        self._save_base_hdf5(handle, comm)
+        self._save_base_hdf5(handle, obs)
 
-    def save_hdf5(self, handle, comm=None, **kwargs):
+    def save_hdf5(self, handle, obs, **kwargs):
         """Save the noise object to an HDF5 file.
 
         Args:
             handle (h5py.Group):  The group to populate.
+            obs (Observation):  The parent observation.
 
         Returns:
             None
 
         """
-        if (comm is None) or (comm.rank == 0):
+        gcomm = obs.comm.comm_group
+        if (gcomm is None) or (gcomm.rank == 0):
             # The rank zero process should always be writing
             if handle is None:
                 raise RuntimeError("HDF5 group is not open on the root process")
-        self._save_hdf5(handle, comm, **kwargs)
+        _ = self.detector_weight(self.detectors[0])
+        self._save_hdf5(handle, obs, **kwargs)
 
     @function_timer
-    def _load_base_hdf5(self, hf, comm):
+    def _load_base_hdf5(self, hf, obs):
         """Read internal data from an open HDF5 group"""
-
+        gcomm = obs.comm.comm_group
         rank = 0
         nproc = 1
-        if comm is not None:
-            rank = comm.rank
-            nproc = comm.size
+        if gcomm is not None:
+            rank = gcomm.rank
+            nproc = gcomm.size
 
-        self._freqs = dict()
-        self._psds = dict()
-        self._rates = dict()
-        self._indices = dict()
-        self._mixmatrix = dict()
+        props = None
+        if rank == 0:
+            props = dict()
+        psd_units = None
+
         indx_pat = re.compile(r"(.*)_indices")
         key_pat = re.compile(r"(.*)_keys")
 
-        # Determine if we need to broadcast results.  This occurs if only one process
-        # has the file open but the communicator has more than one process.
-        need_bcast = hdf5_use_serial(hf, comm)
-
         if hf is not None:
-            # This process is participating.
-            # First load the mixing matrix, which provides all the key and
-            # detector names
-            dets = set()
-            keys = set()
-            self._keys_for_dets = dict()
-            self._dets_for_keys = dict()
-            for det, key, val in hf["mixing_matrix"]:
-                det = det.decode("utf-8")
-                key = key.decode("utf-8")
-                dets.add(det)
-                keys.add(key)
-                if det not in self._keys_for_dets:
-                    self._keys_for_dets[det] = list()
-                if key not in self._dets_for_keys:
-                    self._dets_for_keys[key] = list()
-                if det not in self._mixmatrix:
-                    self._mixmatrix[det] = dict()
-                self._mixmatrix[det][key] = val
-                self._keys_for_dets[det].append(key)
-                self._dets_for_keys[key].append(det)
-            self._keys = list(sorted(keys))
-            self._dets = list(sorted(dets))
+            # This process is participating in dataset open.  However, only one
+            # process will load data from the datasets.  The result will be
+            # scattered at the end.
+
+            # Load the weights
+            dset = hf["detector_weights"]
+            wtunit = u.Unit(dset.attrs["unit"])
+            if rank == 0:
+                props["dets"] = list()
+                props["weights"] = dict()
+                for det, val in dset:
+                    det = det.decode("utf-8")
+                    props["dets"].append(det)
+                    props["weights"][det] = u.Quantity(val, wtunit)
+
+            # Now the mixing matrix
+            dset = hf["mixing_matrix"]
+            if rank == 0:
+                props["freqs"] = dict()
+                props["psds"] = dict()
+                props["indices"] = dict()
+                props["mix"] = dict()
+                for det, key, val in hf["mixing_matrix"]:
+                    det = det.decode("utf-8")
+                    key = key.decode("utf-8")
+                    if det not in props["mix"]:
+                        props["mix"][det] = dict()
+                    props["mix"][det][key] = val
 
             # Get the units
             psd_units = u.Unit(hf.attrs["psd_units"])
@@ -461,60 +778,69 @@ class Noise(object):
                 if dsname == "mixing_matrix":
                     # Already processed above
                     continue
+                if dsname == "detector_weights":
+                    # Already processed above
+                    continue
                 indx_name = f"{dsname}_indices"
                 keys_name = f"{dsname}_keys"
                 if indx_name not in hf.keys() and keys_name not in hf.keys():
                     # This is not a PSD set
                     continue
+
                 # Before loading the PSD data, load the stream names and indices
                 kds = hf[keys_name]
-                psd_keys = [x.decode() for x in kds]
+                if rank == 0:
+                    psd_keys = [x.decode() for x in kds]
                 del kds
+
                 ids = hf[indx_name]
-                psd_indices = list(ids)
+                if rank == 0:
+                    psd_indices = np.array(ids, dtype=np.uint32)
                 del ids
 
                 pds = hf[dsname]
-                freq = pds[0]
-                rate = 2.0 * freq[-1]
-                for key, indx, psdrow in zip(psd_keys, psd_indices, pds[1:]):
-                    self._rates[key] = rate * u.Hz
-                    self._indices[key] = indx
-                    self._freqs[key] = u.Quantity(freq, u.Hz)
-                    self._psds[key] = u.Quantity(psdrow, psd_units)
+                if rank == 0:
+                    freq = pds[0]
+                    for key, indx, psdrow in zip(psd_keys, psd_indices, pds[1:]):
+                        props["indices"][key] = int(indx)
+                        props["freqs"][key] = u.Quantity(freq, u.Hz)
+                        props["psds"][key] = u.Quantity(psdrow, psd_units)
                 del pds
 
-        # Broadcast the results
-        if need_bcast and comm is not None:
-            self._keys = comm.bcast(self._keys, root=0)
-            self._dets = comm.bcast(self._dets, root=0)
-            self._rates = comm.bcast(self._rates, root=0)
-            self._freqs = comm.bcast(self._freqs, root=0)
-            self._psds = comm.bcast(self._psds, root=0)
-            self._indices = comm.bcast(self._indices, root=0)
-            self._mixmatrix = comm.bcast(self._mixmatrix, root=0)
-            self._keys_for_dets = comm.bcast(self._keys_for_dets, root=0)
-            self._dets_for_keys = comm.bcast(self._dets_for_keys, root=0)
+        # The data now exists on the rank zero process of the group.  If we have
+        # multiple processes along each row, broadcast data to the other processes
+        # in the first row.
+        if obs.comm_row_size > 1 and obs.comm_col_rank == 0:
+            props = obs.comm_row.bcast(props, root=0)
 
-    def _load_hdf5(self, handle, comm, **kwargs):
+        # Scatter across each column of the process grid
+        self._scatter_base(
+            obs.comm_col,
+            obs.local_detectors,
+            props,
+        )
+
+    def _load_hdf5(self, handle, obs, **kwargs):
         """Internal method which can be overridden by derived classes."""
-        self._load_base_hdf5(handle, comm)
+        self._load_base_hdf5(handle, obs)
 
-    def load_hdf5(self, handle, comm=None, **kwargs):
+    def load_hdf5(self, handle, obs, **kwargs):
         """Load the noise object from an HDF5 file.
 
         Args:
             handle (h5py.Group):  The group containing noise model.
+            obs (Observation):  The parent observation.
 
         Returns:
             None
 
         """
-        if (comm is None) or (comm.rank == 0):
+        gcomm = obs.comm.comm_group
+        if (gcomm is None) or (gcomm.rank == 0):
             # The rank zero process should always be reading
             if handle is None:
                 raise RuntimeError("HDF5 group is not open on the root process")
-        self._load_hdf5(handle, comm, **kwargs)
+        self._load_hdf5(handle, obs, **kwargs)
 
     def __repr__(self):
         mix_min = np.min([len(y) for x, y in self._mixmatrix.items()])

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -854,31 +854,31 @@ class Noise(object):
         log = Logger.get()
         fail = 0
         if set(self._dets) != set(other._dets):
-            log.info(f"Noise __eq__:  dets {set(self._dets)} != {set(other._dets)}")
+            log.verbose(f"Noise __eq__:  dets {set(self._dets)} != {set(other._dets)}")
             fail = 1
         elif set(self._keys) != set(other._keys):
-            log.info(f"Noise __eq__:  keys {set(self._keys)} != {set(other._keys)}")
+            log.verbose(f"Noise __eq__:  keys {set(self._keys)} != {set(other._keys)}")
             fail = 1
         elif self._rates != other._rates:
-            log.info(f"Noise __eq__:  rates {self._rates} != {other._rates}")
+            log.verbose(f"Noise __eq__:  rates {self._rates} != {other._rates}")
             fail = 1
         elif self._indices != other._indices:
-            log.info(f"Noise __eq__:  indices {self._indices} != {other._indices}")
+            log.verbose(f"Noise __eq__:  indices {self._indices} != {other._indices}")
             fail = 1
         elif self._mixmatrix != other._mixmatrix:
-            log.info(f"Noise __eq__:  mix {self._mixmatrix} != {other._mixmatrix}")
+            log.verbose(f"Noise __eq__:  mix {self._mixmatrix} != {other._mixmatrix}")
             fail = 1
         else:
             for k, v in self._freqs.items():
                 if not np.allclose(v.to_value(u.Hz), other._freqs[k].to_value(u.Hz)):
-                    log.info(f"Noise __eq__:  freqs[{k}] {v} != {other._freqs[k]}")
+                    log.verbose(f"Noise __eq__:  freqs[{k}] {v} != {other._freqs[k]}")
                     fail = 1
             for k, v in self._psds.items():
                 if not np.allclose(
                     v.to_value(u.K**2 * u.second),
                     other._psds[k].to_value(u.K**2 * u.second),
                 ):
-                    log.info(f"Noise __eq__:  psds[{k}] {v} != {other._psds[k]}")
+                    log.verbose(f"Noise __eq__:  psds[{k}] {v} != {other._psds[k]}")
                     fail = 1
         return fail == 0
 

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -854,31 +854,31 @@ class Noise(object):
         log = Logger.get()
         fail = 0
         if set(self._dets) != set(other._dets):
-            log.verbose(f"Noise __eq__:  dets {set(self._dets)} != {set(other._dets)}")
+            log.info(f"Noise __eq__:  dets {set(self._dets)} != {set(other._dets)}")
             fail = 1
         elif set(self._keys) != set(other._keys):
-            log.verbose(f"Noise __eq__:  keys {set(self._keys)} != {set(other._keys)}")
+            log.info(f"Noise __eq__:  keys {set(self._keys)} != {set(other._keys)}")
             fail = 1
         elif self._rates != other._rates:
-            log.verbose(f"Noise __eq__:  rates {self._rates} != {other._rates}")
+            log.info(f"Noise __eq__:  rates {self._rates} != {other._rates}")
             fail = 1
         elif self._indices != other._indices:
-            log.verbose(f"Noise __eq__:  indices {self._indices} != {other._indices}")
+            log.info(f"Noise __eq__:  indices {self._indices} != {other._indices}")
             fail = 1
         elif self._mixmatrix != other._mixmatrix:
-            log.verbose(f"Noise __eq__:  mix {self._mixmatrix} != {other._mixmatrix}")
+            log.info(f"Noise __eq__:  mix {self._mixmatrix} != {other._mixmatrix}")
             fail = 1
         else:
             for k, v in self._freqs.items():
                 if not np.allclose(v.to_value(u.Hz), other._freqs[k].to_value(u.Hz)):
-                    log.verbose(f"Noise __eq__:  freqs[{k}] {v} != {other._freqs[k]}")
+                    log.info(f"Noise __eq__:  freqs[{k}] {v} != {other._freqs[k]}")
                     fail = 1
             for k, v in self._psds.items():
                 if not np.allclose(
                     v.to_value(u.K**2 * u.second),
                     other._psds[k].to_value(u.K**2 * u.second),
                 ):
-                    log.verbose(f"Noise __eq__:  psds[{k}] {v} != {other._psds[k]}")
+                    log.info(f"Noise __eq__:  psds[{k}] {v} != {other._psds[k]}")
                     fail = 1
         return fail == 0
 

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -10,7 +10,7 @@ from astropy import units as u
 
 from .noise import Noise
 from .timing import function_timer
-from .utils import hdf5_use_serial, Logger
+from .utils import Logger, hdf5_use_serial
 
 
 class AnalyticNoise(Noise):

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -139,14 +139,15 @@ class AnalyticNoise(Noise):
         return wt.decompose()
 
     def _gather_sim(self, comm, out):
-        # Gather simulation properties to the rank zero process
+        # Gather simulation properties to the rank zero process.
+        # The output data dictionary is modified in place.
         if comm is None or comm.size == 1:
             out["fmin"] = self._fmin
             out["fknee"] = self._fknee
             out["rate"] = self._rate
             out["alpha"] = self._alpha
             out["NET"] = self._NET
-            return out
+            return
 
         pfmin = comm.gather(self._fmin, root=0)
         pfknee = comm.gather(self._fknee, root=0)

--- a/src/toast/noise_sim.py
+++ b/src/toast/noise_sim.py
@@ -10,7 +10,7 @@ from astropy import units as u
 
 from .noise import Noise
 from .timing import function_timer
-from .utils import hdf5_use_serial
+from .utils import hdf5_use_serial, Logger
 
 
 class AnalyticNoise(Noise):
@@ -320,20 +320,27 @@ class AnalyticNoise(Noise):
         return value
 
     def __eq__(self, other):
+        log = Logger.get()
+        fail = 0
         if not super().__eq__(other):
             # Base class values not equal
-            return False
-        if self._rate != other._rate:
-            return False
-        if self._fmin != other._fmin:
-            return False
-        if self._fknee != other._fknee:
-            return False
-        if self._alpha != other._alpha:
-            return False
-        if self._NET != other._NET:
-            return False
-        return True
+            fail = 1
+        elif self._rate != other._rate:
+            log.verbose(f"AnalyticNoise __eq__:  rate {self._rate} != {other._rate}")
+            fail = 1
+        elif self._fmin != other._fmin:
+            log.verbose(f"AnalyticNoise __eq__:  fmin {self._fmin} != {other._fmin}")
+            fail = 1
+        elif self._fknee != other._fknee:
+            log.verbose(f"AnalyticNoise __eq__:  fknee {self._fknee} != {other._fknee}")
+            fail = 1
+        elif self._alpha != other._alpha:
+            log.verbose(f"AnalyticNoise __eq__:  alpha {self._alpha} != {other._alpha}")
+            fail = 1
+        elif self._NET != other._NET:
+            log.verbose(f"AnalyticNoise __eq__:  NET {self._NET} != {other._NET}")
+            fail = 1
+        return fail == 0
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -461,26 +461,24 @@ class Observation(MutableMapping):
         fail = 0
         if self.name != other.name:
             fail = 1
-            log.verbose(
+            log.info(
                 f"Proc {self.comm.world_rank}:  Obs names {self.name} != {other.name}"
             )
         if self.uid != other.uid:
             fail = 1
-            log.verbose(
-                f"Proc {self.comm.world_rank}:  Obs uid {self.uid} != {other.uid}"
-            )
+            log.info(f"Proc {self.comm.world_rank}:  Obs uid {self.uid} != {other.uid}")
         if self.telescope != other.telescope:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs telescopes not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs telescopes not equal")
         if self.session != other.session:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs sessions not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs sessions not equal")
         if self.dist != other.dist:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
         if self._internal.keys() != other._internal.keys():
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs metadata keys not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs metadata keys not equal")
         for k, v in self._internal.items():
             if v != other._internal[k]:
                 feq = True
@@ -491,19 +489,19 @@ class Observation(MutableMapping):
                     feq = False
                 if not feq:
                     fail = 1
-                    log.verbose(
+                    log.info(
                         f"Proc {self.comm.world_rank}:  Obs metadata[{k}]:  {v} != {other[k]}"
                     )
                     break
         if self.shared != other.shared:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
         if self.detdata != other.detdata:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
         if self.intervals != other.intervals:
             fail = 1
-            log.verbose(f"Proc {self.comm.world_rank}:  Obs intervals not equal")
+            log.info(f"Proc {self.comm.world_rank}:  Obs intervals not equal")
         if self.comm.comm_group is not None:
             fail = self.comm.comm_group.allreduce(fail, op=MPI.SUM)
         return fail == 0

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -461,24 +461,26 @@ class Observation(MutableMapping):
         fail = 0
         if self.name != other.name:
             fail = 1
-            log.info(
+            log.verbose(
                 f"Proc {self.comm.world_rank}:  Obs names {self.name} != {other.name}"
             )
         if self.uid != other.uid:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs uid {self.uid} != {other.uid}")
+            log.verbose(
+                f"Proc {self.comm.world_rank}:  Obs uid {self.uid} != {other.uid}"
+            )
         if self.telescope != other.telescope:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs telescopes not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs telescopes not equal")
         if self.session != other.session:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs sessions not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs sessions not equal")
         if self.dist != other.dist:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
         if self._internal.keys() != other._internal.keys():
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs metadata keys not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs metadata keys not equal")
         for k, v in self._internal.items():
             if v != other._internal[k]:
                 feq = True
@@ -489,19 +491,19 @@ class Observation(MutableMapping):
                     feq = False
                 if not feq:
                     fail = 1
-                    log.info(
+                    log.verbose(
                         f"Proc {self.comm.world_rank}:  Obs metadata[{k}]:  {v} != {other[k]}"
                     )
                     break
         if self.shared != other.shared:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
         if self.detdata != other.detdata:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
         if self.intervals != other.intervals:
             fail = 1
-            log.info(f"Proc {self.comm.world_rank}:  Obs intervals not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs intervals not equal")
         if self.comm.comm_group is not None:
             fail = self.comm.comm_group.allreduce(fail, op=MPI.SUM)
         return fail == 0

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -461,22 +461,26 @@ class Observation(MutableMapping):
         fail = 0
         if self.name != other.name:
             fail = 1
-            log.verbose(f"Obs names {self.name} != {other.name}")
+            log.verbose(
+                f"Proc {self.comm.world_rank}:  Obs names {self.name} != {other.name}"
+            )
         if self.uid != other.uid:
             fail = 1
-            log.verbose(f"Obs uid {self.uid} != {other.uid}")
+            log.verbose(
+                f"Proc {self.comm.world_rank}:  Obs uid {self.uid} != {other.uid}"
+            )
         if self.telescope != other.telescope:
             fail = 1
-            log.verbose("Obs telescopes not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs telescopes not equal")
         if self.session != other.session:
             fail = 1
-            log.verbose("Obs sessions not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs sessions not equal")
         if self.dist != other.dist:
             fail = 1
-            log.verbose("Obs distributions not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
         if self._internal.keys() != other._internal.keys():
             fail = 1
-            log.verbose("Obs metadata keys not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs metadata keys not equal")
         for k, v in self._internal.items():
             if v != other._internal[k]:
                 feq = True
@@ -487,17 +491,19 @@ class Observation(MutableMapping):
                     feq = False
                 if not feq:
                     fail = 1
-                    log.verbose(f"Obs metadata[{k}]:  {v} != {other[k]}")
+                    log.verbose(
+                        f"Proc {self.comm.world_rank}:  Obs metadata[{k}]:  {v} != {other[k]}"
+                    )
                     break
         if self.shared != other.shared:
             fail = 1
-            log.verbose("Obs shared data not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
         if self.detdata != other.detdata:
             fail = 1
-            log.verbose("Obs detdata not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
         if self.intervals != other.intervals:
             fail = 1
-            log.verbose("Obs intervals not equal")
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs intervals not equal")
         if self.comm.comm_group is not None:
             fail = self.comm.comm_group.allreduce(fail, op=MPI.SUM)
         return fail == 0

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -671,6 +671,11 @@ class Observation(MutableMapping):
             dbg=self.name,
         )
 
+        # Redistribute any metadata objects that support it.
+        for k, v in self._internal.items():
+            if hasattr(v, "redistribute"):
+                v.redistribute(self.dist, new_dist)
+
         # Replace our distribution and data managers with the new ones.
         del self.dist
         self.dist = new_dist

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -222,6 +222,20 @@ class DistDetSamp(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __repr__(self):
+        s = f"<DistDetSamp "
+        s += f"P_row {self.comm_row_rank}/{self.comm_row_size} "
+        s += f"P_col {self.comm_col_rank}/{self.comm_col_size} "
+        s += "dets=["
+        for d in self.dets[self.comm.group_rank]:
+            s += f"{d},"
+        s += "]"
+        s += " samples=["
+        off = self.samps[self.comm.group_rank].offset
+        nsamp = self.samps[self.comm.group_rank].n_elem
+        s += f"{off} ... {off+nsamp}]>"
+        return s
+
 
 def compute_1d_offsets(off, n, target_dist):
     """Helper function to compute slices along one dimension.

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -6,6 +6,7 @@
 
 from .arithmetic import Combine
 from .cadence_map import CadenceMap
+from .common_mode_noise import CommonModeNoise
 from .conviqt import SimConviqt, SimTEBConviqt, SimWeightedConviqt
 from .copy import Copy
 from .crosslinking import CrossLinking
@@ -33,7 +34,6 @@ from .mapmaker_utils import (
 from .memory_counter import MemoryCounter
 from .noise_estimation import NoiseEstim
 from .noise_model import DefaultNoiseModel, FitNoiseModel
-from .common_mode_noise import CommonModeNoise
 from .noise_weight import NoiseWeight
 from .operator import Operator
 from .pipeline import Pipeline

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -13,7 +13,7 @@ from .. import qarray as qa
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Instance, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import (
     Environment,
     GlobalTimers,

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -140,11 +140,11 @@ class ElevationNoise(Operator):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.net_factors = list()
-        self.total_factors = list()
-        self.weights_in = list()
-        self.weights_out = list()
-        self.rates = list()
+        self.net_factors = []
+        self.total_factors = []
+        self.weights_in = []
+        self.weights_out = []
+        self.rates = []
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -17,8 +17,8 @@ from .._libtoast import (
     accumulate_observation_matrix,
     build_template_covariance,
     expand_matrix,
-    legendre,
     fourier,
+    legendre,
 )
 from ..mpi import MPI
 from ..observation import default_values as defaults
@@ -234,7 +234,7 @@ class FilterBin(Operator):
 
     det_flag_mask = Int(
         defaults.det_mask_invalid | defaults.det_mask_processing,
-        help="Bit mask value for optional detector flagging"
+        help="Bit mask value for optional detector flagging",
     )
 
     shared_flags = Unicode(

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -87,7 +87,7 @@ class GroundFilter(Operator):
 
     det_flag_mask = Int(
         defaults.det_mask_invalid | defaults.det_mask_processing,
-        help="Bit mask value for optional detector flagging"
+        help="Bit mask value for optional detector flagging",
     )
 
     ground_flag_mask = Int(

--- a/src/toast/ops/hwpfilter.py
+++ b/src/toast/ops/hwpfilter.py
@@ -8,7 +8,7 @@ import numpy as np
 import traitlets
 from astropy import units as u
 
-from .._libtoast import add_templates, bin_invcov, bin_proj, legendre, fourier
+from .._libtoast import add_templates, bin_invcov, bin_proj, fourier, legendre
 from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -37,15 +37,13 @@ class LoadHDF5(Operator):
     # FIXME:  We should add a filtering mechanism here to load a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
-    meta = List(None, allow_none=True, help="Only load this list of meta objects")
+    meta = List(list(), help="Only load this list of meta objects")
 
-    detdata = List(None, allow_none=True, help="Only load this list of detdata objects")
+    detdata = List(list(), help="Only load this list of detdata objects")
 
-    shared = List(None, allow_none=True, help="Only load this list of shared objects")
+    shared = List(list(), help="Only load this list of shared objects")
 
-    intervals = List(
-        None, allow_none=True, help="Only load this list of intervals objects"
-    )
+    intervals = List(list(), help="Only load this list of intervals objects")
 
     sort_by_size = Bool(
         False, help="If True, sort observations by size before load balancing"
@@ -69,19 +67,19 @@ class LoadHDF5(Operator):
         log = Logger.get()
 
         meta_fields = None
-        if self.meta is not None and len(self.meta) > 0:
+        if len(self.meta) > 0:
             meta_fields = list(self.meta)
 
         shared_fields = None
-        if self.shared is not None and len(self.shared) > 0:
+        if len(self.shared) > 0:
             shared_fields = list(self.shared)
 
         detdata_fields = None
-        if self.detdata is not None and len(self.detdata) > 0:
+        if len(self.detdata) > 0:
             detdata_fields = list(self.detdata)
 
         intervals_fields = None
-        if self.intervals is not None and len(self.intervals) > 0:
+        if len(self.intervals) > 0:
             intervals_fields = list(self.intervals)
 
         # FIXME:  Eventually we will use the volume index / DB to select observations

--- a/src/toast/ops/mapmaker_binning.py
+++ b/src/toast/ops/mapmaker_binning.py
@@ -2,9 +2,9 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
 from ..covariance import covariance_apply
 from ..observation import default_values as defaults

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -2,9 +2,9 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution

--- a/src/toast/ops/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils.py
@@ -2,9 +2,9 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
 from .._libtoast import (
     build_noise_weighted,

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -286,17 +286,22 @@ class NoiseEstim(Operator):
                 comm=temp_obs.comm.comm_group,
                 timer=timer,
             )
+            if self.out_model is not None:
+                obs[self.out_model] = temp_obs[self.out_model]
             self.redistribute = False
         return
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         if detectors is not None:
-            msg = "NoiseEstim cannot be run in batch mode"
+            msg = "NoiseEstim cannot be run with"
             raise RuntimeError(msg)
 
         log = Logger.get()
 
+        # FIXME:  The common mode filter would be more efficient if we moved
+        # this block of code to working on a data view with a single observation
+        # that is already re-distributed below.
         if self.focalplane_key is not None:
             if self.pairs is not None:
                 msg = "focalplane_key is not compatible with pairs"
@@ -484,23 +489,27 @@ class NoiseEstim(Operator):
                     noise_psds[det1] = nse_psd[1:] * psd_unit
                     noise_indices[det1] = obs.telescope.focalplane[det1]["uid"]
 
-            self._re_redistribute(orig_obs, obs)
-
             if self.out_model is not None:
-                # Create a noise model
+                # Create a noise model.  Our observation is currently distributed
+                # so that every process has all detectors.
                 if data.comm.comm_group is not None:
                     noise_dets = data.comm.comm_group.bcast(noise_dets, root=0)
                     noise_freqs = data.comm.comm_group.bcast(noise_freqs, root=0)
                     noise_psds = data.comm.comm_group.bcast(noise_psds, root=0)
                     noise_indices = data.comm.comm_group.bcast(noise_indices, root=0)
-                orig_obs[self.out_model] = Noise(
+                obs[self.out_model] = Noise(
                     detectors=noise_dets,
                     freqs=noise_freqs,
                     psds=noise_psds,
                     indices=noise_indices,
                 )
 
-        return
+            # Redistribute the observation, replacing the input TOD with the filtered
+            # one and redistributing the noise model.
+            self._re_redistribute(orig_obs, obs)
+
+            # Delete temporary obs
+            del obs
 
     @function_timer
     def highpass_signal(self, obs, intervals):

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -294,7 +294,7 @@ class NoiseEstim(Operator):
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         if detectors is not None:
-            msg = "NoiseEstim cannot be run with"
+            msg = "NoiseEstim cannot be run with subsets of detectors"
             raise RuntimeError(msg)
 
         log = Logger.get()

--- a/src/toast/ops/noise_estimation_utils.py
+++ b/src/toast/ops/noise_estimation_utils.py
@@ -187,7 +187,7 @@ def crosscov_psd(
     # for the unflagged samples
     naverage = lagmax
 
-    nreal = np.int(np.ceil((time_stop - time_start) / stationary_period))
+    nreal = int(np.ceil((time_stop - time_start) / stationary_period))
 
     # Communicate lagmax samples from the beginning of the array
     # backwards in the MPI communicator
@@ -276,7 +276,7 @@ def crosscov_psd(
     # Collect the estimated covariance functions
 
     my_covs = {}
-    nreal_task = np.int(np.ceil(nreal / ntask))
+    nreal_task = int(np.ceil(nreal / ntask))
 
     if comm is None:
         for ireal in range(nreal):

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -40,12 +40,54 @@ class DefaultNoiseModel(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
 
-        for ob in data.obs:
-            if ob.telescope.focalplane.noise is None:
-                raise RuntimeError("Focalplane does not have a noise model")
-            ob[self.noise_model] = ob.telescope.focalplane.noise
+        noise_keys = set(["psd_fmin", "psd_fknee", "psd_alpha", "psd_net"])
 
-        return
+        for ob in data.obs:
+            fp_data = ob.telescope.focalplane.detector_data
+            has_parameters = False
+            for key in noise_keys:
+                if key not in fp_data.colnames:
+                    break
+            else:
+                has_parameters = True
+            if not has_parameters:
+                msg = f"Observation {ob.name} does not have a focalplane with "
+                msg += "noise parameters.  Skipping."
+                log.warning(msg)
+                ob[self.noise_model] = None
+                continue
+
+            local_dets = set(ob.local_detectors)
+
+            dets = []
+            fmin = {}
+            fknee = {}
+            alpha = {}
+            NET = {}
+            rates = {}
+            indices = {}
+
+            for row in fp_data:
+                name = row["name"]
+                if name not in local_dets:
+                    continue
+                dets.append(name)
+                rates[name] = ob.telescope.focalplane.sample_rate
+                fmin[name] = row["psd_fmin"]
+                fknee[name] = row["psd_fknee"]
+                alpha[name] = row["psd_alpha"]
+                NET[name] = row["psd_net"]
+                indices[name] = row["uid"]
+
+            ob[self.noise_model] = AnalyticNoise(
+                rate=rates,
+                fmin=fmin,
+                detectors=dets,
+                fknee=fknee,
+                alpha=alpha,
+                NET=NET,
+                indices=indices,
+            )
 
     def _finalize(self, data, **kwargs):
         return
@@ -115,33 +157,12 @@ class FitNoiseModel(Operator):
                     log.verbose(msg)
                 nse_freqs[det] = freqs
                 nse_psds[det] = fitted
-            if ob.comm.comm_group is not None:
-                all_nse_freqs = ob.comm.comm_group.gather(nse_freqs, root=0)
-                all_nse_psds = ob.comm.comm_group.gather(nse_psds, root=0)
-                nse_indx = None
-                if ob.comm.group_rank == 0:
-                    nse_freqs = dict()
-                    nse_psds = dict()
-                    for pval in all_nse_freqs:
-                        nse_freqs.update(pval)
-                    for pval in all_nse_psds:
-                        nse_psds.update(pval)
-                    nse_indx = dict()
-                    for det in in_model.detectors:
-                        nse_indx[det] = in_model.index(det)
-                nse_indx = ob.comm.comm_group.bcast(nse_indx, root=0)
-                nse_freqs = ob.comm.comm_group.bcast(nse_freqs, root=0)
-                nse_psds = ob.comm.comm_group.bcast(nse_psds, root=0)
-            else:
-                nse_indx = dict()
-                for det in in_model.detectors:
-                    nse_indx[det] = in_model.index(det)
 
             new_model = Noise(
                 detectors=in_model.detectors,
                 freqs=nse_freqs,
                 psds=nse_psds,
-                indices=nse_indx,
+                indices={x: in_model.index(x) for x in in_model.detectors},
             )
 
             if self.out_model is None or self.noise_model == self.out_model:

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -65,8 +65,7 @@ class PixelsWCS(Operator):
     )
 
     bounds = Tuple(
-        None,
-        allow_none=True,
+        tuple(),
         help="The (lon_min, lon_max, lat_min, lat_max) values (Quantities)",
     )
 
@@ -77,13 +76,11 @@ class PixelsWCS(Operator):
 
     dimensions = Tuple(
         (710, 350),
-        allow_none=True,
         help="The Lon/Lat pixel dimensions of the projection",
     )
 
     resolution = Tuple(
         (0.5 * u.degree, 0.5 * u.degree),
-        allow_none=True,
         help="The Lon/Lat projection resolution (Quantities) along the 2 axes",
     )
 
@@ -177,16 +174,16 @@ class PixelsWCS(Operator):
         # Current values:
         proj = str(self.projection)
         center = self.center
-        if center is not None:
+        if len(center) > 0:
             center = tuple(self.center)
         bounds = self.bounds
-        if bounds is not None:
+        if len(bounds) > 0:
             bounds = tuple(self.bounds)
         dims = self.dimensions
-        if dims is not None:
+        if len(dims) > 0:
             dims = tuple(self.dimensions)
         res = self.resolution
-        if res is not None:
+        if len(res) > 0:
             res = tuple(self.resolution)
 
         # Update to the trait that changed
@@ -194,23 +191,23 @@ class PixelsWCS(Operator):
             proj = change["new"]
         if change["name"] == "center":
             center = change["new"]
-            if center is not None:
-                bounds = None
+            if len(center) > 0:
+                bounds = tuple()
         if change["name"] == "bounds":
             bounds = change["new"]
-            if bounds is not None:
-                center = None
-                if dims is not None and res is not None:
+            if len(bounds) > 0:
+                center = tuple()
+                if len(dims) > 0 and len(res) > 0:
                     # Most likely the user cares about the resolution more...
-                    dims = None
+                    dims = tuple()
         if change["name"] == "dimensions":
             dims = change["new"]
-            if dims is not None and bounds is not None:
-                res = None
+            if len(dims) > 0 and len(bounds) > 0:
+                res = tuple()
         if change["name"] == "resolution":
             res = change["new"]
-            if res is not None and bounds is not None:
-                dims = None
+            if len(res) > 0 and len(bounds) > 0:
+                dims = tuple()
         self._set_wcs(proj, center, bounds, dims, res)
         self.projection = proj
         self.center = center
@@ -221,22 +218,22 @@ class PixelsWCS(Operator):
     def _set_wcs(self, proj, center, bounds, dims, res):
         log = Logger.get()
         log.verbose(f"PixelsWCS: set_wcs {proj}, {center}, {bounds}, {dims}, {res}")
-        if res is not None:
+        if len(res) > 0:
             res = np.array(
                 [
                     res[0].to_value(u.degree),
                     res[1].to_value(u.degree),
                 ]
             )
-        if dims is not None:
+        if len(dims) > 0:
             dims = np.array([self.dimensions[0], self.dimensions[1]])
 
-        if bounds is None:
+        if len(bounds) == 0:
             # Using center, need both resolution and dimensions
-            if center is None:
+            if len(center) == 0:
                 # Cannot calculate yet
                 return
-            if res is None or dims is None:
+            if len(res) == 0 or len(dims) == 0:
                 # Cannot calculate yet
                 return
             pos = np.array(
@@ -247,7 +244,7 @@ class PixelsWCS(Operator):
             )
         else:
             # Using bounds, exactly one of resolution or dimensions specified
-            if res is not None and dims is not None:
+            if len(res) > 0 and len(dims) > 0:
                 # Cannot calculate yet
                 return
 
@@ -265,7 +262,7 @@ class PixelsWCS(Operator):
             )
 
         self.wcs = pixell.wcsutils.build(pos, res, dims, rowmajor=False, system=proj)
-        if dims is None:
+        if len(dims) == 0:
             # Compute from the bounding box corners
             lower_left = self.wcs.wcs_world2pix(np.array([[pos[0, 0], pos[0, 1]]]), 0)[
                 0

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -628,7 +628,7 @@ class CommonModeFilter(Operator):
 
     det_flag_mask = Int(
         defaults.det_mask_invalid | defaults.det_mask_processing,
-        help="Bit mask value for optional detector flagging"
+        help="Bit mask value for optional detector flagging",
     )
 
     shared_flags = Unicode(

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import traitlets
 
-from ..io import save_hdf5, load_hdf5
+from ..io import load_hdf5, save_hdf5
 from ..observation import default_values as defaults
 from ..timing import function_timer
 from ..traits import Bool, Dict, Int, List, Unicode, trait_docs

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -32,19 +32,17 @@ class SaveHDF5(Operator):
     # FIXME:  We should add a filtering mechanism here to dump a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
-    meta = List(None, allow_none=True, help="Only save this list of meta objects")
+    meta = List(list(), allow_none=True, help="Only save this list of meta objects")
 
-    detdata = List(None, allow_none=True, help="Only save this list of detdata objects")
+    detdata = List(list(), help="Only save this list of detdata objects")
 
-    shared = List(None, allow_none=True, help="Only save this list of shared objects")
+    shared = List(list(), help="Only save this list of shared objects")
 
-    intervals = List(
-        None, allow_none=True, help="Only save this list of intervals objects"
-    )
+    intervals = List(list(), help="Only save this list of intervals objects")
 
     times = Unicode(defaults.times, help="Observation shared key for timestamps")
 
-    config = Dict(None, allow_none=True, help="Write this job config to the file")
+    config = Dict(dict(), help="Write this job config to the file")
 
     force_serial = Bool(
         False, help="Use serial HDF5 operations, even if parallel support available"
@@ -70,19 +68,19 @@ class SaveHDF5(Operator):
             data.comm.comm_world.barrier()
 
         meta_fields = None
-        if self.meta is not None and len(self.meta) > 0:
+        if len(self.meta) > 0:
             meta_fields = list(self.meta)
 
         shared_fields = None
-        if self.shared is not None and len(self.shared) > 0:
+        if len(self.shared) > 0:
             shared_fields = list(self.shared)
 
         detdata_fields = None
-        if self.detdata is not None and len(self.detdata) > 0:
+        if len(self.detdata) > 0:
             detdata_fields = list(self.detdata)
 
         intervals_fields = None
-        if self.intervals is not None and len(self.intervals) > 0:
+        if len(self.intervals) > 0:
             intervals_fields = list(self.intervals)
 
         for ob in data.obs:

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -10,7 +10,7 @@ from scipy import interpolate, signal
 from .. import rng
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Callable, Float, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Callable, Float, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -226,8 +226,8 @@ class InjectCosmicRays(Operator):
 
                     glitch_seconds = 0.15  # seconds, i.e. ~ 3samples at 19Hz
                     # we approximate the number of samples to the closest integer
-                    nsamples_high = np.int_(np.around(glitch_seconds * fsampl_sims))
-                    nsamples_low = np.int_(np.around(glitch_seconds * samplerate))
+                    nsamples_high = int(np.around(glitch_seconds * fsampl_sims))
+                    nsamples_low = int(np.around(glitch_seconds * samplerate))
                     # import pdb; pdb.set_trace()
                     # np.random.seed( obsindx//1e3  +detindx//1e3 )
                     n_events = np.random.poisson(n_events_expected)
@@ -257,7 +257,9 @@ class InjectCosmicRays(Operator):
                     # otherwise we've problems in downsampling
 
                     # estimate the timestamps rounding off the events in seconds
-                    time_stamp_glitches = np.int_(np.around(time_glitches * samplerate))
+                    time_stamp_glitches = np.around(time_glitches * samplerate).astype(
+                        np.int64
+                    )
                     # we measure the glitch and the bestfit timeconstant in millisec
                     tglitch = np.linspace(0, glitch_seconds * 1e3, nsamples_high)
                     glitch_func = lambda t, C1, C2, tau: C1 + (C2 * np.exp(-t / tau))

--- a/src/toast/ops/sim_crosstalk.py
+++ b/src/toast/ops/sim_crosstalk.py
@@ -10,7 +10,7 @@ from .. import rng
 from ..noise_sim import AnalyticNoise
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Unit, Unicode, trait_docs
+from ..traits import Bool, Float, Instance, Int, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -245,7 +245,7 @@ class GainDrifter(Operator):
                 # inject the common mode but only an indepedendent slow drift
 
                 if self.detector_mismatch == 1:
-                    gain_common = np.zeros_like(det_group, dtype=np.float_)
+                    gain_common = np.zeros_like(det_group, dtype=np.float64)
                 else:
                     gain_common = []
                     for iw, w in enumerate(det_group):

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -9,7 +9,7 @@ from astropy import units as u
 from .. import rng
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Callable, Float, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Callable, Float, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 from .sim_tod_noise import sim_noise_timestream

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -405,16 +405,17 @@ class SimGround(Operator):
 
         # Although there is no requirement that the sampling is contiguous from one
         # session to the next, for simulations there is no need to restart the
-        # sampling clock for each one.
+        # sampling clock for each one.  In order to help with load balancing, we
+        # distribute all observations across all sessions among process groups.
+        # We distribute these in sequence to minimize the number of boresight
+        # scanning calculations need to be done by each group.
 
-        scan_starts = list()
-        scan_stops = list()
-        scan_offsets = list()
-        scan_samples = list()
+        obs_info = list()
 
         rate = self.telescope.focalplane.sample_rate.to_value(u.Hz)
         incr = 1.0 / rate
         off = 0
+
         for scan in self.schedule.scans:
             ffirst = rate * (scan.start - mission_start).total_seconds()
             first = int(ffirst)
@@ -423,10 +424,28 @@ class SimGround(Operator):
             start = first * incr + mission_start.timestamp()
             ns = 1 + int(rate * (scan.stop.timestamp() - start))
             stop = (ns - 1) * incr + mission_start.timestamp()
-            scan_starts.append(start)
-            scan_stops.append(stop)
-            scan_samples.append(ns)
-            scan_offsets.append(off)
+
+            # The session name is the same as the historical observation name,
+            # which allows re-use of previously cached atmosphere sims.
+            sname = f"{scan.name}-{scan.scan_indx}-{scan.subscan_indx}"
+
+            for obkey, (obtele, detsets) in obs_tele.items():
+                if obkey == "ALL":
+                    obs_name = sname
+                else:
+                    obs_name = f"{sname}_{obkey}"
+                obs_info.append(
+                    {
+                        "name": obs_name,
+                        "sname": sname,
+                        "obkey": obkey,
+                        "scan": scan,
+                        "start": start,
+                        "stop": stop,
+                        "samples": ns,
+                        "offset": off,
+                    }
+                )
             off += ns
 
         # FIXME:  Re-enable this when using astropy for coordinate transforms.
@@ -436,179 +455,176 @@ class SimGround(Operator):
         # Distribute the sessions uniformly among groups.  We take each scan and
         # weight it by the duration in samples.
 
-        groupdist = distribute_discrete(scan_samples, comm.ngroups)
+        obs_samples = [x["samples"] for x in obs_info]
+        groupdist = distribute_discrete(obs_samples, comm.ngroups)
 
-        # Every process group creates its observing sessions
+        # Every process group creates its observations
 
-        group_first_session = groupdist[comm.group][0]
-        group_num_session = groupdist[comm.group][1]
+        group_first_obs = groupdist[comm.group][0]
+        group_num_obs = groupdist[comm.group][1]
 
-        for obindx in range(
-            group_first_session, group_first_session + group_num_session
-        ):
-            scan = self.schedule.scans[obindx]
-
-            # The session name is the same as the historical observation name,
-            # which allows re-use of previously cached atmosphere sims.
-            name = f"{scan.name}-{scan.scan_indx}-{scan.subscan_indx}"
+        last_session = None
+        for obindx in range(group_first_obs, group_first_obs + group_num_obs):
+            scan = obs_info[obindx]["scan"]
+            sname = obs_info[obindx]["sname"]
+            obs_name = obs_info[obindx]["name"]
 
             sys_mem_str = memreport(
                 msg="(whole node)", comm=data.comm.comm_group, silent=True
             )
-            msg = f"Group {data.comm.group} begin observing session {name} "
+            msg = f"Group {data.comm.group} begin observation {obs_name} "
             msg += f"with {sys_mem_str}"
             log.debug_rank(msg, comm=data.comm.comm_group)
 
-            # Simulate the boresight pattern
+            # Simulate the boresight pattern.  If this observation is in the same
+            # session as the previous observation, just re-use the pointing.
 
-            (
-                times,
-                az,
-                el,
-                sample_sets,
-                scan_min_az,
-                scan_max_az,
-                scan_min_el,
-                scan_max_el,
-                ival_elnod,
-                ival_scan_leftright,
-                ival_scan_rightleft,
-                ival_throw_leftright,
-                ival_throw_rightleft,
-                ival_turn_leftright,
-                ival_turn_rightleft,
-            ) = self._simulate_scanning(
-                scan, scan_samples[obindx], rate, comm, samp_ranks
+            if sname != last_session:
+                (
+                    times,
+                    az,
+                    el,
+                    sample_sets,
+                    scan_min_az,
+                    scan_max_az,
+                    scan_min_el,
+                    scan_max_el,
+                    ival_elnod,
+                    ival_scan_leftright,
+                    ival_scan_rightleft,
+                    ival_throw_leftright,
+                    ival_throw_rightleft,
+                    ival_turn_leftright,
+                    ival_turn_rightleft,
+                ) = self._simulate_scanning(
+                    scan, obs_info[obindx]["samples"], rate, comm, samp_ranks
+                )
+
+                # Create weather realization common to all observations in the session
+                weather = None
+                site = self.telescope.site
+                if self.weather is not None:
+                    # Every session has a unique site with unique weather
+                    # realization.
+                    site = copy.deepcopy(site)
+                    mid_time = scan.start + (scan.stop - scan.start) / 2
+                    try:
+                        weather = SimWeather(
+                            time=mid_time,
+                            name=self.weather,
+                            site_uid=site.uid,
+                            realization=self.realization,
+                            max_pwv=self.max_pwv,
+                            median_weather=self.median_weather,
+                        )
+                    except RuntimeError:
+                        # must be a file
+                        weather = SimWeather(
+                            time=mid_time,
+                            file=self.weather,
+                            site_uid=site.uid,
+                            realization=self.realization,
+                            max_pwv=self.max_pwv,
+                            median_weather=self.median_weather,
+                        )
+                    site.weather = weather
+
+                session = Session(
+                    sname,
+                    start=datetime.fromtimestamp(times[0]).astimezone(timezone.utc),
+                    end=datetime.fromtimestamp(times[-1]).astimezone(timezone.utc),
+                )
+
+            # Create the observation
+
+            obtele, detsets = obs_tele[obs_info[obindx]["obkey"]]
+
+            # Instantiate new telescope with site that may be unique to this session
+            telescope = Telescope(
+                obtele.name,
+                uid=obtele.uid,
+                focalplane=obtele.focalplane,
+                site=site,
             )
 
-            session = Session(
-                name,
-                start=datetime.fromtimestamp(times[0]).astimezone(timezone.utc),
-                end=datetime.fromtimestamp(times[-1]).astimezone(timezone.utc),
+            ob = Observation(
+                comm,
+                telescope,
+                len(times),
+                name=obs_name,
+                uid=name_UID(obs_name),
+                session=session,
+                detector_sets=detsets,
+                process_rows=det_ranks,
+                sample_sets=sample_sets,
             )
 
-            # Create weather realization common to all observations in the session
-            weather = None
-            site = self.telescope.site
-            if self.weather is not None:
-                # Every session has a unique site with unique weather
-                # realization.
-                site = copy.deepcopy(site)
-                mid_time = scan.start + (scan.stop - scan.start) / 2
-                try:
-                    weather = SimWeather(
-                        time=mid_time,
-                        name=self.weather,
-                        site_uid=site.uid,
-                        realization=self.realization,
-                        max_pwv=self.max_pwv,
-                        median_weather=self.median_weather,
-                    )
-                except RuntimeError:
-                    # must be a file
-                    weather = SimWeather(
-                        time=mid_time,
-                        file=self.weather,
-                        site_uid=site.uid,
-                        realization=self.realization,
-                        max_pwv=self.max_pwv,
-                        median_weather=self.median_weather,
-                    )
-                site.weather = weather
+            # Scan limits
+            ob["scan_el"] = scan.el  # Nominal elevation
+            ob["scan_min_az"] = scan_min_az * u.radian
+            ob["scan_max_az"] = scan_max_az * u.radian
+            ob["scan_min_el"] = scan_min_el * u.radian
+            ob["scan_max_el"] = scan_max_el * u.radian
 
-            # Create all observations in this session
+            # Create and set shared objects for timestamps, position, velocity, and
+            # boresight.
 
-            for obkey, (obtele, detsets) in obs_tele.items():
-                # Instantiate new telescope so that it has a unique site
-                telescope = Telescope(
-                    obtele.name,
-                    uid=obtele.uid,
-                    focalplane=obtele.focalplane,
-                    site=site,
-                )
+            ob.shared.create_column(
+                self.times,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.position,
+                shape=(ob.n_local_samples, 3),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.velocity,
+                shape=(ob.n_local_samples, 3),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.azimuth,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.elevation,
+                shape=(ob.n_local_samples,),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.boresight_azel,
+                shape=(ob.n_local_samples, 4),
+                dtype=np.float64,
+            )
+            ob.shared.create_column(
+                self.boresight_radec,
+                shape=(ob.n_local_samples, 4),
+                dtype=np.float64,
+            )
 
-                if obkey == "ALL":
-                    obs_name = name
-                else:
-                    obs_name = f"{name}_{obkey}"
+            # Optionally initialize detector data.  Note that the
+            # detectors in each observation have already been pruned
+            # during the splitting.
 
-                ob = Observation(
-                    comm,
-                    telescope,
-                    len(times),
-                    name=obs_name,
-                    uid=name_UID(obs_name),
-                    session=session,
-                    detector_sets=detsets,
-                    process_rows=det_ranks,
-                    sample_sets=sample_sets,
-                )
-
-                # Scan limits
-                ob["scan_el"] = scan.el  # Nominal elevation
-                ob["scan_min_az"] = scan_min_az * u.radian
-                ob["scan_max_az"] = scan_max_az * u.radian
-                ob["scan_min_el"] = scan_min_el * u.radian
-                ob["scan_max_el"] = scan_max_el * u.radian
-
-                # Create and set shared objects for timestamps, position, velocity, and
-                # boresight.
-
-                ob.shared.create_column(
-                    self.times,
-                    shape=(ob.n_local_samples,),
+            if self.det_data is not None:
+                exists_data = ob.detdata.ensure(
+                    self.det_data,
                     dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.position,
-                    shape=(ob.n_local_samples, 3),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.velocity,
-                    shape=(ob.n_local_samples, 3),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.azimuth,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.elevation,
-                    shape=(ob.n_local_samples,),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.boresight_azel,
-                    shape=(ob.n_local_samples, 4),
-                    dtype=np.float64,
-                )
-                ob.shared.create_column(
-                    self.boresight_radec,
-                    shape=(ob.n_local_samples, 4),
-                    dtype=np.float64,
+                    create_units=self.det_data_units,
                 )
 
-                # Optionally initialize detector data.  Note that the
-                # detectors in each observation have already been pruned
-                # during the splitting.
+            if self.det_flags is not None:
+                exists_flags = ob.detdata.ensure(
+                    self.det_flags,
+                    dtype=np.uint8,
+                )
 
-                if self.det_data is not None:
-                    exists_data = ob.detdata.ensure(
-                        self.det_data,
-                        dtype=np.float64,
-                        create_units=self.det_data_units,
-                    )
+            # Only the first rank of the process grid columns sets / computes these.
 
-                if self.det_flags is not None:
-                    exists_flags = ob.detdata.ensure(
-                        self.det_flags,
-                        dtype=np.uint8,
-                    )
-
-                # Only the first rank of the process grid columns sets / computes these.
-
+            if sname != last_session:
                 stamps = None
                 position = None
                 velocity = None
@@ -649,87 +665,86 @@ class SimGround(Operator):
                     # Convert to RA / DEC.  Use pyephem for now.
                     bore_radec = azel_to_radec(site, stamps, bore_azel, use_ephem=True)
 
-                ob.shared[self.times].set(stamps, offset=(0,), fromrank=0)
-                ob.shared[self.azimuth].set(az_data, offset=(0,), fromrank=0)
-                ob.shared[self.elevation].set(el_data, offset=(0,), fromrank=0)
-                ob.shared[self.position].set(position, offset=(0, 0), fromrank=0)
-                ob.shared[self.velocity].set(velocity, offset=(0, 0), fromrank=0)
-                ob.shared[self.boresight_azel].set(bore_azel, offset=(0, 0), fromrank=0)
-                ob.shared[self.boresight_radec].set(
-                    bore_radec, offset=(0, 0), fromrank=0
-                )
+            ob.shared[self.times].set(stamps, offset=(0,), fromrank=0)
+            ob.shared[self.azimuth].set(az_data, offset=(0,), fromrank=0)
+            ob.shared[self.elevation].set(el_data, offset=(0,), fromrank=0)
+            ob.shared[self.position].set(position, offset=(0, 0), fromrank=0)
+            ob.shared[self.velocity].set(velocity, offset=(0, 0), fromrank=0)
+            ob.shared[self.boresight_azel].set(bore_azel, offset=(0, 0), fromrank=0)
+            ob.shared[self.boresight_radec].set(bore_radec, offset=(0, 0), fromrank=0)
 
-                # Simulate HWP angle
+            # Simulate HWP angle
 
-                simulate_hwp_response(
-                    ob,
-                    ob_time_key=self.times,
-                    ob_angle_key=self.hwp_angle,
-                    ob_mueller_key=None,
-                    hwp_start=scan_starts[obindx] * u.second,
-                    hwp_rpm=self.hwp_rpm,
-                    hwp_step=self.hwp_step,
-                    hwp_step_time=self.hwp_step_time,
-                )
+            simulate_hwp_response(
+                ob,
+                ob_time_key=self.times,
+                ob_angle_key=self.hwp_angle,
+                ob_mueller_key=None,
+                hwp_start=obs_info[obindx]["start"] * u.second,
+                hwp_rpm=self.hwp_rpm,
+                hwp_step=self.hwp_step,
+                hwp_step_time=self.hwp_step_time,
+            )
 
-                # Create interval lists for our motion.  Since we simulated the scan on
-                # every process, we don't need to communicate the global timespans of the
-                # intervals (using create or create_col).  We can just create them directly.
+            # Create interval lists for our motion.  Since we simulated the scan on
+            # every process, we don't need to communicate the global timespans of the
+            # intervals (using create or create_col).  We can just create them directly.
 
-                ob.intervals[self.throw_leftright_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_throw_leftright
-                )
-                ob.intervals[self.throw_rightleft_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_throw_rightleft
-                )
-                ob.intervals[self.throw_interval] = (
-                    ob.intervals[self.throw_leftright_interval]
-                    | ob.intervals[self.throw_rightleft_interval]
-                )
-                ob.intervals[self.scan_leftright_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_scan_leftright
-                )
-                ob.intervals[self.turn_leftright_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_turn_leftright
-                )
-                ob.intervals[self.scan_rightleft_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_scan_rightleft
-                )
-                ob.intervals[self.turn_rightleft_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_turn_rightleft
-                )
-                ob.intervals[self.elnod_interval] = IntervalList(
-                    ob.shared[self.times], timespans=ival_elnod
-                )
-                ob.intervals[self.scanning_interval] = (
-                    ob.intervals[self.scan_leftright_interval]
-                    | ob.intervals[self.scan_rightleft_interval]
-                )
-                ob.intervals[self.turnaround_interval] = (
-                    ob.intervals[self.turn_leftright_interval]
-                    | ob.intervals[self.turn_rightleft_interval]
-                )
+            ob.intervals[self.throw_leftright_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_throw_leftright
+            )
+            ob.intervals[self.throw_rightleft_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_throw_rightleft
+            )
+            ob.intervals[self.throw_interval] = (
+                ob.intervals[self.throw_leftright_interval]
+                | ob.intervals[self.throw_rightleft_interval]
+            )
+            ob.intervals[self.scan_leftright_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_scan_leftright
+            )
+            ob.intervals[self.turn_leftright_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_turn_leftright
+            )
+            ob.intervals[self.scan_rightleft_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_scan_rightleft
+            )
+            ob.intervals[self.turn_rightleft_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_turn_rightleft
+            )
+            ob.intervals[self.elnod_interval] = IntervalList(
+                ob.shared[self.times], timespans=ival_elnod
+            )
+            ob.intervals[self.scanning_interval] = (
+                ob.intervals[self.scan_leftright_interval]
+                | ob.intervals[self.scan_rightleft_interval]
+            )
+            ob.intervals[self.turnaround_interval] = (
+                ob.intervals[self.turn_leftright_interval]
+                | ob.intervals[self.turn_rightleft_interval]
+            )
 
-                # Get the Sun's position in horizontal coordinates and define
-                # "Sun up" and "Sun close" intervals according to it
+            # Get the Sun's position in horizontal coordinates and define
+            # "Sun up" and "Sun close" intervals according to it
 
-                add_solar_intervals(
-                    ob.intervals,
-                    site,
-                    ob.shared[self.times],
-                    ob.shared[self.azimuth].data,
-                    ob.shared[self.elevation].data,
-                    self.sun_up_interval,
-                    self.sun_close_interval,
-                    self.sun_close_distance,
-                )
+            add_solar_intervals(
+                ob.intervals,
+                site,
+                ob.shared[self.times],
+                ob.shared[self.azimuth].data,
+                ob.shared[self.elevation].data,
+                self.sun_up_interval,
+                self.sun_close_interval,
+                self.sun_close_distance,
+            )
 
-                obmem = ob.memory_use()
-                obmem_gb = obmem / 1024**3
-                msg = f"Observation {ob.name} using {obmem_gb:0.2f} GB of total memory"
-                log.debug_rank(msg, comm=ob.comm.comm_group)
+            obmem = ob.memory_use()
+            obmem_gb = obmem / 1024**3
+            msg = f"Observation {ob.name} using {obmem_gb:0.2f} GB of total memory"
+            log.debug_rank(msg, comm=ob.comm.comm_group)
 
-                data.obs.append(ob)
+            data.obs.append(ob)
+            # last_session = sname
 
         # For convenience, we additionally create a shared flag field with bits set
         # according to the different intervals.  This basically just saves workflows

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -738,13 +738,17 @@ class SimGround(Operator):
                 self.sun_close_distance,
             )
 
+            msg = f"Group {data.comm.group} finished observation {obs_name}:\n"
+            msg += f"{ob}"
+            log.verbose_rank(msg, comm=data.comm.comm_group)
+
             obmem = ob.memory_use()
             obmem_gb = obmem / 1024**3
             msg = f"Observation {ob.name} using {obmem_gb:0.2f} GB of total memory"
             log.debug_rank(msg, comm=ob.comm.comm_group)
 
             data.obs.append(ob)
-            # last_session = sname
+            last_session = sname
 
         # For convenience, we additionally create a shared flag field with bits set
         # according to the different intervals.  This basically just saves workflows

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -15,7 +15,7 @@ from .. import qarray as qa
 from ..coordinates import azel_to_radec
 from ..dist import distribute_discrete, distribute_uniform
 from ..healpix import ang2vec
-from ..instrument import Session, Telescope, Focalplane
+from ..instrument import Focalplane, Session, Telescope
 from ..intervals import IntervalList, regular_intervals
 from ..noise_sim import AnalyticNoise
 from ..observation import Observation
@@ -29,8 +29,8 @@ from ..traits import (
     Int,
     List,
     Quantity,
-    Unit,
     Unicode,
+    Unit,
     trait_docs,
 )
 from ..utils import (

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -220,7 +220,7 @@ class SimGround(Operator):
 
     elnod_end = Bool(False, help="Perform an el-nod after the scan")
 
-    elnods = List(None, allow_none=True, help="List of relative el_nods")
+    elnods = List(list(), help="List of relative el_nods")
 
     elnod_every_scan = Bool(False, help="Perform el nods every scan")
 

--- a/src/toast/ops/sim_satellite.py
+++ b/src/toast/ops/sim_satellite.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 import numpy as np
 import traitlets
 from astropy import units as u
-from datetime import datetime, timezone, timedelta
 from scipy.constants import degree
 
 from .. import qarray as qa
@@ -19,7 +18,7 @@ from ..observation import Observation
 from ..observation import default_values as defaults
 from ..schedule import SatelliteSchedule
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger, name_UID, rate_from_times
 from .operator import Operator
 from .sim_hwp import simulate_hwp_response

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -15,7 +15,7 @@ from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger, Timer
 from .operator import Operator
 from .pipeline import Pipeline

--- a/src/toast/ops/sim_tod_atm_generate.py
+++ b/src/toast/ops/sim_tod_atm_generate.py
@@ -185,6 +185,8 @@ class GenerateAtmosphere(Operator):
         # also checks that every session has a name.
         data_sessions = data.split(obs_session_name=True, require_full=True)
 
+        # Multiple process groups might have observations from the same session
+
         for sname, sdata in data_sessions.items():
             # Prefix for logging
             log_prefix = f"{group} : {sname} : "

--- a/src/toast/ops/sim_tod_atm_observe.py
+++ b/src/toast/ops/sim_tod_atm_observe.py
@@ -16,7 +16,7 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..observation_dist import global_interval_times
 from ..timing import GlobalTimers, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger, Timer, unit_conversion
 from .operator import Operator
 

--- a/src/toast/ops/sim_tod_dipole.py
+++ b/src/toast/ops/sim_tod_dipole.py
@@ -11,7 +11,7 @@ from .. import qarray as qa
 from ..dipole import dipole
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Int, Quantity, Unit, Unicode, trait_docs
+from ..traits import Bool, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger, unit_conversion
 from .operator import Operator
 

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -138,9 +138,9 @@ def sim_noise_timestream(
         # gaussian Re/Im randoms, packed into a complex valued array
 
         key1 = (
-            int(realization) * int(4294967296) + 
-            int(telescope) * int(65536) + 
-            int(component)
+            int(realization) * int(4294967296)
+            + int(telescope) * int(65536)
+            + int(component)
         )
         key2 = int(sindx) * int(4294967296) + int(detindx)
         counter1 = 0
@@ -150,7 +150,7 @@ def sim_noise_timestream(
             fftlen, sampler="gaussian", key=(key1, key2), counter=(counter1, counter2)
         ).array()
 
-        fdata = np.zeros(npsd, dtype=np.complex)
+        fdata = np.zeros(npsd, dtype=np.complex128)
 
         # Set the DC and Nyquist frequency imaginary part to zero
         fdata[0] = rngdata[0] + 0.0j

--- a/src/toast/ops/sim_tod_noise.py
+++ b/src/toast/ops/sim_tod_noise.py
@@ -12,7 +12,7 @@ from .._libtoast import tod_sim_noise_timestream, tod_sim_noise_timestream_batch
 from ..fft import FFTPlanReal1DStore
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Int, Unit, Unicode, trait_docs
+from ..traits import Bool, Int, Unicode, Unit, trait_docs
 from ..utils import AlignedF64, Logger, rate_from_times, unit_conversion
 from .operator import Operator
 

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -24,8 +24,8 @@ from ..traits import (
     Int,
     List,
     Quantity,
-    Unit,
     Unicode,
+    Unit,
     trait_docs,
 )
 from ..utils import Environment, Logger, Timer

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -185,7 +185,7 @@ class SimScanSynchronousSignal(Operator):
                 ).astype(dtype)
                 sss_map /= np.std(sss_map)
                 lon, lat = hp.pix2ang(
-                    self.nside, np.arange(npix, dtype=np.int), lonlat=True
+                    self.nside, np.arange(npix, dtype=np.int64), lonlat=True
                 )
                 scale = self.scale * (np.abs(lat) / 90 + 0.5) ** self.power
                 sss_map *= scale.to_value(self.units)

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -21,8 +21,8 @@ from ..traits import (
     Instance,
     Int,
     Quantity,
-    Unit,
     Unicode,
+    Unit,
     trait_docs,
 )
 from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned

--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -249,7 +249,7 @@ class Patch(object):
             az2 = unwind_angle(az1, azs[j])
             el2 = els[j]
             azmean = 0.5 * (az1 + az2)
-            az0 = unwind_angle(azmean, np.float(obj.az), np.pi)
+            az0 = unwind_angle(azmean, float(obj.az), np.pi)
             if (az1 - az0) * (az2 - az0) > 0:
                 # the constant meridian is not between the two corners
                 continue
@@ -278,7 +278,7 @@ class Patch(object):
                 els_cross[:i] += 2 * np.pi
                 els_cross = np.sort(els_cross)
         el_mean = np.mean(els_cross)
-        el0 = unwind_angle(el_mean, np.float(obj.alt))
+        el0 = unwind_angle(el_mean, float(obj.alt))
 
         ncross = np.sum(els_cross > el0)
 
@@ -905,7 +905,7 @@ def check_sso(observer, az1, az2, el, sso, angle, el_min, tstart, tstop):
     """
     if az2 < az1:
         az2 += 360
-    naz = max(3, np.int(0.25 * (az2 - az1) * np.cos(np.radians(el))))
+    naz = max(3, int(0.25 * (az2 - az1) * np.cos(np.radians(el))))
     quats = []
     for az in np.linspace(az1, az2, naz):
         quats.append(from_angles(az % 360, el))
@@ -1606,7 +1606,7 @@ def add_scan(
     log = Logger.get()
     ces_time = tstop - tstart
     if ces_time > args.ces_max_time_s:  # and not args.pole_mode:
-        nsub = np.int(np.ceil(ces_time / args.ces_max_time_s))
+        nsub = int(np.ceil(ces_time / args.ces_max_time_s))
         ces_time /= nsub
     aztimes = np.array(aztimes)
     azmins = np.array(azmins)
@@ -2055,7 +2055,7 @@ def build_schedule(args, start_timestamp, stop_timestamp, patches, observer, sun
         el_min = 90
         el_max = 0
         for el in args.elevations_deg.split(","):
-            el = np.float(el)
+            el = float(el)
             el_min = min(el * 0.9, el_min)
             el_max = max(el * 1.1, el_max)
     el_min *= degree
@@ -2286,14 +2286,14 @@ def parse_args(opts=None):
         "--site-alt",
         required=False,
         default=100,
-        type=np.float,
+        type=float,
         help="Observing site altitude [meters]",
     )
     parser.add_argument(
         "--scan-margin",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Random fractional margin [0..1] added to the "
         "scans to smooth out edge effects",
     )
@@ -2301,49 +2301,49 @@ def parse_args(opts=None):
         "--ra-period",
         required=False,
         default=10,
-        type=np.int,
+        type=int,
         help="Period of patch position oscillations in RA [visits]",
     )
     parser.add_argument(
         "--ra-amplitude-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Amplitude of patch position oscillations in RA [deg]",
     )
     parser.add_argument(
         "--dec-period",
         required=False,
         default=10,
-        type=np.int,
+        type=int,
         help="Period of patch position oscillations in DEC [visits]",
     )
     parser.add_argument(
         "--dec-amplitude-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Amplitude of patch position oscillations in DEC [deg]",
     )
     parser.add_argument(
         "--elevation-penalty-limit",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Assign a penalty to observing elevations below this limit [degrees]",
     )
     parser.add_argument(
         "--elevation-penalty-power",
         required=False,
         default=2,
-        type=np.float,
+        type=float,
         help="Power in the elevation penalty function [> 0]",
     )
     parser.add_argument(
         "--elevation-change-limit-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Assign a penalty to changes in elevation larger than this limit [degrees].  "
         "See --elevation-change-penalty and --elevation-change-time-s",
     )
@@ -2351,7 +2351,7 @@ def parse_args(opts=None):
         "--elevation-change-penalty",
         required=False,
         default=1,
-        type=np.float,
+        type=float,
         help="Multiplicative elevation change penalty triggered by "
         "--elevation-change-limit-deg",
     )
@@ -2359,7 +2359,7 @@ def parse_args(opts=None):
         "--elevation-change-time-s",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Time it takes for the telescope to stabilize after a change in observing "
         "elevation [seconds].  Triggered by --elevation-change-limit-deg",
     )
@@ -2403,21 +2403,21 @@ def parse_args(opts=None):
         "--el-min-deg",
         required=False,
         default=30,
-        type=np.float,
+        type=float,
         help="Minimum elevation for a CES",
     )
     parser.add_argument(
         "--el-max-deg",
         required=False,
         default=80,
-        type=np.float,
+        type=float,
         help="Maximum elevation for a CES",
     )
     parser.add_argument(
         "--el-step-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Optional step to apply to minimum elevation",
     )
     parser.add_argument(
@@ -2431,70 +2431,70 @@ def parse_args(opts=None):
         "--fp-radius-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Focal plane radius [deg]",
     )
     parser.add_argument(
         "--sun-avoidance-angle-deg",
         required=False,
         default=30,
-        type=np.float,
+        type=float,
         help="Minimum distance between the Sun and the bore sight [deg]",
     )
     parser.add_argument(
         "--sun-avoidance-altitude-deg",
         required=False,
         default=-18,
-        type=np.float,
+        type=float,
         help="Minimum altitude to apply Solar avoidance [deg]",
     )
     parser.add_argument(
         "--moon-avoidance-angle-deg",
         required=False,
         default=20,
-        type=np.float,
+        type=float,
         help="Minimum distance between the Moon and the bore sight [deg]",
     )
     parser.add_argument(
         "--moon-avoidance-altitude-deg",
         required=False,
         default=-18,
-        type=np.float,
+        type=float,
         help="Minimum altitude to apply Lunar avoidance [deg]",
     )
     parser.add_argument(
         "--sun-el-max-deg",
         required=False,
         default=90,
-        type=np.float,
+        type=float,
         help="Maximum allowed sun elevation [deg]",
     )
     parser.add_argument(
         "--boresight-angle-step-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Boresight rotation step size [deg]",
     )
     parser.add_argument(
         "--boresight-angle-min-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Boresight rotation angle minimum [deg]",
     )
     parser.add_argument(
         "--boresight-angle-max-deg",
         required=False,
         default=360,
-        type=np.float,
+        type=float,
         help="Boresight rotation angle maximum [deg]",
     )
     parser.add_argument(
         "--boresight-angle-time-min",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Boresight rotation step interval [minutes]",
     )
     parser.add_argument(
@@ -2516,13 +2516,13 @@ def parse_args(opts=None):
     parser.add_argument(
         "--operational-days",
         required=False,
-        type=np.int,
+        type=int,
         help="Number of operational days to schedule (empty days do not count)",
     )
     parser.add_argument(
         "--timezone",
         required=False,
-        type=np.int,
+        type=int,
         default=0,
         help="Offset to apply to MJD to separate operational days [hours]",
     )
@@ -2530,21 +2530,21 @@ def parse_args(opts=None):
         "--gap-s",
         required=False,
         default=100,
-        type=np.float,
+        type=float,
         help="Gap between CES:es [seconds]",
     )
     parser.add_argument(
         "--gap-small-s",
         required=False,
         default=10,
-        type=np.float,
+        type=float,
         help="Gap between split CES:es [seconds]",
     )
     parser.add_argument(
         "--time-step-s",
         required=False,
         default=600,
-        type=np.float,
+        type=float,
         help="Time step after failed target acquisition [seconds]",
     )
     parser.add_argument(
@@ -2558,7 +2558,7 @@ def parse_args(opts=None):
         "--ces-max-time-s",
         required=False,
         default=900,
-        type=np.float,
+        type=float,
         help="Maximum length of a CES [seconds]",
     )
     parser.add_argument(
@@ -2576,13 +2576,13 @@ def parse_args(opts=None):
     parser.add_argument(
         "--pol-min",
         required=False,
-        type=np.float,
+        type=float,
         help="Lower plotting range for polarization map",
     )
     parser.add_argument(
         "--pol-max",
         required=False,
-        type=np.float,
+        type=float,
         help="Upper plotting range for polarization map",
     )
     parser.add_argument(
@@ -2603,14 +2603,14 @@ def parse_args(opts=None):
         "--pole-el-step-deg",
         required=False,
         default=0.25,
-        type=np.float,
+        type=float,
         help="Elevation step in pole scheduling mode [deg]",
     )
     parser.add_argument(
         "--pole-ces-time-s",
         required=False,
         default=3000,
-        type=np.float,
+        type=float,
         help="Time to scan at constant elevation in pole mode",
     )
     parser.add_argument(
@@ -2620,14 +2620,14 @@ def parse_args(opts=None):
         "--boresight-offset-el-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Optional offset added to every observing elevation",
     )
     parser.add_argument(
         "--boresight-offset-az-deg",
         required=False,
         default=0,
-        type=np.float,
+        type=float,
         help="Optional offset added to every observing azimuth",
     )
     parser.add_argument(
@@ -2662,35 +2662,35 @@ def parse_args(opts=None):
         "--pole-raster-el-step-deg",
         required=False,
         default=1 / 60,
-        type=np.float,
+        type=float,
         help="Elevation step in pole raster scheduling mode [deg]",
     )
     parser.add_argument(
         "--az-rate-sky-deg",
         required=False,
         default=1.0,
-        type=np.float,
+        type=float,
         help="Azimuthal rate in pole raster scheduling mode [deg]",
     )
     parser.add_argument(
         "--az-accel-mount-deg",
         required=False,
         default=1.0,
-        type=np.float,
+        type=float,
         help="Azimuthal accleration in pole raster scheduling mode [deg]",
     )
     parser.add_argument(
         "--el-rate-deg",
         required=False,
         default=1.0,
-        type=np.float,
+        type=float,
         help="Elevation rate in pole raster scheduling mode [deg]",
     )
     parser.add_argument(
         "--el-accel-deg",
         required=False,
         default=1.0,
-        type=np.float,
+        type=float,
         help="Elevation accleration in pole raster scheduling mode [deg]",
     )
 
@@ -3051,8 +3051,8 @@ def parse_patches(args, observer, sun, moon, start_timestamp, stop_timestamp):
         moon_avoidance_color = "gray"
         alpha = 0.5
         avoidance_alpha = 0.01
-        sun_step = np.int(86400 * 1)
-        moon_step = np.int(86400 * 0.1)
+        sun_step = int(86400 * 1)
+        moon_step = int(86400 * 0.1)
         for iplot, coord in enumerate("CEG"):
             scoord = {"C": "Equatorial", "E": "Ecliptic", "G": "Galactic"}[coord]
             title = scoord  # + ' patch locations'
@@ -3102,7 +3102,7 @@ def parse_patches(args, observer, sun, moon, start_timestamp, stop_timestamp):
                     moon_lw,
                 ),
             ]:
-                for t in range(np.int(start_timestamp), np.int(stop_timestamp), step):
+                for t in range(int(start_timestamp), int(stop_timestamp), step):
                     observer.date = to_DJD(t)
                     sso.compute(observer)
                     lon.append(np.degrees(sso.a_ra))

--- a/src/toast/scripts/toast_config_verify.py
+++ b/src/toast/scripts/toast_config_verify.py
@@ -13,7 +13,7 @@ import sys
 import traceback
 
 import toast
-from toast.config import load_config, dump_toml
+from toast.config import dump_toml, load_config
 from toast.mpi import Comm, get_world
 from toast.utils import Environment, Logger, import_from_name, object_fullname
 

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -301,7 +301,7 @@ class export_obs_meta(object):
         for m_in, m_out in self._noise_models:
             byte_writer = io.BytesIO()
             with h5py.File(byte_writer, "w") as f:
-                obs[m_in].save_hdf5(f, comm=None, force_serial=True)
+                obs[m_in].save_hdf5(f, obs)
             cal[m_out] = c3g.G3VectorUnsignedChar(byte_writer.getvalue())
             del byte_writer
             cal[f"{m_out}_class"] = c3g.G3String(object_fullname(obs[m_in].__class__))

--- a/src/toast/spt3g/spt3g_import.py
+++ b/src/toast/spt3g/spt3g_import.py
@@ -373,8 +373,12 @@ class import_obs_meta(object):
                 )
 
                 # Make a fake obs for loading noise models
+                if MPI is None:
+                    fake_comm = None
+                else:
+                    fake_comm = MPI.COMM_SELF
                 fake_obs = Observation(
-                    Comm(world=MPI.COMM_SELF),
+                    Comm(world=fake_comm),
                     telescope,
                     1,
                     process_rows=1,

--- a/src/toast/spt3g/spt3g_utils.py
+++ b/src/toast/spt3g/spt3g_utils.py
@@ -9,11 +9,20 @@ from astropy import units as u
 
 from ..utils import Environment, Logger
 
-available = True
 try:
+    # First see if we are using spt3g bundled with so3g
+    import so3g
     from spt3g import core as c3g
+
+    available = True
 except ImportError:
-    available = False
+    # Try plain spt3g import
+    try:
+        from spt3g import core as c3g
+
+        available = True
+    except ImportError:
+        available = False
 
 
 def from_g3_scalar_type(val, unit=None):

--- a/src/toast/templates/template.py
+++ b/src/toast/templates/template.py
@@ -2,14 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-from astropy import units as u
 import numpy as np
 import traitlets
+from astropy import units as u
 
 from ..data import Data
 from ..observation import default_values as defaults
 from ..timing import function_timer_stackskip
-from ..traits import Bool, Instance, Int, TraitConfig, Unit, Unicode
+from ..traits import Bool, Instance, Int, TraitConfig, Unicode, Unit
 from ..utils import Logger
 
 

--- a/src/toast/tests/accelerator.py
+++ b/src/toast/tests/accelerator.py
@@ -24,7 +24,7 @@ from ..data import Data
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..traits import Int, Unicode, trait_docs
-from ._helpers import create_comm, create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_comm, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -81,7 +81,7 @@ class ConfigOperator(ops.Operator):
     # with allow_none=False.
     instance_none = Instance(allow_none=True, klass=FakeClass, help="Instance none")
 
-    list_none = List(None, allow_none=True, help="List none")
+    list_empty = List(list(), help="List empty")
     list_string = List(["foo", "bar", "blat"], help="List string default")
     list_string_empty = List(["", "", ""], help="List string empty")
     list_float = List([1.23, 4.56, 7.89], help="List float default")
@@ -92,7 +92,7 @@ class ConfigOperator(ops.Operator):
         [None, True, "", "foo", 1.23, 4.56, 7.89 * u.meter], help="list mixed"
     )
 
-    dict_none = Dict(None, allow_none=True, help="Dict none")
+    dict_empty = Dict(dict(), help="Dict empty")
     dict_string = Dict(
         {"a": "foo", "b": "bar", "c": "blat"}, help="Dict string default"
     )
@@ -106,7 +106,7 @@ class ConfigOperator(ops.Operator):
         help="Dict mixed",
     )
 
-    set_none = Set(None, allow_none=True, help="Set none")
+    set_empty = Set(set(), help="Set empty")
     set_string = Set({"a", "b", "c"}, help="Set string default")
     set_string_empty = Set({"", "", ""}, help="Set string empty")
     set_float = Set({1.23, 4.56, 7.89}, help="Set float default")
@@ -115,7 +115,7 @@ class ConfigOperator(ops.Operator):
     )
     set_mixed = Set({None, "", "foo", True, 4.56, 7.89 * u.meter}, help="Set mixed")
 
-    tuple_none = Tuple(None, allow_none=True, help="Tuple string default")
+    tuple_empty = Tuple(tuple(), help="Tuple empty")
     tuple_string = Tuple(("foo", "bar", "blat"), help="Tuple string default")
     tuple_string_empty = Tuple(("", "", ""), help="Tuple string empty")
     tuple_float = Tuple((1.23, 4.56, 7.89), help="Tuple float")

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -33,15 +33,15 @@ from ..traits import (
     Int,
     List,
     Quantity,
-    Unit,
     Set,
     Tuple,
     Unicode,
+    Unit,
     trait_docs,
     trait_scalar_to_string,
 )
 from ..utils import Environment, Logger
-from ._helpers import create_comm, create_outdir, create_space_telescope, close_data
+from ._helpers import close_data, create_comm, create_outdir, create_space_telescope
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/covariance.py
+++ b/src/toast/tests/covariance.py
@@ -13,7 +13,7 @@ from .. import ops as ops
 from ..covariance import covariance_apply, covariance_invert, covariance_multiply
 from ..mpi import MPI
 from ..pixels import PixelData, PixelDistribution
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/dist.py
+++ b/src/toast/tests/dist.py
@@ -15,12 +15,12 @@ from ..instrument import Session
 from ..mpi import MPI, Comm
 from ..observation import Observation
 from ._helpers import (
+    close_data,
     create_comm,
     create_ground_telescope,
     create_outdir,
     create_satellite_data,
     create_satellite_empty,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/instrument.py
+++ b/src/toast/tests/instrument.py
@@ -264,9 +264,6 @@ class InstrumentTest(MPITestCase):
         with H5File(fp_file, "r", comm=self.comm) as f:
             newfp.load_hdf5(f.handle, comm=self.comm)
 
-        # Test getting noise PSD
-        psd = newfp.noise.psd(names[-1])
-
         # Test convolving with bandpass
         freqs = np.linspace(50, 150, 100) * u.GHz
         values = np.linspace(0, 1, 100)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -14,7 +14,7 @@ from ..data import Data
 from ..io import load_hdf5, save_hdf5
 from ..mpi import MPI
 from ..observation_data import DetectorData
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -173,7 +173,7 @@ class IoHdf5Test(MPITestCase):
         for ob in data.obs:
             original[ob.name] = ob.duplicate(times="times")
 
-        saver = ops.SaveHDF5(volume=datadir, config=config)
+        saver = ops.SaveHDF5(volume=datadir, config=config, verify=True)
         saver.apply(data)
 
         if data.comm.comm_world is not None:
@@ -189,5 +189,33 @@ class IoHdf5Test(MPITestCase):
             if ob != orig:
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
             self.assertTrue(ob == orig)
+
+        close_data(data)
+
+    def test_save_load_ops_f32(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "save_load_ops_f32")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        data, config = self.create_data()
+
+        # Make a copy for later comparison.
+        original = dict()
+        for ob in data.obs:
+            original[ob.name] = ob.duplicate(times="times")
+
+        saver = ops.SaveHDF5(
+            volume=datadir, config=config, detdata_float32=True, verify=True
+        )
+        saver.apply(data)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
 
         close_data(data)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -23,8 +23,19 @@ class IoHdf5Test(MPITestCase):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
         self.outdir = create_outdir(self.comm, fixture_name)
 
-    def create_data(self):
-        # Create fake observing of a small patch
+    def create_data(self, split=False):
+        # Create fake observing of a small patch.  Use a multifrequency
+        # focalplane so we can test split sessions.
+
+        ppp = 10
+        freq_list = [(100 + 10 * x) * u.GHz for x in range(3)]
+        data = create_ground_data(
+            self.comm,
+            freqs=freq_list,
+            pixel_per_process=ppp,
+            split=split,
+        )
+
         data = create_ground_data(self.comm)
 
         # Simple detector pointing
@@ -166,7 +177,7 @@ class IoHdf5Test(MPITestCase):
         if self.comm is not None:
             self.comm.barrier()
 
-        data, config = self.create_data()
+        data, config = self.create_data(split=True)
 
         # Make a copy for later comparison.
         original = dict()
@@ -203,7 +214,7 @@ class IoHdf5Test(MPITestCase):
         if self.comm is not None:
             self.comm.barrier()
 
-        data, config = self.create_data()
+        data, config = self.create_data(split=True)
 
         # Make a copy for later comparison.
         original = dict()

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -26,153 +26,79 @@ class InstrumentTest(MPITestCase):
         self.outdir = create_outdir(self.comm, fixture_name)
 
     def test_noise_hdf5(self):
-        detnames = ["det_01a", "det_01b", "det_02a", "det_02b"]
-        streams = ["strm01", "strm02"]
-        streams.extend(detnames)
-        mix = {
-            "det_01a": {"strm01": 0.25, "det_01a": 1.0},
-            "det_01b": {"strm01": 0.75, "det_01b": 1.0},
-            "det_02a": {"strm02": 0.25, "det_02a": 1.0},
-            "det_02b": {"strm02": 0.75, "det_02b": 1.0},
-        }
-        freqs = np.linspace(0.0001, 5.0, num=50, endpoint=True)
-        nse = Noise(
-            detnames,
-            {x: u.Quantity(freqs, u.Hz) for x in streams},
-            {x: u.Quantity(np.ones(len(freqs)), u.K**2 * u.second) for x in streams},
-            mixmatrix=mix,
-        )
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(self.comm)
 
-        nse_file = os.path.join(self.outdir, "noise.h5")
+        for ob in data.obs:
+            detnames = ob.local_detectors
+            streams = ["strm01", "strm02"]
+            streams.extend(detnames)
+            mix = dict()
+            for idet, det in enumerate(detnames):
+                mix[det] = {
+                    "strm01": 0.25 + 0.5 * (idet % 2),
+                    "strm02": 0.25 + 0.5 * ((idet + 1) % 2),
+                }
+            freqs = np.linspace(0.0001, 5.0, num=50, endpoint=True)
+            nse = Noise(
+                detnames,
+                {x: u.Quantity(freqs, u.Hz) for x in streams},
+                {
+                    x: u.Quantity(np.ones(len(freqs)), u.K**2 * u.second)
+                    for x in streams
+                },
+                mixmatrix=mix,
+            )
 
-        with H5File(nse_file, "w", comm=self.comm) as f:
-            nse.save_hdf5(f.handle, comm=self.comm)
+            nse_file = os.path.join(self.outdir, f"{ob.name}_noise.h5")
 
-        if self.comm is not None:
-            self.comm.barrier()
+            with H5File(nse_file, "w", comm=ob.comm.comm_group) as f:
+                nse.save_hdf5(f.handle, ob)
 
-        new_nse = Noise()
-        with H5File(nse_file, "r", comm=self.comm) as f:
-            new_nse.load_hdf5(f.handle, comm=self.comm)
-        self.assertTrue(nse == new_nse)
+            if ob.comm.comm_group is not None:
+                ob.comm.comm_group.barrier()
 
-    def test_analytic_hdf5(self):
-        detnames = ["det_01a", "det_01b", "det_02a", "det_02b"]
-        rate = {x: 10.0 * u.Hz for x in detnames}
-        fmin = {x: 1e-5 * u.Hz for x in detnames}
-        fknee = {x: 0.05 * u.Hz for x in detnames}
-        alpha = {x: 1.0 for x in detnames}
-        NET = {x: 1.0 * u.K * np.sqrt(1.0 * u.second) for x in detnames}
-
-        nse = AnalyticNoise(
-            detectors=detnames,
-            rate=rate,
-            fmin=fmin,
-            fknee=fknee,
-            alpha=alpha,
-            NET=NET,
-        )
-
-        for droot in ["default", "serial"]:
-            nse_file = os.path.join(self.outdir, f"sim_noise_{droot}.h5")
-            with H5File(
-                nse_file, "w", comm=self.comm, force_serial=(droot == "serial")
-            ) as f:
-                nse.save_hdf5(
-                    f.handle, comm=self.comm, force_serial=(droot == "serial")
-                )
-
-        if self.comm is not None:
-            self.comm.barrier()
-
-        for droot in ["default", "serial"]:
-            nse_file = os.path.join(self.outdir, f"sim_noise_{droot}.h5")
-            new_nse = AnalyticNoise()
-            with H5File(nse_file, "r", comm=self.comm) as f:
-                new_nse.load_hdf5(
-                    f.handle, comm=self.comm, force_serial=(droot == "serial")
-                )
+            new_nse = Noise()
+            with H5File(nse_file, "r", comm=ob.comm.comm_group) as f:
+                new_nse.load_hdf5(f.handle, ob)
             self.assertTrue(nse == new_nse)
 
-    def test_noise_weights(self):
-        rate = 200.0 * u.Hz
-        npix = 1
-        ring = 1
-        # NOTE: increase the number here to test performance of huge focalplanes.
-        while 2 * npix <= 2000:
-            npix += 6 * ring
-            ring += 1
-        fp = fake_hexagon_focalplane(
-            n_pix=npix,
-            sample_rate=rate,
-            psd_fmin=1.0e-5 * u.Hz,
-            psd_net=0.05 * u.K * np.sqrt(1 * u.second),
-            psd_fknee=(rate / 2000.0),
-        )
-        nse = fp.noise
-        freqs = {x: nse.freq(x) for i, x in enumerate(nse.keys)}
-        psds = {x: nse.psd(x) for i, x in enumerate(nse.keys)}
-        indices = {x: 100 + i for i, x in enumerate(nse.keys)}
-        model = Noise(
-            detectors=fp.detectors,
-            freqs=freqs,
-            psds=psds,
-            indices=indices,
-            mixmatrix=nse.mixing_matrix,
-        )
-        for d in fp.detectors:
-            wt = model.detector_weight(d)
+        close_data(data)
 
-    def test_noise_corr_weights(self):
-        rate = 200.0 * u.Hz
-        npix = 1
-        ring = 1
-        # NOTE: increase the number here to test performance of huge focalplanes.
-        while 2 * npix <= 2000:
-            npix += 6 * ring
-            ring += 1
-        fp = fake_hexagon_focalplane(
-            n_pix=npix,
-            sample_rate=rate,
-            psd_fmin=1.0e-5 * u.Hz,
-            psd_net=0.05 * u.K * np.sqrt(1 * u.second),
-            psd_fknee=(rate / 2000.0),
-        )
-        nse = fp.noise
-        corr_freqs = {f"noise_{i}": nse.freq(x) for i, x in enumerate(fp.detectors)}
-        corr_psds = {f"noise_{i}": nse.psd(x) for i, x in enumerate(fp.detectors)}
-        corr_indices = {f"noise_{i}": 100 + i for i, x in enumerate(fp.detectors)}
-        corr_mix = dict()
-        ndet = len(fp.detectors)
-        for i, x in enumerate(fp.detectors):
-            if i == 0:
-                corr_mix[x] = {
-                    f"noise_{ndet-1}": 0.25,
-                    f"noise_{i}": 0.5,
-                    f"noise_{i+1}": 0.25,
-                }
-            elif i == ndet - 1:
-                corr_mix[x] = {
-                    f"noise_{i-1}": 0.25,
-                    f"noise_{i}": 0.5,
-                    f"noise_{0}": 0.25,
-                }
-            else:
-                corr_mix[x] = {
-                    f"noise_{i-1}": 0.25,
-                    f"noise_{i}": 0.5,
-                    f"noise_{i+1}": 0.25,
-                }
-        model = Noise(
-            detectors=fp.detectors,
-            freqs=corr_freqs,
-            psds=corr_psds,
-            mixmatrix=corr_mix,
-            indices=corr_indices,
-        )
+    def test_analytic_hdf5(self):
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(self.comm)
 
-        for d in fp.detectors:
-            wt = model.detector_weight(d)
+        for ob in data.obs:
+            detnames = ob.local_detectors
+
+            rate = {x: 10.0 * u.Hz for x in detnames}
+            fmin = {x: 1e-5 * u.Hz for x in detnames}
+            fknee = {x: 0.05 * u.Hz for x in detnames}
+            alpha = {x: 1.0 for x in detnames}
+            NET = {x: 1.0 * u.K * np.sqrt(1.0 * u.second) for x in detnames}
+
+            nse = AnalyticNoise(
+                detectors=detnames,
+                rate=rate,
+                fmin=fmin,
+                fknee=fknee,
+                alpha=alpha,
+                NET=NET,
+            )
+
+            nse_file = os.path.join(self.outdir, f"{ob.name}_sim_noise.h5")
+            with H5File(nse_file, "w", comm=ob.comm.comm_group) as f:
+                nse.save_hdf5(f.handle, ob)
+
+            if ob.comm.comm_group is not None:
+                ob.comm.comm_group.barrier()
+
+            new_nse = AnalyticNoise()
+            with H5File(nse_file, "r", comm=ob.comm.comm_group) as f:
+                new_nse.load_hdf5(f.handle, ob)
+            self.assertTrue(nse == new_nse)
+        close_data(data)
 
     def test_noise_fit(self):
         # Create a fake satellite data set for testing

--- a/src/toast/tests/noise.py
+++ b/src/toast/tests/noise.py
@@ -15,7 +15,7 @@ from ..instrument_sim import fake_hexagon_focalplane
 from ..io import H5File
 from ..noise import Noise
 from ..noise_sim import AnalyticNoise
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 from .ops_noise_estim import plot_noise_estim_compare
 

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -11,6 +11,7 @@ import numpy.testing as nt
 from astropy import units as u
 from pshmem import MPIShared
 
+from .. import ops
 from ..data import Data
 from ..mpi import MPI, Comm
 from ..observation import DetectorData, Observation
@@ -483,6 +484,8 @@ class ObservationTest(MPITestCase):
         np.random.seed(12345)
         rms = 10.0
         data = create_ground_data(self.comm, sample_rate=10 * u.Hz)
+        ops.DefaultNoiseModel().apply(data)
+
         for obs in data.obs:
             n_samp = obs.n_local_samples
             dets = obs.local_detectors

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -18,11 +18,11 @@ from ..observation import DetectorData, Observation
 from ..observation import default_values as defaults
 from ..observation import set_default_values
 from ._helpers import (
+    close_data,
     create_ground_data,
     create_outdir,
     create_satellite_empty,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_cadence_map.py
+++ b/src/toast/tests/ops_cadence_map.py
@@ -16,7 +16,7 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_common_mode_noise.py
+++ b/src/toast/tests/ops_common_mode_noise.py
@@ -13,7 +13,7 @@ from .. import rng as rng
 from ..noise import Noise
 from ..ops.sim_tod_noise import sim_noise_timestream
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_crosslinking.py
+++ b/src/toast/tests/ops_crosslinking.py
@@ -15,7 +15,7 @@ from ..noise import Noise
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -14,7 +14,7 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_elevation_noise.py
+++ b/src/toast/tests/ops_elevation_noise.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from .. import ops as ops
 from ..data import Data
 from ..mpi import MPI
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -19,11 +19,11 @@ from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import read_healpix
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_ground_data,
     create_outdir,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_flag_sso.py
+++ b/src/toast/tests/ops_flag_sso.py
@@ -12,7 +12,7 @@ from .. import qarray as qa
 from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_gainscrambler.py
+++ b/src/toast/tests/ops_gainscrambler.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 
 from .. import ops
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_groundfilter.py
+++ b/src/toast/tests/ops_groundfilter.py
@@ -14,7 +14,7 @@ from ..noise import Noise
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, fake_flags, close_data
+from ._helpers import close_data, create_ground_data, create_outdir, fake_flags
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_hwpfilter.py
+++ b/src/toast/tests/ops_hwpfilter.py
@@ -14,7 +14,7 @@ from ..noise import Noise
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, fake_flags, close_data
+from ._helpers import close_data, create_ground_data, create_outdir, fake_flags
 from .mpi import MPITestCase
 
 
@@ -72,11 +72,11 @@ class HWPFilterTest(MPITestCase):
                 # Check that the filtered signal is cleaner than the input signal
                 if np.std(new_signal[good]) > np.std(old_signal[good]):
                     import pdb
+
                     import matplotlib.pyplot as plt
+
                     pdb.set_trace()
-                self.assertTrue(
-                    np.std(new_signal[good]) < np.std(old_signal[good])
-                )
+                self.assertTrue(np.std(new_signal[good]) < np.std(old_signal[good]))
                 # Check that the flagged samples were also cleaned and not,
                 # for example, set to zero. Use np.diff() to remove any
                 # residual trend

--- a/src/toast/tests/ops_madam.py
+++ b/src/toast/tests/ops_madam.py
@@ -14,11 +14,11 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -18,7 +18,7 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_fake_sky, create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_fake_sky, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_mapmaker_binning.py
+++ b/src/toast/tests/ops_mapmaker_binning.py
@@ -17,7 +17,7 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_mapmaker_solve.py
+++ b/src/toast/tests/ops_mapmaker_solve.py
@@ -14,7 +14,7 @@ from ..observation import default_values as defaults
 from ..ops.mapmaker_solve import SolverLHS, SolverRHS
 from ..templates import AmplitudesMap, Offset
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_mapmaker_utils.py
+++ b/src/toast/tests/ops_mapmaker_utils.py
@@ -13,7 +13,7 @@ from ..mpi import MPI
 from ..noise import Noise
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_memory_counter.py
+++ b/src/toast/tests/ops_memory_counter.py
@@ -8,7 +8,7 @@ import os
 import numpy as np
 
 from .. import ops as ops
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -18,12 +18,12 @@ from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_ground_data,
     create_outdir,
     create_satellite_data,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_perturbhwp.py
+++ b/src/toast/tests/ops_perturbhwp.py
@@ -14,7 +14,7 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_pointing_healpix.py
+++ b/src/toast/tests/ops_pointing_healpix.py
@@ -13,7 +13,7 @@ from .._libtoast import healpix_pixels, stokes_weights
 from ..healpix import HealpixPixels
 from ..intervals import IntervalList, interval_dtype
 from ..observation import default_values as defaults
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_pointing_wcs.py
+++ b/src/toast/tests/ops_pointing_wcs.py
@@ -18,13 +18,13 @@ from ..observation import default_values as defaults
 from ..pixels_io_wcs import write_wcs_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_boresight_telescope,
     create_comm,
     create_fake_sky,
     create_ground_data,
     create_outdir,
     create_space_telescope,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -16,12 +16,12 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_ground_data,
     create_outdir,
     create_satellite_data,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_scan_healpix.py
+++ b/src/toast/tests/ops_scan_healpix.py
@@ -13,11 +13,11 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData
 from ..pixels_io_healpix import write_healpix_fits, write_healpix_hdf5
 from ._helpers import (
+    close_data,
     create_fake_mask,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_scan_map.py
+++ b/src/toast/tests/ops_scan_map.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from .. import ops as ops
 from ..observation import default_values as defaults
 from ..pixels import PixelData
-from ._helpers import create_fake_sky, create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_fake_sky, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_scan_wcs.py
+++ b/src/toast/tests/ops_scan_wcs.py
@@ -13,11 +13,11 @@ from ..observation import default_values as defaults
 from ..pixels import PixelData
 from ..pixels_io_wcs import write_wcs_fits
 from ._helpers import (
+    close_data,
     create_fake_mask,
     create_fake_sky,
     create_ground_data,
     create_outdir,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sim_cosmic_rays.py
+++ b/src/toast/tests/ops_sim_cosmic_rays.py
@@ -13,11 +13,11 @@ from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sim_crosstalk.py
+++ b/src/toast/tests/ops_sim_crosstalk.py
@@ -12,11 +12,11 @@ from ..covariance import covariance_apply
 from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sim_gaindrifts.py
+++ b/src/toast/tests/ops_sim_gaindrifts.py
@@ -15,11 +15,11 @@ from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -21,7 +21,7 @@ from ..pixels_io_healpix import write_healpix_fits
 from ..schedule import GroundSchedule
 from ..schedule_sim_ground import run_scheduler
 from ..vis import set_matplotlib_backend
-from ._helpers import create_comm, create_outdir, plot_projected_quats, close_data
+from ._helpers import close_data, create_comm, create_outdir, plot_projected_quats
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_sim_satellite.py
+++ b/src/toast/tests/ops_sim_satellite.py
@@ -20,7 +20,7 @@ from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..schedule_sim_satellite import create_satellite_schedule
 from ..vis import set_matplotlib_backend
-from ._helpers import create_comm, create_outdir, plot_projected_quats, close_data
+from ._helpers import close_data, create_comm, create_outdir, plot_projected_quats
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -15,7 +15,7 @@ from ..dipole import dipole
 from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_sim_tod_conviqt.py
+++ b/src/toast/tests/ops_sim_tod_conviqt.py
@@ -14,11 +14,11 @@ from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_beam_alm,
     create_fake_sky_alm,
     create_outdir,
     create_satellite_data,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sim_tod_dipole.py
+++ b/src/toast/tests/ops_sim_tod_dipole.py
@@ -13,7 +13,7 @@ from .. import qarray as qa
 from ..dipole import dipole
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_healpix_ring_satellite, create_outdir, close_data
+from ._helpers import close_data, create_healpix_ring_satellite, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_sim_tod_noise.py
+++ b/src/toast/tests/ops_sim_tod_noise.py
@@ -13,7 +13,7 @@ from .. import rng as rng
 from ..noise import Noise
 from ..ops.sim_tod_noise import sim_noise_timestream
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_sim_tod_totalconvolve.py
+++ b/src/toast/tests/ops_sim_tod_totalconvolve.py
@@ -13,12 +13,12 @@ from .. import qarray as qa
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_beam_alm,
     create_fake_sky_alm,
     create_healpix_ring_satellite,
     create_outdir,
     create_satellite_data,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_sss.py
+++ b/src/toast/tests/ops_sss.py
@@ -12,7 +12,7 @@ from .. import qarray as qa
 from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_statistics.py
+++ b/src/toast/tests/ops_statistics.py
@@ -12,7 +12,7 @@ from astropy import units as u
 from .. import ops as ops
 from ..observation import default_values as defaults
 from ..vis import set_matplotlib_backend
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/ops_time_constant.py
+++ b/src/toast/tests/ops_time_constant.py
@@ -15,11 +15,11 @@ from ..noise import Noise
 from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
+    close_data,
     create_fake_sky,
     create_outdir,
     create_satellite_data,
     fake_flags,
-    close_data,
 )
 from .mpi import MPITestCase
 

--- a/src/toast/tests/ops_yield_cut.py
+++ b/src/toast/tests/ops_yield_cut.py
@@ -13,7 +13,7 @@ from .. import ops as ops
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..vis import set_matplotlib_backend
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/pixels.py
+++ b/src/toast/tests/pixels.py
@@ -4,10 +4,10 @@
 
 import os
 
-from astropy import units as u
 import healpy as hp
 import numpy as np
 import numpy.testing as nt
+from astropy import units as u
 
 from .. import pixels_io_healpix as io
 from ..pixels import PixelData, PixelDistribution

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -26,9 +26,9 @@ from . import math_misc as test_math_misc
 from . import noise as test_noise
 from . import observation as test_observation
 from . import ops_cadence_map as test_ops_cadence_map
+from . import ops_common_mode_noise as test_ops_common_mode_noise
 from . import ops_crosslinking as test_ops_crosslinking
 from . import ops_demodulate as test_ops_demodulate
-from . import ops_perturbhwp as test_ops_perturbhwp
 from . import ops_elevation_noise as test_ops_elevation_noise
 from . import ops_filterbin as test_ops_filterbin
 from . import ops_flag_sso as test_ops_flag_sso
@@ -42,6 +42,7 @@ from . import ops_mapmaker_solve as test_ops_mapmaker_solve
 from . import ops_mapmaker_utils as test_ops_mapmaker_utils
 from . import ops_memory_counter as test_ops_memory_counter
 from . import ops_noise_estim as test_ops_noise_estim
+from . import ops_perturbhwp as test_ops_perturbhwp
 from . import ops_pointing_healpix as test_ops_pointing_healpix
 from . import ops_pointing_wcs as test_ops_pointing_wcs
 from . import ops_polyfilter as test_ops_polyfilter
@@ -56,7 +57,6 @@ from . import ops_sim_satellite as test_ops_sim_satellite
 from . import ops_sim_tod_atm as test_ops_sim_tod_atm
 from . import ops_sim_tod_conviqt as test_ops_sim_tod_conviqt
 from . import ops_sim_tod_dipole as test_ops_sim_tod_dipole
-from . import ops_common_mode_noise as test_ops_common_mode_noise
 from . import ops_sim_tod_noise as test_ops_sim_tod_noise
 from . import ops_sim_tod_totalconvolve as test_ops_sim_tod_totalconvolve
 from . import ops_sss as test_ops_sss

--- a/src/toast/tests/spt3g.py
+++ b/src/toast/tests/spt3g.py
@@ -30,7 +30,7 @@ from ..spt3g import (
     to_g3_time,
     to_g3_unit,
 )
-from ._helpers import create_ground_data, create_outdir, close_data
+from ._helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
 if available:

--- a/src/toast/tests/template_fourier2d.py
+++ b/src/toast/tests/template_fourier2d.py
@@ -12,7 +12,7 @@ from .. import ops
 from ..observation import default_values as defaults
 from ..templates import Fourier2D
 from ..utils import rate_from_times
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/template_gain.py
+++ b/src/toast/tests/template_gain.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from .. import ops
 from ..templates import GainTemplate
 from ..utils import rate_from_times
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/template_offset.py
+++ b/src/toast/tests/template_offset.py
@@ -12,7 +12,7 @@ from .. import ops
 from ..observation import default_values as defaults
 from ..templates import Offset
 from ..utils import rate_from_times
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/tests/template_subharmonic.py
+++ b/src/toast/tests/template_subharmonic.py
@@ -12,7 +12,7 @@ from .. import ops
 from ..observation import default_values as defaults
 from ..templates import SubHarmonic
 from ..utils import rate_from_times
-from ._helpers import create_outdir, create_satellite_data, close_data
+from ._helpers import close_data, create_outdir, create_satellite_data
 from .mpi import MPITestCase
 
 

--- a/src/toast/traits.py
+++ b/src/toast/traits.py
@@ -2,15 +2,14 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import collections
 import copy
 import re
-import collections
 from collections import OrderedDict
 
 import traitlets
 from astropy import units as u
 from traitlets import (
-    TraitType,
     Bool,
     Callable,
     Dict,
@@ -21,6 +20,7 @@ from traitlets import (
     List,
     Set,
     TraitError,
+    TraitType,
     Tuple,
     Undefined,
     Unicode,

--- a/src/toast/traits.py
+++ b/src/toast/traits.py
@@ -175,7 +175,10 @@ def list_get_conf(self, obj=None):
     else:
         v = self.get(obj)
         if v is None:
-            val = "None"
+            raise ValueError(
+                "The toast config system does not support None values for List traits."
+            )
+            # val = "None"
         else:
             val = list()
             for item in v:
@@ -199,7 +202,10 @@ def set_get_conf(self, obj=None):
     else:
         v = self.get(obj)
         if v is None:
-            val = "None"
+            raise ValueError(
+                "The toast config system does not support None values for Set traits."
+            )
+            # val = "None"
         else:
             val = set()
             for item in v:
@@ -223,7 +229,10 @@ def dict_get_conf(self, obj=None):
     else:
         v = self.get(obj)
         if v is None:
-            val = "None"
+            raise ValueError(
+                "The toast config system does not support None values for Dict traits."
+            )
+            # val = "None"
         else:
             val = dict()
             for k, v in v.items():
@@ -247,7 +256,10 @@ def tuple_get_conf(self, obj=None):
     else:
         v = self.get(obj)
         if v is None:
-            val = "None"
+            raise ValueError(
+                "The toast config system does not support None values for Tuple traits."
+            )
+            # val = "None"
         else:
             val = list()
             for item in v:

--- a/src/toast/weather.py
+++ b/src/toast/weather.py
@@ -65,23 +65,29 @@ class Weather(object):
     def __eq__(self, other):
         if self._time_val != other._time_val:
             return False
-        if self._ice_water_val != other._ice_water_val:
+        if not np.isclose(self._ice_water_val.value, other._ice_water_val.value):
             return False
-        if self._liquid_water_val != other._liquid_water_val:
+        if not np.isclose(self._liquid_water_val.value, other._liquid_water_val.value):
             return False
-        if self._pwv_val != other._pwv_val:
+        if not np.isclose(self._pwv_val.value, other._pwv_val.value):
             return False
-        if self._humidity_val != other._humidity_val:
+        if not np.isclose(self._humidity_val.value, other._humidity_val.value):
             return False
-        if self._surface_pressure_val != other._surface_pressure_val:
+        if not np.isclose(
+            self._surface_pressure_val.value, other._surface_pressure_val.value
+        ):
             return False
-        if self._surface_temperature_val != other._surface_temperature_val:
+        if not np.isclose(
+            self._surface_temperature_val.value, other._surface_temperature_val.value
+        ):
             return False
-        if self._air_temperature_val != other._air_temperature_val:
+        if not np.isclose(
+            self._air_temperature_val.value, other._air_temperature_val.value
+        ):
             return False
-        if self._west_wind_val != other._west_wind_val:
+        if not np.isclose(self._west_wind_val.value, other._west_wind_val.value):
             return False
-        if self._south_wind_val != other._south_wind_val:
+        if not np.isclose(self._south_wind_val.value, other._south_wind_val.value):
             return False
         return True
 
@@ -489,6 +495,14 @@ class SimWeather(Weather):
             return False
         if self.median_weather != other.median_weather:
             return False
+        if self._max_pwv is None:
+            if other._max_pwv is not None:
+                return False
+        else:
+            if other._max_pwv is None:
+                return False
+            if not np.isclose(self._max_pwv.value, other._max_pwv.value):
+                return False
         return True
 
     def __ne__(self, other):

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -504,6 +504,11 @@ def simulate_data(args, job, toast_comm, telescope, schedule):
 
     log.info_rank("Simulated data in", comm=world_comm, timer=timer_sim)
 
+    # Add gain errors
+
+    ops.gain_scrambler.apply(data)
+    log.info_rank("  Simulated gain errors in", comm=world_comm, timer=timer)
+
     # Optionally write out the data
     if ops.save_hdf5.volume is None:
         ops.save_hdf5.volume = os.path.join(args.out_dir, "data")
@@ -813,6 +818,7 @@ def main():
         toast.ops.TimeConstant(
             name="convolve_time_constant", deconvolve=False, enabled=False
         ),
+        toast.ops.GainScrambler(name="gain_scrambler", enabled=False),
         toast.ops.SaveHDF5(name="save_hdf5", enabled=False),
         toast.ops.SimNoise(name="sim_noise"),
         toast.ops.PixelsHealpix(name="pixels_healpix_radec"),


### PR DESCRIPTION
* Remove the internal noise model from the focalplane class. Focalplanes have information about all detectors (not only the locally stored ones).

* Add methods to the Noise base class and the AnalyticNoise derived class to handle gather / scatter / redistribution of noise model data.

* Update the hdf5 I/O methods to use these new functions for when reading / writing.

* When redistributing observations, any metadata objects that define a redistribute() method will have that called.

* Update ElevationNoise, NoiseEstim, and FitNoiseModel operators to match the API changes to the noise model.

* Fix warnings throughout the code due to the use of "np.int", "np.int_", and "np.float" types.