### PR TITLE
Code modification introduced for benchmarking

### DIFF
--- a/src/libtoast/src/toast_sys_environment.cpp
+++ b/src/libtoast/src/toast_sys_environment.cpp
@@ -150,7 +150,10 @@ toast::Environment::Environment() {
     func_timers_ = false;
     envval = ::getenv("TOAST_FUNCTIME");
     if (envval != NULL) {
-        func_timers_ = true;
+        std::string envstring(envval);
+        if ((envstring == "1") || (envstring == "true") || (envstring == "yes")) {
+            func_timers_ = true;
+        }
     }
 
     // Select MKL threading layer

--- a/src/toast/__init__.py
+++ b/src/toast/__init__.py
@@ -19,7 +19,7 @@ TOAST_LOGLEVEL=<value>
     * Controls logging of both C++ and Python code.
 
 TOAST_FUNCTIME=<value>
-    * Any non-empty value will enable python function timers in many parts of the code
+    * Values "1", "true", or "yes" will enable python function timers in many parts of the code.
 
 TOAST_GPU_OPENMP=<value>
     * Values "1", "true", or "yes" will enable runtime-support for OpenMP

--- a/src/toast/__init__.py
+++ b/src/toast/__init__.py
@@ -30,6 +30,10 @@ TOAST_GPU_JAX=<value>
     * Values "1", "true", or "yes" will enable runtime support for jax.
     * Requires jax to be available / importable.
 
+TOAST_GPU_HYBRID_PIPELINES=<value>
+    * Values "0", "false", or "no" will disable runtime support for hybrid GPU pipelines.
+    * Requires TOAST_GPU_OPENMP or TOAST_GPU_JAX to be enabled.
+
 OMP_NUM_THREADS=<integer>
     * Toast uses OpenMP threading in several places and the concurrency is set by the
       usual environment variable.

--- a/src/toast/jax/device.py
+++ b/src/toast/jax/device.py
@@ -15,6 +15,7 @@ def slurm_nb_devices():
     else:
         return 1
 
+
 def jax_accel_get_device():
     """Returns the device currenlty used by JAX."""
     # gets local device if it has been designated
@@ -60,5 +61,5 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
         local_device = jax_accel_get_device()
         log = Logger.get()
         log.debug(
-            f"JAX rank {node_rank}/{node_procs} uses device number {device_id}/{nb_devices} ({local_device} mem_fraction:{mem_fraction:.2f})"
+            f"JAX rank {node_rank}/{node_procs} uses {mem_percent}% of device {local_device} ({device_id+1}/{nb_devices})"
         )

--- a/src/toast/jax/device.py
+++ b/src/toast/jax/device.py
@@ -38,9 +38,10 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
 
     Returns:
         None: the device is stored in JAX internal state
+
+    WARNING: no Jax function should be called before the call to `initialize` inside this function.
     """
     if (not disabled) and (node_procs > 1): 
-        # WARNING: we cannot use a Jax function before the call to `initialize`
         # gets id of device to be used by this process
         nb_devices = slurm_nb_devices()
         device_id = node_rank % nb_devices

--- a/src/toast/jax/device.py
+++ b/src/toast/jax/device.py
@@ -1,17 +1,30 @@
 import math
 import os
-
 import jax
-
 from .._libtoast import Logger
 
-jax_local_device = None
-"""
-    The device that JAX operators should be using on this process.
-    Use the function `set_JAX_device` to set this value (this should be done during MPI initialization)
-    Use like this in your JAX code: `jax.device_put(data, device=jax_local_device)`
-    Or set globally with: `jax.config.update("jax_default_device", jax_local_device)`
-"""
+def slurm_nb_devices():
+    """
+    Returns the number of devices available on this node.
+    (without calling a Jax function)
+    """
+    if 'SLURM_GPUS_ON_NODE' in os.environ:
+        return int(os.environ['SLURM_GPUS_ON_NODE'])
+    elif 'SLURM_GPUS_PER_NODE' in os.environ:
+        return int(os.environ['SLURM_GPUS_PER_NODE'])
+    else:
+        return 1
+
+def jax_accel_get_device():
+    """Returns the device currenlty used by JAX."""
+    # gets local device if it has been designated
+    local_device = jax.config.jax_default_device
+    # otherwise gets the first device available
+    if local_device is None:
+        devices = jax.local_devices()
+        if len(devices) > 0:
+            local_device = devices[0]
+    return local_device
 
 
 def jax_accel_assign_device(node_procs, node_rank, disabled):
@@ -24,35 +37,27 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
         disabled (bool): gpu computing is disabled
 
     Returns:
-        None: the device is stored in the jax_local_device global variable and jax.config
+        None: the device is stored in JAX internal state
     """
-    # list of GPUs / CPUs available
-    devices_available = jax.devices()
-    # gets id of device to be used by this process
-    nb_devices = len(devices_available)
-    device_id = 0 if disabled else (node_rank % nb_devices)
-    # sets the device in a local variable and globaly
-    global jax_local_device
-    jax_local_device = devices_available[device_id]
-    jax.config.update("jax_default_device", jax_local_device)
-    # sets the size of the preallocated memory pool (if it is still possible)
-    # we work with integers first to insure rounding down by a percent
-    default_mem_percent = 90
-    process_per_device = math.ceil(node_procs / nb_devices)
-    mem_percent = min(default_mem_percent, default_mem_percent // process_per_device)
-    mem_fraction = mem_percent / 100
-    os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = f"{mem_fraction:.2f}"
-    # displays information on the device picked
-    log = Logger.get()
-    log.debug(
-        f"JAX rank {node_rank}/{node_procs} uses device number {device_id}/{nb_devices} ({jax_local_device} mem_fraction:{mem_fraction:.2f})"
-    )
-
-
-def jax_accel_get_device():
-    """Returns the device currenlty used by JAX or errors out."""
-    if jax_local_device is None:
-        raise RuntimeError(
-            "Jax device is not set, please insure that you have called 'accel_assign_device'"
+    if (not disabled) and (node_procs > 1): 
+        # WARNING: we cannot use a Jax function before the call to `initialize`
+        # gets id of device to be used by this process
+        nb_devices = slurm_nb_devices()
+        device_id = node_rank % nb_devices
+        process_per_device = math.ceil(node_procs / nb_devices)
+        # sets the size of the preallocated memory pool
+        # (this will only work if Jax has not be initialized yet)
+        # we work with integers first to insure rounding down by a percent
+        default_mem_fraction = float(os.environ.get('XLA_PYTHON_CLIENT_MEM_FRACTION', 0.9))
+        default_mem_percent = int(100 * default_mem_fraction)
+        mem_percent = min(default_mem_percent, default_mem_percent // process_per_device)
+        mem_fraction = mem_percent / 100
+        os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = f"{mem_fraction:.2f}"
+        # associate the device to this process
+        jax.distributed.initialize(local_device_ids=[device_id])
+        # displays information on the device picked
+        local_device = jax_accel_get_device()
+        log = Logger.get()
+        log.debug(
+            f"JAX rank {node_rank}/{node_procs} uses device number {device_id}/{nb_devices} ({local_device} mem_fraction:{mem_fraction:.2f})"
         )
-    return jax_local_device

--- a/src/toast/jax/device.py
+++ b/src/toast/jax/device.py
@@ -36,14 +36,16 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
     jax_local_device = devices_available[device_id]
     jax.config.update("jax_default_device", jax_local_device)
     # sets the size of the preallocated memory pool (if it is still possible)
-    default_mem_fraction = 0.99
+    # we work with integers first to insure rounding down by a percent
+    default_mem_percent = 90
     process_per_device = math.ceil(node_procs / nb_devices)
-    mem_fraction = min(default_mem_fraction, default_mem_fraction / process_per_device)
+    mem_percent = min(default_mem_percent, default_mem_percent // process_per_device)
+    mem_fraction = mem_percent / 100
     os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = f"{mem_fraction:.2f}"
     # displays information on the device picked
     log = Logger.get()
     log.debug(
-        f"JAX rank {node_rank}/{node_procs} uses device number {device_id}/{nb_devices} ({jax_local_device})"
+        f"JAX rank {node_rank}/{node_procs} uses device number {device_id}/{nb_devices} ({jax_local_device} mem_fraction:{mem_fraction:.2f})"
     )
 
 

--- a/src/toast/jax/device.py
+++ b/src/toast/jax/device.py
@@ -53,7 +53,7 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
 
     WARNING: no Jax function should be called before the call to `initialize` inside this function.
     """
-    if (not disabled) and (node_procs > 1): 
+    if (not disabled) and (node_procs > 1) and (os.environ.get('JAX_PLATFORM_NAME', 'gpu') != 'cpu'): 
         # gets id of device to be used by this process
         nb_devices = max(1, get_environement_nb_devices())
         device_id = node_rank % nb_devices
@@ -71,6 +71,8 @@ def jax_accel_assign_device(node_procs, node_rank, disabled):
         # displays information on the device picked
         local_device = jax_accel_get_device()
         log = Logger.get()
-        log.debug(
-            f"JAX rank {node_rank}/{node_procs} uses {mem_percent}% of device {local_device} ({device_id+1}/{nb_devices})"
-        )
+        log.debug(f"JAX rank {node_rank}/{node_procs} uses {mem_percent}% of device {local_device} ({device_id+1}/{nb_devices})")
+    else:
+        local_device = jax_accel_get_device()
+        log = Logger.get()
+        log.debug(f"JAX rank {node_rank}/{node_procs} uses device {local_device}")        


### PR DESCRIPTION
This branch introduces a number of modifications that were useful for benchmarking.

In particular:
* having the `TOAST_FUNCTIME` read its value instead of considering any value true (this is useful when switching from true/1 to false/0 inside a script),
* updating the `jax_accel_assign_device` function to deal properly with gpu oversubscription (several process using the same gpu)