### PR TITLE
Conviqt tweaks

### DIFF
--- a/src/toast/ops/common_mode_noise.py
+++ b/src/toast/ops/common_mode_noise.py
@@ -114,8 +114,6 @@ class CommonModeNoise(Operator):
                 raise RuntimeError(msg)
             focalplane = obs.telescope.focalplane
             fsample = focalplane.sample_rate.to_value(u.Hz)
-            freqs = np.linspace(0, fsample / 2, 10000)
-            freqs[0] = 1e-6
 
             # Check that the noise model exists
             if self.noise_model not in obs:
@@ -126,6 +124,8 @@ class CommonModeNoise(Operator):
                 raise RuntimeError(msg)
 
             noise = obs[self.noise_model]
+            # The noise simulation tools require frequencies to agree
+            freqs = noise.freq(noise.keys[0]).to_value(u.Hz)
 
             # Find the unique values of focalplane keys
 

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -771,7 +771,6 @@ class SimTEBConviqt(SimConviqt):
                     det_dict[key] = focalplane[det][key]
                 det_dict["detector"] = det
                 det_dict["mc"] = self.mc
-                print(f"Det Dict for {det}: {det_dict}")
             else:
                 det_dict = None
             det_dict = self.comm.bcast(det_dict, root=source)
@@ -790,7 +789,6 @@ class SimTEBConviqt(SimConviqt):
                 beam_file = self.beam_file_dict[det]
             else:
                 beam_file = self.beam_file.format(**det_dict)
-            print(f"Loading beam for {det} from {beam_file}", flush=True)  # DEBUG
 
             beam_T, beam_P = self.get_TP_beam(beam_file, det, verbose)
 

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -173,7 +173,7 @@ class NoiseEstim(Operator):
     )
 
     pairs = List(
-        default_value=None,
+        # default_value=None,
         trait=Tuple,
         allow_none=True,
         help="Detector pairs to estimate noise for.  Overrides `nosingle` and `nocross`",

--- a/src/toast/traits.py
+++ b/src/toast/traits.py
@@ -175,9 +175,10 @@ def list_get_conf(self, obj=None):
     else:
         v = self.get(obj)
         if v is None:
-            raise ValueError(
-                "The toast config system does not support None values for List traits."
-            )
+            msg = f"The toast config system does not support None values for " \
+                  f"List traits. " \
+                  f"Failed to parse '{self.name}' : '{self.help}'"
+            raise ValueError(msg)
             # val = "None"
         else:
             val = list()


### PR DESCRIPTION
Make the use of the conviqt TEB operator more intuitive: the beam and sky components are now synthesized automatically rather than having the user do it.

The PR also changes the way the beam file names are synthesized. Users can use any focalplane attributes in the file name and they automatically get replaced with the corresponding values in the file path.