### PR TITLE
Kernel timing

### DIFF
--- a/src/toast/accelerator/accel.py
+++ b/src/toast/accelerator/accel.py
@@ -13,6 +13,7 @@ from .._libtoast import accel_get_device as omp_accel_get_device
 from .._libtoast import accel_present as omp_accel_present
 from .._libtoast import accel_update_device as omp_accel_update_device
 from .._libtoast import accel_update_host as omp_accel_update_host
+from ..timing import function_timer
 
 enable_vals = ["1", "yes", "true"]
 disable_vals = ["0", "no", "false"]
@@ -132,7 +133,7 @@ def accel_data_present(data):
         log.warning("Accelerator support not enabled, data not present")
         return False
 
-
+@function_timer
 def accel_data_create(data):
     """Create device buffers.
 
@@ -156,7 +157,7 @@ def accel_data_create(data):
         log = Logger.get()
         log.warning("Accelerator support not enabled, cannot create")
 
-
+@function_timer
 def accel_data_update_device(data):
     """Update device buffers.
 
@@ -181,7 +182,7 @@ def accel_data_update_device(data):
         log.warning("Accelerator support not enabled, not updating device")
         return None
 
-
+@function_timer
 def accel_data_update_host(data):
     """Update host buffers.
 
@@ -206,7 +207,7 @@ def accel_data_update_host(data):
         log = Logger.get()
         log.warning("Accelerator support not enabled, not updating host")
 
-
+@function_timer
 def accel_data_delete(data):
     """Delete device copy of the data.
 

--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -372,6 +372,7 @@ class IntervalList(Sequence, AcceleratorObject):
             accel_data_create(self.data)
         elif use_accel_jax:
             # specialised for the INTERVALS_JAX dtype
+            # NOTE: this call is timed at the INTERVALS_JAX level
             self.data = INTERVALS_JAX(self.data)
 
     def _accel_update_device(self):
@@ -381,6 +382,7 @@ class IntervalList(Sequence, AcceleratorObject):
             _ = accel_data_update_device(self.data)
         elif use_accel_jax:
             # specialised for the INTERVALS_JAX dtype
+            # NOTE: this call is timed at the INTERVALS_JAX level
             self.data = INTERVALS_JAX(self.data)
 
     def _accel_update_host(self):
@@ -391,6 +393,7 @@ class IntervalList(Sequence, AcceleratorObject):
         elif use_accel_jax:
             # specialised for the INTERVALS_JAX dtype
             # this moves the data back into a numpy array
+            # NOTE: this call is timed at the INTERVALS_JAX level
             self.data = self.data.to_host()
 
     def _accel_delete(self):

--- a/src/toast/jax/intervals.py
+++ b/src/toast/jax/intervals.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+from ..timing import function_timer
 
 # TODO we need to clean up the two very similar interval type names
 
@@ -14,6 +15,7 @@ class INTERVALS_JAX:
     each of the inner arrays is converted into a JAX array
     """
 
+    @function_timer
     def __init__(self, data):
         # otherwise
         self.size = data.size
@@ -38,6 +40,7 @@ class INTERVALS_JAX:
             # end+1 as TOAST intervals are inclusive
             return 1 + np.max(intervals.last - intervals.first)
 
+    @function_timer
     def to_host(self):
         """copies data back into the original buffer and returns it"""
         self.host_data.start[:] = self.start

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -532,12 +532,8 @@ class DetectorData(AcceleratorObject):
         log.verbose(f"DetectorData _accel_delete")
         if use_accel_omp:
             accel_data_delete(self._raw)
-        elif use_accel_jax and self._accel_exists():
-            # Ensures _data has been properly reset
-            # if we observe that its types is still a GPU types
-            # does NOT move data back from GPU
-            # using _raw should be equivalent
-            self._data = self._data.host_data
+        elif use_accel_jax:
+            self._data = accel_data_delete(self._data)
 
 
 class DetDataManager(MutableMapping):

--- a/src/toast/ops/mapmaker_utils/kernels.py
+++ b/src/toast/ops/mapmaker_utils/kernels.py
@@ -84,7 +84,7 @@ def build_noise_weighted(
         None
 
     """
-    return build_noise_weighted(
+    return libtoast_build_noise_weighted(
         global2local,
         zmap,
         pixel_index,
@@ -100,8 +100,7 @@ def build_noise_weighted(
         intervals,
         shared_flags,
         shared_flag_mask,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 
@@ -137,7 +136,7 @@ def cov_accum_diag_invnpp(
         None
 
     """
-    return cov_accum_diag_invnpp(
+    return libtoast_cov_accum_diag_invnpp(
         nsub,
         nsubpix,
         nnz,
@@ -146,8 +145,7 @@ def cov_accum_diag_invnpp(
         weights,
         scale,
         invnpp,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 
@@ -177,13 +175,12 @@ def cov_accum_diag_hits(
         None
 
     """
-    return cov_accum_diag_hits(
+    return libtoast_cov_accum_diag_hits(
         nsub,
         nsubpix,
         nnz,
         submap,
         subpix,
         hits,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )

--- a/src/toast/ops/noise_weight/kernels.py
+++ b/src/toast/ops/noise_weight/kernels.py
@@ -33,12 +33,11 @@ def noise_weight(
         None
 
     """
-    return noise_weight(
+    return noise_weight_numpy(
         det_data,
         det_data_index,
         intervals,
         detector_weights,
-        impl=ImplementationType.NUMPY,
         use_accel=use_accel,
     )
 

--- a/src/toast/ops/noise_weight/kernels.py
+++ b/src/toast/ops/noise_weight/kernels.py
@@ -33,11 +33,13 @@ def noise_weight(
         None
 
     """
-    return noise_weight_numpy(
+    # FIXME to be replaced by a *direct* call to libtoast_noise_weight once it is ported
+    return noise_weight(
         det_data,
         det_data_index,
         intervals,
         detector_weights,
+        impl=ImplementationType.NUMPY,
         use_accel=use_accel,
     )
 

--- a/src/toast/ops/pixels_healpix/kernels.py
+++ b/src/toast/ops/pixels_healpix/kernels.py
@@ -57,7 +57,7 @@ def pixels_healpix(
         None
 
     """
-    return pixels_healpix(
+    return libtoast_pixels_healpix(
         quat_index,
         quats,
         shared_flags,
@@ -69,6 +69,5 @@ def pixels_healpix(
         n_pix_submap,
         nside,
         nest,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )

--- a/src/toast/ops/pointing_detector/kernels.py
+++ b/src/toast/ops/pointing_detector/kernels.py
@@ -41,7 +41,7 @@ def pointing_detector(
         None
 
     """
-    return pointing_detector(
+    return libtoast_pointing_detector(
         focalplane,
         boresight,
         quat_index,
@@ -49,8 +49,7 @@ def pointing_detector(
         intervals,
         shared_flags,
         shared_flag_mask,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 

--- a/src/toast/ops/polyfilter/kernels.py
+++ b/src/toast/ops/polyfilter/kernels.py
@@ -35,14 +35,13 @@ def filter_polynomial(
         None
 
     """
-    return filter_polynomial(
+    return libtoast_filter_polynomial(
         order,
         flags,
         signals_list,
         starts,
         stops,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 
@@ -68,14 +67,13 @@ def filter_poly2D(
         None
 
     """
-    return filter_poly2D(
+    return libtoast_filter_poly2D(
         det_groups,
         templates,
         signals,
         masks,
         coeff,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 

--- a/src/toast/ops/scan_map/kernels.py
+++ b/src/toast/ops/scan_map/kernels.py
@@ -64,7 +64,7 @@ def scan_map(
         None.
 
     """
-    return scan_map(
+    return scan_map_compiled(
         global2local,
         n_pix_submap,
         mapdata,
@@ -75,12 +75,11 @@ def scan_map(
         weights,
         weight_index,
         intervals,
-        data_scale=1.0,
-        should_zero=should_zero,
-        should_subtract=should_subtract,
-        should_scale=should_scale,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        data_scale,
+        should_zero,
+        should_subtract,
+        should_scale,
+        use_accel,
     )
 
 

--- a/src/toast/ops/scan_map/kernels.py
+++ b/src/toast/ops/scan_map/kernels.py
@@ -64,7 +64,7 @@ def scan_map(
         None.
 
     """
-    return scan_map_compiled(
+    return scan_map_pseudocompiled(
         global2local,
         n_pix_submap,
         mapdata,
@@ -79,15 +79,14 @@ def scan_map(
         should_zero,
         should_subtract,
         should_scale,
-        use_accel,
-    )
-
-
-# FIXME:  This "compiled" kernel will migrate fully to the _libtoast extension.
-
+        use_accel)
 
 @kernel(impl=ImplementationType.COMPILED, name="scan_map")
-def scan_map_compiled(
+def scan_map_compiled(*args, use_accel=False):
+    return scan_map_pseudocompiled(*args, use_accel)
+
+# FIXME:  This "compiled" kernel will migrate fully to the _libtoast extension.
+def scan_map_pseudocompiled(
     global2local,
     n_pix_submap,
     mapdata,

--- a/src/toast/ops/stokes_weights/kernels.py
+++ b/src/toast/ops/stokes_weights/kernels.py
@@ -45,13 +45,12 @@ def stokes_weights_I(
         None
 
     """
-    return stokes_weights_I(
+    return libtoast_stokes_weights_I(
         weight_index,
         weights,
         intervals,
         cal,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 
@@ -86,7 +85,7 @@ def stokes_weights_IQU(
         None
 
     """
-    return stokes_weights_IQU(
+    return libtoast_stokes_weights_IQU(
         quat_index,
         quats,
         weight_index,
@@ -95,6 +94,5 @@ def stokes_weights_IQU(
         intervals,
         epsilon,
         cal,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -430,11 +430,8 @@ class PixelDistribution(AcceleratorObject):
     def _accel_delete(self):
         if use_accel_omp:
             accel_data_delete(self._glob2loc)
-        elif use_accel_jax and self._accel_exists():
-            # insures glob2loc has been properly reset
-            # if we observe that its types is still a GPU types
-            # does NOT move data back from GPU
-            self._glob2loc = self._glob2loc.host_data
+        elif use_accel_jax:
+            self._glob2loc = accel_data_delete(self._glob2loc)
 
 
 class PixelData(AcceleratorObject):
@@ -1189,8 +1186,5 @@ class PixelData(AcceleratorObject):
     def _accel_delete(self):
         if use_accel_omp:
             accel_data_delete(self.raw)
-        elif use_accel_jax and self._accel_exists():
-            # insures data has been properly reset
-            # if we observe that its types is still a GPU types
-            # does NOT move data back from GPU
-            self.data = self.data.host_data
+        elif use_accel_jax:
+            self.data = accel_data_delete(self.data)

--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -16,6 +16,7 @@ set(ENTRY_POINTS
     toast_mini.py
     toast_obsmatrix_combine.py
     toast_config_verify.py
+    toast_merge_timings.py
 )
 
 foreach(pyscript ${ENTRY_POINTS})

--- a/src/toast/scripts/toast_benchmark_ground.py
+++ b/src/toast/scripts/toast_benchmark_ground.py
@@ -19,6 +19,7 @@ from astropy import units as u
 
 import toast
 import toast.ops
+from toast.accelerator.data_localization import display_datamovement
 from toast import spt3g as t3g
 from toast.schedule_sim_ground import run_scheduler
 from toast.scripts.benchmarking_utilities import (
@@ -558,6 +559,9 @@ def main():
         timer.report("toast_benchmark_ground (gathering and dumping timing info)")
     else:
         timer.stop()
+
+    # display information on GPU data movement when running in debug/verbose mode
+    display_datamovement()
 
 
 if __name__ == "__main__":

--- a/src/toast/scripts/toast_benchmark_satellite.py
+++ b/src/toast/scripts/toast_benchmark_satellite.py
@@ -21,6 +21,7 @@ from astropy import units as u
 
 import toast
 import toast.ops
+from toast.accelerator.data_localization import display_datamovement
 from toast.schedule_sim_satellite import create_satellite_schedule
 from toast.scripts.benchmarking_utilities import (
     compare_output_stats,
@@ -337,7 +338,6 @@ def main():
     )
 
     # dumps all the timing information
-
     timer.stop()
     timer.clear()
     timer.start()
@@ -350,6 +350,8 @@ def main():
     else:
         timer.stop()
 
+    # display information on GPU data movement when running in debug/verbose mode
+    display_datamovement()
 
 if __name__ == "__main__":
     world, procs, rank = toast.mpi.get_world()

--- a/src/toast/scripts/toast_merge_timings.py
+++ b/src/toast/scripts/toast_merge_timings.py
@@ -41,8 +41,8 @@ def load_csv_files(file_paths):
 
         # Replace row names ending with '_compiled', '_jax', or '_numpy' by '_kernel'
         df = df.rename(index=lambda x: x.replace('_compiled', '_kernel')
-                                            .replace('_jax', '_kernel')
-                                            .replace('_numpy', '_kernel'))
+                                        .replace('_jax', '_kernel')
+                                        .replace('_numpy', '_kernel'))
 
         # Rename the 'Mean Time' column to the folder name
         df = df.rename(columns={"Mean Time": folder_name})

--- a/src/toast/scripts/toast_merge_timings.py
+++ b/src/toast/scripts/toast_merge_timings.py
@@ -99,3 +99,14 @@ if __name__ == "__main__":
     output_file = "merged_timings.csv"
     merged_df.to_csv(output_file)
     print(f"\nMerged data saved to '{output_file}'")
+
+"""
+TODO
+produce an aditional merged_kernel_timings.csv file
+when importing individual kernels, add a kernel column that contains None/Jax/default/compiled/numpy/data_movement
+when merging, do a set union (or something similar)
+
+remove rows that are not data movement or different kernels
+extract kernel names
+group by (sum) kernel names
+"""

--- a/src/toast/scripts/toast_merge_timings.py
+++ b/src/toast/scripts/toast_merge_timings.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+This script processes multiple timing.csv files located in the current directory and its subdirectories, performs various operations on their contents, and generates a merged CSV file.
+
+The main steps performed by this script are:
+
+1. Locate all timing.csv files in the current folder and its subfolders.
+2. Load each CSV file into a DataFrame, keeping only the "Timer" and "Mean Time" columns.
+3. Replace row names (index) ending with '_compiled', '_jax', or '_numpy' with '_kernel' in the individual DataFrames.
+4. Merge all DataFrames using the intersection of all row names (Timer column) and keeping only the "Mean Time" columns, which are renamed to the name of each CSV file's containing folder.
+5. Save the merged DataFrame to a new CSV file called merged_timings.csv in the current folder.
+
+To use this script, simply run it in a Python environment with the required dependency (pandas) installed. The script will automatically locate timing.csv files, process them, generate the merged DataFrame and save the merged_timings.csv file.
+"""
+import os
+import glob
+import pandas as pd
+
+def find_csv_files(folder, file_pattern):
+    """
+    Find all CSV files matching the specified pattern in the given folder and its subfolders.
+    
+    :param folder: The root folder to start searching for CSV files.
+    :param file_pattern: The pattern of the CSV files to search for.
+    :return: A list of file paths matching the specified pattern.
+    """
+    return glob.glob(os.path.join(folder, file_pattern), recursive=True)
+
+def load_csv_files(file_paths):
+    """
+    Load CSV files from the given file paths, keeping only the specified columns
+    and setting the index to the Timer column.
+
+    :param file_paths: A list of file paths to load.
+    :return: A list of DataFrames containing the loaded DataFrames.
+    """
+    dataframes = list()
+    for file_path in file_paths:
+        folder_name = os.path.basename(os.path.dirname(file_path))
+        df = pd.read_csv(file_path, index_col="Timer", usecols=["Timer", "Mean Time"])
+
+        # Replace row names ending with '_compiled', '_jax', or '_numpy' by '_kernel'
+        df = df.rename(index=lambda x: x.replace('_compiled', '_kernel')
+                                            .replace('_jax', '_kernel')
+                                            .replace('_numpy', '_kernel'))
+
+        # Rename the 'Mean Time' column to the folder name
+        df = df.rename(columns={"Mean Time": folder_name})
+        dataframes.append(df)
+
+    return dataframes
+
+def merge_dataframes(dataframes):
+    """
+    Merge the given DataFrames using the union of all row names and keeping only
+    the specified columns. The columns are intermeshed as best as possible based
+    on their original order in the input CSV files.
+    
+    :param dataframes: A dictionary of DataFrames to merge.
+    :return: A merged DataFrame with the union of all row names.
+    """
+    # Initialize the merged DataFrame with the first DataFrame
+    merged_df = dataframes[0]
+
+    # Merge the remaining DataFrames one-by-one
+    for df in dataframes[1:]:
+        merged_df = pd.merge(merged_df, df, left_index=True, right_index=True, how='outer')
+
+    return merged_df
+
+if __name__ == "__main__":
+    folder = "."
+    file_pattern = "**/timing.csv"
+    csv_file_paths = find_csv_files(folder, file_pattern)
+    dataframes = load_csv_files(csv_file_paths)
+    merged_df = merge_dataframes(dataframes)
+
+    print("Merged data:")
+    print(merged_df)
+
+    # Save the merged DataFrame to a CSV file
+    output_file = "merged_timings.csv"
+    merged_df.to_csv(output_file)
+    print(f"\nMerged data saved to '{output_file}'")

--- a/src/toast/scripts/toast_merge_timings.py
+++ b/src/toast/scripts/toast_merge_timings.py
@@ -40,9 +40,12 @@ def load_csv_files(file_paths):
         df = pd.read_csv(file_path, index_col="Timer", usecols=["Timer", "Mean Time"])
 
         # Replace row names ending with '_compiled', '_jax', or '_numpy' by '_kernel'
+        # Remove useless prefix / sufix from row names
         df = df.rename(index=lambda x: x.replace('_compiled', '_kernel')
                                         .replace('_jax', '_kernel')
-                                        .replace('_numpy', '_kernel'))
+                                        .replace('_numpy', '_kernel')
+                                        .replace('(function) ', '')
+                                        .replace('._exec', ''))
 
         # Rename the 'Mean Time' column to the folder name
         df = df.rename(columns={"Mean Time": folder_name})

--- a/src/toast/scripts/toast_mini.py
+++ b/src/toast/scripts/toast_mini.py
@@ -271,7 +271,7 @@ def main():
     else:
         timer.stop()
 
-    # display information on GPU data movement
+    # display information on GPU data movement when running in debug/verbose mode
     display_datamovement()
 
 

--- a/src/toast/templates/amplitudes.py
+++ b/src/toast/templates/amplitudes.py
@@ -698,13 +698,9 @@ class Amplitudes(AcceleratorObject):
         if use_accel_omp:
             accel_data_delete(self._raw)
             accel_data_delete(self._raw_flags)
-        elif use_accel_jax and self._accel_exists():
-            # insures local and local_flags have been properly reset
-            # if we observe that their types are still GPU types
-            # does NOT move data back from GPU
-            # using self._raw.array() and self._raw_flags.array() should be equivalent
-            self.local = self.local.host_data
-            self.local_flags = self.local_flags.host_data
+        elif use_accel_jax:
+            self.local = accel_data_delete(self.local)
+            self.local_flags = accel_data_delete(self.local_flags)
 
 
 class AmplitudesMap(MutableMapping, AcceleratorObject):

--- a/src/toast/templates/offset/kernels.py
+++ b/src/toast/templates/offset/kernels.py
@@ -55,17 +55,15 @@ def offset_add_to_signal(
         None
 
     """
-    return offset_add_to_signal(
+    return libtoast_offset_add_to_signal(
         step_length,
         amp_offset,
         n_amp_views,
         amplitudes,
         data_index,
         det_data,
-        intervals,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
-    )
+        intervals, 
+        use_accel)
 
 
 @kernel(impl=ImplementationType.DEFAULT)
@@ -105,7 +103,7 @@ def offset_project_signal(
         None
 
     """
-    return offset_project_signal(
+    return libtoast_offset_project_signal(
         data_index,
         det_data,
         flag_index,
@@ -116,8 +114,7 @@ def offset_project_signal(
         n_amp_views,
         amplitudes,
         intervals,
-        impl=ImplementationType.COMPILED,
-        use_accel=use_accel,
+        use_accel,
     )
 
 
@@ -139,12 +136,11 @@ def offset_apply_diag_precond(
         None
 
     """
-    return offset_apply_diag_precond(
+    return libtoast_offset_apply_diag_precond(
         offset_var,
         amplitudes_in,
         amplitudes_out,
-        impl=ImplementationType.COMPILED,
-        use_accel=False,
+        use_accel,
     )
 
 


### PR DESCRIPTION
* added a `toast_merge_timings.py` script
* default kernel now call the compiled kernel directly with no intermediate dispatch (makes merge between default and compiled/jax/numpy runs possible)
* added function timer to most device data moving function
* added optional display of data movement at the end of the sat/ground benches