### PR TITLE
Clean up use of container traits.

### DIFF
--- a/src/toast/ops/arithmetic.py
+++ b/src/toast/ops/arithmetic.py
@@ -6,7 +6,7 @@ import traitlets
 
 from ..mpi import MPI
 from ..timing import function_timer
-from ..traits import Int, List, Unicode, trait_docs
+from ..traits import Int, Unicode, trait_docs
 from ..utils import Logger, unit_conversion
 from .operator import Operator
 

--- a/src/toast/ops/cadence_map.py
+++ b/src/toast/ops/cadence_map.py
@@ -17,7 +17,7 @@ from ..data import Data
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Instance, Int, Unicode, trait_docs
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
 from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 from .pointing import BuildPixelDistribution

--- a/src/toast/ops/common_mode_noise.py
+++ b/src/toast/ops/common_mode_noise.py
@@ -14,7 +14,7 @@ from ..noise import Noise
 from ..noise_sim import AnalyticNoise
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Float, Int, Quantity, Unicode, trait_docs
 from ..utils import Environment, Logger, name_UID
 from .operator import Operator
 

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -190,8 +190,7 @@ class SimConviqt(Operator):
     )
 
     sky_file_dict = Dict(
-        None,
-        allow_none=True,
+        {},
         help="Dictionary of files containing the sky a_lm expansions. An entry for "
         "each detector name must be present. If provided, supersedes `sky_file`.",
     )
@@ -204,8 +203,7 @@ class SimConviqt(Operator):
     )
 
     beam_file_dict = Dict(
-        None,
-        allow_none=True,
+        {},
         help="Dictionary of files containing the beam a_lm expansions. An entry for "
         "each detector name must be present. If provided, supersedes `beam_file`.",
     )

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -6,7 +6,7 @@ import traitlets
 
 from ..mpi import MPI
 from ..timing import function_timer
-from ..traits import Int, List, Unicode, trait_docs
+from ..traits import Int, List, trait_docs
 from ..utils import Logger
 from .operator import Operator
 
@@ -26,29 +26,20 @@ class Copy(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
-    meta = List(
-        None, allow_none=True, help="List of tuples of Observation meta keys to copy"
-    )
+    meta = List([], help="List of tuples of Observation meta keys to copy")
 
-    detdata = List(
-        None, allow_none=True, help="List of tuples of Observation detdata keys to copy"
-    )
+    detdata = List([], help="List of tuples of Observation detdata keys to copy")
 
-    shared = List(
-        None, allow_none=True, help="List of tuples of Observation shared keys to copy"
-    )
+    shared = List([], help="List of tuples of Observation shared keys to copy")
 
     intervals = List(
-        None,
-        allow_none=True,
+        [],
         help="List of tuples of Observation intervals keys to copy",
     )
 
     @traitlets.validate("meta")
     def _check_meta(self, proposal):
         val = proposal["value"]
-        if val is None:
-            return val
         for v in val:
             if not isinstance(v, (tuple, list)):
                 raise traitlets.TraitError("trait should be a list of tuples")
@@ -61,8 +52,6 @@ class Copy(Operator):
     @traitlets.validate("detdata")
     def _check_detdata(self, proposal):
         val = proposal["value"]
-        if val is None:
-            return val
         for v in val:
             if not isinstance(v, (tuple, list)):
                 raise traitlets.TraitError("trait should be a list of tuples")
@@ -75,8 +64,6 @@ class Copy(Operator):
     @traitlets.validate("shared")
     def _check_shared(self, proposal):
         val = proposal["value"]
-        if val is None:
-            return val
         for v in val:
             if not isinstance(v, (tuple, list)):
                 raise traitlets.TraitError("trait should be a list of tuples")
@@ -93,25 +80,23 @@ class Copy(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
         for ob in data.obs:
-            if self.meta is not None:
-                for in_key, out_key in self.meta:
-                    if out_key in ob:
-                        # The key exists- issue a warning before overwriting.
-                        msg = "Observation key {} already exists- overwriting".format(
-                            out_key
-                        )
-                        log.warning(msg)
-                    ob[out_key] = ob[in_key]
-
-            if self.shared is not None:
-                for in_key, out_key in self.shared:
-                    # Although this is an internal function, the input arguments come
-                    # from existing shared objects and so should already be valid.
-                    ob.shared.assign_mpishared(
-                        out_key, ob.shared[in_key], ob.shared.comm_type(in_key)
+            for in_key, out_key in self.meta:
+                if out_key in ob:
+                    # The key exists- issue a warning before overwriting.
+                    msg = "Observation key {} already exists- overwriting".format(
+                        out_key
                     )
+                    log.warning(msg)
+                ob[out_key] = ob[in_key]
 
-            if self.detdata is not None:
+            for in_key, out_key in self.shared:
+                # Although this is an internal function, the input arguments come
+                # from existing shared objects and so should already be valid.
+                ob.shared.assign_mpishared(
+                    out_key, ob.shared[in_key], ob.shared.comm_type(in_key)
+                )
+
+            if len(self.detdata) > 0:
                 # Get the detectors we are using for this observation
                 dets = ob.select_local_detectors(detectors)
                 if len(dets) == 0:

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -14,7 +14,7 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..pixels_io_healpix import write_healpix_fits
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Unicode, Unit, trait_docs
+from ..traits import Bool, Instance, Int, Unicode, Unit, trait_docs
 from ..utils import Logger
 from .copy import Copy
 from .delete import Delete

--- a/src/toast/ops/delete.py
+++ b/src/toast/ops/delete.py
@@ -5,7 +5,7 @@
 import traitlets
 
 from ..timing import function_timer
-from ..traits import Int, List, Unicode, trait_docs
+from ..traits import Int, List, trait_docs
 from ..utils import Logger
 from .operator import Operator
 
@@ -23,21 +23,14 @@ class Delete(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
-    meta = List(
-        None, allow_none=True, help="List of Observation dictionary keys to delete"
-    )
+    meta = List([], help="List of Observation dictionary keys to delete")
 
-    detdata = List(
-        None, allow_none=True, help="List of Observation detdata keys to delete"
-    )
+    detdata = List([], help="List of Observation detdata keys to delete")
 
-    shared = List(
-        None, allow_none=True, help="List of Observation shared keys to delete"
-    )
+    shared = List([], help="List of Observation shared keys to delete")
 
     intervals = List(
-        None,
-        allow_none=True,
+        [],
         help="List of tuples of Observation intervals keys to delete",
     )
 
@@ -48,24 +41,20 @@ class Delete(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
         for ob in data.obs:
-            if self.detdata is not None:
-                for key in self.detdata:
-                    # This ignores non-existant keys
-                    del ob.detdata[key]
-            if self.shared is not None:
-                for key in self.shared:
-                    # This ignores non-existant keys
-                    del ob.shared[key]
-            if self.intervals is not None:
-                for key in self.intervals:
-                    # This ignores non-existant keys
-                    del ob.intervals[key]
-            if self.meta is not None:
-                for key in self.meta:
-                    try:
-                        del ob[key]
-                    except KeyError:
-                        pass
+            for key in self.detdata:
+                # This ignores non-existant keys
+                del ob.detdata[key]
+            for key in self.shared:
+                # This ignores non-existant keys
+                del ob.shared[key]
+            for key in self.intervals:
+                # This ignores non-existant keys
+                del ob.intervals[key]
+            for key in self.meta:
+                try:
+                    del ob[key]
+                except KeyError:
+                    pass
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -21,7 +21,7 @@ from ..noise import Noise
 from ..observation import Observation
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Instance, Int, Quantity, Unicode, trait_docs
 from ..utils import GlobalTimers, Logger, Timer, dtype_to_aligned, name_UID
 from .operator import Operator
 

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -15,7 +15,7 @@ from ..noise import Noise
 from ..noise_sim import AnalyticNoise
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -5,10 +5,9 @@
 import numpy as np
 import traitlets
 
-from .. import qarray as qa
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Int, List, Unicode, trait_docs
+from ..traits import Int, List, Unicode, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 
@@ -28,9 +27,7 @@ class FlagIntervals(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
-    view_mask = List(
-        None, allow_none=True, help="List of tuples of (view name, bit mask)"
-    )
+    view_mask = List([], help="List of tuples of (view name, bit mask)")
 
     shared_flags = Unicode(
         defaults.shared_flags,
@@ -65,13 +62,16 @@ class FlagIntervals(Operator):
         log = Logger.get()
 
         if self.shared_flags is None:
-            if data.comm.world_rank == 0:
-                log.debug("shared_flags trait is None, nothing to do.")
+            log.debug_rank(
+                "shared_flags trait is None, nothing to do.", comm=data.comm.comm_world
+            )
             return
 
         if self.view_mask is None or len(self.view_mask) == 0:
-            if data.comm.world_rank == 0:
-                log.debug("view_mask trait is empty or not set, nothing to do.")
+            log.debug_rank(
+                "view_mask trait is empty or not set, nothing to do.",
+                comm=data.comm.world_comm,
+            )
             return
 
         fdtype = None

--- a/src/toast/ops/flag_sso.py
+++ b/src/toast/ops/flag_sso.py
@@ -51,16 +51,12 @@ class FlagSSO(Operator):
     det_flag_mask = Int(defaults.det_mask_sso, help="Bit mask to raise flags with")
 
     sso_names = List(
-        # default_value=["Sun", "Moon"],
-        trait=Unicode,
-        allow_none=True,
+        [],
         help="Names of the SSOs, must be recognized by pyEphem",
     )
 
     sso_radii = List(
-        # default_value=[45.0 * u.deg, 5.0 * u.deg],
-        trait=Quantity,
-        allow_none=True,
+        [],
         help="Radii around the sources to flag",
     )
 
@@ -99,16 +95,16 @@ class FlagSSO(Operator):
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
-        env = Environment.get()
         log = Logger.get()
-
-        for trait in "sso_names", "sso_radii":
-            if getattr(self, trait) is None:
-                msg = f"You must set the '{trait}' trait before calling exec()"
-                raise RuntimeError(msg)
 
         if len(self.sso_names) != len(self.sso_radii):
             raise RuntimeError("Each SSO must have a radius")
+
+        if len(self.sso_names) == 0:
+            log.debug_rank(
+                "Empty sso_names, nothing to flag", comm=data.comm.comm_world
+            )
+            return
 
         self.ssos = []
         for sso_name in self.sso_names:

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -14,7 +14,7 @@ from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Int, Unicode, trait_docs
 from ..utils import Environment, Logger, Timer
 from .operator import Operator
 

--- a/src/toast/ops/hwpfilter.py
+++ b/src/toast/ops/hwpfilter.py
@@ -13,7 +13,7 @@ from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Int, Unicode, trait_docs
 from ..utils import Environment, Logger, Timer
 from .operator import Operator
 

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -37,13 +37,13 @@ class LoadHDF5(Operator):
     # FIXME:  We should add a filtering mechanism here to load a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
-    meta = List(list(), help="Only load this list of meta objects")
+    meta = List([], help="Only load this list of meta objects")
 
-    detdata = List(list(), help="Only load this list of detdata objects")
+    detdata = List([], help="Only load this list of detdata objects")
 
-    shared = List(list(), help="Only load this list of shared objects")
+    shared = List([], help="Only load this list of shared objects")
 
-    intervals = List(list(), help="Only load this list of intervals objects")
+    intervals = List([], help="Only load this list of intervals objects")
 
     sort_by_size = Bool(
         False, help="If True, sort observations by size before load balancing"

--- a/src/toast/ops/load_spt3g.py
+++ b/src/toast/ops/load_spt3g.py
@@ -11,7 +11,7 @@ import traitlets
 from ..dist import distribute_discrete
 from ..spt3g import available
 from ..timing import function_timer
-from ..traits import Bool, Instance, Int, Unicode, trait_docs
+from ..traits import Instance, Int, Unicode, trait_docs
 from ..utils import Logger
 from .operator import Operator
 

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -117,7 +117,7 @@ class Madam(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
-    params = Dict(dict(), help="Parameters to pass to madam")
+    params = Dict({}, help="Parameters to pass to madam")
 
     paramfile = Unicode(
         None, allow_none=True, help="Read madam parameters from this file"

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -7,17 +7,15 @@ import traitlets
 from astropy import units as u
 
 from ..observation import default_values as defaults
-from ..pixels import PixelData, PixelDistribution
 from ..templates import AmplitudesMap
 from ..timing import Timer, function_timer
-from ..traits import Bool, Instance, Int, Unicode, Unit, trait_docs
+from ..traits import Instance, Int, Unicode, Unit, trait_docs
 from ..utils import Logger
 from .copy import Copy
 from .delete import Delete
 from .noise_weight import NoiseWeight
 from .operator import Operator
 from .pipeline import Pipeline
-from .reset import Reset
 from .scan_map import ScanMap
 
 

--- a/src/toast/ops/mapmaker_templates.py
+++ b/src/toast/ops/mapmaker_templates.py
@@ -37,9 +37,7 @@ class TemplateMatrix(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
-    templates = List(
-        None, allow_none=True, help="This should be a list of Template instances"
-    )
+    templates = List([], help="This should be a list of Template instances")
 
     amplitudes = Unicode(None, allow_none=True, help="Data key for template amplitudes")
 
@@ -70,8 +68,6 @@ class TemplateMatrix(Operator):
     @traitlets.validate("templates")
     def _check_templates(self, proposal):
         temps = proposal["value"]
-        if temps is None:
-            return temps
         for tp in temps:
             if not isinstance(tp, Template):
                 raise traitlets.TraitError(
@@ -178,6 +174,13 @@ class TemplateMatrix(Operator):
             raise RuntimeError(
                 "You must set the amplitudes trait before calling exec()"
             )
+
+        if len(self.templates) == 0:
+            log.debug_rank(
+                "No templates in TemplateMatrix, nothing to do",
+                comm=data.comm.comm_world,
+            )
+            return
 
         # On the first call, we initialize all templates using the Data instance and
         # the fixed options for view, flagging, etc.

--- a/src/toast/ops/memory_counter.py
+++ b/src/toast/ops/memory_counter.py
@@ -35,6 +35,7 @@ class MemoryCounter(Operator):
 
     def __init__(self, **kwargs):
         self.total_bytes = 0
+        self.sys_mem_str = ""
         super().__init__(**kwargs)
 
     @function_timer

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -23,7 +23,6 @@ from ..observation import default_values as defaults
 from ..timing import function_timer
 from ..traits import (
     Bool,
-    Dict,
     Instance,
     Int,
     List,
@@ -173,9 +172,7 @@ class NoiseEstim(Operator):
     )
 
     pairs = List(
-        # default_value=None,
-        trait=Tuple,
-        allow_none=True,
+        [],
         help="Detector pairs to estimate noise for.  Overrides `nosingle` and `nocross`",
     )
 
@@ -303,7 +300,7 @@ class NoiseEstim(Operator):
         # this block of code to working on a data view with a single observation
         # that is already re-distributed below.
         if self.focalplane_key is not None:
-            if self.pairs is not None:
+            if len(self.pairs) > 0:
                 msg = "focalplane_key is not compatible with pairs"
                 raise RuntimeError(msg)
             # Measure the averages of the signal across the focalplane.
@@ -374,7 +371,7 @@ class NoiseEstim(Operator):
                 det2key = None
                 det_names = obs.all_detectors
                 ndet = len(det_names)
-                if self.pairs is not None:
+                if len(self.pairs) > 0:
                     pairs = self.pairs
                 else:
                     # Construct a list of detector pairs

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -10,7 +10,7 @@ from scipy.optimize import curve_fit, least_squares
 from ..noise import Noise
 from ..noise_sim import AnalyticNoise
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Int, Quantity, Unicode, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/noise_weight.py
+++ b/src/toast/ops/noise_weight.py
@@ -7,7 +7,7 @@ import traitlets
 
 from ..noise_sim import AnalyticNoise
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Int, Unicode, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/pointing.py
+++ b/src/toast/ops/pointing.py
@@ -7,7 +7,7 @@ import traitlets
 
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..traits import Bool, Instance, Int, Unicode, trait_docs
 from ..utils import Logger
 from .delete import Delete
 from .operator import Operator

--- a/src/toast/ops/polyfilter.py
+++ b/src/toast/ops/polyfilter.py
@@ -16,7 +16,7 @@ from .._libtoast import filter_poly2D, filter_polynomial, subtract_mean, sum_det
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Int, Unicode, trait_docs
 from ..utils import (
     AlignedF64,
     AlignedU8,

--- a/src/toast/ops/run_spt3g.py
+++ b/src/toast/ops/run_spt3g.py
@@ -7,7 +7,7 @@ import traitlets
 
 from ..spt3g import available
 from ..timing import function_timer
-from ..traits import Bool, Instance, Int, List, Unicode, trait_docs
+from ..traits import Instance, Int, List, trait_docs
 from ..utils import Logger
 from .operator import Operator
 
@@ -45,7 +45,7 @@ class RunSpt3g(Operator):
     )
 
     modules = List(
-        list(),
+        [],
         help="List of tuples of (callable, **kwargs) that will passed to G3Pipeline.Add()",
     )
 
@@ -89,7 +89,9 @@ class RunSpt3g(Operator):
             )
 
         if len(self.modules) == 0:
-            # Nothing to do!
+            log.debug_rank(
+                "No modules specified, nothing to do.", comm=data.comm.comm_world
+            )
             return
 
         n_obs = len(data.obs)

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -32,17 +32,17 @@ class SaveHDF5(Operator):
     # FIXME:  We should add a filtering mechanism here to dump a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
-    meta = List(list(), allow_none=True, help="Only save this list of meta objects")
+    meta = List([], allow_none=True, help="Only save this list of meta objects")
 
-    detdata = List(list(), help="Only save this list of detdata objects")
+    detdata = List([], help="Only save this list of detdata objects")
 
-    shared = List(list(), help="Only save this list of shared objects")
+    shared = List([], help="Only save this list of shared objects")
 
-    intervals = List(list(), help="Only save this list of intervals objects")
+    intervals = List([], help="Only save this list of intervals objects")
 
     times = Unicode(defaults.times, help="Observation shared key for timestamps")
 
-    config = Dict(dict(), help="Write this job config to the file")
+    config = Dict({}, help="Write this job config to the file")
 
     force_serial = Bool(
         False, help="Use serial HDF5 operations, even if parallel support available"

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -10,7 +10,7 @@ from scipy import interpolate, signal
 from .. import rng
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Callable, Float, Int, Quantity, Unicode, Unit, trait_docs
+from ..traits import Bool, Float, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/sim_crosstalk.py
+++ b/src/toast/ops/sim_crosstalk.py
@@ -10,7 +10,7 @@ from .. import rng
 from ..noise_sim import AnalyticNoise
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
-from ..traits import Bool, Float, Instance, Int, Unicode, Unit, trait_docs
+from ..traits import Float, Int, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger
 from .operator import Operator
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -220,7 +220,7 @@ class SimGround(Operator):
 
     elnod_end = Bool(False, help="Perform an el-nod after the scan")
 
-    elnods = List(list(), help="List of relative el_nods")
+    elnods = List([], help="List of relative el_nods")
 
     elnod_every_scan = Bool(False, help="Perform el nods every scan")
 

--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from .. import rng
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
-from ..traits import Bool, Dict, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Int, Quantity, Unicode, trait_docs
 from ..utils import GlobalTimers, Logger, Timer, dtype_to_aligned, name_UID
 from .operator import Operator
 

--- a/src/toast/ops/sim_tod_atm_generate.py
+++ b/src/toast/ops/sim_tod_atm_generate.py
@@ -17,7 +17,7 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..observation_dist import global_interval_times
 from ..timing import GlobalTimers, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Float, Int, Quantity, Unicode, trait_docs
 from ..utils import Environment, Logger, Timer
 from .operator import Operator
 

--- a/src/toast/ops/sim_tod_atm_observe.py
+++ b/src/toast/ops/sim_tod_atm_observe.py
@@ -16,7 +16,7 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..observation_dist import global_interval_times
 from ..timing import GlobalTimers, function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, Unit, trait_docs
+from ..traits import Bool, Float, Int, Quantity, Unicode, Unit, trait_docs
 from ..utils import Environment, Logger, Timer, unit_conversion
 from .operator import Operator
 

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -18,11 +18,9 @@ from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
 from ..traits import (
-    Bool,
     Float,
     Instance,
     Int,
-    List,
     Quantity,
     Unicode,
     Unit,

--- a/src/toast/ops/statistics.py
+++ b/src/toast/ops/statistics.py
@@ -16,7 +16,7 @@ from .. import qarray as qa
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Int, Unicode, trait_docs
 from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 

--- a/src/toast/ops/time_constant.py
+++ b/src/toast/ops/time_constant.py
@@ -12,7 +12,7 @@ from ..fft import FFTPlanReal1DStore
 from ..mpi import MPI, Comm, MPI_Comm, use_mpi
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Dict, Float, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Float, Int, Quantity, Unicode, trait_docs
 from ..utils import Environment, GlobalTimers, Logger, Timer, dtype_to_aligned
 from .operator import Operator
 

--- a/src/toast/ops/yield_cut.py
+++ b/src/toast/ops/yield_cut.py
@@ -15,7 +15,7 @@ from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..traits import Bool, Float, Int, Unicode, trait_docs
 from ..utils import Environment, Logger, Timer, name_UID
 from .operator import Operator
 


### PR DESCRIPTION
Although container traits (List, Set, Tuple, Dict) formally support None values, it is challenging to distinguish between this and empty containers when passing things through the config dictionary to/from files on disk.  Because of that, we internally enforce these trait types to not have None values.  This work cleans up all operators to conform.  Additionally, there were 3 List trait definitions that tried to enforce the type of the elements with the "trait=" syntax. That caused further issues and these were removed.  In practice we check the container elements already later in the code.