### PR TITLE
Jax bugfix

### DIFF
--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -169,7 +169,7 @@ class Operator(TraitConfig):
         # for a data object.
         log = Logger.get()
         if not self.supports_accel():
-            # No support for OpenACC
+            # No support for OpenMP target offload
             return False
         all_present = True
         req = self.requires()

--- a/src/toast/ops/scan_map/kernels_jax.py
+++ b/src/toast/ops/scan_map/kernels_jax.py
@@ -168,8 +168,8 @@ def scan_map_interval(
         weights_interval = jnp.ones_like(pixels_interval)
     elif weights.ndim == 2:
         weights_interval = JaxIntervals.get(
-            weights, (weight_index, intervals)
-        )  # weights[weight_index, intervals]
+            weights, (weight_index, intervals, jnp.newaxis)
+        )  # weights[weight_index, intervals, np.newaxis]
     else:
         weights_interval = JaxIntervals.get(
             weights, (weight_index, intervals, ALL)

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -137,17 +137,19 @@ class MapmakerTest(MPITestCase):
         mapper.apply(data)
 
         # Check that we can also run in full-memory mode
+        use_accel = False
         if accel_enabled():
+            use_accel = True
             data.accel_create(pixels.requires())
             data.accel_create(weights.requires())
             data.accel_update_device(pixels.requires())
             data.accel_update_device(weights.requires())
 
-        pixels.apply(data)
-        weights.apply(data)
+        pixels.apply(data, use_accel=use_accel)
+        weights.apply(data, use_accel=use_accel)
         binner.full_pointing = True
         mapper.name = "test2"
-        mapper.apply(data)
+        mapper.apply(data, use_accel=use_accel)
 
         close_data(data)
 

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -138,12 +138,14 @@ class MapmakerTest(MPITestCase):
 
         # Check that we can also run in full-memory mode
         use_accel = False
-        if accel_enabled():
+        if accel_enabled() and (pixels.supports_accel() and weights.supports_accel() and mapper.supports_accel()):
             use_accel = True
             data.accel_create(pixels.requires())
             data.accel_create(weights.requires())
+            data.accel_create(mapper.requires())
             data.accel_update_device(pixels.requires())
             data.accel_update_device(weights.requires())
+            data.accel_update_device(mapper.requires())
 
         pixels.apply(data, use_accel=use_accel)
         weights.apply(data, use_accel=use_accel)


### PR DESCRIPTION
Introduces fixes to get two unit tests running with JAX enabled.

Modification to the `ops_mapmaker.py` file are up for debate.