### PR TITLE
fixed missing/order for provide

### DIFF
--- a/src/toast/ops/noise_weight/noise_weight.py
+++ b/src/toast/ops/noise_weight/noise_weight.py
@@ -106,7 +106,7 @@ class NoiseWeight(Operator):
         return req
 
     def _provides(self):
-        return dict()
+        return {"detdata": [self.det_data]}
 
     def _implementations(self):
         return [

--- a/src/toast/ops/operator.py
+++ b/src/toast/ops/operator.py
@@ -143,7 +143,7 @@ class Operator(TraitConfig):
         return dict()
 
     def provides(self):
-        """Dictionary of Observation keys created by this Operator.
+        """Dictionary of Observation keys created or modified by this Operator.
 
         This dictionary should have 5 keys, each containing a list of "global",
         "metadata", "detdata", "shared", and "intervals" fields.  Global keys are

--- a/src/toast/ops/scan_map/scan_map.py
+++ b/src/toast/ops/scan_map/scan_map.py
@@ -172,8 +172,7 @@ class ScanMap(Operator):
         return req
 
     def _provides(self):
-        prov = {"meta": list(), "shared": list(), "detdata": list()}
-        return prov
+        return {"detdata": [self.det_data]}
 
     def _implementations(self):
         return [


### PR DESCRIPTION
Added missing `requires` for operators.

This introduce occasional overlaps between `requires` and `provides` (something that did not previously occur in the codebase) which required tweaking the order of operations in the `requires`/`provides` for the `Pipeline` class (otherwise we end up with missing `requires`/`provides` for the full pipeline) as well as not deleting intermediate product (otherwise we end up with missing `requires` in the pipeline, that particular change that was coming with hybrid pipelines anyway).