### PR TITLE
fix np.bool to np.bool_

### DIFF
--- a/src/toast/fod/noise_estimation.py
+++ b/src/toast/fod/noise_estimation.py
@@ -438,7 +438,7 @@ class OpNoiseEstim:
 
                 psdvalues = np.array([x[col] for x in all_psds])
                 smooth_values = scipy.signal.medfilt(psdvalues, 11)
-                good = np.ones(psdvalues.size, dtype=np.bool)
+                good = np.ones(psdvalues.size, dtype=bool)
                 good[psdvalues == 0] = False
 
                 for i in range(10):

--- a/src/toast/fod/psd_math.py
+++ b/src/toast/fod/psd_math.py
@@ -156,7 +156,7 @@ def crosscov_psd(
     extended_signal1 = np.zeros(nsamp + nextend, dtype=np.float64)
     if signal2 is not None:
         extended_signal2 = np.zeros(nsamp + nextend, dtype=np.float64)
-    extended_flags = np.zeros(nsamp + nextend, dtype=np.bool)
+    extended_flags = np.zeros(nsamp + nextend, dtype=bool)
     extended_times = np.zeros(nsamp + nextend, dtype=times.dtype)
 
     extended_signal1[:nsamp] = signal1

--- a/src/toast/schedule.py
+++ b/src/toast/schedule.py
@@ -1172,7 +1172,7 @@ def scan_patch(
     # and now track when all corners are past the elevation
     tstop = t
     tstep = 60
-    to_cross = np.ones(len(patch.corners), dtype=np.bool)
+    to_cross = np.ones(len(patch.corners), dtype=bool)
     scan_started = False
     while True:
         if tstop > stop_timestamp or tstop - t > 86400:

--- a/src/toast/tests/psd_math.py
+++ b/src/toast/tests/psd_math.py
@@ -156,7 +156,7 @@ class PSDTest(MPITestCase):
                 autocovs = autocov_psd(
                     np.arange(ntod) / self.rate,
                     noisetod,
-                    np.zeros(ntod, dtype=np.bool),
+                    np.zeros(ntod, dtype=bool),
                     lagmax,
                     ntod,
                     self.rate,

--- a/src/toast/tod/polyfilter.py
+++ b/src/toast/tod/polyfilter.py
@@ -295,7 +295,7 @@ class OpPolyFilter2D(Operator):
                     nsample = istop - istart
 
                     templates = np.zeros([ndet, nmode])
-                    masks = np.zeros([ndet, nsample], dtype=np.bool)
+                    masks = np.zeros([ndet, nsample], dtype=bool)
                     proj = np.zeros([nmode, nsample])
                     norms = np.zeros(nmode)
 

--- a/src/toast/todmap/pointing.py
+++ b/src/toast/todmap/pointing.py
@@ -94,7 +94,7 @@ class OpPointingHpix(Operator):
         self._nside_submap = min(nside, nside_submap)
         self._npix_submap = 12 * self._nside_submap ** 2
         self._nsubmap = (self._nside // self._nside_submap) ** 2
-        self._hit_submaps = np.zeros(self._nsubmap, dtype=np.bool)
+        self._hit_submaps = np.zeros(self._nsubmap, dtype=bool)
 
         # initialize the healpix pixels object
         self.hpix = HealpixPixels(self._nside)
@@ -372,7 +372,7 @@ class OpMuellerPointingHpix(Operator):
         self._nside_submap = min(nside, nside_submap)
         self._npix_submap = 12 * self._nside_submap ** 2
         self._nsubmap = (self._nside // self._nside_submap) ** 2
-        self._hit_submaps = np.zeros(self._nsubmap, dtype=np.bool)
+        self._hit_submaps = np.zeros(self._nsubmap, dtype=bool)
         self._hwp_parameters_set = hwp_parameters_set
         # initialize the healpix pixels object
         self.hpix = HealpixPixels(self._nside)


### PR DESCRIPTION
command used: `find -iname '*.py' -exec sed -i -E 's/np\.bool([^_])/bool\1/g' {} +`

This is fixing a failure in TOAST test "test_binned (toast.tests.binned.BinnedTest)" with the following error with newer versions of Numpy:

AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations