### PR TITLE
Add general support for compression of DetectorData

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,31 @@ find_package(AATM)
 
 find_package(SuiteSparse)
 
+# We require libFLAC >= 1.4.0 for 32bit integer support
+set(USE_FLAC FALSE)
+if(DISABLE_FLAC)
+    message(STATUS "FLAC support disabled")
+else()
+    find_package(FLAC)
+    if(FLAC_FOUND)
+        string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\..*" "\\1" FLAC_MAJ_VERSION "${FLAC_VERSION}")
+        string(REGEX REPLACE "^[0-9]+\\.([0-9]+)\\..*" "\\1" FLAC_MIN_VERSION "${FLAC_VERSION}")
+        if(FLAC_MAJ_VERSION GREATER 1)
+            # Future proofing
+            message(STATUS "Found FLAC version ${FLAC_VERSION}, enabling support")
+            set(USE_FLAC TRUE)
+        else()
+            if(FLAC_MIN_VERSION GREATER_EQUAL 4)
+                message(STATUS "Found FLAC version ${FLAC_VERSION}, enabling support")
+                set(USE_FLAC TRUE)
+            endif()
+        endif()
+    endif()
+    if(NOT USE_FLAC)
+        message(STATUS "Did not find FLAC >= 1.4.0")
+    endif()
+endif()
+
 find_package(PythonInterp REQUIRED)
 
 # Internal products

--- a/cmake/FindFLAC.cmake
+++ b/cmake/FindFLAC.cmake
@@ -1,0 +1,66 @@
+# - Find FLAC
+# Find the native FLAC includes and libraries
+#
+#  FLAC_INCLUDE_DIRS - where to find FLAC headers.
+#  FLAC_LIBRARIES    - List of libraries when using libFLAC.
+#  FLAC_FOUND        - True if libFLAC found.
+#  FLAC_DEFINITIONS  - FLAC compile definitons 
+
+if (FLAC_INCLUDE_DIR)
+    # Already in cache, be silent
+    set (FLAC_FIND_QUIETLY TRUE)
+endif ()
+
+find_package (Ogg QUIET)
+
+find_package (PkgConfig QUIET)
+pkg_check_modules(PC_FLAC QUIET flac)
+
+set(FLAC_VERSION ${PC_FLAC_VERSION})
+
+find_path (FLAC_INCLUDE_DIR FLAC/stream_decoder.h
+	HINTS
+		${PC_FLAC_INCLUDEDIR}
+		${PC_FLAC_INCLUDE_DIRS}
+		${FLAC_ROOT}
+	)
+
+# MSVC built libraries can name them *_static, which is good as it
+# distinguishes import libraries from static libraries with the same extension.
+find_library (FLAC_LIBRARY
+	NAMES
+		FLAC
+		libFLAC
+		libFLAC_dynamic
+		libFLAC_static
+	HINTS
+		${PC_FLAC_LIBDIR}
+		${PC_FLAC_LIBRARY_DIRS}
+		${FLAC_ROOT}
+	)
+
+# Handle the QUIETLY and REQUIRED arguments and set FLAC_FOUND to TRUE if
+# all listed variables are TRUE.
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args (FLAC
+	REQUIRED_VARS
+		FLAC_LIBRARY
+		FLAC_INCLUDE_DIR
+	VERSION_VAR
+        FLAC_VERSION
+	)
+
+if (FLAC_FOUND)
+	set (FLAC_INCLUDE_DIRS ${FLAC_INCLUDE_DIR})
+	set (FLAC_LIBRARIES ${FLAC_LIBRARY} ${OGG_LIBRARIES})
+    if (NOT TARGET FLAC::FLAC)
+		add_library(FLAC::FLAC UNKNOWN IMPORTED)
+		set_target_properties(FLAC::FLAC PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES "${FLAC_INCLUDE_DIR}"
+			IMPORTED_LOCATION "${FLAC_LIBRARY}"
+			INTERFACE_LINK_LIBRARIES Ogg::ogg
+			)
+	endif ()
+endif ()
+
+mark_as_advanced(FLAC_INCLUDE_DIR FLAC_LIBRARY)

--- a/cmake/FindFLAC.cmake
+++ b/cmake/FindFLAC.cmake
@@ -1,3 +1,12 @@
+# Copied without modification from libsndfile 
+# (https://github.com/libsndfile/libsndfile)
+#
+# (C) Erik de Castro Lopo <erikd@mega-nerd.com>
+#
+# Released under LGPL v2.1
+# https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+#
+#
 # - Find FLAC
 # Find the native FLAC includes and libraries
 #

--- a/etc/flac_test/Makefile
+++ b/etc/flac_test/Makefile
@@ -1,3 +1,6 @@
+# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
 
 CXX := g++
 CXXFLAGS := -O0 -g -fPIC -I/home/kisner/software/conda/envs/toast/include

--- a/etc/flac_test/Makefile
+++ b/etc/flac_test/Makefile
@@ -1,0 +1,10 @@
+
+CXX := g++
+CXXFLAGS := -O0 -g -fPIC -I/home/kisner/software/conda/envs/toast/include
+
+flac_test : main.cpp
+	$(CXX) $(CXXFLAGS) -o flac_test main.cpp -lFLAC -lm
+
+clean :
+	rm -f flac_test *.o
+

--- a/etc/flac_test/main.cpp
+++ b/etc/flac_test/main.cpp
@@ -1,0 +1,342 @@
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstring>
+#include <algorithm>
+
+#include <random>
+#include <vector>
+#include <unordered_map>
+#include <map>
+#include <limits>
+
+#include <FLAC/stream_encoder.h>
+#include <FLAC/stream_decoder.h>
+
+
+void fake_data(std::vector <int32_t> & data) {
+    std::random_device dev;
+    std::mt19937 rng(dev());
+
+    int32_t max = std::numeric_limits<int32_t>::max() / 2;
+    int32_t min = -max;
+    std::uniform_int_distribution<std::mt19937::result_type> dist(min, max);
+
+    for (auto & p : data) {
+        p = dist(rng);
+    }
+    return;
+}
+
+
+
+typedef struct {
+    std::vector <uint8_t> * compressed;
+} enc_write_callback_data;
+
+
+FLAC__StreamEncoderWriteStatus enc_write_callback(
+    const FLAC__StreamEncoder *encoder, 
+    const FLAC__byte buffer[], 
+    size_t bytes, 
+    uint32_t samples, 
+    uint32_t current_frame, 
+    void *client_data
+) {
+    enc_write_callback_data * data = (enc_write_callback_data *)client_data;
+    std::cerr << "Encode frame " << current_frame << " got " << bytes << " bytes for " << samples << " samples" << std::endl;
+    data->compressed->insert(
+        data->compressed->end(), 
+        buffer, 
+        buffer + bytes
+    );
+    return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
+}
+
+
+void encode_flac(
+    std::vector <int32_t> const & data, 
+    std::vector <uint8_t> & bytes,
+    std::vector <int64_t> & offsets,
+    uint32_t level, 
+    int64_t stride
+) {
+    // If stride is specified, check consistency.
+    int64_t n_sub;
+    if (stride > 0) {
+        if (data.size() % stride != 0) {
+            std::cerr << "Stride " << stride << " does not evenly divide into " << data.size() << std::endl;
+            return;
+        }
+        n_sub = (int64_t)(data.size() / stride);
+    } else {
+        n_sub = 1;
+        stride = data.size();
+    }
+    offsets.resize(n_sub);
+    bytes.clear();
+
+    enc_write_callback_data write_callback_data;
+    write_callback_data.compressed = &bytes;
+
+    // settings
+
+    bool success;
+
+    FLAC__StreamEncoderInitStatus status;
+
+    FLAC__StreamEncoder * encoder;
+
+    for (int64_t sub = 0; sub < n_sub; ++sub) {
+        offsets[sub] = bytes.size();
+
+        std::cerr << "Encoding " << stride << " samples at byte offset " << offsets[sub] << " starting at data element " << (sub * stride) << std::endl;
+
+        encoder = FLAC__stream_encoder_new();
+
+        success = FLAC__stream_encoder_set_compression_level(encoder, level);
+        if (! success) {
+            std::cerr << "Failed to set compression level" << std::endl;
+            return;
+        }
+
+        success = FLAC__stream_encoder_set_blocksize(encoder, 0);
+        if (! success) {
+            std::cerr << "Failed to set blocksize" << std::endl;
+            return;
+        }
+
+        success = FLAC__stream_encoder_set_channels(encoder, 1);
+        if (! success) {
+            std::cerr << "Failed to set channels" << std::endl;
+            return;
+        }
+
+        success = FLAC__stream_encoder_set_bits_per_sample(encoder, 32);
+        if (! success) {
+            std::cerr << "Failed to set bits per sample" << std::endl;
+            return;
+        }
+
+        status = FLAC__stream_encoder_init_stream(
+            encoder, 
+            enc_write_callback, 
+            NULL, 
+            NULL, 
+            NULL, 
+            (void *)&write_callback_data
+        );
+        if (status != FLAC__STREAM_ENCODER_INIT_STATUS_OK) {
+            std::cerr << "Failed to init encoder, status = " << status << std::endl;
+            return;
+        }
+
+        success = FLAC__stream_encoder_process_interleaved(
+            encoder,
+            &(data[sub * stride]),
+            stride
+        );
+        if (! success) {
+            std::cerr << "  Failed" << std::endl;
+            FLAC__StreamEncoderState state = FLAC__stream_encoder_get_state(encoder);
+            std::cerr << "  state was " << state << std::endl;
+            break;
+        }
+        success = FLAC__stream_encoder_finish(encoder);
+        if (! success) {
+            std::cerr << "Failed encode finish" << std::endl;
+        }
+
+        FLAC__stream_encoder_delete(encoder);
+    }
+
+    return;
+}
+
+// ------------- decoding -------------------
+
+typedef struct {
+    std::vector <uint8_t> const * input;
+    size_t in_offset;
+    size_t in_end;
+    std::vector <int32_t> * output;
+} dec_callback_data;
+
+
+FLAC__StreamDecoderReadStatus dec_read_callback(
+    const FLAC__StreamDecoder * decoder, 
+    FLAC__byte buffer[], 
+    size_t * bytes, 
+    void * client_data
+) {
+    dec_callback_data * callback_data = (dec_callback_data*)client_data;
+    std::vector <uint8_t> const * input = callback_data->input;
+    size_t offset = callback_data->in_offset;
+    size_t remaining = callback_data->in_end - offset;
+    std::cerr << "Decode read:  " << remaining << " bytes remaining" << std::endl;
+
+    // The bytes requested by the decoder
+    size_t n_buffer = (*bytes);
+
+    if (remaining == 0) {
+        // No data left
+        (*bytes) = 0;
+        std::cerr << "Decode read:  0 bytes remaining, END_OF_STREAM" << std::endl;
+        return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+    } else {
+        // We have some data left
+        if (n_buffer == 0) {
+            // ... but there is no place to put it!
+            std::cerr << "Decode read:  0 bytes in buffer, ABORT" << std::endl;
+            return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+        } else {
+            if (remaining > n_buffer) {
+                // Only copy in what there is space for
+                std::cerr << "Decode read:  putting " << n_buffer << " bytes at offset " << offset << " into buffer, CONTINUE" << std::endl;
+                for (size_t i = 0; i < n_buffer; ++i) {
+                    buffer[i] = (*input)[offset + i];
+                }
+                callback_data->in_offset += n_buffer;
+                return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+            } else {
+                // Copy in the rest of the buffer and reset the number of bytes
+                std::cerr << "Decode read:  putting remainder of " << remaining << " bytes at offset " << offset << " into buffer, CONTINUE" << std::endl;
+                for (size_t i = 0; i < remaining; ++i) {
+                    buffer[i] = (*input)[offset + i];
+                }
+                callback_data->in_offset += remaining;
+                (*bytes) = remaining;
+                return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+            }
+        }
+    }
+    // Should never get here...
+    return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+}
+
+
+FLAC__StreamDecoderWriteStatus dec_write_callback(
+    const FLAC__StreamDecoder * decoder, 
+    const FLAC__Frame * frame, 
+    const FLAC__int32 * const buffer[], 
+    void * client_data
+) {
+    dec_callback_data * data = (dec_callback_data *)client_data;
+    size_t offset = data->output->size();
+    uint32_t blocksize = frame->header.blocksize;
+    data->output->resize(offset + blocksize);
+    for (size_t i = 0; i < blocksize; ++i) {
+        (*data->output)[offset + i] = buffer[0][i];
+    }
+    return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+}
+
+
+void dec_err_callback(
+    const FLAC__StreamDecoder * decoder,
+    FLAC__StreamDecoderErrorStatus status,
+    void *client_data
+) {
+    dec_callback_data * data = (dec_callback_data *)client_data;
+
+    return;
+}
+
+
+void decode_flac(
+    std::vector <uint8_t> const & bytes,
+    std::vector <int64_t> const & offsets,
+    std::vector <int32_t> & data
+) {
+    dec_callback_data callback_data;
+    callback_data.input = &bytes;
+    callback_data.output = &data;
+
+    FLAC__StreamDecoder * decoder;
+
+
+    bool success;
+
+    FLAC__StreamDecoderInitStatus status;
+    
+
+    size_t n_sub = offsets.size();
+
+    for (size_t sub = 0; sub < n_sub; ++sub) {
+        callback_data.in_offset = offsets[sub];
+        if (sub == n_sub - 1) {
+            callback_data.in_end = bytes.size();
+        } else {
+            callback_data.in_end = offsets[sub + 1];
+        }
+        std::cerr << "Decoding chunk " << sub << " at byte offset " << callback_data.in_offset << " with " << (callback_data.in_end - callback_data.in_offset) << " bytes" << std::endl;
+        
+        decoder = FLAC__stream_decoder_new();
+
+        status = FLAC__stream_decoder_init_stream(
+            decoder, 
+            dec_read_callback, 
+            NULL, 
+            NULL, 
+            NULL, 
+            NULL,
+            dec_write_callback,
+            NULL,
+            dec_err_callback,
+            (void *)&callback_data
+        );
+        if (status != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
+            std::cerr << "Failed to init decoder, status = " << status << std::endl;
+            return;
+        }
+        
+        success = FLAC__stream_decoder_process_until_end_of_stream(decoder);
+        if (! success) {
+            std::cerr << "  Failed" << std::endl;
+            break;
+        }
+
+        success = FLAC__stream_decoder_finish(decoder);
+        if (! success) {
+            std::cerr << "Failed decode finish" << std::endl;
+        }
+
+        FLAC__stream_decoder_delete(decoder);
+    }
+    
+
+    return;
+}
+
+
+int main(int argc, char * argv[]) {
+
+    int64_t n_det = 10;
+    int64_t n_samp = 100000;
+
+    std::vector <int32_t> data(n_samp * n_det);
+    std::vector <uint8_t> compressed;
+    std::vector <int64_t> offsets;
+    std::vector <int32_t> output;
+
+    fake_data(data);
+
+    encode_flac(data, compressed, offsets, 5, n_samp);
+
+    std::cout << "Input was " << n_samp * n_det * 8 << " bytes, compress to " << compressed.size() << " bytes" << std::endl;
+
+    decode_flac(compressed, offsets, output);
+
+    for (int64_t i = 0; i < n_det; ++i) {
+        for (int64_t j = 0; j < n_samp; ++j) {
+            if (data[i * n_samp + j] != output[i * n_samp + j]) {
+                std::cerr << "Det " << i << ", sample " << j << ": " << output[i * n_samp + j] << " != " << data[i * n_samp + j] << std::endl;
+            }
+        }
+    }
+    
+    
+    return 0;
+}
+

--- a/etc/flac_test/main.cpp
+++ b/etc/flac_test/main.cpp
@@ -1,3 +1,6 @@
+// Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
 
 #include <iostream>
 #include <string>

--- a/platforms/conda_dev.sh
+++ b/platforms/conda_dev.sh
@@ -7,6 +7,8 @@
 
 set -e
 
+opts="$@"
+
 if [ "x${CONDA_PREFIX}" = "x" ]; then
     echo "You must activate a conda environment before using this script."
     exit 1
@@ -55,4 +57,4 @@ cmake \
     -DLAPACK_LIBRARIES="${LIBDIR}/liblapack.${shext}" \
     -DSUITESPARSE_INCLUDE_DIR_HINTS="${PREFIX}/include" \
     -DSUITESPARSE_LIBRARY_DIR_HINTS="${LIBDIR}" \
-    ..
+    ${opts} ..

--- a/platforms/conda_dev_pkgs.txt
+++ b/platforms/conda_dev_pkgs.txt
@@ -17,3 +17,4 @@ pytest
 coveralls
 pytest-cov
 ducc0
+libflac

--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -50,6 +50,7 @@ pybind11_add_module(_libtoast MODULE
     _libtoast/template_offset.cpp
     _libtoast/accelerator.cpp
     _libtoast/qarray_core.cpp
+    _libtoast/io_compression_flac.cpp
     _libtoast/ops_pointing_detector.cpp
     _libtoast/ops_stokes_weights.cpp
     _libtoast/ops_pixels_healpix.cpp
@@ -83,6 +84,13 @@ if(CHOLMOD_FOUND)
     target_compile_definitions(_libtoast PRIVATE HAVE_CHOLMOD=1)
     target_include_directories(_libtoast PUBLIC "${CHOLMOD_INCLUDE_DIR}")
 endif(CHOLMOD_FOUND)
+
+if(USE_FLAC)
+    target_compile_definitions(_libtoast PRIVATE HAVE_FLAC=1)
+    target_compile_options(_libtoast PRIVATE "${FLAC_DEFINITIONS}")
+    target_include_directories(_libtoast PUBLIC "${FLAC_INCLUDE_DIRS}")
+    target_link_libraries(_libtoast PRIVATE "${FLAC_LIBRARIES}")
+endif(USE_FLAC)
 
 if(CUDAToolkit_FOUND AND NOT CUDA_DISABLED)
     target_compile_definitions(_libtoast PRIVATE HAVE_CUDALIBS=1)

--- a/src/toast/_libtoast/io_compression_flac.cpp
+++ b/src/toast/_libtoast/io_compression_flac.cpp
@@ -1,0 +1,557 @@
+
+// Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+// All rights reserved.  Use of this source code is governed by
+// a BSD-style license that can be found in the LICENSE file.
+
+#include <module.hpp>
+
+
+#ifdef HAVE_FLAC
+#include <FLAC/stream_encoder.h>
+#include <FLAC/stream_decoder.h>
+
+
+typedef struct {
+    toast::AlignedU8 * compressed;
+} enc_write_callback_data;
+
+
+FLAC__StreamEncoderWriteStatus enc_write_callback(
+    const FLAC__StreamEncoder *encoder, 
+    const FLAC__byte buffer[], 
+    size_t bytes, 
+    uint32_t samples, 
+    uint32_t current_frame, 
+    void *client_data
+) {
+    enc_write_callback_data * data = (enc_write_callback_data *)client_data;
+    data->compressed->insert(
+        data->compressed->end(), 
+        buffer, 
+        buffer + bytes
+    );
+    return FLAC__STREAM_ENCODER_WRITE_STATUS_OK;
+}
+
+
+void encode_flac(
+    int32_t * const data,
+    size_t n_data, 
+    toast::AlignedU8 & bytes,
+    toast::AlignedI64 & offsets,
+    uint32_t level, 
+    int64_t stride
+) {
+    // If stride is specified, check consistency.
+    int64_t n_sub;
+    if (stride > 0) {
+        if (n_data % stride != 0) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Stride " << stride << " does not evenly divide into " << n_data;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+        n_sub = (int64_t)(n_data / stride);
+    } else {
+        n_sub = 1;
+        stride = n_data;
+    }
+    offsets.resize(n_sub);
+    bytes.clear();
+
+    enc_write_callback_data write_callback_data;
+    write_callback_data.compressed = &bytes;
+
+    bool success;
+    FLAC__StreamEncoderInitStatus status;
+    FLAC__StreamEncoder * encoder;
+
+    for (int64_t sub = 0; sub < n_sub; ++sub) {
+        offsets[sub] = bytes.size();
+
+        // std::cerr << "Encoding " << stride << " samples at byte offset " << offsets[sub] << " starting at data element " << (sub * stride) << std::endl;
+
+        encoder = FLAC__stream_encoder_new();
+
+        success = FLAC__stream_encoder_set_compression_level(encoder, level);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to set compression level to " << level;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        success = FLAC__stream_encoder_set_blocksize(encoder, 0);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to set encoder blocksize to " << 0;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        success = FLAC__stream_encoder_set_channels(encoder, 1);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to set encoder channels to " << 1;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        success = FLAC__stream_encoder_set_bits_per_sample(encoder, 32);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to set encoder bits per sample to " << 32;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        status = FLAC__stream_encoder_init_stream(
+            encoder, 
+            enc_write_callback, 
+            NULL, 
+            NULL, 
+            NULL, 
+            (void *)&write_callback_data
+        );
+        if (status != FLAC__STREAM_ENCODER_INIT_STATUS_OK) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to initialize stream encoder, status = " << status;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        success = FLAC__stream_encoder_process_interleaved(
+            encoder,
+            &(data[sub * stride]),
+            stride
+        );
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed on encoder_process_interleaved for chunk " << sub;
+            o << ", elements " << sub*stride << " - " << (sub+1)*stride;
+            o << ", at byte offset " << offsets[sub];
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+        success = FLAC__stream_encoder_finish(encoder);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed on encoder_finish";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        FLAC__stream_encoder_delete(encoder);
+    }
+
+    return;
+}
+
+
+typedef struct {
+    uint8_t const * input;
+    size_t in_nbytes;
+    size_t in_offset;
+    size_t in_end;
+    toast::AlignedI32 * output;
+} dec_callback_data;
+
+
+FLAC__StreamDecoderReadStatus dec_read_callback(
+    const FLAC__StreamDecoder * decoder, 
+    FLAC__byte buffer[], 
+    size_t * bytes, 
+    void * client_data
+) {
+    dec_callback_data * callback_data = (dec_callback_data*)client_data;
+    uint8_t const * input = callback_data->input;
+    size_t offset = callback_data->in_offset;
+    size_t remaining = callback_data->in_end - offset;
+    // std::cerr << "Decode read:  " << remaining << " bytes remaining" << std::endl;
+
+    // The bytes requested by the decoder
+    size_t n_buffer = (*bytes);
+
+    if (remaining == 0) {
+        // No data left
+        (*bytes) = 0;
+        // std::cerr << "Decode read:  0 bytes remaining, END_OF_STREAM" << std::endl;
+        return FLAC__STREAM_DECODER_READ_STATUS_END_OF_STREAM;
+    } else {
+        // We have some data left
+        if (n_buffer == 0) {
+            // ... but there is no place to put it!
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Stream decoder gave us zero length buffer, but we have ";
+            o << remaining << " bytes left";
+            log.error(o.str().c_str());
+            // std::cerr << "Decode read:  0 bytes in buffer, ABORT" << std::endl;
+            return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+        } else {
+            if (remaining > n_buffer) {
+                // Only copy in what there is space for
+                // std::cerr << "Decode read:  putting " << n_buffer << " bytes at offset " << offset << " into buffer, CONTINUE" << std::endl;
+                for (size_t i = 0; i < n_buffer; ++i) {
+                    buffer[i] = input[offset + i];
+                }
+                callback_data->in_offset += n_buffer;
+                return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+            } else {
+                // Copy in the rest of the buffer and reset the number of bytes
+                //std::cerr << "Decode read:  putting remainder of " << remaining << " bytes at offset " << offset << " into buffer, CONTINUE" << std::endl;
+                for (size_t i = 0; i < remaining; ++i) {
+                    buffer[i] = input[offset + i];
+                }
+                callback_data->in_offset += remaining;
+                (*bytes) = remaining;
+                return FLAC__STREAM_DECODER_READ_STATUS_CONTINUE;
+            }
+        }
+    }
+    // Should never get here...
+    return FLAC__STREAM_DECODER_READ_STATUS_ABORT;
+}
+
+
+FLAC__StreamDecoderWriteStatus dec_write_callback(
+    const FLAC__StreamDecoder * decoder, 
+    const FLAC__Frame * frame, 
+    const FLAC__int32 * const buffer[], 
+    void * client_data
+) {
+    dec_callback_data * data = (dec_callback_data *)client_data;
+    size_t offset = data->output->size();
+    uint32_t blocksize = frame->header.blocksize;
+    data->output->resize(offset + blocksize);
+    for (size_t i = 0; i < blocksize; ++i) {
+        (*data->output)[offset + i] = buffer[0][i];
+    }
+    return FLAC__STREAM_DECODER_WRITE_STATUS_CONTINUE;
+}
+
+
+void dec_err_callback(
+    const FLAC__StreamDecoder * decoder,
+    FLAC__StreamDecoderErrorStatus status,
+    void *client_data
+) {
+    dec_callback_data * data = (dec_callback_data *)client_data;
+
+    auto log = toast::Logger::get();
+    std::ostringstream o;
+    o << "Stream decode error (" << status << ") at input byte range ";
+    o << data->in_offset << " - " << data->in_end << ", output size = ";
+    o << data->output->size();
+    log.error(o.str().c_str());
+    throw std::runtime_error(o.str().c_str());
+    return;
+}
+
+
+void decode_flac(
+    uint8_t * const bytes,
+    size_t n_bytes,
+    int64_t * const offsets,
+    size_t n_offset,
+    toast::AlignedI32 & data
+) {
+    dec_callback_data callback_data;
+    callback_data.input = bytes;
+    callback_data.in_nbytes = n_bytes;
+    callback_data.output = &data;
+
+    FLAC__StreamDecoder * decoder;
+    bool success;
+    FLAC__StreamDecoderInitStatus status;
+    
+    size_t n_sub = n_offset;
+
+    for (size_t sub = 0; sub < n_sub; ++sub) {
+        callback_data.in_offset = offsets[sub];
+        if (sub == n_sub - 1) {
+            callback_data.in_end = n_bytes;
+        } else {
+            callback_data.in_end = offsets[sub + 1];
+        }
+        //std::cerr << "Decoding chunk " << sub << " at byte offset " << callback_data.in_offset << " with " << (callback_data.in_end - callback_data.in_offset) << " bytes" << std::endl;
+        
+        decoder = FLAC__stream_decoder_new();
+
+        status = FLAC__stream_decoder_init_stream(
+            decoder, 
+            dec_read_callback, 
+            NULL, 
+            NULL, 
+            NULL, 
+            NULL,
+            dec_write_callback,
+            NULL,
+            dec_err_callback,
+            (void *)&callback_data
+        );
+        if (status != FLAC__STREAM_DECODER_INIT_STATUS_OK) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed to initialize decoder, status = " << status;
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+        
+        success = FLAC__stream_decoder_process_until_end_of_stream(decoder);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed on decoder_process_until_end_of_stream for chunk " << sub;
+            o << ", byte range " << callback_data.in_offset << " - ";
+            o << callback_data.in_end;
+            o << ", output size = " << callback_data.output->size();
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        success = FLAC__stream_decoder_finish(decoder);
+        if (! success) {
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "Failed on decoder_finish";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+        }
+
+        FLAC__stream_decoder_delete(decoder);
+    }
+
+    return;
+}
+
+#endif
+
+
+void init_io_compression_flac(py::module & m) {
+    // FLAC compression
+
+    m.def(
+        "have_flac_support", []() {
+            #ifdef HAVE_FLAC
+            return true;
+            #else
+            return false;
+            #endif
+        }, R"(
+        Return True if TOAST is compiled with FLAC support.
+    )");
+
+    m.def(
+        "compress_flac_2D", [](
+            py::buffer data,
+            uint32_t level
+        ) {
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            int32_t * raw_data = extract_buffer <int32_t> (
+                data, "int32 data", 2, temp_shape, {-1, -1}
+            );
+            int64_t n_chunk = temp_shape[0];
+            int64_t n_chunk_elem = temp_shape[1];
+
+            toast::AlignedU8 bytes;
+            toast::AlignedI64 offsets;
+
+            #ifdef HAVE_FLAC
+            encode_flac(
+                raw_data,
+                n_chunk * n_chunk_elem, 
+                bytes,
+                offsets,
+                level, 
+                n_chunk_elem
+            );
+            #else
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "TOAST was not built with libFLAC support";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+            #endif
+
+            // std::cout << "compress_flac_2D returning buffer @ " << (int64_t)bytes.data() << std::endl;
+            
+            return py::make_tuple(py::cast(bytes), py::cast(offsets));
+        }, py::arg("data"), py::arg("level"), R"(
+        Compress 2D 32bit integer data with FLAC.
+
+        Each row of the input is compressed separately, and the byte offset
+        into the output stream is returned.
+
+        Args:
+            data (array, int32):  The 2D array of integer data.
+            level (uint32):  The compression level (0-8).
+
+        Returns:
+            (tuple):  The (byte array, offsets).
+
+    )");
+
+    m.def(
+        "decompress_flac_2D", [](
+            py::buffer data,
+            py::buffer offsets
+        ) {
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            uint8_t * raw_data = extract_buffer <uint8_t> (
+                data, "FLAC bytes", 1, temp_shape, {-1}
+            );
+            int64_t n_bytes = temp_shape[0];
+
+            int64_t * raw_offsets = extract_buffer <int64_t> (
+                offsets, "FLAC offsets", 1, temp_shape, {-1}
+            );
+            int64_t n_offset = temp_shape[0];
+
+            toast::AlignedI32 output;
+
+            #ifdef HAVE_FLAC
+            decode_flac(
+                raw_data,
+                n_bytes,
+                raw_offsets,
+                n_offset,
+                output
+            );
+            #else
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "TOAST was not built with libFLAC support";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+            #endif
+
+            // std::cout << "decompress_flac_2D returning buffer @ " << (int64_t)output.data() << std::endl;
+            
+            return py::cast(output);
+        }, py::arg("data"), py::arg("offsets"), R"(
+        Decompress FLAC bytes into 2D 32bit integer data.
+
+        The array of bytes is decompressed and returned.
+
+        Args:
+            data (array, uint8):  The 1D array of bytes.
+            offsets (array, int64):  The array of offsets into the byte array.
+
+        Returns:
+            (array):  The array of 32bit integers.
+
+    )");
+
+    m.def(
+        "compress_flac", [](
+            py::buffer data,
+            uint32_t level
+        ) {
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            int32_t * raw_data = extract_buffer <int32_t> (
+                data, "int32 data", 1, temp_shape, {-1}
+            );
+            int64_t n = temp_shape[0];
+
+            toast::AlignedU8 bytes;
+            toast::AlignedI64 offsets;
+
+            #ifdef HAVE_FLAC
+            encode_flac(
+                raw_data,
+                n, 
+                bytes,
+                offsets,
+                level, 
+                0
+            );
+            #else
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "TOAST was not built with libFLAC support";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+            #endif
+
+            // std::cout << "compress_flac returning buffer @ " << (int64_t)bytes.data() << std::endl;
+            
+            return py::cast(bytes);
+        }, py::arg("data"), py::arg("level"), R"(
+        Compress 1D 32bit integer data with FLAC.
+
+        The 1D array is compressed and the byte array is returned.
+
+        Args:
+            data (array, int32):  The 1D array of integer data.
+            level (uint32):  The compression level (0-8).
+
+        Returns:
+            (array):  The byte array.
+
+    )");
+
+    m.def(
+        "decompress_flac", [](
+            py::buffer data
+        ) {
+            // This is used to return the actual shape of each buffer
+            std::vector <int64_t> temp_shape(3);
+
+            uint8_t * raw_data = extract_buffer <uint8_t> (
+                data, "FLAC bytes", 1, temp_shape, {-1}
+            );
+            int64_t n_bytes = temp_shape[0];
+
+            toast::AlignedI32 output;
+
+            int64_t offset = 0;
+
+            #ifdef HAVE_FLAC
+            decode_flac(
+                raw_data,
+                n_bytes,
+                &offset,
+                1,
+                output
+            );
+            #else
+            auto log = toast::Logger::get();
+            std::ostringstream o;
+            o << "TOAST was not built with libFLAC support";
+            log.error(o.str().c_str());
+            throw std::runtime_error(o.str().c_str());
+            #endif
+
+            // std::cout << "decompress_flac returning buffer @ " << (int64_t)output.data() << std::endl;
+            
+            return py::cast(output);
+        }, py::arg("data"), R"(
+        Decompress FLAC bytes into 1D 32bit integer data.
+
+        The array of bytes is decompressed and returned.
+
+        Args:
+            data (array, uint8):  The 1D array of bytes.
+
+        Returns:
+            (array):  The array of 32bit integers.
+
+    )");
+
+    return;
+}

--- a/src/toast/_libtoast/module.cpp
+++ b/src/toast/_libtoast/module.cpp
@@ -49,6 +49,7 @@ PYBIND11_MODULE(_libtoast, m) {
     init_ops_stokes_weights(m);
     init_ops_pixels_healpix(m);
     init_ops_mapmaker_utils(m);
+    init_io_compression_flac(m);
 
     // Internal unit test runner
     m.def(

--- a/src/toast/_libtoast/module.hpp
+++ b/src/toast/_libtoast/module.hpp
@@ -422,5 +422,6 @@ void init_ops_pointing_detector(py::module & m);
 void init_ops_stokes_weights(py::module & m);
 void init_ops_pixels_healpix(py::module & m);
 void init_ops_mapmaker_utils(py::module & m);
+void init_io_compression_flac(py::module & m);
 
 #endif // ifndef LIBTOAST_HPP

--- a/src/toast/io/CMakeLists.txt
+++ b/src/toast/io/CMakeLists.txt
@@ -5,6 +5,9 @@ install(FILES
     __init__.py
     observation_hdf_save.py
     observation_hdf_load.py
+    observation_hdf_load_v0.py
     hdf_utils.py
+    compression.py
+    compression_flac.py
     DESTINATION ${PYTHON_SITE}/toast/io
 )

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -7,3 +7,4 @@
 from .hdf_utils import H5File, have_hdf5_parallel, hdf5_config, hdf5_open
 from .observation_hdf_load import load_hdf5
 from .observation_hdf_save import save_hdf5
+from .compression import compress_detdata, decompress_detdata

--- a/src/toast/io/compression.py
+++ b/src/toast/io/compression.py
@@ -1,0 +1,274 @@
+# Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import gzip
+import numpy as np
+from astropy import units as u
+
+from ..timing import function_timer
+from ..utils import Logger, AlignedU8
+from ..observation_data import DetectorData
+
+from .compression_flac import compress_detdata_flac, decompress_detdata_flac
+
+
+@function_timer
+def compress_detdata(detdata, comp_params=None):
+    """Compress a DetectorData object.
+
+    The comp_params dictionary should include at least a key "type" set to one
+    of the supported compression types:  "none", "gzip", or "flac".  For each
+    compression type, additional parameters may be specified:
+
+    gzip:
+        "level": 0-9 (9 is used if not specified)
+
+    flac:
+        "level": 0-8 (5 is the default)
+        "quanta":  The floating point amount that should correspond to one
+            integer value in the compressed data.  If not specified, the
+            full amplitude of the input data (less the mean) will correspond
+            to the range of 32bit integer values.  This can be an array, a
+            scalar, or None.
+
+    The compressed bytes are returned in an ndarray of type uint8.  The byte ranges
+    are a tuple for each detector specifying the (start byte, end byte).
+
+    Args:
+        detdata (DetectorData):  The object to compress.
+        comp_params (dict):  Dictionary of compression parameters.
+
+    Returns:
+        (tuple): The (compressed bytes, byte ranges, updated params)
+
+    """
+    log = Logger.get()
+
+    if comp_params is None:
+        comp_params = {"type": "none"}
+    if "type" not in comp_params:
+        raise ValueError("comp_params must contain the 'type' key")
+
+    comp_params["detectors"] = detdata.detectors
+    n_det = len(detdata.detectors)
+    comp_params["det_shape"] = detdata.detector_shape
+    comp_params["dtype"] = detdata.dtype
+    comp_params["units"] = detdata.units
+
+    msg = f"Compressing detector data {detdata} with {comp_params}"
+    log.verbose(msg)
+
+    det_stride = 1
+    for ds in detdata.detector_shape:
+        det_stride *= ds
+
+    if comp_params["type"] == "none":
+        det_stride = 1
+        for ds in detdata.detector_shape:
+            det_stride *= ds
+        det_bytes = det_stride * detdata.dtype.itemsize
+        comp_ranges = [(x * det_bytes, (x + 1) * det_bytes) for x in range(n_det)]
+        comp_bytes = np.array(detdata.flatdata.view(dtype=np.uint8), dtype=np.uint8)
+        return (
+            comp_bytes,
+            comp_ranges,
+            comp_params,
+        )
+
+    elif comp_params["type"] == "gzip":
+        comp_bytes = AlignedU8()
+        off = 0
+        if "level" in comp_params:
+            comp_level = comp_params["level"]
+        else:
+            comp_level = 9
+            comp_params["level"] = comp_level
+        start_bytes = list()
+        for idet, det in enumerate(detdata.detectors):
+            start_bytes.append(off)
+            dbytes = gzip.compress(
+                detdata[det, :].tobytes(), compresslevel=comp_level, mtime=0
+            )
+            nb = len(dbytes)
+            comp_bytes.resize(off + nb)
+            comp_bytes[off : off + nb] = dbytes
+            off += nb
+        comp_ranges = list()
+        last = None
+        for idet in range(n_det):
+            if idet == n_det - 1:
+                cur = (last[1], len(comp_bytes))
+            else:
+                cur = (start_bytes[idet], start_bytes[idet + 1])
+            comp_ranges.append(cur)
+            last = cur
+        return (comp_bytes.array(), comp_ranges, comp_params)
+
+    elif comp_params["type"] == "flac":
+        ftypes = [np.dtype(np.float32), np.dtype(np.float64)]
+        itypes = [np.dtype(np.int32), np.dtype(np.int64)]
+
+        # Check parameters
+        if "level" in comp_params:
+            comp_level = comp_params["level"]
+        else:
+            comp_level = 5
+            comp_params["level"] = comp_level
+        if "quanta" in comp_params:
+            quanta = comp_params["quanta"]
+            if detdata.dtype in itypes:
+                raise RuntimeError(
+                    "Cannot specify quanta for FLAC compression of integers"
+                )
+        else:
+            quanta = None
+            comp_params["quanta"] = quanta
+
+        if detdata.dtype in ftypes:
+            (
+                comp_bytes,
+                comp_ranges,
+                comp_params["data_offsets"],
+                comp_params["data_gains"],
+            ) = compress_detdata_flac(detdata, level=comp_level, quanta=quanta)
+        elif detdata.dtype == np.dtype(np.int64):
+            (
+                comp_bytes,
+                comp_ranges,
+                comp_params["data_offsets"],
+            ) = compress_detdata_flac(detdata, level=comp_level)
+        elif detdata.dtype == np.dtype(np.int32):
+            (
+                comp_bytes,
+                comp_ranges,
+            ) = compress_detdata_flac(detdata, level=comp_level)
+        else:
+            msg = f"FLAC Compression of type '{detdata.dtype}' is not supported"
+            raise RuntimeError(msg)
+
+        return (comp_bytes, comp_ranges, comp_params)
+    else:
+        msg = f"Compression type \"{comp_params['type']}\" is not supported"
+        raise NotImplementedError(msg)
+
+
+@function_timer
+def decompress_detdata(comp_bytes, comp_ranges, comp_params, detdata=None):
+    """Decompress bytes and construct a DetectorData object
+
+    If detdata is not None, its properties are checked and the data is decompressed
+    into this container.  Otherwise a new DetectorData object is created and returned.
+
+    Args:
+        comp_bytes (array):  The stream of compressed bytes.
+        comp_ranges (array):  The starting byte offset for each detector.
+        comp_params (dict):  Compression parameters.
+        detdata (DetectorData):  (Optional) starting instance to fill.
+
+    Returns:
+        (DetectorData):  Object containing the decompressed data.
+
+    """
+    log = Logger.get()
+    for prop in ["type", "det_shape", "dtype", "units"]:
+        if prop not in comp_params:
+            msg = f"key '{prop}' not found in comp_params"
+            raise ValueError(msg)
+
+    if detdata is not None:
+        detectors = detdata.detectors
+    elif "detectors" in comp_params:
+        detectors = comp_params["detectors"]
+    else:
+        raise ValueError(
+            "Must either provide detdata or a detectors list in comp_params"
+        )
+
+    n_det = len(detectors)
+    detector_shape = comp_params["det_shape"]
+    dtype = comp_params["dtype"]
+    units = comp_params["units"]
+
+    msg = f"Decompressing detector data with {comp_params}, {len(comp_bytes)} bytes"
+    msg += f", offsets = {comp_ranges}"
+    log.verbose(msg)
+
+    if detdata is None:
+        # Create a new object
+        detdata = DetectorData(
+            detectors,
+            detector_shape,
+            dtype,
+            units=units,
+        )
+    else:
+        # We are populating an existing data object.  Verify consistent
+        # properties.
+        if detectors != detdata.detectors:
+            msg = f"Input detdata container has different detectors "
+            msg += f"({detdata.detectors}) than compressed data "
+            msg += f"({detectors})"
+            raise RuntimeError(msg)
+        if detector_shape != detdata.detector_shape:
+            msg = f"Input detdata container has different det shape "
+            msg += f"({detdata.detector_shape}) than compressed data "
+            msg += f"({detector_shape})"
+            raise RuntimeError(msg)
+        if dtype != detdata.dtype:
+            msg = f"Input detdata container has different dtype "
+            msg += f"({detdata.dtype}) than compressed data "
+            msg += f"({dtype})"
+            raise RuntimeError(msg)
+        if units != detdata.units:
+            msg = f"Input detdata container has different units "
+            msg += f"({detdata.units}) than compressed data "
+            msg += f"({units})"
+            raise RuntimeError(msg)
+
+    det_stride = 1
+    for ds in detector_shape:
+        det_stride *= ds
+
+    if comp_params["type"] == "none":
+        n_elem = n_det * det_stride
+        view = np.ndarray(
+            n_elem,
+            dtype=dtype,
+            buffer=comp_bytes,
+        )
+        detdata[:] = view.reshape((n_det,) + detector_shape)
+
+    elif comp_params["type"] == "gzip":
+        for idet, det in enumerate(detectors):
+            slc = slice(comp_ranges[idet][0], comp_ranges[idet][1], 1)
+            dbytes = gzip.decompress(comp_bytes[slc])
+            view = np.ndarray(
+                det_stride,
+                dtype=dtype,
+                buffer=dbytes,
+            ).reshape(detector_shape)
+            detdata[det, :] = view
+
+    elif comp_params["type"] == "flac":
+        data_offsets = None
+        if "data_offsets" in comp_params:
+            data_offsets = comp_params["data_offsets"]
+        dslices = list()
+
+        data_gains = None
+        if "data_gains" in comp_params:
+            data_gains = comp_params["data_gains"]
+        decompress_detdata_flac(
+            detdata,
+            comp_bytes,
+            comp_ranges,
+            det_offsets=data_offsets,
+            det_gains=data_gains,
+        )
+
+    else:
+        msg = f"Compression type \"{comp_params['type']}\" is not supported"
+        raise NotImplementedError(msg)
+
+    return detdata

--- a/src/toast/io/compression_flac.py
+++ b/src/toast/io/compression_flac.py
@@ -1,0 +1,271 @@
+# Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import time
+import numpy as np
+
+from .._libtoast import (
+    have_flac_support,
+    compress_flac,
+    decompress_flac,
+    compress_flac_2D,
+    decompress_flac_2D,
+)
+from ..utils import Logger, AlignedU8, dtype_to_aligned
+
+
+def float2int(data, quanta=None):
+    """Convert floating point data to integers.
+
+    This function subtracts the mean and rescales data before rounding to 32bit
+    integer values.
+
+    Args:
+        data (array):  The floating point data.
+        quanta (float):  The floating point quantity corresponding to one integer
+            resolution amount in the output.
+
+    Returns:
+        (tuple):  The (integer data, offset, gain)
+
+    """
+    dmin = np.amin(data)
+    dmax = np.amax(data)
+    offset = 0.5 * (dmin + dmax)
+    amp = 1.01 * max(np.abs(dmin - offset), np.abs(dmax - offset))
+    if quanta is None:
+        # Use the full bit range of int32 FLAC.  Actually we lose one bit
+        # Due to internal FLAC implementation.
+        max_flac = np.iinfo(np.int32).max // 2
+        quanta = amp / max_flac
+    if quanta == 0:
+        # This can happen if fed a vector of all zeros
+        quanta = 1.0
+    gain = 1.0 / quanta
+
+    return (
+        np.array(np.around(gain * (data - offset)), dtype=np.int32),
+        offset,
+        gain,
+    )
+
+
+def int64to32(data):
+    """Convert 64bit integers to 32bit.
+
+    This finds the 64bit integer mean and subtracts it.  It then checks that the value
+    will fit in 32bit integers.  If you want to treat the integer values as floating
+    point data, use float2int instead.
+
+    Args:
+        data (array):  The 64bit integer data.
+
+    Returns:
+        (tuple):  The (integer data, offset)
+
+    """
+    if data.dtype != np.dtype(np.int64):
+        raise ValueError("Only int64 data is supported")
+
+    dmin = np.amin(data)
+    dmax = np.amax(data)
+    offset = int(round(0.5 * (dmin + dmax)))
+
+    temp = np.array(data - offset, dtype=np.int64)
+
+    # FLAC uses an extra bit...
+    flac_max = np.iinfo(np.int32).max // 2
+
+    bad = np.logical_or(temp > flac_max, temp < -flac_max)
+    n_bad = np.count_nonzero(bad)
+    if n_bad > 0:
+        msg = f"64bit integers minus {offset} has {n_bad} values outside 32bit range"
+        raise RuntimeError(msg)
+
+    return (
+        temp.astype(np.int32),
+        offset,
+    )
+
+
+def int2float(idata, offset, gain):
+    """Restore floating point data from integers.
+
+    The gain and offset are applied and the resulting float32 data is returned.
+
+    Args:
+        idata (array):  The 32bit integer data.
+        offset (float):  The offset used in the original conversion.
+        gain (float):  The gain used in the original conversion.
+
+    Returns:
+        (array):  The restored float32 data.
+
+    """
+    if len(idata.shape) > 1:
+        raise ValueError("Only works with flat packed arrays")
+    coeff = 1.0 / gain
+    return np.array((idata * coeff) + offset, dtype=np.float32)
+
+
+def compress_detdata_flac(detdata, level=5, quanta=None):
+    """Compress a 2D DetectorData array into FLAC bytes.
+
+    The input data is converted to 32bit integers.  The "quanta" value is used
+    for floating point data conversion and represents the floating point increment
+    for a single integer value.  If quanta is None, each detector timestream is
+    scaled independently based on its data range.  If quanta is a scalar, all
+    detectors are scaled with the same value.  If quanta is an array, it specifies
+    the scaling independently for each detector.
+
+    The following rules specify the data conversion that is performed depending on
+    the input type:
+
+        int32:  No conversion.
+
+        int64:  Subtract the integer closest to the mean, then truncate to lower
+            32 bits, and check that the higher bits were zero.
+
+        float32:  Subtract the mean and scale data based on the quanta value (see
+            above).  Then round to nearest 32bit integer.
+
+        float64:  Subtract the mean and scale data based on the quanta value (see
+            above).  Then round to nearest 32bit integer.
+
+    After conversion to 32bit integers, each detector's data is separately compressed
+    into a sequence of FLAC bytes, which is appended to the total.  The offset in
+    bytes for each detector is recorded.
+
+    Args:
+        detdata (DetectorData):  The input detector data.
+        level (int):  Compression level
+        quanta (array):  For floating point data, the increment of each integer.
+
+    Returns:
+        (tuple):  The (compressed bytes, byte ranges,
+            [detector value offset, detector value gain])
+
+    """
+    if not have_flac_support():
+        raise RuntimeError("TOAST was not compiled with libFLAC support")
+
+    if quanta is not None:
+        try:
+            nq = len(quanta)
+            # This is a sequence
+            if nq != len(detdata.detectors):
+                raise ValueError(
+                    "If not a scalar, quanta must have a value for each detector"
+                )
+            dquanta = quanta
+        except TypeError:
+            # This is a scalar, applied to all detectors
+            dquanta = quanta * np.ones(len(detdata.detectors), dtype=np.float64)
+    else:
+        dquanta = [None for x in detdata.detectors]
+
+    comp_bytes = AlignedU8()
+
+    if detdata.dtype == np.dtype(np.int32):
+        pass
+    elif detdata.dtype == np.dtype(np.int64):
+        data_ioffsets = np.zeros(len(detdata.detectors), dtype=np.int64)
+    elif detdata.dtype == np.dtype(np.float32) or detdata.dtype == np.dtype(np.float64):
+        data_offsets = np.zeros(len(detdata.detectors), dtype=np.float64)
+        data_gains = np.ones(len(detdata.detectors), dtype=np.float64)
+    else:
+        raise ValueError(f"Unsupported data type '{detdata.dtype}'")
+
+    start_bytes = list()
+    for idet, det in enumerate(detdata.detectors):
+        cur = comp_bytes.size()
+        start_bytes.append(cur)
+
+        if detdata.dtype == np.dtype(np.int32):
+            intdata = detdata[idet].reshape(-1)
+        elif detdata.dtype == np.dtype(np.int64):
+            intdata, ioff = int64to32(detdata[idet, :].reshape(-1))
+            data_ioffsets[idet] = ioff
+        else:
+            intdata, foff, fgain = float2int(
+                detdata[idet, :].reshape(-1), quanta=dquanta[idet]
+            )
+            data_offsets[idet] = foff
+            data_gains[idet] = fgain
+
+        dbytes = compress_flac(intdata, level)
+        ext = len(dbytes)
+        comp_bytes.resize(cur + ext)
+        comp_bytes[cur : cur + ext] = dbytes
+
+    comp_ranges = list()
+    for idet in range(len(detdata.detectors)):
+        if idet == len(detdata.detectors) - 1:
+            comp_ranges.append((start_bytes[idet], comp_bytes.size()))
+        else:
+            comp_ranges.append((start_bytes[idet], start_bytes[idet + 1]))
+
+    if detdata.dtype == np.dtype(np.int32):
+        return (comp_bytes.array(), comp_ranges)
+    elif detdata.dtype == np.dtype(np.int64):
+        return (comp_bytes.array(), comp_ranges, data_ioffsets)
+    else:
+        return (comp_bytes.array(), comp_ranges, data_offsets, data_gains)
+
+
+def decompress_detdata_flac(
+    detdata, flacbytes, byte_ranges, det_offsets=None, det_gains=None
+):
+    """Decompress FLAC bytes into a DetectorData array.
+
+    Given an existing DetectorData object, decompress individual detector data from
+    the FLAC byte stream given the starting byte for each detector and optionally
+    the offset and gain factor to apply to convert the native 32bit integers into
+    the output type.
+
+    Args:
+        detdata (DetectorData):  The object to fill with decompressed data.
+        flacbytes (array):  Compressed FLAC bytes
+        byte_ranges (list):  The byte range for each detector.
+        det_offsets (array):  The offset to apply to each detector during type
+            conversion.
+        det_gains (array):  The scale factor to apply to each detector during
+            type conversion.
+
+    Returns:
+        None
+
+    """
+    if not have_flac_support():
+        raise RuntimeError("TOAST was not compiled with libFLAC support")
+
+    # Since we may have discontiguous slices into the bytestream, we decompress
+    # all data types one detector at a time.
+
+    for idet, det in enumerate(detdata.detectors):
+        slc = slice(byte_ranges[idet][0], byte_ranges[idet][1], 1)
+        idata = decompress_flac(flacbytes[slc])
+        if detdata.dtype == np.dtype(np.int32):
+            # Just copy it into place
+            detdata[idet] = idata.array().reshape(detdata.detector_shape)
+        elif detdata.dtype == np.dtype(np.int64):
+            detdata[idet] = idata.array().reshape(detdata.detector_shape)
+            if det_offsets is not None:
+                detdata[idet] += det_offsets[idet]
+        elif detdata.dtype == np.dtype(np.float32) or detdata.dtype == np.dtype(
+            np.float64
+        ):
+            if det_offsets is None:
+                doff = 0.0
+            else:
+                doff = det_offsets[idet]
+            if det_gains is None:
+                dgain = 1.0
+            else:
+                dgain = det_gains[idet]
+            detdata[idet] = int2float(idata.array(), doff, dgain).reshape(
+                detdata.detector_shape
+            )
+        else:
+            raise ValueError(f"Unsupported data type '{detdata.dtype}'")

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -2,6 +2,7 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import ast
 import json
 import os
 import re
@@ -10,6 +11,7 @@ from datetime import datetime, timezone
 import h5py
 import numpy as np
 from astropy import units as u
+from astropy.table import QTable
 
 from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
 from ..mpi import MPI
@@ -18,6 +20,8 @@ from ..timing import GlobalTimers, Timer, function_timer
 from ..utils import Environment, Logger, dtype_to_aligned, import_from_name
 from ..weather import SimWeather
 from .hdf_utils import check_dataset_buffer_size, hdf5_config, hdf5_open
+from .observation_hdf_load_v0 import load_hdf5_detdata_v0
+from .compression import decompress_detdata
 
 
 @function_timer
@@ -176,29 +180,70 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
         units = None
         full_shape = None
         dtype = None
+
+        compressed = False
+        cgrp = None
+        comp_params = dict()
+        comp_ranges = None
+        comp_offsets = None
+        comp_gains = None
+        comp_nbytes = None
+
         if hgrp is not None:
-            ds = hgrp[field]
-            full_shape = ds.shape
-            dtype = ds.dtype
-            units = u.Unit(str(ds.attrs["units"]))
+            if isinstance(hgrp[field], h5py.Dataset):
+                # This is uncompressed data
+                ds = hgrp[field]
+                full_shape = ds.shape
+                dtype = ds.dtype
+                units = u.Unit(str(ds.attrs["units"]))
+            else:
+                # This must be a group of datasets containing compressed data
+                cgrp = hgrp[field]
+                ds = cgrp["compressed"]
+                units = u.Unit(str(ds.attrs["units"]))
+                comp_params["units"] = units
+                dtype = np.dtype(ds.attrs["dtype"])
+                comp_params["dtype"] = dtype
+                det_shape = tuple(ast.literal_eval(ds.attrs["det_shape"]))
+                comp_params["det_shape"] = det_shape
+                comp_nbytes = len(ds)
+
+                ds_ranges = cgrp["ranges"]
+                n_det = len(ds_ranges)
+                comp_ranges = np.zeros((n_det, 2), dtype=np.int64)
+                slc = (slice(0, n_det, 1), slice(0, 2, 1))
+                ds_ranges.read_direct(comp_ranges, slc, slc)
+
+                if "offsets" in cgrp:
+                    ds_offsets = cgrp["offsets"]
+                    comp_offsets = np.zeros(n_det, np.float64)
+                    slc = (slice(0, n_det, 1),)
+                    ds_offsets.read_direct(comp_offsets, slc, slc)
+
+                if "gains" in cgrp:
+                    ds_gains = cgrp["gains"]
+                    comp_gains = np.zeros(n_det, np.float64)
+                    slc = (slice(0, n_det, 1),)
+                    ds_gains.read_direct(comp_gains, slc, slc)
+
+                full_shape = (n_det,) + det_shape
+                comp_params["type"] = ds.attrs["comp_type"]
+                compressed = True
+
         if serial_load:
+            compressed = obs.comm.comm_group.bcast(compressed, root=0)
             units = obs.comm.comm_group.bcast(units, root=0)
             full_shape = obs.comm.comm_group.bcast(full_shape, root=0)
             dtype = obs.comm.comm_group.bcast(dtype, root=0)
+            if compressed:
+                comp_nbytes = obs.comm.comm_group.bcast(comp_nbytes, root=0)
+                comp_ranges = obs.comm.comm_group.bcast(comp_ranges, root=0)
+                comp_offsets = obs.comm.comm_group.bcast(comp_offsets, root=0)
+                comp_gains = obs.comm.comm_group.bcast(comp_gains, root=0)
 
-        detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
-        hf_slice = [
-            slice(det_off, det_off + det_nelem, 1),
-            slice(samp_off, samp_off + samp_nelem, 1),
-        ]
         sample_shape = None
         if len(full_shape) > 2:
             sample_shape = full_shape[2:]
-            for dim in full_shape[2:]:
-                detdata_slice.append(slice(0, dim))
-                hf_slice.append(slice(0, dim))
-        detdata_slice = tuple(detdata_slice)
-        hf_slice = tuple(hf_slice)
 
         # All processes create their local detector data
         obs.detdata.create(
@@ -209,25 +254,137 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
             units=units,
         )
 
-        # All processes independently load their data if running in
-        # parallel.  If loading serially, one process reads ands broadcasts.
-        # We implement it this way instead of using a scatter, since the
-        # data for each process is not contiguous in the dataset.
+        # All processes independently load their data if running in parallel.
+        # If loading serially, one process reads and sends blocks of detector
+        # data.  We can do this since we previously checked that for serial loads
+        # the data is distributed by detector.
 
         if serial_load:
-            full_slice = tuple([slice(0, x) for x in full_shape])
-            buffer = None
-            if ds is not None:
-                buffer = np.zeros(full_shape, dtype=dtype)
-                ds.read_direct(buffer, full_slice, full_slice)
-            if obs.comm.comm_group is not None:
-                buffer = obs.comm.comm_group.bcast(buffer, root=0)
-            obs.detdata[field].data[detdata_slice] = buffer[hf_slice]
-            del buffer
+            if compressed:
+                # Each process has the information about all detectors' byte
+                # range and compression parameters.  We just need to send
+                # the bytes.
+                for proc, detrange in enumerate(dist_dets):
+                    first_det = detrange.offset
+                    last_det = detrange.offset + detrange.n_elem - 1
+
+                    first_byte = comp_ranges[first_det][0]
+                    end_byte = comp_ranges[last_det][1]
+                    local_ranges = np.zeros(
+                        (detrange.n_elem, 2),
+                        dtype=np.int64,
+                    )
+                    for d in range(detrange.n_elem):
+                        local_ranges[d, 0] = comp_ranges[first_det + d][0] - first_byte
+                        local_ranges[d, 1] = comp_ranges[first_det + d][1] - first_byte
+
+                    if comp_offsets is not None:
+                        comp_params["data_offsets"] = comp_offsets[
+                            first_det : last_det + 1
+                        ]
+                    if comp_gains is not None:
+                        comp_params["data_gains"] = comp_gains[first_det : last_det + 1]
+
+                    pbytes = end_byte - first_byte
+                    pslice = (slice(0, pbytes, 1),)
+                    hslice = (slice(first_byte, end_byte, 1),)
+
+                    if obs.comm.group_rank == 0:
+                        buffer = np.zeros(pbytes, dtype=np.uint8)
+                        ds.read_direct(buffer, hslice, pslice)
+                        if proc == 0:
+                            # Decompress our own data
+                            decompress_detdata(
+                                buffer,
+                                local_ranges,
+                                comp_params,
+                                detdata=obs.detdata[field],
+                            )
+                        else:
+                            # Send
+                            obs.comm.comm_group.Send(buffer, dest=proc, tag=proc)
+                    elif obs.comm.group_rank == proc:
+                        # Receive and decompress
+                        buffer = np.zeros(pbytes, dtype=np.uint8)
+                        obs.comm.comm_group.Recv(buffer, source=0, tag=proc)
+                        decompress_detdata(
+                            buffer,
+                            local_ranges,
+                            comp_params,
+                            detdata=obs.detdata[field],
+                        )
+            else:
+                for proc, detrange in enumerate(dist_dets):
+                    first_det = detrange.offset
+                    end_det = detrange.offset + detrange.n_elem
+                    n_local_det = detrange.n_elem
+                    pslice = (slice(0, n_local_det, 1), slice(0, obs.n_all_samples, 1))
+                    hslice = (
+                        slice(first_det, end_det, 1),
+                        slice(0, obs.n_all_samples, 1),
+                    )
+                    if obs.comm.group_rank == 0:
+                        buffer = np.zeros((n_local_det, obs.n_all_samples), dtype=dtype)
+                        ds.read_direct(buffer, hslice, pslice)
+                        if proc == 0:
+                            # Copy data into place
+                            obs.detdata[field][:] = buffer
+                        else:
+                            # Send
+                            obs.comm.comm_group.Send(
+                                buffer.reshape(-1), dest=proc, tag=proc
+                            )
+                            del buffer
+                    elif obs.comm.group_rank == proc:
+                        # Receive and store
+                        buffer = np.zeros((n_local_det, obs.n_all_samples), dtype=dtype)
+                        obs.comm.comm_group.Recv(buffer, source=0, tag=proc)
+                        obs.detdata[field][:] = buffer
+                        del buffer
         else:
-            msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
-            check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
-            ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
+            if compressed:
+                last_det = det_off + det_nelem - 1
+                first_byte = comp_ranges[det_off][0]
+                end_byte = comp_ranges[last_det][1]
+                local_ranges = np.zeros(
+                    (det_nelem, 2),
+                    dtype=np.int64,
+                )
+                for d in range(det_nelem):
+                    local_ranges[d, 0] = comp_ranges[det_off + d][0] - first_byte
+                    local_ranges[d, 1] = comp_ranges[det_off + d][1] - first_byte
+
+                if comp_offsets is not None:
+                    comp_params["data_offsets"] = comp_offsets[det_off : last_det + 1]
+                if comp_gains is not None:
+                    comp_params["data_gains"] = comp_gains[det_off : last_det + 1]
+
+                pbytes = end_byte - first_byte
+                pslice = (slice(0, pbytes, 1),)
+                hslice = (slice(first_byte, end_byte, 1),)
+                buffer = np.zeros(pbytes, dtype=np.uint8)
+                ds.read_direct(buffer, hslice, pslice)
+                decompress_detdata(
+                    buffer,
+                    local_ranges,
+                    comp_params,
+                    detdata=obs.detdata[field],
+                )
+            else:
+                detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
+                hf_slice = [
+                    slice(det_off, det_off + det_nelem, 1),
+                    slice(samp_off, samp_off + samp_nelem, 1),
+                ]
+                if len(full_shape) > 2:
+                    for dim in full_shape[2:]:
+                        detdata_slice.append(slice(0, dim))
+                        hf_slice.append(slice(0, dim))
+                detdata_slice = tuple(detdata_slice)
+                hf_slice = tuple(hf_slice)
+                msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
+                check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
+                ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
 
         if obs.comm.comm_group is not None:
             obs.comm.comm_group.barrier()
@@ -284,9 +441,6 @@ def load_hdf5_intervals(obs, hgrp, times, fields, log_prefix, parallel):
         )
 
 
-# FIXME:  Add options here to prune detectors on load.
-
-
 @function_timer
 def load_hdf5(
     path,
@@ -296,6 +450,7 @@ def load_hdf5(
     detdata=None,
     shared=None,
     intervals=None,
+    detectors=None,
     force_serial=False,
 ):
     """Load an HDF5 observation.
@@ -310,10 +465,12 @@ def load_hdf5(
         process_rows (int):  (Optional) The size of the rectangular process grid
             in the detector direction.  This number must evenly divide into the size of
             comm.  If not specified, defaults to the size of the communicator.
-        meta (list):  Only save this list of metadata objects.
-        detdata (list):  Only save this list of detdata objects.
-        shared (list):  Only save this list of shared objects.
-        intervals (list):  Only save this list of intervals objects.
+        meta (list):  Only load this list of metadata objects.
+        detdata (list):  Only load this list of detdata objects.
+        shared (list):  Only load this list of shared objects.
+        intervals (list):  Only load this list of intervals objects.
+        detectors (list):  Only load this list of detectors from all detector data
+            objects.
         force_serial (bool):  If True, do not use HDF5 parallel support,
             even if it is available.
 
@@ -339,6 +496,16 @@ def load_hdf5(
     hfgroup = None
 
     parallel, _, _ = hdf5_config(comm=comm.comm_group, force_serial=force_serial)
+    if (
+        (not parallel)
+        and (process_rows is not None)
+        and (process_rows != comm.group_size)
+    ):
+        msg = f"When loading observations with serial HDF5, process_rows must equal "
+        msg += "the group size"
+        log.error(msg)
+        raise RuntimeError(msg)
+
     hf = hdf5_open(path, "r", comm=comm.comm_group, force_serial=force_serial)
     hgroup = hf
 
@@ -347,6 +514,39 @@ def load_hdf5(
         comm=comm.comm_group,
         timer=timer,
     )
+
+    # The rank zero process gets the file format version and communicates to all
+    # processes in the group, regardless of whether they are participating in
+    # the load.
+    file_version = None
+    if rank == 0:
+        # Data format version check
+        file_version = int(hgroup.attrs["toast_format_version"])
+    if comm.comm_group is not None:
+        file_version = comm.comm_group.bcast(file_version, root=0)
+
+    # As the file format evolves, we might close the file at this point and call
+    # an earlier version of the loader.  However, v0 and v1 only differ in the
+    # detector data loading, so we can just branch at that point.
+    #
+    # Example for future:
+    # if file_version == 12345:
+    #     # Close file and call older version
+    #     del hgroup
+    #     if hf is not None:
+    #         hf.close()
+    #     del hf
+    #     return load_hdf5_v12345(...)
+    #
+    if file_version == 0 and detectors is not None:
+        msg = f"HDF5 file '{path}' uses format v0 which does not support loading"
+        msg = " a subset of detectors"
+        log.error(msg)
+        raise RuntimeError(msg)
+    if file_version > 1:
+        msg = f"HDF5 file '{path}' using unsupported data format {file_version}"
+        log.error(msg)
+        raise RuntimeError(msg)
 
     telescope = None
     obs_samples = None
@@ -357,13 +557,6 @@ def load_hdf5(
     obs_sample_sets = None
 
     if hgroup is not None:
-        # Data format version check
-        file_version = int(hgroup.attrs["toast_format_version"])
-        if file_version != 0:
-            msg = f"HDF5 file '{path}' using unsupported data format {file_version}"
-            log.error(msg)
-            raise RuntimeError(msg)
-
         # Observation properties
         obs_name = str(hgroup.attrs["observation_name"])
         obs_uid = int(hgroup.attrs["observation_uid"])
@@ -457,8 +650,43 @@ def load_hdf5(
                 session_name, uid=session_uid, start=session_start, end=session_end
             )
 
-        focalplane = Focalplane()
-        focalplane.load_hdf5(inst_group, comm=None)
+        raw_focalplane = Focalplane()
+        raw_focalplane.load_hdf5(inst_group, comm=None)
+
+        if detectors is None:
+            focalplane = raw_focalplane
+        else:
+            # Slice focalplane to include only these detectors.  Also modify
+            # detector sets to include only these detectors.
+            keep = set(detectors)
+            fp_rows = [x["name"] in keep for x in raw_focalplane.detector_data]
+            fp_data = QTable(raw_focalplane.detector_data[fp_rows])
+
+            focalplane = Focalplane(
+                detector_data=fp_data,
+                sample_rate=raw_focalplane.sample_rate,
+                field_of_view=raw_focalplane.field_of_view,
+            )
+            new_detsets = list()
+            if isinstance(obs_det_sets, list):
+                # List of lists
+                for ds in obs_det_sets:
+                    new_ds = list()
+                    for d in ds:
+                        if d in keep:
+                            new_ds.append(d)
+                    if len(new_ds) > 0:
+                        new_detsets.append(new_ds)
+            else:
+                # Must be a dictionary
+                for dskey, ds in obs_det_sets.items():
+                    new_ds = list()
+                    for d in ds:
+                        if d in keep:
+                            new_ds.append(d)
+                    if len(new_ds) > 0:
+                        new_detsets.append(new_ds)
+            obs_det_sets = new_detsets
 
         telescope = telescope_class(
             telescope_name, uid=telescope_uid, focalplane=focalplane, site=site
@@ -624,7 +852,10 @@ def load_hdf5(
     detdata_group = None
     if hgroup is not None:
         detdata_group = hgroup["detdata"]
-    load_hdf5_detdata(obs, detdata_group, detdata, log_prefix, parallel)
+    if file_version == 0:
+        load_hdf5_detdata_v0(obs, detdata_group, detdata, log_prefix, parallel)
+    else:
+        load_hdf5_detdata(obs, detdata_group, detdata, log_prefix, parallel)
     del detdata_group
     log.debug_rank(
         f"{log_prefix} Finished detector data in",

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -236,6 +236,7 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
             full_shape = obs.comm.comm_group.bcast(full_shape, root=0)
             dtype = obs.comm.comm_group.bcast(dtype, root=0)
             if compressed:
+                comp_params = obs.comm.comm_group.bcast(comp_params, root=0)
                 comp_nbytes = obs.comm.comm_group.bcast(comp_nbytes, root=0)
                 comp_ranges = obs.comm.comm_group.bcast(comp_ranges, root=0)
                 comp_offsets = obs.comm.comm_group.bcast(comp_offsets, root=0)

--- a/src/toast/io/observation_hdf_load_v0.py
+++ b/src/toast/io/observation_hdf_load_v0.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+
+import numpy as np
+from astropy import units as u
+
+from ..mpi import MPI
+from ..timing import Timer, function_timer
+from ..utils import Logger
+from .hdf_utils import check_dataset_buffer_size
+
+
+@function_timer
+def load_hdf5_detdata_v0(obs, hgrp, fields, log_prefix, parallel):
+    log = Logger.get()
+
+    timer = Timer()
+    timer.start()
+
+    # Get references to the distribution of detectors and samples
+    dist_samps = obs.dist.samps
+    dist_dets = obs.dist.det_indices
+
+    # Data ranges for this process
+    samp_off = dist_samps[obs.comm.group_rank].offset
+    samp_nelem = dist_samps[obs.comm.group_rank].n_elem
+    det_off = dist_dets[obs.comm.group_rank].offset
+    det_nelem = dist_dets[obs.comm.group_rank].n_elem
+
+    serial_load = False
+    if obs.comm.group_size > 1 and not parallel:
+        # We are doing a serial load, but we have multiple processes
+        # in the group.
+        serial_load = True
+
+    field_list = None
+    if hgrp is not None:
+        field_list = list(hgrp.keys())
+    if serial_load and obs.comm.comm_group is not None:
+        # Broadcast the field list
+        field_list = obs.comm.comm_group.bcast(field_list, root=0)
+
+    for field in field_list:
+        if fields is not None and field not in fields:
+            continue
+        ds = None
+        units = None
+        full_shape = None
+        dtype = None
+        if hgrp is not None:
+            ds = hgrp[field]
+            full_shape = ds.shape
+            dtype = ds.dtype
+            units = u.Unit(str(ds.attrs["units"]))
+        if serial_load:
+            units = obs.comm.comm_group.bcast(units, root=0)
+            full_shape = obs.comm.comm_group.bcast(full_shape, root=0)
+            dtype = obs.comm.comm_group.bcast(dtype, root=0)
+
+        detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
+        hf_slice = [
+            slice(det_off, det_off + det_nelem, 1),
+            slice(samp_off, samp_off + samp_nelem, 1),
+        ]
+        sample_shape = None
+        if len(full_shape) > 2:
+            sample_shape = full_shape[2:]
+            for dim in full_shape[2:]:
+                detdata_slice.append(slice(0, dim))
+                hf_slice.append(slice(0, dim))
+        detdata_slice = tuple(detdata_slice)
+        hf_slice = tuple(hf_slice)
+
+        # All processes create their local detector data
+        obs.detdata.create(
+            field,
+            sample_shape=sample_shape,
+            dtype=dtype,
+            detectors=obs.local_detectors,
+            units=units,
+        )
+
+        # All processes independently load their data if running in
+        # parallel.  If loading serially, one process reads ands broadcasts.
+        # We implement it this way instead of using a scatter, since the
+        # data for each process is not contiguous in the dataset.
+
+        if serial_load:
+            full_slice = tuple([slice(0, x) for x in full_shape])
+            buffer = None
+            if ds is not None:
+                buffer = np.zeros(full_shape, dtype=dtype)
+                ds.read_direct(buffer, full_slice, full_slice)
+            if obs.comm.comm_group is not None:
+                buffer = obs.comm.comm_group.bcast(buffer, root=0)
+            obs.detdata[field].data[detdata_slice] = buffer[hf_slice]
+            del buffer
+        else:
+            msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
+            check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
+            ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
+
+        if obs.comm.comm_group is not None:
+            obs.comm.comm_group.barrier()
+        log.verbose_rank(
+            f"{log_prefix}  Detdata finished {field} read in",
+            comm=obs.comm.comm_group,
+            timer=timer,
+        )
+        del ds

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -439,7 +439,13 @@ class DetectorData(AcceleratorObject):
             return False
         if self.units != other.units:
             return False
-        if not np.allclose(self.data, other.data):
+        if self.dtype == np.dtype(np.float64):
+            if not np.allclose(self.data, other.data, rtol=1.0e-5, atol=1.0e-8):
+                return False
+        elif self.dtype == np.dtype(np.float32):
+            if not np.allclose(self.data, other.data, rtol=1.0e-3, atol=1.0e-5):
+                return False
+        elif not np.array_equal(self.data, other.data):
             return False
         return True
 
@@ -1065,8 +1071,7 @@ class DetDataManager(MutableMapping):
             log.verbose(f"  keys {self._internal.keys()} != {other._internal.keys()}")
             return False
         for k in self._internal.keys():
-            # if self._internal[k] != other._internal[k]:
-            if not np.allclose(self._internal[k], other._internal[k]):
+            if self._internal[k] != other._internal[k]:
                 msg = f"  detector data {k} not equal:  "
                 msg += f"{self._internal[k]} != {other._internal[k]}"
                 log.verbose(msg)

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -443,7 +443,7 @@ class DetectorData(AcceleratorObject):
             if not np.allclose(self.data, other.data, rtol=1.0e-5, atol=1.0e-8):
                 return False
         elif self.dtype == np.dtype(np.float32):
-            if not np.allclose(self.data, other.data, rtol=1.0e-3, atol=1.0e-5):
+            if not np.allclose(self.data, other.data, rtol=1.0e-4, atol=1.0e-7):
                 return False
         elif not np.array_equal(self.data, other.data):
             return False

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -8,11 +8,132 @@ import numpy as np
 import traitlets
 
 from ..io import load_hdf5, save_hdf5
+from ..mpi import MPI, comm_equal
 from ..observation import default_values as defaults
 from ..timing import function_timer
 from ..traits import Bool, Dict, Int, List, Unicode, trait_docs
 from ..utils import Logger
 from .operator import Operator
+
+
+def obs_approx_equal(obs1, obs2):
+    """Compare observations with relaxed floating point data comparisons.
+
+    Normal equality tests for detector data may be too stringent in the case where
+    float64 data is compressed to 32bit integer FLAC data.  Here we do a normal equality
+    test except for detector data that has floating point values, where we instead
+    use an increased tolerance.
+
+    Args:
+        obs1 (Observation):  The first observation to compare.
+        obs2 (Observation):  The second observation to compare.
+
+    Returns:
+        (bool):  True if observations are approximately equal.
+
+    """
+    log = Logger.get()
+    fail = 0
+    if obs1.name != obs2.name:
+        fail = 1
+        log.verbose(
+            f"Proc {obs1.comm.world_rank}:  Obs names {obs1.name} != {obs2.name}"
+        )
+    if obs1.uid != obs2.uid:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs uid {obs1.uid} != {obs2.uid}")
+    if obs1.telescope != obs2.telescope:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs telescopes not equal")
+    if obs1.session != obs2.session:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs sessions not equal")
+    if obs1.dist != obs2.dist:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs distributions not equal")
+    if set(obs1._internal.keys()) != set(obs2._internal.keys()):
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs metadata keys not equal")
+    for k, v in obs1._internal.items():
+        if v != obs2._internal[k]:
+            feq = True
+            try:
+                feq = np.allclose(v, obs2._internal[k])
+            except Exception:
+                # Not floating point data
+                feq = False
+            if not feq:
+                fail = 1
+                log.verbose(
+                    f"Proc {obs1.comm.world_rank}:  Obs metadata[{k}]:  {v} != {obs2[k]}"
+                )
+                break
+    if obs1.shared != obs2.shared:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs shared data not equal")
+    if obs1.intervals != obs2.intervals:
+        fail = 1
+        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs intervals not equal")
+
+    # Walk through the detector data
+    o1d = obs1.detdata
+    o2d = obs2.detdata
+    if o1d.detectors != o2d.detectors:
+        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata detectors"
+        msg += f" {o1d.detectors} != {o2d.detectors}"
+        log.verbose(msg)
+        fail = 1
+    if o1d.samples != o2d.samples:
+        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata samples "
+        msg += f"{o1d.samples} != {o2d.samples}"
+        log.verbose(msg)
+        fail = 1
+    if set(o1d._internal.keys()) != set(o2d._internal.keys()):
+        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata keys "
+        msg += f"{o1d._internal.keys()} != {o2d._internal.keys()}"
+        log.verbose(msg)
+        fail = 1
+    for k in o1d._internal.keys():
+        if o1d[k].detectors != o2d[k].detectors:
+            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} detectors "
+            msg += f"{o1d[k].detectors} != {o2d[k].detectors}"
+            log.verbose(msg)
+            fail = 1
+        if o1d[k].dtype.char != o2d[k].dtype.char:
+            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} dtype "
+            msg += f"{o1d[k].dtype} != {o2d[k].dtype}"
+            log.verbose(msg)
+            fail = 1
+        if o1d[k].shape != o2d[k].shape:
+            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} shape "
+            msg += f"{o1d[k].shape} != {o2d[k].shape}"
+            log.verbose(msg)
+            fail = 1
+        if o1d[k].units != o2d[k].units:
+            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} units "
+            msg += f"{o1d[k].units} != {o2d[k].units}"
+            log.verbose(msg)
+            fail = 1
+        if o1d[k].dtype == np.dtype(np.float64):
+            if not np.allclose(o1d[k].data, o2d[k].data, rtol=1.0e-5, atol=1.0e-8):
+                msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} array "
+                msg += f"{o1d[k].data} != {o2d[k].data}"
+                log.verbose(msg)
+                fail = 1
+        elif o1d[k].dtype == np.dtype(np.float32):
+            if not np.allclose(o1d[k].data, o2d[k].data, rtol=1.0e-3, atol=1.0e-5):
+                msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} array "
+                msg += f"{o1d[k].data} != {o2d[k].data}"
+                log.verbose(msg)
+                fail = 1
+        elif not np.array_equal(o1d[k].data, o2d[k].data):
+            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} array "
+            msg += f"{o1d[k].data} != {o2d[k].data}"
+            log.verbose(msg)
+            fail = 1
+    if obs1.comm.comm_group is not None:
+        fail = obs1.comm.comm_group.allreduce(fail, op=MPI.SUM)
+    return fail == 0
 
 
 @trait_docs
@@ -179,7 +300,7 @@ class SaveHDF5(Operator):
                     force_serial=self.force_serial,
                 )
 
-                if compare != original:
+                if not obs_approx_equal(compare, original):
                     msg = f"Observation HDF5 verify failed:\n"
                     msg += f"Input = {original}\n"
                     msg += f"Loaded = {compare}"

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ install(FILES
     ops_perturbhwp.py
     ops_filterbin.py
     io_hdf5.py
+    io_compression.py
     ops_noise_estim.py
     ops_yield_cut.py
     ops_elevation_noise.py

--- a/src/toast/tests/io_compression.py
+++ b/src/toast/tests/io_compression.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 

--- a/src/toast/tests/io_compression.py
+++ b/src/toast/tests/io_compression.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import sys
+
+import numpy as np
+from astropy import units as u
+
+from .. import ops as ops
+from ..data import Data
+from ..io import compress_detdata, decompress_detdata, save_hdf5, load_hdf5
+from ..io.compression_flac import (
+    have_flac_support,
+    float2int,
+    int2float,
+    int64to32,
+    compress_detdata_flac,
+    decompress_detdata_flac,
+    compress_flac,
+    decompress_flac,
+    compress_flac_2D,
+    decompress_flac_2D,
+)
+from ..observation_data import DetectorData
+from ..observation import default_values as defaults
+from ..utils import AlignedU8, AlignedI32
+from ..timing import Timer
+from ._helpers import close_data, create_ground_data, create_outdir
+from .mpi import MPITestCase
+
+
+class IoCompressionTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+        self.types = {
+            "f64": np.float64,
+            "f32": np.float32,
+            "i64": np.int64,
+            "i32": np.int32,
+        }
+        self.fakedets = ["D00A", "D00B", "D01A", "D01B"]
+
+    def test_type_conversion(self):
+        rng = np.random.default_rng(12345)
+
+        n_test = 10000
+
+        off = 1.0e6
+        scale = 100.0
+        data = scale * rng.random(size=n_test, dtype=np.float64) + off
+        idata, doff, dgain = float2int(data)
+        check = int2float(idata, doff, dgain)
+        self.assertTrue(np.allclose(check, data, rtol=1.0e-6, atol=1.0e-5))
+
+        rng_max = np.iinfo(np.int32).max // 2
+        i64data = rng.integers(
+            -rng_max,
+            rng_max,
+            size=n_test,
+            dtype=np.int64,
+        )
+        idata, ioff = int64to32(i64data)
+        check = np.array(idata, dtype=np.int64) + ioff
+        self.assertTrue(np.array_equal(check, i64data))
+
+    def test_flac_lowlevel(self):
+        if not have_flac_support():
+            print("FLAC disabled, skipping...")
+            return
+
+        timer1 = Timer()
+        timer2 = Timer()
+
+        n_det = 20
+        n_samp = 100000
+
+        rng = np.random.default_rng(12345)
+
+        rng_max = np.iinfo(np.int32).max // 2
+        input = rng.integers(
+            -rng_max,
+            rng_max,
+            size=(n_det * n_samp),
+            dtype=np.int32,
+        ).reshape((n_det, n_samp))
+
+        # Compare results of 1D and 2D compression
+
+        timer2.start()
+        fbytes2, foffs2 = compress_flac_2D(input, 5)
+        timer2.stop()
+
+        # print(f"Compress 2D one shot in {timer2.seconds()} s")
+        timer2.clear()
+
+        fbytes1 = AlignedU8()
+        foffs1 = np.zeros(n_det, dtype=np.int64)
+        timer1.start()
+        for d in range(n_det):
+            cur = fbytes1.size()
+            foffs1[d] = cur
+            dbytes = compress_flac(input[d], 5)
+            ext = len(dbytes)
+            fbytes1.resize(cur + ext)
+            fbytes1[cur : cur + ext] = dbytes
+        timer1.stop()
+
+        # print(f"Compress {n_det} dets with 1D in {timer1.seconds()} s")
+        timer1.clear()
+
+        self.assertTrue(len(fbytes1) == len(fbytes2))
+        self.assertTrue(np.array_equal(fbytes1, fbytes2))
+        self.assertTrue(np.array_equal(foffs1, foffs2))
+
+        timer2.start()
+        output2 = decompress_flac_2D(fbytes2, foffs2)
+        timer2.stop()
+
+        # print(f"Decompress 2D one shot in {timer2.seconds()} s")
+        timer2.clear()
+
+        output1 = AlignedI32()
+        timer1.start()
+        for d in range(n_det):
+            cur = output1.size()
+            if d == n_det - 1:
+                slc = slice(foffs1[d], len(fbytes1), 1)
+            else:
+                slc = slice(foffs1[d], foffs1[d + 1], 1)
+            dout = decompress_flac(fbytes1[slc])
+            ext = len(dout)
+            output1.resize(cur + ext)
+            output1[cur : cur + ext] = dout
+        timer1.stop()
+
+        # print(f"Decompress {n_det} dets with 1D in {timer1.seconds()} s")
+        timer1.clear()
+
+        self.assertTrue(np.array_equal(output1, output2))
+
+    def test_roundtrip_detdata(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+        n_samp = 100000
+
+        rng = np.random.default_rng(12345)
+
+        comp_types = ["none", "gzip"]
+        if have_flac_support():
+            comp_types.append("flac")
+        else:
+            print("FLAC disabled, skipping 'flac' compression type")
+
+        for comp_type in comp_types:
+            for dtname, dt in self.types.items():
+                # Use fake data with multiple elements per sample, just to test
+                # correct handling.
+                detdata = DetectorData(
+                    self.fakedets,
+                    (n_samp, 4),
+                    dtype=dt,
+                    units=u.K,
+                )
+                if dtname == "f32" or dtname == "f64":
+                    detdata.flatdata[:] = rng.random(
+                        size=(4 * n_samp * len(self.fakedets)), dtype=dt
+                    )
+                else:
+                    rng_max = np.iinfo(np.int32).max // 2
+                    detdata.flatdata[:] = rng.integers(
+                        0,
+                        rng_max,
+                        size=(4 * n_samp * len(self.fakedets)),
+                        dtype=dt,
+                    )
+
+                # print(
+                #     f"Uncompressed {comp_type}:{dtname} is {detdata.memory_use()} bytes"
+                # )
+                comp_data = compress_detdata(detdata, {"type": comp_type})
+                # print(f"  Compressed {comp_type}:{dtname} is {len(comp_data[0])} bytes")
+                new_detdata = decompress_detdata(
+                    comp_data[0], comp_data[1], comp_data[2]
+                )
+                check = np.allclose(new_detdata[:], detdata[:], atol=1.0e-5)
+                if not check:
+                    print(f"Orig:  {detdata}")
+                    print(f"New:  {new_detdata}")
+                    self.assertTrue(False)
+                del new_detdata
+                del detdata
+
+    def create_data(self):
+        data = create_ground_data(self.comm)
+
+        # Simple detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight="boresight_azel", quats="quats_azel"
+        )
+
+        # Create a noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model="noise_model",
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(noise_model=el_model.out_model)
+        sim_noise.apply(data)
+
+        # Simulate atmosphere
+        sim_atm = ops.SimAtmosphere(
+            detector_pointing=detpointing_azel,
+        )
+        sim_atm.apply(data)
+
+        # Delete temporary object.
+        for ob in data.obs:
+            del ob.detdata["quats_azel"]
+
+        return data
+
+    def test_roundtrip_memory(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        data = self.create_data()
+
+        comp_types = ["none", "gzip"]
+        if have_flac_support():
+            comp_types.append("flac")
+        else:
+            print("FLAC disabled, skipping 'flac' compression type")
+
+        for comp_type in comp_types:
+            # Extract compressed versions of signal and flags
+            for ob in data.obs:
+                for key in [defaults.det_data]:
+                    # msg = f"{ob.name} uncompressed {comp_type}:{key} is "
+                    # msg += f"{ob.detdata[key].memory_use()} bytes"
+                    # print(msg)
+                    comp_data = compress_detdata(ob.detdata[key], {"type": comp_type})
+                    # msg = f"{ob.name}   compressed {comp_type}:{key} is "
+                    # msg += f"{len(comp_data[0])} bytes"
+                    # print(msg)
+                    new_detdata = decompress_detdata(
+                        comp_data[0], comp_data[1], comp_data[2]
+                    )
+                    check = np.allclose(new_detdata[:], ob.detdata[key][:], atol=1.0e-5)
+                    if not check:
+                        print(f"Orig:  {ob.detdata[key]}")
+                        print(f"New:  {new_detdata}")
+                        self.assertTrue(False)
+
+                if comp_type == "flac":
+                    continue
+
+                comp_data = compress_detdata(
+                    ob.detdata[defaults.det_flags], {"type": comp_type}
+                )
+                new_detdata = decompress_detdata(
+                    comp_data[0], comp_data[1], comp_data[2]
+                )
+                if new_detdata != ob.detdata[defaults.det_flags]:
+                    print(f"Orig:  {ob.detdata[defaults.det_flags]}")
+                    print(f"New:  {new_detdata}")
+                    self.assertTrue(False)
+
+        close_data(data)
+
+    def test_roundtrip_hdf5(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        testdir = os.path.join(self.outdir, "test_hdf5")
+        if rank == 0:
+            os.makedirs(testdir)
+        nocompdir = os.path.join(self.outdir, "test_hdf5_nocomp")
+        if rank == 0:
+            os.makedirs(nocompdir)
+
+        data = self.create_data()
+
+        obfiles = list()
+        for obs in data.obs:
+            _ = save_hdf5(
+                obs,
+                nocompdir,
+                meta=None,
+                detdata=[
+                    defaults.det_data,
+                    defaults.det_flags,
+                ],
+                shared=None,
+                intervals=None,
+                config=None,
+                times=defaults.times,
+                force_serial=False,
+                detdata_float32=True,
+            )
+            if have_flac_support():
+                dcomp = (defaults.det_data, {"type": "flac"})
+            else:
+                print("FLAC disabled, default to detdata compression='none'")
+                dcomp = (defaults.det_data, {"type": "none"})
+            obf = save_hdf5(
+                obs,
+                testdir,
+                meta=None,
+                detdata=[
+                    dcomp,
+                    (defaults.det_flags, {"type": "gzip"}),
+                ],
+                shared=None,
+                intervals=None,
+                config=None,
+                times=defaults.times,
+                force_serial=False,
+                detdata_float32=False,
+            )
+            obfiles.append(obf)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        # Load the data and check
+        check_data = Data(comm=data.comm)
+
+        for hfile in obfiles:
+            check_data.obs.append(load_hdf5(hfile, check_data.comm))
+
+        # Verify.  The other unit tests will check general HDF5 I/O in the case without
+        # compression.  Here we are testing the round trip of DetectorData objects.
+        for ob, orig in zip(check_data.obs, data.obs):
+            if ob.detdata[defaults.det_flags] != orig.detdata[defaults.det_flags]:
+                msg = f"---- Proc {data.comm.world_rank} flags not equal ---\n"
+                msg += f"{orig.detdata[defaults.det_flags]}\n"
+                msg += f"{ob.detdata[defaults.det_flags]}"
+                print(msg)
+                self.assertTrue(False)
+            if not np.allclose(
+                ob.detdata[defaults.det_data],
+                orig.detdata[defaults.det_data],
+                atol=1.0e-4,
+                rtol=1.0e-5,
+            ):
+                msg = f"---- Proc {data.comm.world_rank} signal not equal ---\n"
+                msg += f"{orig.detdata[defaults.det_data]}\n"
+                msg += f"{ob.detdata[defaults.det_data]}"
+                print(msg)
+                self.assertTrue(False)
+
+        close_data(data)
+
+    def test_hdf5_verify(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        testdir = os.path.join(self.outdir, "verify_hdf5")
+        if rank == 0:
+            os.makedirs(testdir)
+
+        data = self.create_data()
+
+        if have_flac_support():
+            dcomp = (defaults.det_data, {"type": "flac"})
+        else:
+            print("FLAC disabled, default to detdata compression='none'")
+            dcomp = (defaults.det_data, {"type": "none"})
+
+        saver = ops.SaveHDF5(
+            volume=testdir,
+            detdata=[
+                dcomp,
+                (defaults.det_flags, {"type": "gzip"}),
+            ],
+            detdata_float32=True,
+            verify=True,
+        )
+        saver.apply(data)
+
+        close_data(data)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -36,8 +36,6 @@ class IoHdf5Test(MPITestCase):
             split=split,
         )
 
-        data = create_ground_data(self.comm)
-
         # Simple detector pointing
         detpointing_azel = ops.PointingDetectorSimple(
             boresight="boresight_azel", quats="quats_azel"
@@ -142,7 +140,10 @@ class IoHdf5Test(MPITestCase):
                 if ddata.dtype.char == "d":
                     # Hack in a replacement
                     new_dd = DetectorData(
-                        ddata.detectors, ddata.shape, np.float32, units=ddata.units
+                        ddata.detectors,
+                        ddata.detector_shape,
+                        np.float32,
+                        units=ddata.units,
                     )
                     new_dd[:] = original[ob.name].detdata[field][:]
                     original[ob.name].detdata._internal[field] = new_dd

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -22,6 +22,7 @@ from . import healpix as test_healpix
 from . import instrument as test_instrument
 from . import intervals as test_intervals
 from . import io_hdf5 as test_io_hdf5
+from . import io_compression as test_io_compression
 from . import math_misc as test_math_misc
 from . import noise as test_noise
 from . import observation as test_observation
@@ -217,6 +218,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_template_gain))
 
         suite.addTest(loader.loadTestsFromModule(test_io_hdf5))
+        suite.addTest(loader.loadTestsFromModule(test_io_compression))
 
         suite.addTest(loader.loadTestsFromModule(test_accelerator))
 

--- a/wheels/install_deps_linux.sh
+++ b/wheels/install_deps_linux.sh
@@ -143,6 +143,40 @@ tar xzf ${aatm_pkg} \
     && popd >/dev/null 2>&1 \
     && popd >/dev/null 2>&1
 
+# Install libFLAC
+
+flac_version=1.4.2
+flac_dir=flac-${flac_version}
+flac_pkg=${flac_dir}.tar.gz
+
+echo "Fetching libFLAC..."
+
+if [ ! -e ${flac_pkg} ]; then
+    curl -SL "https://github.com/xiph/flac/archive/refs/tags/${flac_version}.tar.gz" -o "${flac_pkg}"
+fi
+
+echo "Building libFLAC..."
+
+rm -rf ${flac_dir}
+tar xzf ${flac_pkg} \
+    && pushd ${flac_dir} >/dev/null 2>&1 \
+    && mkdir -p build \
+    && pushd build >/dev/null 2>&1 \
+    && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DWITH_OGG=OFF \
+    -DINSTALL_MANPAGES=OFF \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    .. \
+    && make -j ${MAKEJ} install \
+    && popd >/dev/null 2>&1 \
+    && popd >/dev/null 2>&1
+
 # Install SuiteSparse
 
 ssparse_version=6.0.3

--- a/wheels/install_deps_osx.sh
+++ b/wheels/install_deps_osx.sh
@@ -217,6 +217,40 @@ tar xzf ${aatm_pkg} \
     && popd >/dev/null 2>&1 \
     && popd >/dev/null 2>&1
 
+# Install libFLAC
+
+flac_version=1.4.2
+flac_dir=flac-${flac_version}
+flac_pkg=${flac_dir}.tar.gz
+
+echo "Fetching libFLAC..."
+
+if [ ! -e ${flac_pkg} ]; then
+    curl -SL "https://github.com/xiph/flac/archive/refs/tags/${flac_version}.tar.gz" -o "${flac_pkg}"
+fi
+
+echo "Building libFLAC..."
+
+rm -rf ${flac_dir}
+tar xzf ${flac_pkg} \
+    && pushd ${flac_dir} >/dev/null 2>&1 \
+    && mkdir -p build \
+    && pushd build >/dev/null 2>&1 \
+    && cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_C_COMPILER="${CC}" \
+    -DCMAKE_CXX_COMPILER="${CXX}" \
+    -DCMAKE_C_FLAGS="${CFLAGS}" \
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DWITH_OGG=OFF \
+    -DINSTALL_MANPAGES=OFF \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    .. \
+    && make -j ${MAKEJ} install \
+    && popd >/dev/null 2>&1 \
+    && popd >/dev/null 2>&1
+
 # Install SuiteSparse
 
 ssparse_version=6.0.3


### PR DESCRIPTION
The DetectorData class is our primary container for timestream data from a set of co-sampled detectors.  This is used for signal, flags, detector pointing, etc.  When storing this data to disk, it is useful to compress it.  This work adds support for gzip and flac compression (and a "none" type for testing) of DetectorData:

* Add optional compile time support for linking to libFLAC versions >= 1.4.0, which was the first version to support 32bit integers.

* Add compiled utility functions for compressing / decompressing 32bit integer data with FLAC, and pybind11 interfaces to these.

* Add new file `io/compression.py`, which has functions for compressing and decompressing DetectorData.  The compressed format is a stream of bytes, a set of byte ranges for each detector, and a dictionary of compression properties.

* Conditional routines to compress / decompress DetectorData with FLAC.  For floating point data, an optional resolution can be specified for each detector to represent the floating point amount of one integer bit.  Default behavior maps the full amplitude range of the input to the signed 31bit range supported in flac.