### PR TITLE
Collection of improvements for working with real ground data

### DIFF
--- a/src/toast/CMakeLists.txt
+++ b/src/toast/CMakeLists.txt
@@ -141,6 +141,7 @@ install(FILES
     observation_dist.py
     observation_data.py
     observation_view.py
+    pointing_utils.py
     vis.py
     rng.py
     qarray.py

--- a/src/toast/coordinates.py
+++ b/src/toast/coordinates.py
@@ -221,11 +221,8 @@ def azel_to_radec(site, times, azel, use_ephem=False):
 
     sparse_quat = qa.norm(sparse_quat)
 
-    # Construnct dense transform
-
+    # Construct dense transform
     transform = qa.slerp(times, sparse_times, sparse_quat)
-
-    # Rotate the input quaternions
 
     # return qa.mult(azel, transform)
     # return qa.mult(azel, qa.inv(transform))

--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -1018,7 +1018,7 @@ def plot_focalplane(
             boresight X/Y/Z.
 
     Returns:
-        None
+        (Figure):  The figure.
 
     """
     if focalplane is None:

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -82,6 +82,21 @@ def set_default_values(values=None):
         "sun_close": 64,
         "elnod": 1 + 2 + 4,
         #
+        # ground-specific interval names
+        #
+        "scanning_interval": "scanning",
+        "turnaround_interval": "turnaround",
+        "throw_leftright_interval": "throw_leftright",
+        "throw_rightleft_interval": "throw_rightleft",
+        "throw_interval": "throw",
+        "scan_leftright_interval": "scan_leftright",
+        "scan_rightleft_interval": "scan_rightleft",
+        "turn_leftright_interval": "turn_leftright",
+        "turn_rightleft_interval": "turn_rightleft",
+        "elnod_interval": "elnod",
+        "sun_up_interval": "sun_up",
+        "sun_close_interval": "sun_close",
+        #
         # Units
         #
         "det_data_units": u.Kelvin,
@@ -223,7 +238,7 @@ class Observation(MutableMapping):
         self.intervals = IntervalsManager(self.dist, n_samples)
 
         # Set up local per-detector cutting
-        self._detflags = {x: 0 for x in self.dist.dets[self.dist.comm.group_rank]}
+        self._detflags = {x: int(0) for x in self.dist.dets[self.dist.comm.group_rank]}
 
     # Fully clear the observation
 
@@ -356,7 +371,7 @@ class Observation(MutableMapping):
                 msg = f"Cannot update per-detector flag for '{k}', which is"
                 msg += " not a local detector"
                 raise RuntimeError(msg)
-            self._detflags[k] |= v
+            self._detflags[k] |= int(v)
 
     def set_local_detector_flags(self, vals):
         """Set the per-detector flagging.
@@ -376,7 +391,7 @@ class Observation(MutableMapping):
                 msg = f"Cannot set per-detector flag for '{k}', which is"
                 msg += " not a local detector"
                 raise RuntimeError(msg)
-            self._detflags[k] = v
+            self._detflags[k] = int(v)
 
     def select_local_detectors(
         self,

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -222,6 +222,9 @@ class Observation(MutableMapping):
         self.shared = SharedDataManager(self.dist)
         self.intervals = IntervalsManager(self.dist, n_samples)
 
+        # Set up local per-detector cutting
+        self._detflags = {x: 0 for x in self.dist.dets[self.dist.comm.group_rank]}
+
     # Fully clear the observation
 
     def clear(self):
@@ -330,19 +333,92 @@ class Observation(MutableMapping):
         """
         return self.dist.dets[self.dist.comm.group_rank]
 
-    def select_local_detectors(self, selection=None):
+    @property
+    def local_detector_flags(self):
+        """(dict): The local per-detector flags"""
+        return self._detflags
+
+    def update_local_detector_flags(self, vals):
+        """Update the per-detector flagging.
+
+        This does a bitwise OR with the existing flag values.
+
+        Args:
+            vals (dict):  The flag values for one or more detectors.
+
+        Returns:
+            None
+
         """
-        (list): The detectors assigned to this process, optionally pruned.
+        ldets = set(self.local_detectors)
+        for k, v in vals.items():
+            if k not in ldets:
+                msg = f"Cannot update per-detector flag for '{k}', which is"
+                msg += " not a local detector"
+                raise RuntimeError(msg)
+            self._detflags[k] |= v
+
+    def set_local_detector_flags(self, vals):
+        """Set the per-detector flagging.
+
+        This resets the per-detector flags to the specified values.
+
+        Args:
+            vals (dict):  The flag values for one or more detectors.
+
+        Returns:
+            None
+
         """
-        if selection is None:
-            return self.local_detectors
+        ldets = set(self.local_detectors)
+        for k, v in vals.items():
+            if k not in ldets:
+                msg = f"Cannot set per-detector flag for '{k}', which is"
+                msg += " not a local detector"
+                raise RuntimeError(msg)
+            self._detflags[k] = v
+
+    def select_local_detectors(
+        self,
+        selection=None,
+        flagmask=(default_values.det_mask_invalid | default_values.det_mask_processing),
+    ):
+        """Get the local detectors assigned to this process.
+
+        This takes the full list of local detectors and optionally prunes them
+        by the specified selection and / or applies per-detector flags with
+        the given mask.
+
+        Args:
+            selection (list):  Only return detectors in this set.
+            flagmask (uint8):  Apply this mask to per-detector flags and only
+                include detectors with a result of zero (good).
+
+        Returns:
+            (list):  The selected detectors.
+
+        """
+        if flagmask is None:
+            good = set(self.local_detectors)
         else:
-            dets = list()
+            good = set(
+                [
+                    x
+                    for x in self.local_detectors
+                    if (self.local_detector_flags[x] & flagmask) == 0
+                ]
+            )
+        dets = list()
+        if selection is None:
+            for det in self.local_detectors:
+                if det in good:
+                    dets.append(det)
+        else:
             sel_set = set(selection)
             for det in self.local_detectors:
-                if det in sel_set:
+                if (det in sel_set) and (det in good):
                     dets.append(det)
-            return dets
+        return dets
 
     # Detector set distribution
 
@@ -656,6 +732,18 @@ class Observation(MutableMapping):
         else:
             detector_sets = override_detector_sets
 
+        # Get the total set of per-detector flags
+        if self.comm_col_size == 1:
+            all_det_flags = self.local_detector_flags
+        else:
+            pdflags = self.comm_col.gather(self.local_detector_flags, root=0)
+            all_det_flags = None
+            if self.comm_col_rank == 0:
+                all_det_flags = dict()
+                for pf in pdflags:
+                    all_det_flags.update(pf)
+            all_det_flags = self.comm_col.bcast(all_det_flags, root=0)
+
         # Create the new distribution
         new_dist = DistDetSamp(
             self.dist.samples,
@@ -697,6 +785,11 @@ class Observation(MutableMapping):
         self.intervals.clear()
         del self.intervals
         self.intervals = new_intervals_manager
+
+        # Restore detector flags for our new local detectors
+        self.set_local_detector_flags(
+            {x: all_det_flags[x] for x in self.local_detectors}
+        )
 
     # Accelerator use
 

--- a/src/toast/ops/CMakeLists.txt
+++ b/src/toast/ops/CMakeLists.txt
@@ -57,6 +57,7 @@ install(FILES
     noise_estimation.py
     noise_estimation_utils.py
     yield_cut.py
+    azimuth_intervals.py
     DESTINATION ${PYTHON_SITE}/toast/ops
 )
 

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -5,6 +5,7 @@
 # Import Operators into our public API
 
 from .arithmetic import Combine
+from .azimuth_intervals import AzimuthIntervals
 from .cadence_map import CadenceMap
 from .common_mode_noise import CommonModeNoise
 from .conviqt import SimConviqt, SimTEBConviqt, SimWeightedConviqt
@@ -33,7 +34,7 @@ from .mapmaker_utils import (
 )
 from .memory_counter import MemoryCounter
 from .noise_estimation import NoiseEstim
-from .noise_model import DefaultNoiseModel, FitNoiseModel
+from .noise_model import DefaultNoiseModel, FitNoiseModel, FlagNoiseFit
 from .noise_weight import NoiseWeight
 from .operator import Operator
 from .pipeline import Pipeline

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+from time import time
+
+import numpy as np
+import traitlets
+from astropy import units as u
+from scipy.ndimage import uniform_filter1d
+
+from .. import qarray as qa
+from .._libtoast import add_templates, bin_invcov, bin_proj, legendre
+from ..data import Data
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Int, Unicode, trait_docs, Float
+from ..utils import Environment, Logger, Timer, rate_from_times
+from ..vis import set_matplotlib_backend
+from .operator import Operator
+
+
+@trait_docs
+class AzimuthIntervals(Operator):
+    """Build intervals that describe the scanning motion in azimuth.
+
+    This operator passes through the azimuth angle and builds the list of
+    intervals for standard types of scanning / turnaround motion.  Note
+    that it only makes sense to use this operator for ground-based
+    telescopes that primarily scan in azimuth rather than more complicated (e.g.
+    lissajous) patterns.
+
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
+    azimuth = Unicode(defaults.azimuth, help="Observation shared key for Azimuth")
+
+    scanning_interval = Unicode("scanning", help="Interval name for scanning")
+
+    turnaround_interval = Unicode("turnaround", help="Interval name for turnarounds")
+
+    throw_leftright_interval = Unicode(
+        "throw_leftright", help="Interval name for left to right scans + turnarounds"
+    )
+
+    throw_rightleft_interval = Unicode(
+        "throw_rightleft", help="Interval name for right to left scans + turnarounds"
+    )
+
+    throw_interval = Unicode(
+        "throw", help="Interval name for scan + turnaround intervals"
+    )
+
+    scan_leftright_interval = Unicode(
+        "scan_leftright", help="Interval name for left to right scans"
+    )
+
+    turn_leftright_interval = Unicode(
+        "turn_leftright", help="Interval name for turnarounds after left to right scans"
+    )
+
+    scan_rightleft_interval = Unicode(
+        "scan_rightleft", help="Interval name for right to left scans"
+    )
+
+    turn_rightleft_interval = Unicode(
+        "turn_rightleft", help="Interval name for turnarounds after right to left scans"
+    )
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid, help="Bit mask value for bad azimuth pointing"
+    )
+
+    window_seconds = Float(0.25, help="Smoothing window in seconds")
+
+    debug_root = Unicode(
+        None,
+        allow_none=True,
+        help="If not None, dump debug plots to this root file name",
+    )
+
+    @traitlets.validate("shared_flag_mask")
+    def _check_shared_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Flag mask should be a positive integer")
+        return check
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        env = Environment.get()
+        log = Logger.get()
+
+        for obs in data.obs:
+            # For now, we just have the first process row do the calculation.  It
+            # is relatively fast.
+
+            throw_times = None
+            stable_times = None
+
+            # Sample rate
+            stamps = obs.shared[self.times].data
+            (rate, dt, dt_min, dt_max, dt_std) = rate_from_times(stamps)
+
+            if obs.comm_col_rank == 0:
+                # Smoothing window in samples
+                window = int(rate * self.window_seconds)
+
+                # The scan velocity
+                scan_vel = np.gradient(obs.shared[self.azimuth].data)
+
+                # Smooth with moving window
+                wscan_vel = uniform_filter1d(scan_vel, size=window, mode="nearest")
+
+                # When the velocity changes sign, we have a turnaround
+                vel_switch = np.where(wscan_vel[:-1] * wscan_vel[1:] < 0)[0] + 1
+                throw_times = [
+                    (stamps[x[0]], stamps[x[1]])
+                    for x in zip(vel_switch[:-1], vel_switch[1:])
+                ]
+
+                # The peak to peak range of the scan velocity
+                vel_range = np.amax(wscan_vel) - np.amin(wscan_vel)
+
+                # The smoothed scan acceleration
+                scan_accel = uniform_filter1d(
+                    np.gradient(wscan_vel),
+                    size=window,
+                    mode="nearest",
+                )
+
+                accel_range = np.amax(scan_accel) - np.amin(scan_accel)
+
+                # When the acceleration is zero to some tolerance, we are
+                # scanning.
+                stable = (np.absolute(scan_accel) < 0.1 * accel_range) * np.ones(
+                    len(scan_accel), dtype=np.int8
+                )
+                begin_stable = np.where(stable[1:] - stable[:-1] == 1)[0]
+                end_stable = np.where(stable[:-1] - stable[1:] == 1)[0]
+                if begin_stable[0] > end_stable[0]:
+                    # We start in the middle of a scan
+                    begin_stable = np.concatenate(([0], begin_stable))
+                if begin_stable[-1] > end_stable[-1]:
+                    # We end in the middle of a scan
+                    end_stable = np.concatenate((end_stable, [obs.n_local_samples]))
+                stable_times = [
+                    (stamps[x[0]], stamps[x[1] - 1])
+                    for x in zip(begin_stable, end_stable)
+                ]
+
+                if self.debug_root is not None:
+                    set_matplotlib_backend()
+
+                    import matplotlib.pyplot as plt
+
+                    # Dump some plots
+                    out_file = f"{self.debug_root}_{obs.comm_row_rank}.pdf"
+                    if len(vel_switch) >= 5:
+                        # Plot a few scans
+                        n_plot = vel_switch[4]
+                    else:
+                        # Plot it all
+                        n_plot = obs.n_local_samples
+
+                    swplot = vel_switch[vel_switch <= n_plot]
+                    bstable = begin_stable[begin_stable <= n_plot]
+                    estable = end_stable[end_stable <= n_plot]
+
+                    fig = plt.figure(dpi=100, figsize=(8, 16))
+
+                    ax = fig.add_subplot(4, 1, 1)
+                    ax.plot(
+                        np.arange(n_plot),
+                        obs.shared[self.azimuth].data[:n_plot],
+                        "-",
+                    )
+
+                    ax = fig.add_subplot(4, 1, 2)
+                    ax.plot(np.arange(n_plot), stable[:n_plot], "-")
+                    ax.vlines(bstable, ymin=-1, ymax=2, color="green")
+                    ax.vlines(estable, ymin=-1, ymax=2, color="red")
+
+                    ax = fig.add_subplot(4, 1, 3)
+                    ax.plot(np.arange(n_plot), scan_vel[:n_plot], "-")
+                    ax.plot(np.arange(n_plot), wscan_vel[:n_plot], "-")
+                    ax.vlines(
+                        swplot,
+                        ymin=np.amin(scan_vel),
+                        ymax=np.amax(scan_vel),
+                    )
+
+                    ax = fig.add_subplot(4, 1, 4)
+                    ax.plot(np.arange(n_plot), scan_accel[:n_plot], "-")
+
+                    plt.savefig(out_file)
+                    plt.close()
+
+            # Now create the intervals across each process column
+
+            # The throw intervals are between turnarounds
+            obs.intervals.create_col(
+                self.throw_interval, throw_times, stamps, fromrank=0
+            )
+
+            # Stable scanning intervals
+            obs.intervals.create_col(
+                self.scanning_interval, stable_times, stamps, fromrank=0
+            )
+
+            # Turnarounds are the inverse of stable scanning
+            obs.intervals[self.turnaround_interval] = ~obs.intervals[
+                self.scanning_interval
+            ]
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "shared": [self.times, self.azimuth],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        return req
+
+    def _provides(self):
+        return {
+            "intervals": [
+                self.scanning_interval,
+                self.turnaround_interval,
+                self.scan_leftright_interval,
+                self.scan_rightleft_interval,
+                self.turn_leftright_interval,
+                self.turn_rightleft_interval,
+                self.throw_interval,
+                self.throw_leftright_interval,
+                self.throw_rightleft_interval,
+            ]
+        }

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -15,7 +15,7 @@ from ..data import Data
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Int, Unicode, trait_docs, Float
+from ..traits import Bool, Float, Int, Unicode, trait_docs
 from ..utils import Environment, Logger, Timer, rate_from_times
 from ..vis import set_matplotlib_backend
 from .operator import Operator
@@ -41,36 +41,44 @@ class AzimuthIntervals(Operator):
 
     azimuth = Unicode(defaults.azimuth, help="Observation shared key for Azimuth")
 
-    scanning_interval = Unicode("scanning", help="Interval name for scanning")
+    scanning_interval = Unicode(
+        defaults.scanning_interval, help="Interval name for scanning"
+    )
 
-    turnaround_interval = Unicode("turnaround", help="Interval name for turnarounds")
+    turnaround_interval = Unicode(
+        defaults.turnaround_interval, help="Interval name for turnarounds"
+    )
 
     throw_leftright_interval = Unicode(
-        "throw_leftright", help="Interval name for left to right scans + turnarounds"
+        defaults.throw_leftright_interval,
+        help="Interval name for left to right scans + turnarounds",
     )
 
     throw_rightleft_interval = Unicode(
-        "throw_rightleft", help="Interval name for right to left scans + turnarounds"
+        defaults.throw_rightleft_interval,
+        help="Interval name for right to left scans + turnarounds",
     )
 
     throw_interval = Unicode(
-        "throw", help="Interval name for scan + turnaround intervals"
+        defaults.throw_interval, help="Interval name for scan + turnaround intervals"
     )
 
     scan_leftright_interval = Unicode(
-        "scan_leftright", help="Interval name for left to right scans"
+        defaults.scan_leftright_interval, help="Interval name for left to right scans"
     )
 
     turn_leftright_interval = Unicode(
-        "turn_leftright", help="Interval name for turnarounds after left to right scans"
+        defaults.turn_leftright_interval,
+        help="Interval name for turnarounds after left to right scans",
     )
 
     scan_rightleft_interval = Unicode(
-        "scan_rightleft", help="Interval name for right to left scans"
+        defaults.scan_rightleft_interval, help="Interval name for right to left scans"
     )
 
     turn_rightleft_interval = Unicode(
-        "turn_rightleft", help="Interval name for turnarounds after right to left scans"
+        defaults.turn_rightleft_interval,
+        help="Interval name for turnarounds after right to left scans",
     )
 
     shared_flags = Unicode(

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -252,7 +252,7 @@ class MapMaker(Operator):
             reset_pix_dist=self.reset_pix_dist,
             report_memory=self.report_memory,
         )
-        amplitudes_solve.apply(data, use_accel=use_accel)
+        amplitudes_solve.apply(data, detectors=detectors, use_accel=use_accel)
 
         log.info_rank(
             f"{log_prefix}  finished template amplitude solve in",
@@ -386,7 +386,7 @@ class MapMaker(Operator):
                 template_matrix=self.template_matrix,
                 output=out_cleaned,
             )
-            amplitudes_apply.apply(data, use_accel=use_accel)
+            amplitudes_apply.apply(data, detectors=detectors, use_accel=use_accel)
 
             log.info_rank(
                 f"{log_prefix}  finished apply template amplitudes in",
@@ -676,12 +676,7 @@ class Calibrate(Operator):
             reset_pix_dist=self.reset_pix_dist,
             report_memory=self.report_memory,
         )
-        amplitudes_solve.apply(data, use_accel=use_accel)
-
-        print(
-            f"Solved amplitudes, {data[amplitudes_solve.amplitudes]}, on accel = {data[amplitudes_solve.amplitudes].accel_in_use()}",
-            flush=True,
-        )
+        amplitudes_solve.apply(data, detectors=detectors, use_accel=use_accel)
 
         log.info_rank(
             f"{log_prefix}  finished template amplitude solve in",
@@ -714,7 +709,7 @@ class Calibrate(Operator):
             template_matrix=self.template_matrix,
             output=out_calib,
         )
-        amplitudes_apply.apply(data, use_accel=use_accel)
+        amplitudes_apply.apply(data, detectors=detectors, use_accel=use_accel)
 
         log.info_rank(
             f"{log_prefix}  finished apply template amplitudes in",

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -348,17 +348,6 @@ class FitNoiseModel(Operator):
         fknee = x[0]
         alpha = x[1]
         current = self._evaluate_log_model(freqs, fmin, net, fknee, alpha)
-
-        # Weight the difference so that low frequencies do not impact the fit.  This is
-        # basically a high-pass butterworth.
-        # n_freq = len(freqs)
-        # hp = np.arange(n_freq, dtype=np.float64)
-        # hp *= 2.0 / n_freq
-        # weights = 0.1 + 2.0 / np.sqrt(1.0 + np.power(hp, -4))
-        # resid = np.multiply(weights, current - logdata)
-        # print(
-        #     f"      current-data = {current - logdata}, weights = {weights}, resid = {resid}"
-        # )
         resid = current - logdata
         return resid
 

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -700,14 +700,14 @@ class CommonModeFilter(Operator):
             )
             log.debug_rank(
                 f"{data.comm.group:4} : Duplicated observation in",
-                comm=temp_ob.comm,
+                comm=temp_ob.comm.comm_group,
                 timer=timer,
             )
             # Redistribute this temporary observation to be distributed by sample sets
             temp_ob.redistribute(1, times=self.times, override_sample_sets=None)
             log.debug_rank(
                 f"{data.comm.group:4} : Redistributed observation in",
-                comm=temp_ob.comm,
+                comm=temp_ob.comm.comm_group,
                 timer=timer,
             )
             comm = None
@@ -729,14 +729,14 @@ class CommonModeFilter(Operator):
             )
             log.debug_rank(
                 f"{data.comm.group:4} : Re-redistributed observation in",
-                comm=temp_ob.comm,
+                comm=temp_ob.comm.comm_group,
                 timer=timer,
             )
             # Copy data to original observation
             obs.detdata[self.det_data][:] = temp_ob.detdata[self.det_data][:]
             log.debug_rank(
                 f"{data.comm.group:4} : Copied observation data in",
-                comm=temp_ob.comm,
+                comm=temp_ob.comm.comm_group,
                 timer=timer,
             )
         return

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -224,46 +224,55 @@ class SimGround(Operator):
 
     elnod_every_scan = Bool(False, help="Perform el nods every scan")
 
-    scanning_interval = Unicode("scanning", help="Interval name for scanning")
+    scanning_interval = Unicode(
+        defaults.scanning_interval, help="Interval name for scanning"
+    )
 
-    turnaround_interval = Unicode("turnaround", help="Interval name for turnarounds")
+    turnaround_interval = Unicode(
+        defaults.turnaround_interval, help="Interval name for turnarounds"
+    )
 
     throw_leftright_interval = Unicode(
-        "throw_leftright", help="Interval name for left to right scans + turnarounds"
+        defaults.throw_leftright_interval,
+        help="Interval name for left to right scans + turnarounds",
     )
 
     throw_rightleft_interval = Unicode(
-        "throw_rightleft", help="Interval name for right to left scans + turnarounds"
+        defaults.throw_rightleft_interval,
+        help="Interval name for right to left scans + turnarounds",
     )
 
     throw_interval = Unicode(
-        "throw", help="Interval name for scan + turnaround intervals"
+        defaults.throw_interval, help="Interval name for scan + turnaround intervals"
     )
 
     scan_leftright_interval = Unicode(
-        "scan_leftright", help="Interval name for left to right scans"
+        defaults.scan_leftright_interval, help="Interval name for left to right scans"
     )
 
     turn_leftright_interval = Unicode(
-        "turn_leftright", help="Interval name for turnarounds after left to right scans"
+        defaults.turn_leftright_interval,
+        help="Interval name for turnarounds after left to right scans",
     )
 
     scan_rightleft_interval = Unicode(
-        "scan_rightleft", help="Interval name for right to left scans"
+        defaults.scan_rightleft_interval, help="Interval name for right to left scans"
     )
 
     turn_rightleft_interval = Unicode(
-        "turn_rightleft", help="Interval name for turnarounds after right to left scans"
+        defaults.turn_rightleft_interval,
+        help="Interval name for turnarounds after right to left scans",
     )
 
-    elnod_interval = Unicode("elnod", help="Interval name for elnods")
+    elnod_interval = Unicode(defaults.elnod_interval, help="Interval name for elnods")
 
     sun_up_interval = Unicode(
-        "sun_up", help="Interval name for times when the sun is up"
+        defaults.sun_up_interval, help="Interval name for times when the sun is up"
     )
 
     sun_close_interval = Unicode(
-        "sun_close", help="Interval name for times when the sun is close"
+        defaults.sun_close_interval,
+        help="Interval name for times when the sun is close",
     )
 
     sun_close_distance = Quantity(45.0 * u.degree, help="'Sun close' flagging distance")

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -1119,6 +1119,17 @@ class SimGround(Operator):
                 self.velocity,
             ],
             "detdata": list(),
+            "intervals": [
+                self.scanning_interval,
+                self.turnaround_interval,
+                self.scan_leftright_interval,
+                self.scan_rightleft_interval,
+                self.turn_leftright_interval,
+                self.turn_rightleft_interval,
+                self.throw_interval,
+                self.throw_leftright_interval,
+                self.throw_rightleft_interval,
+            ],
         }
         if self.det_data is not None:
             prov["detdata"].append(self.det_data)

--- a/src/toast/pointing_utils.py
+++ b/src/toast/pointing_utils.py
@@ -1,0 +1,152 @@
+# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+# Pointing utility functions used by templates and operators
+
+
+import numpy as np
+from astropy import units as u
+
+from . import qarray as qa
+from .mpi import MPI
+from .timing import GlobalTimers, Timer, function_timer
+
+
+@function_timer
+def scan_range_lonlat(
+    obs,
+    boresight,
+    flags=None,
+    flag_mask=0,
+    field_of_view=None,
+    is_azimuth=False,
+    center_offset=None,
+    samples=None,
+):
+    """Compute the range of detector pointing in longitude / latitude.
+
+    This uses the focalplane field of view and the boresight pointing to compute
+    the extent of the pointing for one observation.
+
+    Args:
+        obs (Observation):  The observation to process.
+        boresight (str):  The boresight Az/El pointing name.
+        flags (str):  The flag name to use for excluding pointing samples
+        flag_mask (int):  The flag mask for excluding samples.
+        field_of_view (Quantity):  Override the focalplane FOV.
+        is_azimuth (bool):  If True, we are working in Az/El coordinates where
+            the azimuth angle is the negative of the ISO phi angle.
+        center_offset (str):  The optional source
+        samples (slice):  The sample slice to use for the calculation.
+
+    Returns:
+        (tuple):  The (Lon min, Lon max, Lat min, Lat max) as quantities.
+
+    """
+    if field_of_view is not None:
+        fov = field_of_view
+    else:
+        fov = obs.telescope.focalplane.field_of_view
+    fp_radius = 0.5 * fov.to_value(u.radian)
+
+    if samples is None:
+        slc = slice(0, obs.n_local_samples, 1)
+    else:
+        slc = samples
+
+    # Get the flags if needed.
+    fdata = None
+    if flags is not None:
+        fdata = np.array(obs.shared[flags][slc])
+        fdata &= flag_mask
+
+    # work in parallel
+    rank = obs.comm.group_rank
+    ntask = obs.comm.group_size
+
+    # Create a fake focalplane of detectors in a circle around the boresight
+    xaxis, yaxis, zaxis = np.eye(3)
+    ndet = 64
+    phidet = np.linspace(0, 2 * np.pi, ndet, endpoint=False)
+    detquats = []
+    thetarot = qa.rotation(yaxis, fp_radius)
+    for phi in phidet:
+        phirot = qa.rotation(zaxis, phi)
+        detquat = qa.mult(phirot, thetarot)
+        detquats.append(detquat)
+
+    # Get fake detector pointing
+
+    center_lonlat = None
+    if center_offset is not None:
+        center_lonlat = np.array(obs.shared[center_offset][slc, :])
+        center_lonlat[:, :] *= np.pi / 180.0
+
+    lon = []
+    lat = []
+    quats = obs.shared[boresight][slc, :][rank::ntask].copy()
+    rank_good = slice(None)
+    if fdata is not None:
+        rank_good = fdata[rank::ntask] == 0
+
+    for idet, detquat in enumerate(detquats):
+        theta, phi, _ = qa.to_iso_angles(qa.mult(quats, detquat))
+        if center_lonlat is None:
+            if is_azimuth:
+                lon.append(2 * np.pi - phi[rank_good])
+            else:
+                lon.append(phi[rank_good])
+            lat.append(np.pi / 2 - theta[rank_good])
+        else:
+            if is_azimuth:
+                lon.append(
+                    2 * np.pi
+                    - phi[rank_good]
+                    - center_lonlat[rank::ntask, 0][rank_good]
+                )
+            else:
+                lon.append(phi[rank_good] - center_lonlat[rank::ntask, 0][rank_good])
+            lat.append(
+                (np.pi / 2 - theta[rank_good])
+                - center_lonlat[rank::ntask, 1][rank_good]
+            )
+    lon = np.unwrap(np.hstack(lon))
+    lat = np.hstack(lat)
+
+    # find the extremes
+    lonmin = np.amin(lon)
+    lonmax = np.amax(lon)
+    latmin = np.amin(lat)
+    latmax = np.amax(lat)
+
+    if lonmin < -2 * np.pi:
+        lonmin += 2 * np.pi
+        lonmax += 2 * np.pi
+    elif lonmax > 2 * np.pi:
+        lonmin -= 2 * np.pi
+        lonmax -= 2 * np.pi
+
+    # Combine results
+    if obs.comm.comm_group is not None:
+        lonlatmin = np.zeros(2, dtype=np.float64)
+        lonlatmax = np.zeros(2, dtype=np.float64)
+        lonlatmin[0] = lonmin
+        lonlatmin[1] = latmin
+        lonlatmax[0] = lonmax
+        lonlatmax[1] = latmax
+        all_lonlatmin = np.zeros(2, dtype=np.float64)
+        all_lonlatmax = np.zeros(2, dtype=np.float64)
+        obs.comm.comm_group.Allreduce(lonlatmin, all_lonlatmin, op=MPI.MIN)
+        obs.comm.comm_group.Allreduce(lonlatmax, all_lonlatmax, op=MPI.MAX)
+        lonmin = all_lonlatmin[0]
+        latmin = all_lonlatmin[1]
+        lonmax = all_lonlatmax[0]
+        latmax = all_lonlatmax[1]
+
+    return (
+        lonmin * u.radian,
+        lonmax * u.radian,
+        latmin * u.radian,
+        latmax * u.radian,
+    )

--- a/src/toast/templates/fourier2d.py
+++ b/src/toast/templates/fourier2d.py
@@ -330,6 +330,8 @@ class Fourier2D(Template):
         for iob, ob in enumerate(self.data.obs):
             if detector not in ob.local_detectors:
                 continue
+            if detector not in ob.detdata[self.det_data].detectors:
+                continue
             views = ob.view[self.view]
             for ivw, vw in enumerate(views):
                 amp_slice = slice(
@@ -347,6 +349,8 @@ class Fourier2D(Template):
     def _project_signal(self, detector, amplitudes, **kwargs):
         for iob, ob in enumerate(self.data.obs):
             if detector not in ob.local_detectors:
+                continue
+            if detector not in ob.detdata[self.det_data].detectors:
                 continue
             views = ob.view[self.view]
             for ivw, vw in enumerate(views):

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -218,6 +218,8 @@ class Offset(Template):
             for iob, ob in enumerate(new_data.obs):
                 if det not in ob.local_detectors:
                     continue
+                if det not in ob.detdata[self.det_data].detectors:
+                    continue
 
                 # "Noise weight" (time-domain inverse variance)
                 detnoise = 1.0
@@ -292,6 +294,8 @@ class Offset(Template):
             for det in self._all_dets:
                 for iob, ob in enumerate(new_data.obs):
                     if det not in ob.local_detectors:
+                        continue
+                    if det not in ob.detdata[self.det_data].detectors:
                         continue
                     if iob not in self._filters:
                         self._filters[iob] = dict()
@@ -409,13 +413,6 @@ class Offset(Template):
         log.verbose(f"Offset variance = {self._offsetvar}")
         return
 
-    def __del__(self):
-        if hasattr(self, "_offsetvar"):
-            del self._offsetvar
-        if hasattr(self, "_offsetvar_raw"):
-            self._offsetvar_raw.clear()
-            del self._offsetvar_raw
-
     # Helper functions for noise / preconditioner calculations
 
     def _interpolate_psd(self, x, lfreq, lpsd):
@@ -500,6 +497,8 @@ class Offset(Template):
         for iob, ob in enumerate(self.data.obs):
             if detector not in ob.local_detectors:
                 continue
+            if detector not in ob.detdata[self.det_data].detectors:
+                continue
             det_indx = ob.detdata[self.det_data].indices([detector])
             # The step length for this observation
             step_length = self._step_length(
@@ -580,6 +579,8 @@ class Offset(Template):
         for iob, ob in enumerate(self.data.obs):
             if detector not in ob.local_detectors:
                 continue
+            if detector not in ob.detdata[self.det_data].detectors:
+                continue
             det_indx = ob.detdata[self.det_data].indices([detector])
             if self.det_flags is not None:
                 flag_indx = ob.detdata[self.det_flags].indices([detector])
@@ -647,6 +648,8 @@ class Offset(Template):
             for iob, ob in enumerate(self.data.obs):
                 if det not in ob.local_detectors:
                     continue
+                if det not in ob.detdata[self.det_data].detectors:
+                    continue
                 for ivw, vw in enumerate(ob.view[self.view].detdata[self.det_data]):
                     n_amp_view = self._obs_views[iob][ivw]
                     amp_slice = slice(offset, offset + n_amp_view, 1)
@@ -670,6 +673,8 @@ class Offset(Template):
                 offset = self._det_start[det]
                 for iob, ob in enumerate(self.data.obs):
                     if det not in ob.local_detectors:
+                        continue
+                    if det not in ob.detdata[self.det_data].detectors:
                         continue
                     # Loop over views
                     views = ob.view[self.view]

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -38,7 +38,7 @@ class FilterBinTest(MPITestCase):
 
     def test_filterbin(self):
         # Create a fake ground data set for testing
-        data = create_ground_data(self.comm)
+        data = create_ground_data(self.comm, turnarounds_invalid=True)
 
         nside = 256
 

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -309,7 +309,8 @@ class NoiseEstimTest(MPITestCase):
             fitter = ops.FitNoiseModel()
 
             for case, (input_freq, input_psd) in enumerate(zip(test_freq, test_psd)):
-                fit_data, result = fitter._fit_log_psd(input_freq, input_psd)
+                fit = fitter._fit_log_psd(input_freq, input_psd)
+                result = fit["fit_result"]
                 print(f"result solution = {result.x}")
                 print(f"result cost = {result.cost}")
                 print(f"result fun = {result.fun}")
@@ -319,6 +320,13 @@ class NoiseEstimTest(MPITestCase):
                 print(f"result message = {result.message}")
                 print(f"result status = {result.status}")
                 print(f"result active_mask = {result.active_mask}")
+                fit_data = fitter._evaluate_model(
+                    input_freq,
+                    fit["fmin"],
+                    fit["NET"],
+                    fit["fknee"],
+                    fit["alpha"],
+                )
 
                 fig = plt.figure(figsize=[12, 8])
                 ax = fig.add_subplot(1, 1, 1)

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -37,7 +37,7 @@ class PolyFilterTest(MPITestCase):
 
     def test_polyfilter(self):
         # Create a fake ground data set for testing
-        data = create_ground_data(self.comm)
+        data = create_ground_data(self.comm, turnarounds_invalid=True)
 
         # Create some detector pointing matrices
         detpointing = ops.PointingDetectorSimple()
@@ -127,7 +127,7 @@ class PolyFilterTest(MPITestCase):
 
     def test_polyfilter_trend(self):
         # Create a fake ground data set for testing
-        data = create_ground_data(self.comm)
+        data = create_ground_data(self.comm, turnarounds_invalid=True)
 
         # Create some detector pointing matrices
         detpointing = ops.PointingDetectorSimple()

--- a/src/toast/vis.py
+++ b/src/toast/vis.py
@@ -4,6 +4,11 @@
 
 import warnings
 
+import astropy.io.fits as af
+import numpy as np
+from astropy import units as u
+from astropy.wcs import WCS
+
 _matplotlib_backend = None
 
 
@@ -20,3 +25,200 @@ def set_matplotlib_backend(backend="pdf"):
     except:
         msg = "Could not set the matplotlib backend to '{}'".format(_matplotlib_backend)
         warnings.warn(msg)
+
+
+def plot_noise_estim(
+    fname,
+    est_freq,
+    est_psd,
+    fit_freq=None,
+    fit_psd=None,
+    true_net=None,
+    true_freq=None,
+    true_psd=None,
+    semilog=False,
+):
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure(figsize=[12, 8])
+    ax = fig.add_subplot(1, 1, 1)
+    if (true_freq is not None) and (true_psd is not None):
+        # Plot the truth
+        if semilog:
+            ax.semilogx(
+                true_freq.to_value(u.Hz),
+                true_psd.to_value(u.K**2 * u.s),
+                color="black",
+                label="Input Truth",
+            )
+        else:
+            ax.loglog(
+                true_freq.to_value(u.Hz),
+                true_psd.to_value(u.K**2 * u.s),
+                color="black",
+                label="Input Truth",
+            )
+        if true_net is not None:
+            net = true_net.to_value(u.K / u.Hz**0.5)
+            ax.axhline(
+                net**2,
+                label=f"NET = {net:.3f} K" + " / $\sqrt{\mathrm{Hz}}$",
+                linestyle="--",
+                color="black",
+            )
+    if semilog:
+        ax.semilogx(
+            est_freq.to_value(u.Hz),
+            est_psd.to_value(u.K**2 * u.s),
+            color="red",
+            label="Estimated",
+        )
+    else:
+        ax.loglog(
+            est_freq.to_value(u.Hz),
+            est_psd.to_value(u.K**2 * u.s),
+            color="red",
+            label="Estimated",
+        )
+    if (fit_freq is not None) and (fit_psd is not None):
+        if semilog:
+            ax.semilogx(
+                fit_freq.to_value(u.Hz),
+                fit_psd.to_value(u.K**2 * u.s),
+                color="blue",
+                label="Fit to 1/f Model",
+            )
+        else:
+            ax.loglog(
+                fit_freq.to_value(u.Hz),
+                fit_psd.to_value(u.K**2 * u.s),
+                color="blue",
+                label="Fit to 1/f Model",
+            )
+    ax.set_xlim(est_freq[0].to_value(u.Hz), est_freq[-1].to_value(u.Hz))
+    ax.set_ylim(
+        np.amin(est_psd.to_value(u.K**2 * u.s)),
+        1.1 * np.amax(est_psd.to_value(u.K**2 * u.s)),
+    )
+    ax.set_xlabel("Frequency [Hz]")
+    ax.set_ylabel("PSD [K$^2$ / Hz]")
+    ax.legend(loc="best")
+    if fname is None:
+        plt.show()
+    else:
+        fig.savefig(fname)
+    plt.close()
+
+
+def plot_wcs_maps(
+    hitfile=None, mapfile=None, range_I=None, range_Q=None, range_U=None, truth=None
+):
+    """Plot WCS projected output maps.
+
+    This is a helper function to plot typical outputs of the mapmaker.
+
+    Args:
+        hitfile (str):  Path to the hits file.
+        mapfile (str):  Path to the map file.
+        range_I (tuple):  The min / max values of the Intensity map to plot.
+        range_Q (tuple):  The min / max values of the Q map to plot.
+        range_U (tuple):  The min / max values of the U map to plot.
+        truth (str):  Path to the input truth map in the case of simulations.
+
+    """
+    import matplotlib.pyplot as plt
+
+    figsize = (12, 12)
+    figdpi = 100
+
+    def plot_single(wcs, hdata, hindx, vmin, vmax, out):
+        fig = plt.figure(figsize=figsize, dpi=figdpi)
+        ax = fig.add_subplot(projection=wcs, slices=("x", "y", hindx))
+        im = ax.imshow(
+            np.transpose(hdu.data[hindx, :, :]), cmap="jet", vmin=vmin, vmax=vmax
+        )
+        ax.grid(color="white", ls="solid")
+        ax.set_xlabel("Longitude")
+        ax.set_ylabel("Latitude")
+        plt.colorbar(im, orientation="vertical")
+        plt.savefig(out, format="pdf")
+        plt.close()
+
+    def map_range(hdata):
+        minval = np.amin(hdata)
+        maxval = np.amax(hdata)
+        margin = 0.05 * (maxval - minval)
+        if margin == 0:
+            margin = -1
+        minval -= margin
+        maxval += margin
+        return minval, maxval
+
+    def sym_range(hdata):
+        minval, maxval = map_range(hdata)
+        ext = max(np.absolute(minval), np.absolute(maxval))
+        return -ext, ext
+
+    def sub_mono(hitdata, mdata):
+        if hitdata is None:
+            return
+        goodpix = np.logical_and((hitdata > 0), (mdata != 0))
+        mono = np.mean(mdata[goodpix])
+        print(f"Monopole = {mono}")
+        mdata[goodpix] -= mono
+        mdata[np.logical_not(goodpix)] = 0
+
+    hitdata = None
+    if hitfile is not None:
+        hdulist = af.open(hitfile)
+        hdu = hdulist[0]
+        hitdata = np.array(hdu.data[0, :, :])
+        wcs = WCS(hdu.header)
+        maxhits = np.amax(hdu.data[0, :, :])
+        plot_single(wcs, hdu, 0, 0, maxhits, f"{hitfile}.pdf")
+        del hdu
+        hdulist.close()
+
+    if mapfile is not None:
+        hdulist = af.open(mapfile)
+        hdu = hdulist[0]
+        wcs = WCS(hdu.header)
+
+        if truth is not None:
+            thdulist = af.open(truth)
+            thdu = thdulist[0]
+
+        sub_mono(hitdata, hdu.data[0, :, :])
+        mmin, mmax = sym_range(hdu.data[0, :, :])
+        if range_I is not None:
+            mmin, mmax = range_I
+        plot_single(wcs, hdu, 0, mmin, mmax, f"{mapfile}_I.pdf")
+        if truth is not None:
+            tmin, tmax = sym_range(thdu.data[0, :, :])
+            hdu.data[0, :, :] -= thdu.data[0, :, :]
+            plot_single(wcs, hdu, 0, tmin, tmax, f"{mapfile}_resid_I.pdf")
+
+        if hdu.data.shape[0] > 1:
+            mmin, mmax = sym_range(hdu.data[1, :, :])
+            if range_Q is not None:
+                mmin, mmax = range_Q
+            plot_single(wcs, hdu, 1, mmin, mmax, f"{mapfile}_Q.pdf")
+            if truth is not None:
+                tmin, tmax = sym_range(thdu.data[1, :, :])
+                hdu.data[1, :, :] -= thdu.data[1, :, :]
+                plot_single(wcs, hdu, 1, tmin, tmax, f"{mapfile}_resid_Q.pdf")
+
+            mmin, mmax = sym_range(hdu.data[2, :, :])
+            if range_U is not None:
+                mmin, mmax = range_U
+            plot_single(wcs, hdu, 2, mmin, mmax, f"{mapfile}_U.pdf")
+            if truth is not None:
+                tmin, tmax = sym_range(thdu.data[2, :, :])
+                hdu.data[2, :, :] -= thdu.data[2, :, :]
+                plot_single(wcs, hdu, 2, tmin, tmax, f"{mapfile}_resid_U.pdf")
+
+        if truth is not None:
+            del thdu
+            thdulist.close()
+        del hdu
+        hdulist.close()

--- a/src/toast/widgets.py
+++ b/src/toast/widgets.py
@@ -130,7 +130,10 @@ class ObservationWidget(object):
     def _interval_select_widget(self):
         """Create a widget that selects intervals."""
         inames = [self.not_selected]
-        inames.extend(self.obs.intervals.keys())
+        for k in self.obs.intervals.keys():
+            if k == self.obs.intervals.all_name:
+                continue
+            inames.append(k)
         w_intr = widgets.SelectMultiple(
             options=inames,
             value=[inames[0]],
@@ -145,11 +148,7 @@ class ObservationWidget(object):
             # Ignore the fake click when the button is created.
             return
         current = self.app.children
-        try:
-            # Pre v8 this was private.
-            current_titles = {int(x): y for x, y in self.app._titles.items()}
-        except:
-            current_titles = {int(x): y for x, y in self.app.titles}
+        current_titles = {x: y for x, y in enumerate(self.app.titles)}
         new_children = list()
         new_titles = dict()
         for tb in range(0, tabindex):
@@ -164,8 +163,7 @@ class ObservationWidget(object):
             if self.close_buttons[k] > tabindex:
                 self.close_buttons[k] -= 1
         self.app.children = new_children
-        for tb in range(len(self.app.children)):
-            self.app.set_title(tb, new_titles[tb])
+        self.app.titles = [new_titles[tb] for tb in range(len(self.app.children))]
 
     def _detdata_display(self, name):
         """Create a detector data display widget."""
@@ -408,6 +406,8 @@ class ObservationWidget(object):
 
         intr_info = dict()
         for k in self.obs.intervals.keys():
+            if k == self.obs.intervals.all_name:
+                continue
             idata = self.obs.intervals[k]
             nintr = len(idata)
             intr_info[k] = f"{nintr} spans"


### PR DESCRIPTION
* Add a new operator (AzimuthIntervals) which uses smoothed versions of the azimuth velocity and acceleration to detect azimuth scan patterns and define the typical intervals.

* Add support for per-detector flags that apply to an entire observation.  These can be set / updated and use the same masks as per-sample detector flags.  These flags can now be used to optionally control selection of local detectors for processing.

* Add new operator (FlagNoiseFit) which uses the analytic fit to the noise estimate to flag detectors for an observation.  The current implementation can flag outliers in both the estimated NET and knee frequency values.

* Visualization:  small fixes to ipython widget and improvements to WCS and noise estimation plotting functions.

* Set the SimGround bitmask to enable turnarounds in the unit tests

* Allow optionally running with a single process group in the unit tests, even if using >= 2 processes.

* Pull out duplicate code to compute the detector scan range for and observation.  Use this common function in atmosphere simulation and WCS projection autoscaling.

* When fitting an analytic 1/f model to estimated noise PSDs, allow overriding the frequency range that is considered the white noise plateau.