### PR TITLE
Redesigning OpenMP target offload loops

### DIFF
--- a/src/toast/_libtoast/ops_mapmaker_utils.cpp
+++ b/src/toast/_libtoast/ops_mapmaker_utils.cpp
@@ -9,22 +9,22 @@
 #include <intervals.hpp>
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp declare target
+#pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 void build_noise_weighted_inner(
-    int32_t const * pixel_index,
-    int32_t const * weight_index,
-    int32_t const * flag_index,
-    int32_t const * data_index,
-    int64_t const * global2local,
-    double const * data,
-    uint8_t const * det_flags,
-    uint8_t const * shared_flags,
-    int64_t const * pixels,
-    double const * weights,
-    double const * det_scale,
-    double * zmap,
+    int32_t const *pixel_index,
+    int32_t const *weight_index,
+    int32_t const *flag_index,
+    int32_t const *data_index,
+    int64_t const *global2local,
+    double const *data,
+    uint8_t const *det_flags,
+    uint8_t const *shared_flags,
+    int64_t const *pixels,
+    double const *weights,
+    double const *det_scale,
+    double *zmap,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
@@ -33,8 +33,8 @@ void build_noise_weighted_inner(
     uint8_t shared_mask,
     int64_t n_pix_submap,
     bool use_shared_flags,
-    bool use_det_flags
-) {
+    bool use_det_flags)
+{
     int32_t w_indx = weight_index[idet];
     int32_t p_indx = pixel_index[idet];
     int32_t f_indx = flag_index[idet];
@@ -52,19 +52,21 @@ void build_noise_weighted_inner(
     int64_t zoff;
 
     uint8_t det_check = 0;
-    if (use_det_flags) {
+    if (use_det_flags)
+    {
         det_check = det_flags[off_f] & det_mask;
     }
     uint8_t shared_check = 0;
-    if (use_shared_flags) {
+    if (use_shared_flags)
+    {
         shared_check = shared_flags[isamp] & shared_mask;
     }
 
     if (
         (pixels[off_p] >= 0) &&
         (det_check == 0) &&
-        (shared_check == 0)
-    ) {
+        (shared_check == 0))
+    {
         // Good data, accumulate
         global_submap = (int64_t)(pixels[off_p] / n_pix_submap);
 
@@ -77,8 +79,9 @@ void build_noise_weighted_inner(
 
         scaled_data = data[off_d] * det_scale[idet];
 
-        for (int64_t iweight = 0; iweight < nnz; iweight++) {
-            #pragma omp atomic update
+        for (int64_t iweight = 0; iweight < nnz; iweight++)
+        {
+#pragma omp atomic update
             zmap[zoff + iweight] += scaled_data * weights[off_wt + iweight];
         }
     }
@@ -86,29 +89,30 @@ void build_noise_weighted_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp end declare target
+#pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void init_ops_mapmaker_utils(py::module & m) {
+void init_ops_mapmaker_utils(py::module &m)
+{
     m.def(
         "build_noise_weighted", [](
-            py::buffer global2local,
-            py::buffer zmap,
-            py::buffer pixel_index,
-            py::buffer pixels,
-            py::buffer weight_index,
-            py::buffer weights,
-            py::buffer data_index,
-            py::buffer det_data,
-            py::buffer flag_index,
-            py::buffer det_flags,
-            py::buffer det_scale,
-            uint8_t det_flag_mask,
-            py::buffer intervals,
-            py::buffer shared_flags,
-            uint8_t shared_flag_mask,
-            bool use_accel
-        ) {
+                                    py::buffer global2local,
+                                    py::buffer zmap,
+                                    py::buffer pixel_index,
+                                    py::buffer pixels,
+                                    py::buffer weight_index,
+                                    py::buffer weights,
+                                    py::buffer data_index,
+                                    py::buffer det_data,
+                                    py::buffer flag_index,
+                                    py::buffer det_flags,
+                                    py::buffer det_scale,
+                                    uint8_t det_flag_mask,
+                                    py::buffer intervals,
+                                    py::buffer shared_flags,
+                                    uint8_t shared_flag_mask,
+                                    bool use_accel)
+        {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
             bool offload = (!omgr.device_is_host()) && use_accel;
@@ -197,7 +201,7 @@ void init_ops_mapmaker_utils(py::module & m) {
             }
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
                 double * dev_weights = omgr.device_ptr(raw_weights);
@@ -207,81 +211,79 @@ void init_ops_mapmaker_utils(py::module & m) {
                 uint8_t * dev_shared_flags = omgr.device_ptr(raw_shared_flags);
                 uint8_t * dev_det_flags = omgr.device_ptr(raw_det_flags);
 
-                # pragma omp target data             \
-                map(to:                              \
-                raw_weight_index[0:n_det],           \
-                raw_pixel_index[0:n_det],            \
-                raw_flag_index[0:n_det],             \
-                raw_data_index[0:n_det],             \
-                raw_det_scale[0:n_det],              \
-                raw_global2local[0:n_global_submap], \
-                n_view,                              \
-                n_det,                               \
-                n_samp,                              \
-                nnz,                                 \
-                n_pix_submap,                        \
-                det_flag_mask,                       \
-                shared_flag_mask,                    \
-                use_shared_flags,                    \
-                use_det_flags                        \
-                )
-                {
-                    # pragma omp target teams distribute collapse(2) \
-                    is_device_ptr(                                   \
-                    dev_pixels,                                      \
-                    dev_weights,                                     \
-                    dev_det_data,                                    \
-                    dev_det_flags,                                   \
-                    dev_intervals,                                   \
-                    dev_shared_flags,                                \
-                    dev_zmap                                         \
-                    )
-                    for (int64_t idet = 0; idet < n_det; idet++) {
-                        for (int64_t iview = 0; iview < n_view; iview++) {
-                            # pragma omp parallel default(shared)
-                            {
-                                # pragma omp for
-                                for (
-                                    int64_t isamp = dev_intervals[iview].first;
-                                    isamp <= dev_intervals[iview].last;
-                                    isamp++
-                                ) {
-                                    build_noise_weighted_inner(
-                                        raw_pixel_index,
-                                        raw_weight_index,
-                                        raw_flag_index,
-                                        raw_data_index,
-                                        raw_global2local,
-                                        dev_det_data,
-                                        dev_det_flags,
-                                        dev_shared_flags,
-                                        dev_pixels,
-                                        dev_weights,
-                                        raw_det_scale,
-                                        dev_zmap,
-                                        isamp,
-                                        n_samp,
-                                        idet,
-                                        nnz,
-                                        det_flag_mask,
-                                        shared_flag_mask,
-                                        n_pix_submap,
-                                        use_shared_flags,
-                                        use_det_flags
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
+// Calculate the maximum interval size on the CPU
+int64_t max_interval_size = 0;
+for (int64_t iview = 0; iview < n_view; iview++) {
+    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+    if (interval_size > max_interval_size) {
+        max_interval_size = interval_size;
+    }
+}
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+#pragma omp target data map(to : raw_weight_index[0 : n_det],          \
+                                raw_pixel_index[0 : n_det],            \
+                                raw_flag_index[0 : n_det],             \
+                                raw_data_index[0 : n_det],             \
+                                raw_det_scale[0 : n_det],              \
+                                raw_global2local[0 : n_global_submap], \
+                                n_view,                                \
+                                n_det,                                 \
+                                n_samp,                                \
+                                max_interval_size,                     \
+                                nnz,                                   \
+                                n_pix_submap,                          \
+                                det_flag_mask,                         \
+                                shared_flag_mask,                      \
+                                use_shared_flags,                      \
+                                use_det_flags)
+{
+#pragma omp target teams distribute parallel for collapse(3)
+    for (int64_t idet = 0; idet < n_det; idet++) {
+        for (int64_t iview = 0; iview < n_view; iview++) {
+                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                    // Adjust for the actual start of the interval
+                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                    // Check if the value is out of range for the current interval
+                    if (adjusted_isamp > dev_intervals[iview].last) {
+                        continue;
+                    }
+
+                    build_noise_weighted_inner(
+                        raw_pixel_index,
+                        raw_weight_index,
+                        raw_flag_index,
+                        raw_data_index,
+                        raw_global2local,
+                        dev_det_data,
+                        dev_det_flags,
+                        dev_shared_flags,
+                        dev_pixels,
+                        dev_weights,
+                        raw_det_scale,
+                        dev_zmap,
+                        adjusted_isamp,
+                        n_samp,
+                        idet,
+                        nnz,
+                        det_flag_mask,
+                        shared_flag_mask,
+                        n_pix_submap,
+                        use_shared_flags,
+                        use_det_flags
+                    );
+                }
+        }
+    }
+}
+
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t idet = 0; idet < n_det; idet++) {
                     for (int64_t iview = 0; iview < n_view; iview++) {
-                        #pragma omp parallel default(shared)
+#pragma omp parallel default(shared)
                         {
-                            #pragma omp for
+#pragma omp for
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -315,6 +317,5 @@ void init_ops_mapmaker_utils(py::module & m) {
                     }
                 }
             }
-            return;
-        });
+            return; });
 }

--- a/src/toast/_libtoast/ops_noise_weight.cpp
+++ b/src/toast/_libtoast/ops_noise_weight.cpp
@@ -8,16 +8,16 @@
 
 #include <accelerator.hpp>
 
-
-void init_ops_noise_weight(py::module & m) {
+void init_ops_noise_weight(py::module &m)
+{
     m.def(
         "noise_weight", [](
-            py::buffer det_data,
-            py::buffer data_index,
-            py::buffer intervals,
-            py::buffer detector_weights,
-            bool use_accel
-        ) {
+                            py::buffer det_data,
+                            py::buffer data_index,
+                            py::buffer intervals,
+                            py::buffer detector_weights,
+                            bool use_accel)
+        {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
             bool offload = (!omgr.device_is_host()) && use_accel;
@@ -45,49 +45,51 @@ void init_ops_noise_weight(py::module & m) {
             );
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
 
-                # pragma omp target data  \
-                map(to:                   \
-                raw_data_index[0:n_det],  \
-                raw_det_weights[0:n_det], \
-                n_view,                   \
-                n_det,                    \
-                n_samp                    \
-                )
-                {
-                    # pragma omp target teams distribute collapse(2) \
-                    is_device_ptr(                                   \
-                    dev_det_data,                                    \
-                    dev_intervals                                    \
-                    )
-                    for (int64_t idet = 0; idet < n_det; idet++) {
-                        for (int64_t iview = 0; iview < n_view; iview++) {
-                            # pragma omp parallel
-                            {
-                                # pragma omp for default(shared)
-                                for (
-                                    int64_t isamp = dev_intervals[iview].first;
-                                    isamp <= dev_intervals[iview].last;
-                                    isamp++
-                                ) {
-                                    int32_t d_indx = raw_data_index[idet];
-                                    int64_t off_d = d_indx * n_samp + isamp;
-                                    dev_det_data[off_d] *= raw_det_weights[idet];
-                                }
-                            }
-                        }
-                    }
+// Calculate the maximum interval size on the CPU
+int64_t max_interval_size = 0;
+for (int64_t iview = 0; iview < n_view; iview++) {
+    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+    if (interval_size > max_interval_size) {
+        max_interval_size = interval_size;
+    }
+}
+
+#pragma omp target data map(to : raw_data_index[0 : n_det], \
+                                raw_det_weights[0 : n_det], \
+                                n_view,                     \
+                                n_det,                      \
+                                n_samp)
+{
+#pragma omp target teams distribute parallel for collapse(3)
+    for (int64_t idet = 0; idet < n_det; idet++) {
+        for (int64_t iview = 0; iview < n_view; iview++) {
+            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                // Adjust for the actual start of the interval
+                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                // Check if the value is out of range for the current interval
+                if (adjusted_isamp > dev_intervals[iview].last) {
+                    continue;
                 }
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+                int32_t d_indx = raw_data_index[idet];
+                int64_t off_d = d_indx * n_samp + adjusted_isamp;
+                dev_det_data[off_d] *= raw_det_weights[idet];
+            }
+        }
+    }
+}
+
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t idet = 0; idet < n_det; idet++) {
                     for (int64_t iview = 0; iview < n_view; iview++) {
-                        #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
                             isamp <= raw_intervals[iview].last;
@@ -101,6 +103,5 @@ void init_ops_noise_weight(py::module & m) {
                 }
             }
 
-            return;
-        });
+            return; });
 }

--- a/src/toast/_libtoast/ops_noise_weight.cpp
+++ b/src/toast/_libtoast/ops_noise_weight.cpp
@@ -8,15 +8,14 @@
 
 #include <accelerator.hpp>
 
-void init_ops_noise_weight(py::module &m)
-{
+void init_ops_noise_weight(py::module & m) {
     m.def(
         "noise_weight", [](
-                            py::buffer det_data,
-                            py::buffer data_index,
-                            py::buffer intervals,
-                            py::buffer detector_weights,
-                            bool use_accel)
+            py::buffer det_data,
+            py::buffer data_index,
+            py::buffer intervals,
+            py::buffer detector_weights,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -45,51 +44,54 @@ void init_ops_noise_weight(py::module &m)
             );
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
-                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                Interval * dev_intervals = omgr.device_ptr(
+                    raw_intervals);
 
-// Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
-
-#pragma omp target data map(to : raw_data_index[0 : n_det], \
-                                raw_det_weights[0 : n_det], \
-                                n_view,                     \
-                                n_det,                      \
-                                n_samp)
-{
-#pragma omp target teams distribute parallel for collapse(3)
-    for (int64_t idet = 0; idet < n_det; idet++) {
-        for (int64_t iview = 0; iview < n_view; iview++) {
-            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                // Adjust for the actual start of the interval
-                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
-
-                // Check if the value is out of range for the current interval
-                if (adjusted_isamp > dev_intervals[iview].last) {
-                    continue;
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
+                    }
                 }
 
-                int32_t d_indx = raw_data_index[idet];
-                int64_t off_d = d_indx * n_samp + adjusted_isamp;
-                dev_det_data[off_d] *= raw_det_weights[idet];
-            }
-        }
-    }
-}
+                # pragma omp target data map(to : raw_data_index[0 : n_det], \
+                raw_det_weights[0 : n_det],                                  \
+                n_view,                                                      \
+                n_det,                                                       \
+                n_samp)
+                {
+                    # pragma omp target teams distribute parallel for collapse(3)
+                    for (int64_t idet = 0; idet < n_det; idet++) {
+                        for (int64_t iview = 0; iview < n_view; iview++) {
+                            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                                // Adjust for the actual start of the interval
+                                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                                // Check if the value is out of range for the current
+                                // interval
+                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                    continue;
+                                }
+
+                                int32_t d_indx = raw_data_index[idet];
+                                int64_t off_d = d_indx * n_samp + adjusted_isamp;
+                                dev_det_data[off_d] *= raw_det_weights[idet];
+                            }
+                        }
+                    }
+                }
+
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t idet = 0; idet < n_det; idet++) {
                     for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                        #pragma omp parallel for default(shared)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
                             isamp <= raw_intervals[iview].last;
@@ -103,5 +105,6 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                 }
             }
 
-            return; });
+            return;
+        });
 }

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -10,7 +10,6 @@
 
 #include <accelerator.hpp>
 
-
 // 2/PI
 #define TWOINVPI 0.63661977236758134308
 
@@ -18,8 +17,10 @@
 #define TWOTHIRDS 0.66666666666666666667
 
 // Helper table initialization
-void hpix_init_utab(uint64_t * utab) {
-    for (uint64_t m = 0; m < 0x100; ++m) {
+void hpix_init_utab(uint64_t *utab)
+{
+    for (uint64_t m = 0; m < 0x100; ++m)
+    {
         utab[m] = (m & 0x1) | ((m & 0x2) << 1) | ((m & 0x4) << 2) |
                   ((m & 0x8) << 3) | ((m & 0x10) << 4) | ((m & 0x20) << 5) |
                   ((m & 0x40) << 6) | ((m & 0x80) << 7);
@@ -28,36 +29,41 @@ void hpix_init_utab(uint64_t * utab) {
 }
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp declare target
+#pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void pixels_healpix_qa_rotate(double const * q_in, double const * v_in,
-                              double * v_out) {
+void pixels_healpix_qa_rotate(double const *q_in, double const *v_in,
+                              double *v_out)
+{
     // The input quaternion has already been normalized on the host.
 
-    double xw =  q_in[3] * q_in[0];
-    double yw =  q_in[3] * q_in[1];
-    double zw =  q_in[3] * q_in[2];
+    double xw = q_in[3] * q_in[0];
+    double yw = q_in[3] * q_in[1];
+    double zw = q_in[3] * q_in[2];
     double x2 = -q_in[0] * q_in[0];
-    double xy =  q_in[0] * q_in[1];
-    double xz =  q_in[0] * q_in[2];
+    double xy = q_in[0] * q_in[1];
+    double xz = q_in[0] * q_in[2];
     double y2 = -q_in[1] * q_in[1];
-    double yz =  q_in[1] * q_in[2];
+    double yz = q_in[1] * q_in[2];
     double z2 = -q_in[2] * q_in[2];
 
     v_out[0] = 2 * ((y2 + z2) * v_in[0] + (xy - zw) * v_in[1] +
-                    (yw + xz) * v_in[2]) + v_in[0];
+                    (yw + xz) * v_in[2]) +
+               v_in[0];
 
     v_out[1] = 2 * ((zw + xy) * v_in[0] + (x2 + z2) * v_in[1] +
-                    (yz - xw) * v_in[2]) + v_in[1];
+                    (yz - xw) * v_in[2]) +
+               v_in[1];
 
     v_out[2] = 2 * ((xz - yw) * v_in[0] + (xw + yz) * v_in[1] +
-                    (x2 + y2) * v_in[2]) + v_in[2];
+                    (x2 + y2) * v_in[2]) +
+               v_in[2];
 
     return;
 }
 
-uint64_t hpix_xy2pix(uint64_t * utab, uint64_t x, uint64_t y) {
+uint64_t hpix_xy2pix(uint64_t *utab, uint64_t x, uint64_t y)
+{
     return utab[x & 0xff] | (utab[(x >> 8) & 0xff] << 16) |
            (utab[(x >> 16) & 0xff] << 32) |
            (utab[(x >> 24) & 0xff] << 48) |
@@ -66,8 +72,9 @@ uint64_t hpix_xy2pix(uint64_t * utab, uint64_t x, uint64_t y) {
            (utab[(y >> 24) & 0xff] << 49);
 }
 
-void hpix_vec2zphi(double const * vec, double * phi, int * region, double * z,
-                   double * rtz) {
+void hpix_vec2zphi(double const *vec, double *phi, int *region, double *z,
+                   double *rtz)
+{
     // region encodes BOTH the sign of Z and whether its
     // absolute value is greater than 2/3.
     (*z) = vec[2];
@@ -79,8 +86,9 @@ void hpix_vec2zphi(double const * vec, double * phi, int * region, double * z,
     return;
 }
 
-void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
-                    int region, double z, double rtz, int64_t * pix) {
+void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
+                    int region, double z, double rtz, int64_t *pix)
+{
     double tt = (phi >= 0.0) ? phi * TWOINVPI : phi * TWOINVPI + 4.0;
     int64_t x;
     int64_t y;
@@ -94,13 +102,14 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
     int64_t ntt;
     double tp;
 
-    double dnside = static_cast <double> (nside);
+    double dnside = static_cast<double>(nside);
     int64_t twonside = 2 * nside;
     double halfnside = 0.5 * dnside;
     double tqnside = 0.75 * dnside;
     int64_t nsideminusone = nside - 1;
 
-    if ((region == 1) || (region == -1)) {
+    if ((region == 1) || (region == -1))
+    {
         temp1 = halfnside + dnside * tt;
         temp2 = tqnside * z;
 
@@ -110,17 +119,24 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
         ifp = jp >> factor;
         ifm = jm >> factor;
 
-        if (ifp == ifm) {
+        if (ifp == ifm)
+        {
             face = (ifp == 4) ? (int64_t)4 : ifp + 4;
-        } else if (ifp < ifm) {
+        }
+        else if (ifp < ifm)
+        {
             face = ifp;
-        } else {
+        }
+        else
+        {
             face = ifm + 8;
         }
 
         x = jm & nsideminusone;
         y = nsideminusone - (jp & nsideminusone);
-    } else {
+    }
+    else
+    {
         ntt = (int64_t)tt;
 
         tp = tt - (double)ntt;
@@ -130,18 +146,23 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
         jp = (int64_t)(tp * temp1);
         jm = (int64_t)((1.0 - tp) * temp1);
 
-        if (jp >= nside) {
+        if (jp >= nside)
+        {
             jp = nsideminusone;
         }
-        if (jm >= nside) {
+        if (jm >= nside)
+        {
             jm = nsideminusone;
         }
 
-        if (z >= 0) {
+        if (z >= 0)
+        {
             face = ntt;
             x = nsideminusone - jm;
             y = nsideminusone - jp;
-        } else {
+        }
+        else
+        {
             face = ntt + 8;
             x = jp;
             y = jm;
@@ -156,7 +177,8 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
 }
 
 void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, double z,
-                    double rtz, int64_t * pix) {
+                    double rtz, int64_t *pix)
+{
     double tt = (phi >= 0.0) ? phi * TWOINVPI : phi * TWOINVPI + 4.0;
     double tp;
     int64_t longpart;
@@ -168,7 +190,7 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
     int64_t ir;
     int64_t kshift;
 
-    double dnside = static_cast <double> (nside);
+    double dnside = static_cast<double>(nside);
     int64_t fournside = 4 * nside;
     double halfnside = 0.5 * dnside;
     double tqnside = 0.75 * dnside;
@@ -176,7 +198,8 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
     int64_t ncap = 2 * (nside * nside - nside);
     int64_t npix = 12 * nside * nside;
 
-    if ((region == 1) || (region == -1)) {
+    if ((region == 1) || (region == -1))
+    {
         temp1 = halfnside + dnside * tt;
         temp2 = tqnside * z;
 
@@ -190,7 +213,9 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
         ip = ip % fournside;
 
         (*pix) = ncap + ((ir - 1) * fournside + ip);
-    } else {
+    }
+    else
+    {
         tp = tt - floor(tt);
 
         temp1 = dnside * rtz;
@@ -203,7 +228,7 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
         ip -= longpart;
 
         (*pix) = (region > 0) ? (2 * ir * (ir - 1) + ip)
-                 : (npix - 2 * ir * (ir + 1) + ip);
+                              : (npix - 2 * ir * (ir + 1) + ip);
     }
 
     return;
@@ -212,20 +237,20 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
 void pixels_healpix_nest_inner(
     int64_t nside,
     int64_t factor,
-    uint64_t * utab,
-    int32_t const * quat_index,
-    int32_t const * pixel_index,
-    double const * quats,
-    uint8_t const * flags,
-    uint8_t * hsub,
-    int64_t * pixels,
+    uint64_t *utab,
+    int32_t const *quat_index,
+    int32_t const *pixel_index,
+    double const *quats,
+    uint8_t const *flags,
+    uint8_t *hsub,
+    int64_t *pixels,
     int64_t n_pix_submap,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
     uint8_t mask,
-    bool use_flags
-) {
+    bool use_flags)
+{
     const double zaxis[3] = {0.0, 0.0, 1.0};
     int32_t p_indx = pixel_index[idet];
     int32_t q_indx = quat_index[idet];
@@ -241,9 +266,12 @@ void pixels_healpix_nest_inner(
     pixels_healpix_qa_rotate(&(quats[qoff]), zaxis, dir);
     hpix_vec2zphi(dir, &phi, &region, &z, &rtz);
     hpix_zphi2nest(nside, factor, utab, phi, region, z, rtz, &(pixels[poff]));
-    if (use_flags && ((flags[isamp] & mask) != 0)) {
+    if (use_flags && ((flags[isamp] & mask) != 0))
+    {
         pixels[poff] = -1;
-    } else {
+    }
+    else
+    {
         sub_map = (int64_t)(pixels[poff] / n_pix_submap);
         hsub[sub_map] = 1;
     }
@@ -254,19 +282,19 @@ void pixels_healpix_nest_inner(
 void pixels_healpix_ring_inner(
     int64_t nside,
     int64_t factor,
-    int32_t const * quat_index,
-    int32_t const * pixel_index,
-    double const * quats,
-    uint8_t const * flags,
-    uint8_t * hsub,
-    int64_t * pixels,
+    int32_t const *quat_index,
+    int32_t const *pixel_index,
+    double const *quats,
+    uint8_t const *flags,
+    uint8_t *hsub,
+    int64_t *pixels,
     int64_t n_pix_submap,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
     uint8_t mask,
-    bool use_flags
-) {
+    bool use_flags)
+{
     const double zaxis[3] = {0.0, 0.0, 1.0};
     int32_t p_indx = pixel_index[idet];
     int32_t q_indx = quat_index[idet];
@@ -282,9 +310,12 @@ void pixels_healpix_ring_inner(
     pixels_healpix_qa_rotate(&(quats[qoff]), zaxis, dir);
     hpix_vec2zphi(dir, &phi, &region, &z, &rtz);
     hpix_zphi2ring(nside, factor, phi, region, z, rtz, &(pixels[poff]));
-    if (use_flags && ((flags[isamp] & mask) != 0)) {
+    if (use_flags && ((flags[isamp] & mask) != 0))
+    {
         pixels[poff] = -1;
-    } else {
+    }
+    else
+    {
         sub_map = (int64_t)(pixels[poff] / n_pix_submap);
         hsub[sub_map] = 1;
     }
@@ -293,25 +324,26 @@ void pixels_healpix_ring_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp end declare target
+#pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void init_ops_pixels_healpix(py::module & m) {
+void init_ops_pixels_healpix(py::module &m)
+{
     m.def(
         "pixels_healpix", [](
-            py::buffer quat_index,
-            py::buffer quats,
-            py::buffer shared_flags,
-            uint8_t shared_flag_mask,
-            py::buffer pixel_index,
-            py::buffer pixels,
-            py::buffer intervals,
-            py::buffer hit_submaps,
-            int64_t n_pix_submap,
-            int64_t nside,
-            bool nest,
-            bool use_accel
-        ) {
+                              py::buffer quat_index,
+                              py::buffer quats,
+                              py::buffer shared_flags,
+                              uint8_t shared_flag_mask,
+                              py::buffer pixel_index,
+                              py::buffer pixels,
+                              py::buffer intervals,
+                              py::buffer hit_submaps,
+                              int64_t n_pix_submap,
+                              int64_t nside,
+                              bool nest,
+                              bool use_accel)
+        {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
             bool offload = (!omgr.device_is_host()) && use_accel;
@@ -366,7 +398,7 @@ void init_ops_pixels_healpix(py::module & m) {
             }
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
@@ -383,110 +415,102 @@ void init_ops_pixels_healpix(py::module & m) {
 
                 uint64_t * dev_utab = omgr.device_ptr(utab);
 
-                # pragma omp target data  \
-                map(to:                   \
-                raw_pixel_index[0:n_det], \
-                raw_quat_index[0:n_det],  \
-                n_pix_submap,             \
-                nside,                    \
-                factor,                   \
-                nest,                     \
-                n_view,                   \
-                n_det,                    \
-                n_samp,                   \
-                shared_flag_mask,         \
-                use_flags                 \
-                )                         \
-                map(tofrom: raw_hsub[0:n_submap])
-                {
-                    if (nest) {
-                        # pragma omp target teams distribute collapse(2) \
-                        is_device_ptr(                                   \
-                        dev_pixels,                                      \
-                        dev_quats,                                       \
-                        dev_flags,                                       \
-                        dev_intervals,                                   \
-                        dev_utab                                         \
-                        )
-                        for (int64_t idet = 0; idet < n_det; idet++) {
-                            for (int64_t iview = 0; iview < n_view; iview++) {
-                                # pragma omp parallel
-                                {
-                                    # pragma omp for default(shared)
-                                    for (
-                                        int64_t isamp = dev_intervals[iview].first;
-                                        isamp <= dev_intervals[iview].last;
-                                        isamp++
-                                    ) {
-                                        pixels_healpix_nest_inner(
-                                            nside,
-                                            factor,
-                                            dev_utab,
-                                            raw_quat_index,
-                                            raw_pixel_index,
-                                            dev_quats,
-                                            dev_flags,
-                                            raw_hsub,
-                                            dev_pixels,
-                                            n_pix_submap,
-                                            isamp,
-                                            n_samp,
-                                            idet,
-                                            shared_flag_mask,
-                                            use_flags
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    } else {
-                        # pragma omp target teams distribute collapse(2) \
-                        is_device_ptr(                                   \
-                        dev_pixels,                                      \
-                        dev_quats,                                       \
-                        dev_flags,                                       \
-                        dev_intervals,                                   \
-                        dev_utab                                         \
-                        )
-                        for (int64_t idet = 0; idet < n_det; idet++) {
-                            for (int64_t iview = 0; iview < n_view; iview++) {
-                                # pragma omp parallel
-                                {
-                                    # pragma omp for default(shared)
-                                    for (
-                                        int64_t isamp = dev_intervals[iview].first;
-                                        isamp <= dev_intervals[iview].last;
-                                        isamp++
-                                    ) {
-                                        pixels_healpix_ring_inner(
-                                            nside,
-                                            factor,
-                                            raw_quat_index,
-                                            raw_pixel_index,
-                                            dev_quats,
-                                            dev_flags,
-                                            raw_hsub,
-                                            dev_pixels,
-                                            n_pix_submap,
-                                            isamp,
-                                            n_samp,
-                                            idet,
-                                            shared_flag_mask,
-                                            use_flags
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+ // Calculate the maximum interval size on the CPU
+int64_t max_interval_size = 0;
+for (int64_t iview = 0; iview < n_view; iview++) {
+    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+    if (interval_size > max_interval_size) {
+        max_interval_size = interval_size;
+    }
+}
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+#pragma omp target data map(to : raw_pixel_index[0 : n_det], \
+                                raw_quat_index[0 : n_det],   \
+                                n_pix_submap,                \
+                                nside,                       \
+                                factor,                      \
+                                nest,                        \
+                                n_view,                      \
+                                n_det,                       \
+                                n_samp,                      \
+                                shared_flag_mask,            \
+                                use_flags)                   \
+    map(tofrom : raw_hsub[0 : n_submap])
+{
+    if (nest) {
+#pragma omp target teams distribute parallel for collapse(3)
+        for (int64_t idet = 0; idet < n_det; idet++) {
+            for (int64_t iview = 0; iview < n_view; iview++) {
+                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                    // Adjust for the actual start of the interval
+                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                    // Check if the value is out of range for the current interval
+                    if (adjusted_isamp > dev_intervals[iview].last) {
+                        continue;
+                    }
+
+                    pixels_healpix_nest_inner(
+                        nside,
+                        factor,
+                        dev_utab,
+                        raw_quat_index,
+                        raw_pixel_index,
+                        dev_quats,
+                        dev_flags,
+                        raw_hsub,
+                        dev_pixels,
+                        n_pix_submap,
+                        adjusted_isamp,
+                        n_samp,
+                        idet,
+                        shared_flag_mask,
+                        use_flags
+                    );
+                }
+            }
+        }
+    } else {
+#pragma omp target teams distribute parallel for collapse(3)
+        for (int64_t idet = 0; idet < n_det; idet++) {
+            for (int64_t iview = 0; iview < n_view; iview++) {
+                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                    // Adjust for the actual start of the interval
+                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                    // Check if the value is out of range for the current interval
+                    if (adjusted_isamp > dev_intervals[iview].last) {
+                        continue;
+                    }
+
+                    pixels_healpix_ring_inner(
+                        nside,
+                        factor,
+                        raw_quat_index,
+                        raw_pixel_index,
+                        dev_quats,
+                        dev_flags,
+                        raw_hsub,
+                        dev_pixels,
+                        n_pix_submap,
+                        adjusted_isamp,
+                        n_samp,
+                        idet,
+                        shared_flag_mask,
+                        use_flags
+                    );
+                }
+            }
+        }
+    }
+}
+
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 if (nest) {
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-                            #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -515,7 +539,7 @@ void init_ops_pixels_healpix(py::module & m) {
                 } else {
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-                            #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -542,6 +566,5 @@ void init_ops_pixels_healpix(py::module & m) {
                     }
                 }
             }
-            return;
-        });
+            return; });
 }

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -437,72 +437,57 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                                 use_flags)                   \
     map(tofrom : raw_hsub[0 : n_submap])
 {
-    if (nest) {
 #pragma omp target teams distribute parallel for collapse(3)
-        for (int64_t idet = 0; idet < n_det; idet++) {
-            for (int64_t iview = 0; iview < n_view; iview++) {
-                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                    // Adjust for the actual start of the interval
-                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+for (int64_t idet = 0; idet < n_det; idet++) {
+    for (int64_t iview = 0; iview < n_view; iview++) {
+        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+            // Adjust for the actual start of the interval
+            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                    // Check if the value is out of range for the current interval
-                    if (adjusted_isamp > dev_intervals[iview].last) {
-                        continue;
-                    }
-
-                    pixels_healpix_nest_inner(
-                        nside,
-                        factor,
-                        dev_utab,
-                        raw_quat_index,
-                        raw_pixel_index,
-                        dev_quats,
-                        dev_flags,
-                        raw_hsub,
-                        dev_pixels,
-                        n_pix_submap,
-                        adjusted_isamp,
-                        n_samp,
-                        idet,
-                        shared_flag_mask,
-                        use_flags
-                    );
-                }
+            // Check if the value is out of range for the current interval
+            if (adjusted_isamp > dev_intervals[iview].last) {
+                continue;
             }
-        }
-    } else {
-#pragma omp target teams distribute parallel for collapse(3)
-        for (int64_t idet = 0; idet < n_det; idet++) {
-            for (int64_t iview = 0; iview < n_view; iview++) {
-                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                    // Adjust for the actual start of the interval
-                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                    // Check if the value is out of range for the current interval
-                    if (adjusted_isamp > dev_intervals[iview].last) {
-                        continue;
-                    }
-
-                    pixels_healpix_ring_inner(
-                        nside,
-                        factor,
-                        raw_quat_index,
-                        raw_pixel_index,
-                        dev_quats,
-                        dev_flags,
-                        raw_hsub,
-                        dev_pixels,
-                        n_pix_submap,
-                        adjusted_isamp,
-                        n_samp,
-                        idet,
-                        shared_flag_mask,
-                        use_flags
-                    );
-                }
+            if (nest) {
+                pixels_healpix_nest_inner(
+                    nside,
+                    factor,
+                    dev_utab,
+                    raw_quat_index,
+                    raw_pixel_index,
+                    dev_quats,
+                    dev_flags,
+                    raw_hsub,
+                    dev_pixels,
+                    n_pix_submap,
+                    adjusted_isamp,
+                    n_samp,
+                    idet,
+                    shared_flag_mask,
+                    use_flags
+                );
+            } else {
+                pixels_healpix_ring_inner(
+                    nside,
+                    factor,
+                    raw_quat_index,
+                    raw_pixel_index,
+                    dev_quats,
+                    dev_flags,
+                    raw_hsub,
+                    dev_pixels,
+                    n_pix_submap,
+                    adjusted_isamp,
+                    n_samp,
+                    idet,
+                    shared_flag_mask,
+                    use_flags
+                );
             }
         }
     }
+}
 }
 
 #endif // ifdef HAVE_OPENMP_TARGET

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -17,10 +17,8 @@
 #define TWOTHIRDS 0.66666666666666666667
 
 // Helper table initialization
-void hpix_init_utab(uint64_t *utab)
-{
-    for (uint64_t m = 0; m < 0x100; ++m)
-    {
+void hpix_init_utab(uint64_t * utab) {
+    for (uint64_t m = 0; m < 0x100; ++m) {
         utab[m] = (m & 0x1) | ((m & 0x2) << 1) | ((m & 0x4) << 2) |
                   ((m & 0x8) << 3) | ((m & 0x10) << 4) | ((m & 0x20) << 5) |
                   ((m & 0x40) << 6) | ((m & 0x80) << 7);
@@ -29,12 +27,11 @@ void hpix_init_utab(uint64_t *utab)
 }
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp declare target
+# pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void pixels_healpix_qa_rotate(double const *q_in, double const *v_in,
-                              double *v_out)
-{
+void pixels_healpix_qa_rotate(double const * q_in, double const * v_in,
+                              double * v_out) {
     // The input quaternion has already been normalized on the host.
 
     double xw = q_in[3] * q_in[0];
@@ -62,8 +59,7 @@ void pixels_healpix_qa_rotate(double const *q_in, double const *v_in,
     return;
 }
 
-uint64_t hpix_xy2pix(uint64_t *utab, uint64_t x, uint64_t y)
-{
+uint64_t hpix_xy2pix(uint64_t * utab, uint64_t x, uint64_t y) {
     return utab[x & 0xff] | (utab[(x >> 8) & 0xff] << 16) |
            (utab[(x >> 16) & 0xff] << 32) |
            (utab[(x >> 24) & 0xff] << 48) |
@@ -72,9 +68,8 @@ uint64_t hpix_xy2pix(uint64_t *utab, uint64_t x, uint64_t y)
            (utab[(y >> 24) & 0xff] << 49);
 }
 
-void hpix_vec2zphi(double const *vec, double *phi, int *region, double *z,
-                   double *rtz)
-{
+void hpix_vec2zphi(double const * vec, double * phi, int * region, double * z,
+                   double * rtz) {
     // region encodes BOTH the sign of Z and whether its
     // absolute value is greater than 2/3.
     (*z) = vec[2];
@@ -86,9 +81,8 @@ void hpix_vec2zphi(double const *vec, double *phi, int *region, double *z,
     return;
 }
 
-void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
-                    int region, double z, double rtz, int64_t *pix)
-{
+void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t * utab, double phi,
+                    int region, double z, double rtz, int64_t * pix) {
     double tt = (phi >= 0.0) ? phi * TWOINVPI : phi * TWOINVPI + 4.0;
     int64_t x;
     int64_t y;
@@ -102,14 +96,13 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
     int64_t ntt;
     double tp;
 
-    double dnside = static_cast<double>(nside);
+    double dnside = static_cast <double> (nside);
     int64_t twonside = 2 * nside;
     double halfnside = 0.5 * dnside;
     double tqnside = 0.75 * dnside;
     int64_t nsideminusone = nside - 1;
 
-    if ((region == 1) || (region == -1))
-    {
+    if ((region == 1) || (region == -1)) {
         temp1 = halfnside + dnside * tt;
         temp2 = tqnside * z;
 
@@ -119,24 +112,17 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
         ifp = jp >> factor;
         ifm = jm >> factor;
 
-        if (ifp == ifm)
-        {
+        if (ifp == ifm) {
             face = (ifp == 4) ? (int64_t)4 : ifp + 4;
-        }
-        else if (ifp < ifm)
-        {
+        } else if (ifp < ifm) {
             face = ifp;
-        }
-        else
-        {
+        } else {
             face = ifm + 8;
         }
 
         x = jm & nsideminusone;
         y = nsideminusone - (jp & nsideminusone);
-    }
-    else
-    {
+    } else {
         ntt = (int64_t)tt;
 
         tp = tt - (double)ntt;
@@ -146,23 +132,18 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
         jp = (int64_t)(tp * temp1);
         jm = (int64_t)((1.0 - tp) * temp1);
 
-        if (jp >= nside)
-        {
+        if (jp >= nside) {
             jp = nsideminusone;
         }
-        if (jm >= nside)
-        {
+        if (jm >= nside) {
             jm = nsideminusone;
         }
 
-        if (z >= 0)
-        {
+        if (z >= 0) {
             face = ntt;
             x = nsideminusone - jm;
             y = nsideminusone - jp;
-        }
-        else
-        {
+        } else {
             face = ntt + 8;
             x = jp;
             y = jm;
@@ -177,8 +158,7 @@ void hpix_zphi2nest(int64_t nside, int64_t factor, uint64_t *utab, double phi,
 }
 
 void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, double z,
-                    double rtz, int64_t *pix)
-{
+                    double rtz, int64_t * pix) {
     double tt = (phi >= 0.0) ? phi * TWOINVPI : phi * TWOINVPI + 4.0;
     double tp;
     int64_t longpart;
@@ -190,7 +170,7 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
     int64_t ir;
     int64_t kshift;
 
-    double dnside = static_cast<double>(nside);
+    double dnside = static_cast <double> (nside);
     int64_t fournside = 4 * nside;
     double halfnside = 0.5 * dnside;
     double tqnside = 0.75 * dnside;
@@ -198,8 +178,7 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
     int64_t ncap = 2 * (nside * nside - nside);
     int64_t npix = 12 * nside * nside;
 
-    if ((region == 1) || (region == -1))
-    {
+    if ((region == 1) || (region == -1)) {
         temp1 = halfnside + dnside * tt;
         temp2 = tqnside * z;
 
@@ -213,9 +192,7 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
         ip = ip % fournside;
 
         (*pix) = ncap + ((ir - 1) * fournside + ip);
-    }
-    else
-    {
+    } else {
         tp = tt - floor(tt);
 
         temp1 = dnside * rtz;
@@ -237,20 +214,19 @@ void hpix_zphi2ring(int64_t nside, int64_t factor, double phi, int region, doubl
 void pixels_healpix_nest_inner(
     int64_t nside,
     int64_t factor,
-    uint64_t *utab,
-    int32_t const *quat_index,
-    int32_t const *pixel_index,
-    double const *quats,
-    uint8_t const *flags,
-    uint8_t *hsub,
-    int64_t *pixels,
+    uint64_t * utab,
+    int32_t const * quat_index,
+    int32_t const * pixel_index,
+    double const * quats,
+    uint8_t const * flags,
+    uint8_t * hsub,
+    int64_t * pixels,
     int64_t n_pix_submap,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
     uint8_t mask,
-    bool use_flags)
-{
+    bool use_flags) {
     const double zaxis[3] = {0.0, 0.0, 1.0};
     int32_t p_indx = pixel_index[idet];
     int32_t q_indx = quat_index[idet];
@@ -266,12 +242,9 @@ void pixels_healpix_nest_inner(
     pixels_healpix_qa_rotate(&(quats[qoff]), zaxis, dir);
     hpix_vec2zphi(dir, &phi, &region, &z, &rtz);
     hpix_zphi2nest(nside, factor, utab, phi, region, z, rtz, &(pixels[poff]));
-    if (use_flags && ((flags[isamp] & mask) != 0))
-    {
+    if (use_flags && ((flags[isamp] & mask) != 0)) {
         pixels[poff] = -1;
-    }
-    else
-    {
+    } else {
         sub_map = (int64_t)(pixels[poff] / n_pix_submap);
         hsub[sub_map] = 1;
     }
@@ -282,19 +255,18 @@ void pixels_healpix_nest_inner(
 void pixels_healpix_ring_inner(
     int64_t nside,
     int64_t factor,
-    int32_t const *quat_index,
-    int32_t const *pixel_index,
-    double const *quats,
-    uint8_t const *flags,
-    uint8_t *hsub,
-    int64_t *pixels,
+    int32_t const * quat_index,
+    int32_t const * pixel_index,
+    double const * quats,
+    uint8_t const * flags,
+    uint8_t * hsub,
+    int64_t * pixels,
     int64_t n_pix_submap,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
     uint8_t mask,
-    bool use_flags)
-{
+    bool use_flags) {
     const double zaxis[3] = {0.0, 0.0, 1.0};
     int32_t p_indx = pixel_index[idet];
     int32_t q_indx = quat_index[idet];
@@ -310,12 +282,9 @@ void pixels_healpix_ring_inner(
     pixels_healpix_qa_rotate(&(quats[qoff]), zaxis, dir);
     hpix_vec2zphi(dir, &phi, &region, &z, &rtz);
     hpix_zphi2ring(nside, factor, phi, region, z, rtz, &(pixels[poff]));
-    if (use_flags && ((flags[isamp] & mask) != 0))
-    {
+    if (use_flags && ((flags[isamp] & mask) != 0)) {
         pixels[poff] = -1;
-    }
-    else
-    {
+    } else {
         sub_map = (int64_t)(pixels[poff] / n_pix_submap);
         hsub[sub_map] = 1;
     }
@@ -324,25 +293,24 @@ void pixels_healpix_ring_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp end declare target
+# pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void init_ops_pixels_healpix(py::module &m)
-{
+void init_ops_pixels_healpix(py::module & m) {
     m.def(
         "pixels_healpix", [](
-                              py::buffer quat_index,
-                              py::buffer quats,
-                              py::buffer shared_flags,
-                              uint8_t shared_flag_mask,
-                              py::buffer pixel_index,
-                              py::buffer pixels,
-                              py::buffer intervals,
-                              py::buffer hit_submaps,
-                              int64_t n_pix_submap,
-                              int64_t nside,
-                              bool nest,
-                              bool use_accel)
+            py::buffer quat_index,
+            py::buffer quats,
+            py::buffer shared_flags,
+            uint8_t shared_flag_mask,
+            py::buffer pixel_index,
+            py::buffer pixels,
+            py::buffer intervals,
+            py::buffer hit_submaps,
+            int64_t n_pix_submap,
+            int64_t nside,
+            bool nest,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -398,7 +366,7 @@ void init_ops_pixels_healpix(py::module &m)
             }
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
@@ -413,104 +381,110 @@ void init_ops_pixels_healpix(py::module &m)
                     omgr.update_device((void *)utab, utab_bytes);
                 }
 
-                uint64_t * dev_utab = omgr.device_ptr(utab);
+                uint64_t * dev_utab = omgr.device_ptr(
+                    utab);
 
- // Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
-
-#pragma omp target data map(to : raw_pixel_index[0 : n_det], \
-                                raw_quat_index[0 : n_det],   \
-                                n_pix_submap,                \
-                                nside,                       \
-                                factor,                      \
-                                nest,                        \
-                                n_view,                      \
-                                n_det,                       \
-                                n_samp,                      \
-                                shared_flag_mask,            \
-                                use_flags)                   \
-    map(tofrom : raw_hsub[0 : n_submap])
-{
-    if (nest) {
-#pragma omp target teams distribute parallel for collapse(3)
-        for (int64_t idet = 0; idet < n_det; idet++) {
-            for (int64_t iview = 0; iview < n_view; iview++) {
-                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                    // Adjust for the actual start of the interval
-                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
-
-                    // Check if the value is out of range for the current interval
-                    if (adjusted_isamp > dev_intervals[iview].last) {
-                        continue;
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
                     }
-
-                    pixels_healpix_nest_inner(
-                        nside,
-                        factor,
-                        dev_utab,
-                        raw_quat_index,
-                        raw_pixel_index,
-                        dev_quats,
-                        dev_flags,
-                        raw_hsub,
-                        dev_pixels,
-                        n_pix_submap,
-                        adjusted_isamp,
-                        n_samp,
-                        idet,
-                        shared_flag_mask,
-                        use_flags
-                    );
                 }
-            }
-        }
-    } else {
-#pragma omp target teams distribute parallel for collapse(3)
-        for (int64_t idet = 0; idet < n_det; idet++) {
-            for (int64_t iview = 0; iview < n_view; iview++) {
-                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                    // Adjust for the actual start of the interval
-                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                    // Check if the value is out of range for the current interval
-                    if (adjusted_isamp > dev_intervals[iview].last) {
-                        continue;
+                # pragma omp target data map(to : raw_pixel_index[0 : n_det], \
+                raw_quat_index[0 : n_det],                                    \
+                n_pix_submap,                                                 \
+                nside,                                                        \
+                factor,                                                       \
+                nest,                                                         \
+                n_view,                                                       \
+                n_det,                                                        \
+                n_samp,                                                       \
+                shared_flag_mask,                                             \
+                use_flags)                                                    \
+                map(tofrom : raw_hsub[0 : n_submap])
+                {
+                    if (nest) {
+                        # pragma omp target teams distribute parallel for collapse(3)
+                        for (int64_t idet = 0; idet < n_det; idet++) {
+                            for (int64_t iview = 0; iview < n_view; iview++) {
+                                for (int64_t isamp = 0; isamp < max_interval_size;
+                                     isamp++) {
+                                    // Adjust for the actual start of the interval
+                                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                                    // Check if the value is out of range for the
+                                    // current interval
+                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                        continue;
+                                    }
+
+                                    pixels_healpix_nest_inner(
+                                        nside,
+                                        factor,
+                                        dev_utab,
+                                        raw_quat_index,
+                                        raw_pixel_index,
+                                        dev_quats,
+                                        dev_flags,
+                                        raw_hsub,
+                                        dev_pixels,
+                                        n_pix_submap,
+                                        adjusted_isamp,
+                                        n_samp,
+                                        idet,
+                                        shared_flag_mask,
+                                        use_flags
+                                    );
+                                }
+                            }
+                        }
+                    } else {
+                        # pragma omp target teams distribute parallel for collapse(3)
+                        for (int64_t idet = 0; idet < n_det; idet++) {
+                            for (int64_t iview = 0; iview < n_view; iview++) {
+                                for (int64_t isamp = 0; isamp < max_interval_size;
+                                     isamp++) {
+                                    // Adjust for the actual start of the interval
+                                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                                    // Check if the value is out of range for the
+                                    // current interval
+                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                        continue;
+                                    }
+
+                                    pixels_healpix_ring_inner(
+                                        nside,
+                                        factor,
+                                        raw_quat_index,
+                                        raw_pixel_index,
+                                        dev_quats,
+                                        dev_flags,
+                                        raw_hsub,
+                                        dev_pixels,
+                                        n_pix_submap,
+                                        adjusted_isamp,
+                                        n_samp,
+                                        idet,
+                                        shared_flag_mask,
+                                        use_flags
+                                    );
+                                }
+                            }
+                        }
                     }
-
-                    pixels_healpix_ring_inner(
-                        nside,
-                        factor,
-                        raw_quat_index,
-                        raw_pixel_index,
-                        dev_quats,
-                        dev_flags,
-                        raw_hsub,
-                        dev_pixels,
-                        n_pix_submap,
-                        adjusted_isamp,
-                        n_samp,
-                        idet,
-                        shared_flag_mask,
-                        use_flags
-                    );
                 }
-            }
-        }
-    }
-}
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 if (nest) {
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                            #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -539,7 +513,7 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                 } else {
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                            #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -566,5 +540,6 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                     }
                 }
             }
-            return; });
+            return;
+        });
 }

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -437,57 +437,72 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                                 use_flags)                   \
     map(tofrom : raw_hsub[0 : n_submap])
 {
+    if (nest) {
 #pragma omp target teams distribute parallel for collapse(3)
-for (int64_t idet = 0; idet < n_det; idet++) {
-    for (int64_t iview = 0; iview < n_view; iview++) {
-        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-            // Adjust for the actual start of the interval
-            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+        for (int64_t idet = 0; idet < n_det; idet++) {
+            for (int64_t iview = 0; iview < n_view; iview++) {
+                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                    // Adjust for the actual start of the interval
+                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-            // Check if the value is out of range for the current interval
-            if (adjusted_isamp > dev_intervals[iview].last) {
-                continue;
+                    // Check if the value is out of range for the current interval
+                    if (adjusted_isamp > dev_intervals[iview].last) {
+                        continue;
+                    }
+
+                    pixels_healpix_nest_inner(
+                        nside,
+                        factor,
+                        dev_utab,
+                        raw_quat_index,
+                        raw_pixel_index,
+                        dev_quats,
+                        dev_flags,
+                        raw_hsub,
+                        dev_pixels,
+                        n_pix_submap,
+                        adjusted_isamp,
+                        n_samp,
+                        idet,
+                        shared_flag_mask,
+                        use_flags
+                    );
+                }
             }
+        }
+    } else {
+#pragma omp target teams distribute parallel for collapse(3)
+        for (int64_t idet = 0; idet < n_det; idet++) {
+            for (int64_t iview = 0; iview < n_view; iview++) {
+                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                    // Adjust for the actual start of the interval
+                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-            if (nest) {
-                pixels_healpix_nest_inner(
-                    nside,
-                    factor,
-                    dev_utab,
-                    raw_quat_index,
-                    raw_pixel_index,
-                    dev_quats,
-                    dev_flags,
-                    raw_hsub,
-                    dev_pixels,
-                    n_pix_submap,
-                    adjusted_isamp,
-                    n_samp,
-                    idet,
-                    shared_flag_mask,
-                    use_flags
-                );
-            } else {
-                pixels_healpix_ring_inner(
-                    nside,
-                    factor,
-                    raw_quat_index,
-                    raw_pixel_index,
-                    dev_quats,
-                    dev_flags,
-                    raw_hsub,
-                    dev_pixels,
-                    n_pix_submap,
-                    adjusted_isamp,
-                    n_samp,
-                    idet,
-                    shared_flag_mask,
-                    use_flags
-                );
+                    // Check if the value is out of range for the current interval
+                    if (adjusted_isamp > dev_intervals[iview].last) {
+                        continue;
+                    }
+
+                    pixels_healpix_ring_inner(
+                        nside,
+                        factor,
+                        raw_quat_index,
+                        raw_pixel_index,
+                        dev_quats,
+                        dev_flags,
+                        raw_hsub,
+                        dev_pixels,
+                        n_pix_submap,
+                        adjusted_isamp,
+                        n_samp,
+                        idet,
+                        shared_flag_mask,
+                        use_flags
+                    );
+                }
             }
         }
     }
-}
 }
 
 #endif // ifdef HAVE_OPENMP_TARGET

--- a/src/toast/_libtoast/ops_pointing_detector.cpp
+++ b/src/toast/_libtoast/ops_pointing_detector.cpp
@@ -11,15 +11,14 @@
 #include <accelerator.hpp>
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp declare target
+# pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 // FIXME:  this ridiculous code duplication is due to nvc++
 // not supporting loadable device objects in shared libraries.
 // So we must duplicate this across compilation units.
 
-void pointing_detector_qa_mult(double const *p, double const *q, double *r)
-{
+void pointing_detector_qa_mult(double const * p, double const * q, double * r) {
     r[0] = p[0] * q[3] + p[1] * q[2] -
            p[2] * q[1] + p[3] * q[0];
     r[1] = -p[0] * q[2] + p[1] * q[3] +
@@ -32,33 +31,28 @@ void pointing_detector_qa_mult(double const *p, double const *q, double *r)
 }
 
 void pointing_detector_inner(
-    int32_t const *q_index,
-    uint8_t const *flags,
-    double const *boresight,
-    double const *fp,
-    double *quats,
+    int32_t const * q_index,
+    uint8_t const * flags,
+    double const * boresight,
+    double const * fp,
+    double * quats,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
     uint8_t mask,
-    bool use_flags)
-{
+    bool use_flags) {
     int32_t qidx = q_index[idet];
     double temp_bore[4];
     uint8_t check = 0;
-    if (use_flags)
-    {
+    if (use_flags) {
         check = flags[isamp] & mask;
     }
-    if (check == 0)
-    {
+    if (check == 0) {
         temp_bore[0] = boresight[4 * isamp];
         temp_bore[1] = boresight[4 * isamp + 1];
         temp_bore[2] = boresight[4 * isamp + 2];
         temp_bore[3] = boresight[4 * isamp + 3];
-    }
-    else
-    {
+    } else {
         temp_bore[0] = 0.0;
         temp_bore[1] = 0.0;
         temp_bore[2] = 0.0;
@@ -72,24 +66,23 @@ void pointing_detector_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp end declare target
+# pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void init_ops_pointing_detector(py::module &m)
-{
+void init_ops_pointing_detector(py::module & m) {
     // FIXME:  We are temporarily passing in an array of detector quaternions,
     // but eventually should support passing the core focalplane table.
 
     m.def(
         "pointing_detector", [](
-                                 py::buffer focalplane,
-                                 py::buffer boresight,
-                                 py::buffer quat_index,
-                                 py::buffer quats,
-                                 py::buffer intervals,
-                                 py::buffer shared_flags,
-                                 uint8_t shared_flag_mask,
-                                 bool use_accel)
+            py::buffer focalplane,
+            py::buffer boresight,
+            py::buffer quat_index,
+            py::buffer quats,
+            py::buffer intervals,
+            py::buffer shared_flags,
+            uint8_t shared_flag_mask,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -134,64 +127,67 @@ void init_ops_pointing_detector(py::module &m)
             }
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 double * dev_boresight = omgr.device_ptr(raw_boresight);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                uint8_t * dev_flags = omgr.device_ptr(raw_flags);
+                uint8_t * dev_flags = omgr.device_ptr(
+                    raw_flags);
 
-// Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
-
-#pragma omp target data map(to : raw_focalplane[0 : 4 * n_det], \
-                                raw_quat_index[0 : n_det],      \
-                                shared_flag_mask,               \
-                                n_view,                         \
-                                n_det,                          \
-                                n_samp,                         \
-                                use_flags)
-{
-#pragma omp target teams distribute parallel for collapse(3)
-    for (int64_t idet = 0; idet < n_det; idet++) {
-        for (int64_t iview = 0; iview < n_view; iview++) {
-            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                // Adjust for the actual start of the interval
-                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
-
-                // Check if the value is out of range for the current interval
-                if (adjusted_isamp > dev_intervals[iview].last) {
-                    continue;
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
+                    }
                 }
 
-                pointing_detector_inner(
-                    raw_quat_index,
-                    dev_flags,
-                    dev_boresight,
-                    raw_focalplane,
-                    dev_quats,
-                    adjusted_isamp,
-                    n_samp,
-                    idet,
-                    shared_flag_mask,
-                    use_flags
-                );
-            }
-        }
-    }
-}
+                # pragma omp target data map(to : raw_focalplane[0 : 4 * n_det], \
+                raw_quat_index[0 : n_det],                                       \
+                shared_flag_mask,                                                \
+                n_view,                                                          \
+                n_det,                                                           \
+                n_samp,                                                          \
+                use_flags)
+                {
+                    # pragma omp target teams distribute parallel for collapse(3)
+                    for (int64_t idet = 0; idet < n_det; idet++) {
+                        for (int64_t iview = 0; iview < n_view; iview++) {
+                            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                                // Adjust for the actual start of the interval
+                                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                                // Check if the value is out of range for the current
+                                // interval
+                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                    continue;
+                                }
+
+                                pointing_detector_inner(
+                                    raw_quat_index,
+                                    dev_flags,
+                                    dev_boresight,
+                                    raw_focalplane,
+                                    dev_quats,
+                                    adjusted_isamp,
+                                    n_samp,
+                                    idet,
+                                    shared_flag_mask,
+                                    use_flags
+                                );
+                            }
+                        }
+                    }
+                }
+
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t idet = 0; idet < n_det; idet++) {
                     for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                        #pragma omp parallel for default(shared)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
                             isamp <= raw_intervals[iview].last;
@@ -214,5 +210,6 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                 }
             }
 
-            return; });
+            return;
+        });
 }

--- a/src/toast/_libtoast/ops_scan_map.cpp
+++ b/src/toast/_libtoast/ops_scan_map.cpp
@@ -9,19 +9,19 @@
 #include <intervals.hpp>
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp declare target
+#pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 template <typename T>
 void scan_map_inner(
-    int32_t const * pixel_index,
-    int32_t const * weight_index,
-    int32_t const * data_index,
-    int64_t const * global2local,
-    double * data,
-    int64_t const * pixels,
-    double const * weights,
-    T const * mapdata,
+    int32_t const *pixel_index,
+    int32_t const *weight_index,
+    int32_t const *data_index,
+    int64_t const *global2local,
+    double *data,
+    int64_t const *pixels,
+    double const *weights,
+    T const *mapdata,
     double data_scale,
     int64_t isamp,
     int64_t n_samp,
@@ -30,7 +30,8 @@ void scan_map_inner(
     int64_t n_pix_submap,
     bool should_zero,
     bool should_subtract,
-    bool should_scale) {
+    bool should_scale)
+{
     int32_t w_indx = weight_index[idet];
     int32_t p_indx = pixel_index[idet];
     int32_t d_indx = data_index[idet];
@@ -45,11 +46,13 @@ void scan_map_inner(
     int64_t global_submap;
     int64_t map_off;
 
-    if (should_zero) {
+    if (should_zero)
+    {
         data[off_d] = 0.0;
     }
 
-    if (pixels[off_p] >= 0) {
+    if (pixels[off_p] >= 0)
+    {
         // Good data, accumulate
         global_submap = (int64_t)(pixels[off_p] / n_pix_submap);
 
@@ -61,16 +64,22 @@ void scan_map_inner(
         off_wt = nnz * off_w;
 
         tod_val = 0.0;
-        for (int64_t iweight = 0; iweight < nnz; iweight++) {
+        for (int64_t iweight = 0; iweight < nnz; iweight++)
+        {
             tod_val += weights[off_wt + iweight] * mapdata[map_off + iweight];
         }
         tod_val *= data_scale;
 
-        if (should_subtract) {
+        if (should_subtract)
+        {
             data[off_d] -= tod_val;
-        } else if (should_scale)   {
+        }
+        else if (should_scale)
+        {
             data[off_d] *= tod_val;
-        } else   {
+        }
+        else
+        {
             data[off_d] += tod_val;
         }
     }
@@ -78,11 +87,12 @@ void scan_map_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-# pragma omp end declare target
+#pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 template <typename T>
-void register_ops_scan_map(py::module & m, char const * name) {
+void register_ops_scan_map(py::module &m, char const *name)
+{
     m.def(name,
           [](
               py::buffer global2local,
@@ -101,129 +111,148 @@ void register_ops_scan_map(py::module & m, char const * name) {
               bool should_scale,
               bool use_accel)
           {
-              auto & omgr = OmpManager::get();
+              auto &omgr = OmpManager::get();
               int dev = omgr.get_device();
               bool offload = (!omgr.device_is_host()) && use_accel;
 
-// This is used to return the actual shape of each buffer
-              std::vector <int64_t> temp_shape(3);
+              // This is used to return the actual shape of each buffer
+              std::vector<int64_t> temp_shape(3);
 
-              int32_t * raw_pixel_index = extract_buffer <int32_t> (
+              int32_t *raw_pixel_index = extract_buffer<int32_t>(
                   pixel_index, "pixel_index", 1, temp_shape, {-1});
               int64_t n_det = temp_shape[0];
 
-              int64_t * raw_pixels = extract_buffer <int64_t> (
+              int64_t *raw_pixels = extract_buffer<int64_t>(
                   pixels, "pixels", 2, temp_shape, {-1, -1});
               int64_t n_samp = temp_shape[1];
 
-              int32_t * raw_weight_index = extract_buffer <int32_t> (
+              int32_t *raw_weight_index = extract_buffer<int32_t>(
                   weight_index, "weight_index", 1, temp_shape, {n_det});
 
-// Handle the case of either 2 or 3 dims
+              // Handle the case of either 2 or 3 dims
               auto winfo = weights.request();
-              double * raw_weights;
+              double *raw_weights;
               int64_t nnz;
-              if (winfo.ndim == 2) {
+              if (winfo.ndim == 2)
+              {
                   nnz = 1;
-                  raw_weights = extract_buffer <double> (
+                  raw_weights = extract_buffer<double>(
                       weights, "weights", 2, temp_shape, {-1, n_samp});
-              } else   {
-                  raw_weights = extract_buffer <double> (
+              }
+              else
+              {
+                  raw_weights = extract_buffer<double>(
                       weights, "weights", 3, temp_shape, {-1, n_samp, -1});
                   nnz = temp_shape[2];
               }
 
-              int32_t * raw_data_index = extract_buffer <int32_t> (
+              int32_t *raw_data_index = extract_buffer<int32_t>(
                   data_index, "data_index", 1, temp_shape, {n_det});
-              double * raw_det_data = extract_buffer <double> (
+              double *raw_det_data = extract_buffer<double>(
                   det_data, "det_data", 2, temp_shape, {-1, n_samp});
 
-              Interval * raw_intervals = extract_buffer <Interval> (
+              Interval *raw_intervals = extract_buffer<Interval>(
                   intervals, "intervals", 1, temp_shape, {-1});
               int64_t n_view = temp_shape[0];
 
-              int64_t * raw_global2local = extract_buffer <int64_t> (
+              int64_t *raw_global2local = extract_buffer<int64_t>(
                   global2local, "global2local", 1, temp_shape, {-1});
               int64_t n_global_submap = temp_shape[0];
 
-              T * raw_mapdata = extract_buffer <T> (
+              T *raw_mapdata = extract_buffer<T>(
                   mapdata, "mapdata", 3, temp_shape, {-1, n_pix_submap, nnz});
               int64_t n_local_submap = temp_shape[0];
 
-              if (offload) {
-                  #ifdef HAVE_OPENMP_TARGET
+              if (offload)
+              {
+#ifdef HAVE_OPENMP_TARGET
 
-                  int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
-                  double * dev_weights = omgr.device_ptr(raw_weights);
-                  double * dev_det_data = omgr.device_ptr(raw_det_data);
-                  Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                  T * dev_mapdata = omgr.device_ptr(raw_mapdata);
+                  int64_t *dev_pixels = omgr.device_ptr(raw_pixels);
+                  double *dev_weights = omgr.device_ptr(raw_weights);
+                  double *dev_det_data = omgr.device_ptr(raw_det_data);
+                  Interval *dev_intervals = omgr.device_ptr(raw_intervals);
+                  T *dev_mapdata = omgr.device_ptr(raw_mapdata);
 
-                  # pragma omp target data               \
-                  map(to : raw_weight_index[0 : n_det],  \
-                  raw_pixel_index[0 : n_det],            \
-                  raw_data_index[0 : n_det],             \
-                  raw_global2local[0 : n_global_submap], \
-                  n_view,                                \
-                  n_det,                                 \
-                  n_samp,                                \
-                  nnz,                                   \
-                  n_pix_submap,                          \
-                  data_scale,                            \
-                  should_scale,                          \
-                  should_subtract,                       \
-                  should_zero)
+                  // calculate the maximum interval size
+                  int64_t max_interval_size = 0;
+                  for (int64_t iview = 0; iview < n_view; iview++)
                   {
-                      # pragma omp target teams distribute collapse(2) \
-                      is_device_ptr(                                   \
-                      dev_pixels,                                      \
-                      dev_weights,                                     \
-                      dev_det_data,                                    \
-                      dev_intervals,                                   \
-                      dev_mapdata)
-                      for (int64_t idet = 0; idet < n_det; idet++) {
-                          for (int64_t iview = 0; iview < n_view; iview++) {
-                              # pragma omp parallel
+                      int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+                      if (interval_size > max_interval_size)
+                      {
+                          max_interval_size = interval_size;
+                      }
+                  }
+
+#pragma omp target data map(to : raw_weight_index[0 : n_det],          \
+                                raw_pixel_index[0 : n_det],            \
+                                raw_data_index[0 : n_det],             \
+                                raw_global2local[0 : n_global_submap], \
+                                n_view,                                \
+                                n_det,                                 \
+                                n_samp,                                \
+                                max_interval_size,                     \
+                                nnz,                                   \
+                                n_pix_submap,                          \
+                                data_scale,                            \
+                                should_scale,                          \
+                                should_subtract,                       \
+                                should_zero)
+                  {
+#pragma omp target teams distribute parallel for collapse(3)
+                      for (int64_t idet = 0; idet < n_det; idet++)
+                      {
+                          for (int64_t iview = 0; iview < n_view; iview++)
+                          {
+                              for (int64_t isamp = 0; isamp < max_interval_size; isamp++)
                               {
-                                  # pragma omp for default(shared)
-                                  for (
-                                      int64_t isamp = dev_intervals[iview].first;
-                                      isamp <= dev_intervals[iview].last;
-                                      isamp++) {
-                                      scan_map_inner <T> (
-                                          raw_pixel_index,
-                                          raw_weight_index,
-                                          raw_data_index,
-                                          raw_global2local,
-                                          dev_det_data,
-                                          dev_pixels,
-                                          dev_weights,
-                                          dev_mapdata,
-                                          data_scale,
-                                          isamp,
-                                          n_samp,
-                                          idet,
-                                          nnz,
-                                          n_pix_submap,
-                                          should_zero,
-                                          should_subtract,
-                                          should_scale);
+                                  // adjust for the actual start of the interval
+                                  int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+                                  // check if the value is out of range for the current interval
+                                  if (adjusted_isamp > dev_intervals[iview].last)
+                                  {
+                                      continue;
                                   }
+
+                                  scan_map_inner<T>(
+                                      raw_pixel_index,
+                                      raw_weight_index,
+                                      raw_data_index,
+                                      raw_global2local,
+                                      dev_det_data,
+                                      dev_pixels,
+                                      dev_weights,
+                                      dev_mapdata,
+                                      data_scale,
+                                      adjusted_isamp,
+                                      n_samp,
+                                      idet,
+                                      nnz,
+                                      n_pix_submap,
+                                      should_zero,
+                                      should_subtract,
+                                      should_scale);
                               }
                           }
                       }
                   }
 
-                  #endif // ifdef HAVE_OPENMP_TARGET
-              } else   {
-                  for (int64_t idet = 0; idet < n_det; idet++) {
-                      for (int64_t iview = 0; iview < n_view; iview++) {
-                          #pragma omp parallel for default(shared)
+#endif // ifdef HAVE_OPENMP_TARGET
+              }
+              else
+              {
+                  for (int64_t idet = 0; idet < n_det; idet++)
+                  {
+                      for (int64_t iview = 0; iview < n_view; iview++)
+                      {
+#pragma omp parallel for default(shared)
                           for (
                               int64_t isamp = raw_intervals[iview].first;
                               isamp <= raw_intervals[iview].last;
-                              isamp++) {
-                              scan_map_inner <T> (
+                              isamp++)
+                          {
+                              scan_map_inner<T>(
                                   raw_pixel_index,
                                   raw_weight_index,
                                   raw_data_index,
@@ -251,9 +280,10 @@ void register_ops_scan_map(py::module & m, char const * name) {
     return;
 }
 
-void init_ops_scan_map(py::module & m) {
-    register_ops_scan_map <double> (m, "ops_scan_map_float64");
-    register_ops_scan_map <float> (m, "ops_scan_map_float32");
-    register_ops_scan_map <int64_t> (m, "ops_scan_map_int64");
-    register_ops_scan_map <int32_t> (m, "ops_scan_map_int32");
+void init_ops_scan_map(py::module &m)
+{
+    register_ops_scan_map<double>(m, "ops_scan_map_float64");
+    register_ops_scan_map<float>(m, "ops_scan_map_float32");
+    register_ops_scan_map<int64_t>(m, "ops_scan_map_int64");
+    register_ops_scan_map<int32_t>(m, "ops_scan_map_int32");
 }

--- a/src/toast/_libtoast/ops_scan_map.cpp
+++ b/src/toast/_libtoast/ops_scan_map.cpp
@@ -173,7 +173,7 @@ void register_ops_scan_map(py::module &m, char const *name)
                   Interval *dev_intervals = omgr.device_ptr(raw_intervals);
                   T *dev_mapdata = omgr.device_ptr(raw_mapdata);
 
-                  // calculate the maximum interval size
+                  // Calculate the maximum interval size on the CPU
                   int64_t max_interval_size = 0;
                   for (int64_t iview = 0; iview < n_view; iview++)
                   {

--- a/src/toast/_libtoast/ops_scan_map.cpp
+++ b/src/toast/_libtoast/ops_scan_map.cpp
@@ -9,19 +9,19 @@
 #include <intervals.hpp>
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp declare target
+# pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 template <typename T>
 void scan_map_inner(
-    int32_t const *pixel_index,
-    int32_t const *weight_index,
-    int32_t const *data_index,
-    int64_t const *global2local,
-    double *data,
-    int64_t const *pixels,
-    double const *weights,
-    T const *mapdata,
+    int32_t const * pixel_index,
+    int32_t const * weight_index,
+    int32_t const * data_index,
+    int64_t const * global2local,
+    double * data,
+    int64_t const * pixels,
+    double const * weights,
+    T const * mapdata,
     double data_scale,
     int64_t isamp,
     int64_t n_samp,
@@ -30,8 +30,7 @@ void scan_map_inner(
     int64_t n_pix_submap,
     bool should_zero,
     bool should_subtract,
-    bool should_scale)
-{
+    bool should_scale) {
     int32_t w_indx = weight_index[idet];
     int32_t p_indx = pixel_index[idet];
     int32_t d_indx = data_index[idet];
@@ -46,13 +45,11 @@ void scan_map_inner(
     int64_t global_submap;
     int64_t map_off;
 
-    if (should_zero)
-    {
+    if (should_zero) {
         data[off_d] = 0.0;
     }
 
-    if (pixels[off_p] >= 0)
-    {
+    if (pixels[off_p] >= 0) {
         // Good data, accumulate
         global_submap = (int64_t)(pixels[off_p] / n_pix_submap);
 
@@ -64,22 +61,16 @@ void scan_map_inner(
         off_wt = nnz * off_w;
 
         tod_val = 0.0;
-        for (int64_t iweight = 0; iweight < nnz; iweight++)
-        {
+        for (int64_t iweight = 0; iweight < nnz; iweight++) {
             tod_val += weights[off_wt + iweight] * mapdata[map_off + iweight];
         }
         tod_val *= data_scale;
 
-        if (should_subtract)
-        {
+        if (should_subtract) {
             data[off_d] -= tod_val;
-        }
-        else if (should_scale)
-        {
+        } else if (should_scale) {
             data[off_d] *= tod_val;
-        }
-        else
-        {
+        } else {
             data[off_d] += tod_val;
         }
     }
@@ -87,12 +78,11 @@ void scan_map_inner(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp end declare target
+# pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 template <typename T>
-void register_ops_scan_map(py::module &m, char const *name)
-{
+void register_ops_scan_map(py::module & m, char const * name) {
     m.def(name,
           [](
               py::buffer global2local,
@@ -111,111 +101,105 @@ void register_ops_scan_map(py::module &m, char const *name)
               bool should_scale,
               bool use_accel)
           {
-              auto &omgr = OmpManager::get();
+              auto & omgr = OmpManager::get();
               int dev = omgr.get_device();
               bool offload = (!omgr.device_is_host()) && use_accel;
 
-              // This is used to return the actual shape of each buffer
-              std::vector<int64_t> temp_shape(3);
+// This is used to return the actual shape of each buffer
+              std::vector <int64_t> temp_shape(3);
 
-              int32_t *raw_pixel_index = extract_buffer<int32_t>(
+              int32_t * raw_pixel_index = extract_buffer <int32_t> (
                   pixel_index, "pixel_index", 1, temp_shape, {-1});
               int64_t n_det = temp_shape[0];
 
-              int64_t *raw_pixels = extract_buffer<int64_t>(
+              int64_t * raw_pixels = extract_buffer <int64_t> (
                   pixels, "pixels", 2, temp_shape, {-1, -1});
               int64_t n_samp = temp_shape[1];
 
-              int32_t *raw_weight_index = extract_buffer<int32_t>(
+              int32_t * raw_weight_index = extract_buffer <int32_t> (
                   weight_index, "weight_index", 1, temp_shape, {n_det});
 
-              // Handle the case of either 2 or 3 dims
+// Handle the case of either 2 or 3 dims
               auto winfo = weights.request();
-              double *raw_weights;
+              double * raw_weights;
               int64_t nnz;
-              if (winfo.ndim == 2)
-              {
+              if (winfo.ndim == 2) {
                   nnz = 1;
-                  raw_weights = extract_buffer<double>(
+                  raw_weights = extract_buffer <double> (
                       weights, "weights", 2, temp_shape, {-1, n_samp});
-              }
-              else
-              {
-                  raw_weights = extract_buffer<double>(
+              } else {
+                  raw_weights = extract_buffer <double> (
                       weights, "weights", 3, temp_shape, {-1, n_samp, -1});
                   nnz = temp_shape[2];
               }
 
-              int32_t *raw_data_index = extract_buffer<int32_t>(
+              int32_t * raw_data_index = extract_buffer <int32_t> (
                   data_index, "data_index", 1, temp_shape, {n_det});
-              double *raw_det_data = extract_buffer<double>(
+              double * raw_det_data = extract_buffer <double> (
                   det_data, "det_data", 2, temp_shape, {-1, n_samp});
 
-              Interval *raw_intervals = extract_buffer<Interval>(
+              Interval * raw_intervals = extract_buffer <Interval> (
                   intervals, "intervals", 1, temp_shape, {-1});
               int64_t n_view = temp_shape[0];
 
-              int64_t *raw_global2local = extract_buffer<int64_t>(
+              int64_t * raw_global2local = extract_buffer <int64_t> (
                   global2local, "global2local", 1, temp_shape, {-1});
               int64_t n_global_submap = temp_shape[0];
 
-              T *raw_mapdata = extract_buffer<T>(
+              T * raw_mapdata = extract_buffer <T> (
                   mapdata, "mapdata", 3, temp_shape, {-1, n_pix_submap, nnz});
               int64_t n_local_submap = temp_shape[0];
 
-              if (offload)
-              {
-#ifdef HAVE_OPENMP_TARGET
+              if (offload) {
+                  #ifdef HAVE_OPENMP_TARGET
 
-                  int64_t *dev_pixels = omgr.device_ptr(raw_pixels);
-                  double *dev_weights = omgr.device_ptr(raw_weights);
-                  double *dev_det_data = omgr.device_ptr(raw_det_data);
-                  Interval *dev_intervals = omgr.device_ptr(raw_intervals);
-                  T *dev_mapdata = omgr.device_ptr(raw_mapdata);
+                  int64_t * dev_pixels = omgr.device_ptr(raw_pixels);
+                  double * dev_weights = omgr.device_ptr(raw_weights);
+                  double * dev_det_data = omgr.device_ptr(raw_det_data);
+                  Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                  T * dev_mapdata = omgr.device_ptr(
+                      raw_mapdata);
 
                   // Calculate the maximum interval size on the CPU
                   int64_t max_interval_size = 0;
-                  for (int64_t iview = 0; iview < n_view; iview++)
-                  {
-                      int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-                      if (interval_size > max_interval_size)
-                      {
+                  for (int64_t iview = 0; iview < n_view; iview++) {
+                      int64_t interval_size = raw_intervals[iview].last -
+                                              raw_intervals[iview].first + 1;
+                      if (interval_size > max_interval_size) {
                           max_interval_size = interval_size;
                       }
                   }
 
-#pragma omp target data map(to : raw_weight_index[0 : n_det],          \
-                                raw_pixel_index[0 : n_det],            \
-                                raw_data_index[0 : n_det],             \
-                                raw_global2local[0 : n_global_submap], \
-                                n_view,                                \
-                                n_det,                                 \
-                                n_samp,                                \
-                                max_interval_size,                     \
-                                nnz,                                   \
-                                n_pix_submap,                          \
-                                data_scale,                            \
-                                should_scale,                          \
-                                should_subtract,                       \
-                                should_zero)
+                  # pragma omp target data map(to : raw_weight_index[0 : n_det], \
+                  raw_pixel_index[0 : n_det],                                    \
+                  raw_data_index[0 : n_det],                                     \
+                  raw_global2local[0 : n_global_submap],                         \
+                  n_view,                                                        \
+                  n_det,                                                         \
+                  n_samp,                                                        \
+                  max_interval_size,                                             \
+                  nnz,                                                           \
+                  n_pix_submap,                                                  \
+                  data_scale,                                                    \
+                  should_scale,                                                  \
+                  should_subtract,                                               \
+                  should_zero)
                   {
-#pragma omp target teams distribute parallel for collapse(3)
-                      for (int64_t idet = 0; idet < n_det; idet++)
-                      {
-                          for (int64_t iview = 0; iview < n_view; iview++)
-                          {
-                              for (int64_t isamp = 0; isamp < max_interval_size; isamp++)
-                              {
+                      # pragma omp target teams distribute parallel for collapse(3)
+                      for (int64_t idet = 0; idet < n_det; idet++) {
+                          for (int64_t iview = 0; iview < n_view; iview++) {
+                              for (int64_t isamp = 0; isamp < max_interval_size;
+                                   isamp++) {
                                   // adjust for the actual start of the interval
                                   int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                                  // check if the value is out of range for the current interval
-                                  if (adjusted_isamp > dev_intervals[iview].last)
-                                  {
+                                  // check if the value is out of range for the current
+                                  // interval
+                                  if (adjusted_isamp > dev_intervals[iview].last) {
                                       continue;
                                   }
 
-                                  scan_map_inner<T>(
+                                  scan_map_inner <T> (
                                       raw_pixel_index,
                                       raw_weight_index,
                                       raw_data_index,
@@ -238,21 +222,16 @@ void register_ops_scan_map(py::module &m, char const *name)
                       }
                   }
 
-#endif // ifdef HAVE_OPENMP_TARGET
-              }
-              else
-              {
-                  for (int64_t idet = 0; idet < n_det; idet++)
-                  {
-                      for (int64_t iview = 0; iview < n_view; iview++)
-                      {
-#pragma omp parallel for default(shared)
+                  #endif // ifdef HAVE_OPENMP_TARGET
+              } else {
+                  for (int64_t idet = 0; idet < n_det; idet++) {
+                      for (int64_t iview = 0; iview < n_view; iview++) {
+                          #pragma omp parallel for default(shared)
                           for (
                               int64_t isamp = raw_intervals[iview].first;
                               isamp <= raw_intervals[iview].last;
-                              isamp++)
-                          {
-                              scan_map_inner<T>(
+                              isamp++) {
+                              scan_map_inner <T> (
                                   raw_pixel_index,
                                   raw_weight_index,
                                   raw_data_index,
@@ -280,10 +259,9 @@ void register_ops_scan_map(py::module &m, char const *name)
     return;
 }
 
-void init_ops_scan_map(py::module &m)
-{
-    register_ops_scan_map<double>(m, "ops_scan_map_float64");
-    register_ops_scan_map<float>(m, "ops_scan_map_float32");
-    register_ops_scan_map<int64_t>(m, "ops_scan_map_int64");
-    register_ops_scan_map<int32_t>(m, "ops_scan_map_int32");
+void init_ops_scan_map(py::module & m) {
+    register_ops_scan_map <double> (m, "ops_scan_map_float64");
+    register_ops_scan_map <float> (m, "ops_scan_map_float32");
+    register_ops_scan_map <int64_t> (m, "ops_scan_map_int64");
+    register_ops_scan_map <int32_t> (m, "ops_scan_map_int32");
 }

--- a/src/toast/_libtoast/ops_stokes_weights.cpp
+++ b/src/toast/_libtoast/ops_stokes_weights.cpp
@@ -11,16 +11,15 @@
 #include <accelerator.hpp>
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp declare target
+# pragma omp declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
 // FIXME:  this ridiculous code duplication is due to nvc++
 // not supporting loadable device objects in shared libraries.
 // So we must duplicate this across compilation units.
 
-void stokes_weights_qa_rotate(double const *q_in, double const *v_in,
-                              double *v_out)
-{
+void stokes_weights_qa_rotate(double const * q_in, double const * v_in,
+                              double * v_out) {
     // The input quaternion has already been normalized on the host.
 
     double xw = q_in[3] * q_in[0];
@@ -49,9 +48,8 @@ void stokes_weights_qa_rotate(double const *q_in, double const *v_in,
 }
 
 void stokes_weights_alpha(
-    double const *quats,
-    double *alpha)
-{
+    double const * quats,
+    double * alpha) {
     const double xaxis[3] = {1.0, 0.0, 0.0};
     const double zaxis[3] = {0.0, 0.0, 1.0};
     double vd[3];
@@ -65,7 +63,9 @@ void stokes_weights_alpha(
     double vm_y = vd[2] * sin(ang_xy);
     double vm_z = -sqrt(1.0 - vd[2] * vd[2]);
 
-    double alpha_y = (vd[0] * (vm_y * vo[2] - vm_z * vo[1]) - vd[1] * (vm_x * vo[2] - vm_z * vo[0]) + vd[2] * (vm_x * vo[1] - vm_y * vo[0]));
+    double alpha_y =
+        (vd[0] * (vm_y * vo[2] - vm_z * vo[1]) - vd[1] * (vm_x * vo[2] - vm_z * vo[0]) +
+         vd[2] * (vm_x * vo[1] - vm_y * vo[0]));
     double alpha_x = (vm_x * vo[0] + vm_y * vo[1] + vm_z * vo[2]);
 
     (*alpha) = atan2(alpha_y, alpha_x);
@@ -74,16 +74,15 @@ void stokes_weights_alpha(
 
 void stokes_weights_IQU_inner(
     double cal,
-    int32_t const *quat_index,
-    int32_t const *weight_index,
-    double const *quats,
-    double const *epsilon,
-    double *weights,
+    int32_t const * quat_index,
+    int32_t const * weight_index,
+    double const * quats,
+    double const * epsilon,
+    double * weights,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
-    double U_sign)
-{
+    double U_sign) {
     double eta = (1.0 - epsilon[idet]) / (1.0 + epsilon[idet]);
     int32_t q_indx = quat_index[idet];
     int32_t w_indx = weight_index[idet];
@@ -105,18 +104,17 @@ void stokes_weights_IQU_inner(
 
 void stokes_weights_IQU_inner_hwp(
     double cal,
-    int32_t const *quat_index,
-    int32_t const *weight_index,
-    double const *quats,
-    double const *hwp,
-    double const *epsilon,
-    double const *gamma,
-    double *weights,
+    int32_t const * quat_index,
+    int32_t const * weight_index,
+    double const * quats,
+    double const * hwp,
+    double const * epsilon,
+    double const * gamma,
+    double * weights,
     int64_t isamp,
     int64_t n_samp,
     int64_t idet,
-    double U_sign)
-{
+    double U_sign) {
     double eta = (1.0 - epsilon[idet]) / (1.0 + epsilon[idet]);
     int32_t q_indx = quat_index[idet];
     int32_t w_indx = weight_index[idet];
@@ -138,27 +136,26 @@ void stokes_weights_IQU_inner_hwp(
 }
 
 #ifdef HAVE_OPENMP_TARGET
-#pragma omp end declare target
+# pragma omp end declare target
 #endif // ifdef HAVE_OPENMP_TARGET
 
-void init_ops_stokes_weights(py::module &m)
-{
+void init_ops_stokes_weights(py::module & m) {
     // FIXME:  For now, we are passing in the epsilon array.  Once the full
     // focalplane table is staged to GPU, change this code to use that.
 
     m.def(
         "stokes_weights_IQU", [](
-                                  py::buffer quat_index,
-                                  py::buffer quats,
-                                  py::buffer weight_index,
-                                  py::buffer weights,
-                                  py::buffer hwp,
-                                  py::buffer intervals,
-                                  py::buffer epsilon,
-                                  py::buffer gamma,
-                                  double cal,
-                                  bool IAU,
-                                  bool use_accel)
+            py::buffer quat_index,
+            py::buffer quats,
+            py::buffer weight_index,
+            py::buffer weights,
+            py::buffer hwp,
+            py::buffer intervals,
+            py::buffer epsilon,
+            py::buffer gamma,
+            double cal,
+            bool IAU,
+            bool use_accel)
         {
             // NOTE:  Flags are not needed here, since the quaternions
             // have already had bad samples converted to null rotations.
@@ -217,43 +214,47 @@ void init_ops_stokes_weights(py::module &m)
             }
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_quats = omgr.device_ptr(raw_quats);
                 double * dev_weights = omgr.device_ptr(raw_weights);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                double * dev_hwp = omgr.device_ptr(raw_hwp);
+                double * dev_hwp = omgr.device_ptr(
+                    raw_hwp);
 
                 // Calculate the maximum interval size on the CPU
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
-                    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
                 }
 
-#pragma omp target data map(to : raw_weight_index[0 : n_det], \
-                                raw_quat_index[0 : n_det],    \
-                                raw_epsilon[0 : n_det],       \
-                                raw_gamma[0 : n_det],         \
-                                cal,                          \
-                                U_sign,                       \
-                                n_view,                       \
-                                n_det,                        \
-                                n_samp,                       \
-                                max_interval_size)
+                # pragma omp target data map(to : raw_weight_index[0 : n_det], \
+                raw_quat_index[0 : n_det],                                     \
+                raw_epsilon[0 : n_det],                                        \
+                raw_gamma[0 : n_det],                                          \
+                cal,                                                           \
+                U_sign,                                                        \
+                n_view,                                                        \
+                n_det,                                                         \
+                n_samp,                                                        \
+                max_interval_size)
                 {
                     if (!use_hwp) {
-// No HWP
-#pragma omp target teams distribute parallel for collapse(3)
+                        // No HWP
+                        # pragma omp target teams distribute parallel for collapse(3)
                         for (int64_t idet = 0; idet < n_det; idet++) {
                             for (int64_t iview = 0; iview < n_view; iview++) {
-                                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                                for (int64_t isamp = 0; isamp < max_interval_size;
+                                     isamp++) {
                                     // adjust for the actual start of the interval
                                     int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                                    // check if the value is out of range for the current interval
+                                    // check if the value is out of range for the
+                                    // current interval
                                     if (adjusted_isamp > dev_intervals[iview].last) {
                                         continue;
                                     }
@@ -274,15 +275,17 @@ void init_ops_stokes_weights(py::module &m)
                             }
                         }
                     } else {
-// We have a HWP
-#pragma omp target teams distribute parallel for collapse(3)
+                        // We have a HWP
+                        # pragma omp target teams distribute parallel for collapse(3)
                         for (int64_t idet = 0; idet < n_det; idet++) {
                             for (int64_t iview = 0; iview < n_view; iview++) {
-                                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                                for (int64_t isamp = 0; isamp < max_interval_size;
+                                     isamp++) {
                                     // adjust for the actual start of the interval
                                     int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                                    // check if the value is out of range for the current interval
+                                    // check if the value is out of range for the
+                                    // current interval
                                     if (adjusted_isamp > dev_intervals[iview].last) {
                                         continue;
                                     }
@@ -307,13 +310,13 @@ void init_ops_stokes_weights(py::module &m)
                     }
                 }
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 if (!use_hwp) {
                     // No HWP
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                            #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -338,7 +341,7 @@ void init_ops_stokes_weights(py::module &m)
                     // We are using a HWP
                     for (int64_t idet = 0; idet < n_det; idet++) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                            #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
@@ -363,15 +366,16 @@ void init_ops_stokes_weights(py::module &m)
                     }
                 }
             }
-            return; });
+            return;
+        });
 
     m.def(
         "stokes_weights_I", [](
-                                py::buffer weight_index,
-                                py::buffer weights,
-                                py::buffer intervals,
-                                double cal,
-                                bool use_accel)
+            py::buffer weight_index,
+            py::buffer weights,
+            py::buffer intervals,
+            double cal,
+            bool use_accel)
         {
             // NOTE:  Flags are not needed here, since the quaternions
             // have already had bad samples converted to null rotations.
@@ -399,47 +403,51 @@ void init_ops_stokes_weights(py::module &m)
             int64_t n_view = temp_shape[0];
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_weights = omgr.device_ptr(raw_weights);
-                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
+                Interval * dev_intervals = omgr.device_ptr(
+                    raw_intervals);
 
-// Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
-
-#pragma omp target data map(to : raw_weight_index[0 : n_det], n_view, n_det, n_samp, cal)
-{
-#pragma omp target teams distribute parallel for collapse(3)
-    for (int64_t idet = 0; idet < n_det; idet++) {
-        for (int64_t iview = 0; iview < n_view; iview++) {
-            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                // Adjust for the actual start of the interval
-                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
-
-                // Check if the value is out of range for the current interval
-                if (adjusted_isamp > dev_intervals[iview].last) {
-                    continue;
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
+                    }
                 }
 
-                int32_t w_indx = raw_weight_index[idet];
-                int64_t off = (w_indx * n_samp) + adjusted_isamp;
-                dev_weights[off] = cal;
-            }
-        }
-    }
-}
+                # pragma \
+                omp target data map(to : raw_weight_index[0 : n_det], n_view, n_det, n_samp, cal)
+                {
+                    # pragma omp target teams distribute parallel for collapse(3)
+                    for (int64_t idet = 0; idet < n_det; idet++) {
+                        for (int64_t iview = 0; iview < n_view; iview++) {
+                            for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                                // Adjust for the actual start of the interval
+                                int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                                // Check if the value is out of range for the current
+                                // interval
+                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                    continue;
+                                }
+
+                                int32_t w_indx = raw_weight_index[idet];
+                                int64_t off = (w_indx * n_samp) + adjusted_isamp;
+                                dev_weights[off] = cal;
+                            }
+                        }
+                    }
+                }
+
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t idet = 0; idet < n_det; idet++) {
                     for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                        #pragma omp parallel for default(shared)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
                             isamp <= raw_intervals[iview].last;
@@ -452,5 +460,6 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                     }
                 }
             }
-            return; });
+            return;
+        });
 }

--- a/src/toast/_libtoast/ops_stokes_weights.cpp
+++ b/src/toast/_libtoast/ops_stokes_weights.cpp
@@ -160,78 +160,75 @@ void init_ops_stokes_weights(py::module &m)
                                   bool IAU,
                                   bool use_accel)
         {
-            // NOTE:  Flags are not needed here, since the quaternions
-            // have already had bad samples converted to null rotations.
+        // NOTE:  Flags are not needed here, since the quaternions
+        // have already had bad samples converted to null rotations.
 
-            auto & omgr = OmpManager::get();
-            int dev = omgr.get_device();
-            bool offload = (!omgr.device_is_host()) && use_accel;
+        auto &omgr = OmpManager::get();
+        int dev = omgr.get_device();
+        bool offload = (!omgr.device_is_host()) && use_accel;
 
-            // This is used to return the actual shape of each buffer
-            std::vector <int64_t> temp_shape(3);
+        // This is used to return the actual shape of each buffer
+        std::vector<int64_t> temp_shape(3);
 
-            int32_t * raw_quat_index = extract_buffer <int32_t> (
-                quat_index, "quat_index", 1, temp_shape, {-1}
-            );
-            int64_t n_det = temp_shape[0];
+        int32_t *raw_quat_index = extract_buffer<int32_t>(
+            quat_index, "quat_index", 1, temp_shape, {-1});
+        int64_t n_det = temp_shape[0];
 
-            int32_t * raw_weight_index = extract_buffer <int32_t> (
-                weight_index, "weight_index", 1, temp_shape, {n_det}
-            );
+        int32_t *raw_weight_index = extract_buffer<int32_t>(
+            weight_index, "weight_index", 1, temp_shape, {n_det});
 
-            double * raw_weights = extract_buffer <double> (
-                weights, "weights", 3, temp_shape, {-1, -1, 3}
-            );
-            int64_t n_samp = temp_shape[1];
+        double *raw_weights = extract_buffer<double>(
+            weights, "weights", 3, temp_shape, {-1, -1, 3});
+        int64_t n_samp = temp_shape[1];
 
-            double * raw_quats = extract_buffer <double> (
-                quats, "quats", 3, temp_shape, {-1, n_samp, 4}
-            );
+        double *raw_quats = extract_buffer<double>(
+            quats, "quats", 3, temp_shape, {-1, n_samp, 4});
 
-            double * raw_hwp = extract_buffer <double> (
-                hwp, "hwp", 1, temp_shape, {-1}
-            );
-            bool use_hwp = true;
-            if (temp_shape[0] != n_samp) {
-                // We are not using a HWP
-                raw_hwp = omgr.null_ptr <double> ();
-                use_hwp = false;
-            }
+        double *raw_hwp = extract_buffer<double>(
+            hwp, "hwp", 1, temp_shape, {-1});
+        bool use_hwp = true;
+        if (temp_shape[0] != n_samp)
+        {
+            // We are not using a HWP
+            raw_hwp = omgr.null_ptr<double>();
+            use_hwp = false;
+        }
 
-            Interval * raw_intervals = extract_buffer <Interval> (
-                intervals, "intervals", 1, temp_shape, {-1}
-            );
-            int64_t n_view = temp_shape[0];
+        Interval *raw_intervals = extract_buffer<Interval>(
+            intervals, "intervals", 1, temp_shape, {-1});
+        int64_t n_view = temp_shape[0];
 
-            double * raw_epsilon = extract_buffer <double> (
-                epsilon, "epsilon", 1, temp_shape, {n_det}
-            );
+        double *raw_epsilon = extract_buffer<double>(
+            epsilon, "epsilon", 1, temp_shape, {n_det});
 
-            double * raw_gamma = extract_buffer <double> (
-                gamma, "gamma", 1, temp_shape, {n_det}
-            );
+        double *raw_gamma = extract_buffer<double>(
+            gamma, "gamma", 1, temp_shape, {n_det});
 
-            double U_sign = 1.0;
-            if (IAU) {
-                U_sign = -1.0;
-            }
+        double U_sign = 1.0;
+        if (IAU)
+        {
+            U_sign = -1.0;
+        }
 
-            if (offload) {
+        if (offload)
+        {
 #ifdef HAVE_OPENMP_TARGET
 
-                double * dev_quats = omgr.device_ptr(raw_quats);
-                double * dev_weights = omgr.device_ptr(raw_weights);
-                Interval * dev_intervals = omgr.device_ptr(raw_intervals);
-                double * dev_hwp = omgr.device_ptr(raw_hwp);
+            double *dev_quats = omgr.device_ptr(raw_quats);
+            double *dev_weights = omgr.device_ptr(raw_weights);
+            Interval *dev_intervals = omgr.device_ptr(raw_intervals);
+            double *dev_hwp = omgr.device_ptr(raw_hwp);
 
-                // calculate the maximum interval size
-                int64_t max_interval_size = 0;
-                for (int64_t iview = 0; iview < n_view; iview++) {
-                    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-                    if (interval_size > max_interval_size) {
-                        max_interval_size = interval_size;
-                    }
+            // calculate the maximum interval size
+            int64_t max_interval_size = 0;
+            for (int64_t iview = 0; iview < n_view; iview++)
+            {
+                int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
+                if (interval_size > max_interval_size)
+                {
+                    max_interval_size = interval_size;
                 }
+            }
 
 #pragma omp target data map(to : raw_weight_index[0 : n_det], \
                                 raw_quat_index[0 : n_det],    \
@@ -243,83 +240,76 @@ void init_ops_stokes_weights(py::module &m)
                                 n_det,                        \
                                 n_samp,                       \
                                 max_interval_size)
+            {
+
+#pragma omp target teams distribute parallel for collapse(3)
+                for (int64_t idet = 0; idet < n_det; idet++)
                 {
-                    // TODO confirm that this test does change performances (the branch predictor should let us ignore it)
-                    if (!use_hwp) {
-// No HWP
-#pragma omp target teams distribute parallel for collapse(3)
-                        for (int64_t idet = 0; idet < n_det; idet++) {
-                            for (int64_t iview = 0; iview < n_view; iview++) {
-                                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                                    // adjust for the actual start of the interval
-                                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+                    for (int64_t iview = 0; iview < n_view; iview++)
+                    {
+                        for (int64_t isamp = 0; isamp < max_interval_size; isamp++)
+                        {
+                            // adjust for the actual start of the interval
+                            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                                    // check if the value is out of range for the current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
-                                        continue;
-                                    }
-
-                                    stokes_weights_IQU_inner(
-                                        cal,
-                                        raw_quat_index,
-                                        raw_weight_index,
-                                        dev_quats,
-                                        raw_epsilon,
-                                        dev_weights,
-                                        adjusted_isamp,
-                                        n_samp,
-                                        idet,
-                                        U_sign
-                                    );
-                                }
+                            // check if the value is out of range for the current interval
+                            if (adjusted_isamp > dev_intervals[iview].last)
+                            {
+                                continue;
                             }
-                        }
-                    } else {
-// We have a HWP
-#pragma omp target teams distribute parallel for collapse(3)
-                        for (int64_t idet = 0; idet < n_det; idet++) {
-                            for (int64_t iview = 0; iview < n_view; iview++) {
-                                for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-                                    // adjust for the actual start of the interval
-                                    int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-                                    // check if the value is out of range for the current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
-                                        continue;
-                                    }
-
-                                    stokes_weights_IQU_inner_hwp(
-                                        cal,
-                                        raw_quat_index,
-                                        raw_weight_index,
-                                        dev_quats,
-                                        dev_hwp,
-                                        raw_epsilon,
-                                        raw_gamma,
-                                        dev_weights,
-                                        adjusted_isamp,
-                                        n_samp,
-                                        idet,
-                                        U_sign
-                                    );
-                                }
+                            if (use_hwp)
+                            {
+                                stokes_weights_IQU_inner_hwp(
+                                    cal,
+                                    raw_quat_index,
+                                    raw_weight_index,
+                                    dev_quats,
+                                    dev_hwp,
+                                    raw_epsilon,
+                                    raw_gamma,
+                                    dev_weights,
+                                    adjusted_isamp,
+                                    n_samp,
+                                    idet,
+                                    U_sign);
+                            }
+                            else
+                            {
+                                stokes_weights_IQU_inner(
+                                    cal,
+                                    raw_quat_index,
+                                    raw_weight_index,
+                                    dev_quats,
+                                    raw_epsilon,
+                                    dev_weights,
+                                    adjusted_isamp,
+                                    n_samp,
+                                    idet,
+                                    U_sign);
                             }
                         }
                     }
                 }
+            }
 
 #endif // ifdef HAVE_OPENMP_TARGET
-            } else {
-                if (!use_hwp) {
+            }
+            else
+            {
+                if (!use_hwp)
+                {
                     // No HWP
-                    for (int64_t idet = 0; idet < n_det; idet++) {
-                        for (int64_t iview = 0; iview < n_view; iview++) {
+                    for (int64_t idet = 0; idet < n_det; idet++)
+                    {
+                        for (int64_t iview = 0; iview < n_view; iview++)
+                        {
 #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
-                                isamp++
-                            ) {
+                                isamp++)
+                            {
                                 stokes_weights_IQU_inner(
                                     cal,
                                     raw_quat_index,
@@ -330,21 +320,24 @@ void init_ops_stokes_weights(py::module &m)
                                     isamp,
                                     n_samp,
                                     idet,
-                                    U_sign
-                                );
+                                    U_sign);
                             }
                         }
                     }
-                } else {
+                }
+                else
+                {
                     // We are using a HWP
-                    for (int64_t idet = 0; idet < n_det; idet++) {
-                        for (int64_t iview = 0; iview < n_view; iview++) {
+                    for (int64_t idet = 0; idet < n_det; idet++)
+                    {
+                        for (int64_t iview = 0; iview < n_view; iview++)
+                        {
 #pragma omp parallel for default(shared)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
                                 isamp <= raw_intervals[iview].last;
-                                isamp++
-                            ) {
+                                isamp++)
+                            {
                                 stokes_weights_IQU_inner_hwp(
                                     cal,
                                     raw_quat_index,
@@ -357,8 +350,7 @@ void init_ops_stokes_weights(py::module &m)
                                     isamp,
                                     n_samp,
                                     idet,
-                                    U_sign
-                                );
+                                    U_sign);
                             }
                         }
                     }

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -205,6 +205,7 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                                 amp_view_off[0 : n_view], \
                                 use_flags)
 {
+                // TODO the paralelism can likely be improved on this function
 #pragma omp target teams distribute collapse(2)
     for (int64_t iview = 0; iview < n_view; iview++) {
         for (int64_t isamp = 0; isamp < max_interval_size; isamp += step_length) {

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -11,17 +11,18 @@
 
 // FIXME:  docstrings need to be updated if we keep these versions of the code.
 
-void init_template_offset(py::module & m) {
+void init_template_offset(py::module &m)
+{
     m.def(
         "template_offset_add_to_signal", [](
-            int64_t step_length,
-            int64_t amp_offset,
-            py::buffer n_amp_views,
-            py::buffer amplitudes,
-            int32_t data_index,
-            py::buffer det_data,
-            py::buffer intervals,
-            bool use_accel)
+                                             int64_t step_length,
+                                             int64_t amp_offset,
+                                             py::buffer n_amp_views,
+                                             py::buffer amplitudes,
+                                             int32_t data_index,
+                                             py::buffer det_data,
+                                             py::buffer intervals,
+                                             bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -57,47 +58,52 @@ void init_template_offset(py::module & m) {
             }
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
                 double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
 
-                # pragma omp target data \
-                map(to:                  \
-                n_view,                  \
-                n_samp,                  \
-                data_index,              \
-                step_length,             \
-                amp_offset,              \
-                amp_view_off[0:n_view]   \
-                )
-                {
-                    # pragma omp target teams distribute \
-                    is_device_ptr(                       \
-                    dev_amplitudes,                      \
-                    dev_det_data,                        \
-                    dev_intervals)
-                    for (int64_t iview = 0; iview < n_view; iview++) {
-                        # pragma omp parallel for default(shared)
-                        for (
-                            int64_t isamp = dev_intervals[iview].first;
-                            isamp <= dev_intervals[iview].last;
-                            isamp++
-                        ) {
-                            int64_t d = data_index * n_samp + isamp;
-                            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
-                                (isamp - dev_intervals[iview].first) / step_length
-                            );
-                            dev_det_data[d] += dev_amplitudes[amp];
-                        }
-                    }
-                }
+// Calculate the maximum interval size on the CPU
+int64_t max_interval_size = 0;
+for (int64_t iview = 0; iview < n_view; iview++) {
+    int64_t interval_size = dev_intervals[iview].last - dev_intervals[iview].first + 1;
+    if (interval_size > max_interval_size) {
+        max_interval_size = interval_size;
+    }
+}
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+#pragma omp target data map(to : n_view,     \
+                                n_samp,      \
+                                data_index,  \
+                                step_length, \
+                                amp_offset,  \
+                                amp_view_off[0 : n_view])
+{
+#pragma omp target teams distribute parallel for collapse(2)
+    for (int64_t iview = 0; iview < n_view; iview++) {
+        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+            // Adjust for the actual start of the interval
+            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+            // Check if the value is out of range for the current interval
+            if (adjusted_isamp > dev_intervals[iview].last) {
+                continue;
+            }
+
+            int64_t d = data_index * n_samp + adjusted_isamp;
+            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
+                (adjusted_isamp - dev_intervals[iview].first) / step_length
+            );
+            dev_det_data[d] += dev_amplitudes[amp];
+        }
+    }
+}
+
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t iview = 0; iview < n_view; iview++) {
-                    #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
                         isamp <= raw_intervals[iview].last;
@@ -114,22 +120,21 @@ void init_template_offset(py::module & m) {
 
             delete amp_view_off;
 
-            return;
-        });
+            return; });
 
     m.def(
         "template_offset_project_signal", [](
-            int32_t data_index,
-            py::buffer det_data,
-            int32_t flag_index,
-            py::buffer flag_data,
-            uint8_t flag_mask,
-            int64_t step_length,
-            int64_t amp_offset,
-            py::buffer n_amp_views,
-            py::buffer amplitudes,
-            py::buffer intervals,
-            bool use_accel)
+                                              int32_t data_index,
+                                              py::buffer det_data,
+                                              int32_t flag_index,
+                                              py::buffer flag_data,
+                                              uint8_t flag_mask,
+                                              int64_t step_length,
+                                              int64_t amp_offset,
+                                              py::buffer n_amp_views,
+                                              py::buffer amplitudes,
+                                              py::buffer intervals,
+                                              bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -175,67 +180,66 @@ void init_template_offset(py::module & m) {
             }
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
                 uint8_t * dev_det_flags = omgr.device_ptr(raw_det_flags);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
                 double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
 
-                # pragma omp target data \
-                map(to:                  \
-                n_view,                  \
-                n_samp,                  \
-                data_index,              \
-                flag_index,              \
-                step_length,             \
-                amp_offset,              \
-                amp_view_off[0:n_view],  \
-                use_flags                \
-                )
-                {
-                    # pragma omp target teams distribute \
-                    is_device_ptr(                       \
-                    dev_amplitudes,                      \
-                    dev_det_data,                        \
-                    dev_det_flags,                       \
-                    dev_intervals)
-                    for (int64_t iview = 0; iview < n_view; iview++) {
-                        # pragma omp parallel default(shared)
-                        {
-                            double contrib;
-                            # pragma omp for
-                            for (
-                                int64_t isamp = dev_intervals[iview].first;
-                                isamp <= dev_intervals[iview].last;
-                                isamp++
-                            ) {
-                                int64_t d = data_index * n_samp + isamp;
-                                int64_t amp = amp_offset + amp_view_off[iview] +
-                                              (int64_t)(
-                                    (isamp - dev_intervals[iview].first) / step_length
-                                              );
-                                contrib = 0.0;
-                                if (use_flags) {
-                                    int64_t f = flag_index * n_samp + isamp;
-                                    uint8_t check = dev_det_flags[f] & flag_mask;
-                                    if (check == 0) {
-                                        contrib = dev_det_data[d];
-                                    }
-                                } else {
-                                    contrib = dev_det_data[d];
-                                }
-                                # pragma omp atomic update
-                                dev_amplitudes[amp] += contrib;
-                            }
-                        }
-                    }
-                }
+// Calculate the maximum interval size on the CPU
+int64_t max_interval_size = 0;
+for (int64_t iview = 0; iview < n_view; iview++) {
+    int64_t interval_size = dev_intervals[iview].last - dev_intervals[iview].first + 1;
+    if (interval_size > max_interval_size) {
+        max_interval_size = interval_size;
+    }
+}
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+#pragma omp target data map(to : n_view,                  \
+                                n_samp,                   \
+                                data_index,               \
+                                flag_index,               \
+                                step_length,              \
+                                amp_offset,               \
+                                amp_view_off[0 : n_view], \
+                                use_flags)
+{
+#pragma omp target teams distribute parallel for collapse(2)
+    for (int64_t iview = 0; iview < n_view; iview++) {
+        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+            // Adjust for the actual start of the interval
+            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+
+            // Check if the value is out of range for the current interval
+            if (adjusted_isamp > dev_intervals[iview].last) {
+                continue;
+            }
+
+            int64_t d = data_index * n_samp + adjusted_isamp;
+            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
+                (adjusted_isamp - dev_intervals[iview].first) / step_length
+            );
+            double contrib = 0.0;
+            if (use_flags) {
+                int64_t f = flag_index * n_samp + adjusted_isamp;
+                uint8_t check = dev_det_flags[f] & flag_mask;
+                if (check == 0) {
+                    contrib = dev_det_data[d];
+                }
+            } else {
+                contrib = dev_det_data[d];
+            }
+#pragma omp atomic update
+            dev_amplitudes[amp] += contrib;
+        }
+    }
+}
+
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t iview = 0; iview < n_view; iview++) {
-                    #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
                         isamp <= raw_intervals[iview].last;
@@ -255,21 +259,20 @@ void init_template_offset(py::module & m) {
                         } else {
                             contrib = raw_det_data[d];
                         }
-                        #pragma omp atomic update
+#pragma omp atomic update
                         raw_amplitudes[amp] += contrib;
                     }
                 }
             }
             delete amp_view_off;
-            return;
-        });
+            return; });
 
     m.def(
         "template_offset_apply_diag_precond", [](
-            py::buffer offset_var,
-            py::buffer amplitudes_in,
-            py::buffer amplitudes_out,
-            bool use_accel)
+                                                  py::buffer offset_var,
+                                                  py::buffer amplitudes_in,
+                                                  py::buffer amplitudes_out,
+                                                  bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -292,25 +295,24 @@ void init_template_offset(py::module & m) {
             );
 
             if (offload) {
-                #ifdef HAVE_OPENMP_TARGET
+#ifdef HAVE_OPENMP_TARGET
 
                 double * dev_amp_in = omgr.device_ptr(raw_amp_in);
                 double * dev_amp_out = omgr.device_ptr(raw_amp_out);
                 double * dev_offset_var = omgr.device_ptr(raw_offset_var);
 
-                # pragma omp target data \
-                map(to                   \
-                : n_amp)
+#pragma omp target data \
+map(to : n_amp)
                 {
-                    # pragma omp target \
-                    is_device_ptr(      \
-                    dev_amp_in,         \
-                    dev_amp_out,        \
-                    dev_offset_var)
+#pragma omp target       \
+is_device_ptr(           \
+        dev_amp_in,      \
+            dev_amp_out, \
+            dev_offset_var)
                     {
-                        # pragma omp parallel default(shared)
+#pragma omp parallel default(shared)
                         {
-                            # pragma omp for
+#pragma omp for
                             for (int64_t iamp = 0; iamp < n_amp; iamp++) {
                                 dev_amp_out[iamp] = dev_amp_in[iamp];
                                 dev_amp_out[iamp] *= dev_offset_var[iamp];
@@ -319,16 +321,15 @@ void init_template_offset(py::module & m) {
                     }
                 }
 
-                #endif // ifdef HAVE_OPENMP_TARGET
+#endif // ifdef HAVE_OPENMP_TARGET
             } else {
-                #pragma omp parallel for default(shared)
+#pragma omp parallel for default(shared)
                 for (int64_t iamp = 0; iamp < n_amp; iamp++) {
                     raw_amp_out[iamp] = raw_amp_in[iamp];
                     raw_amp_out[iamp] *= raw_offset_var[iamp];
                 }
             }
-            return;
-        });
+            return; });
 
     return;
 }

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -11,18 +11,17 @@
 
 // FIXME:  docstrings need to be updated if we keep these versions of the code.
 
-void init_template_offset(py::module &m)
-{
+void init_template_offset(py::module & m) {
     m.def(
         "template_offset_add_to_signal", [](
-                                             int64_t step_length,
-                                             int64_t amp_offset,
-                                             py::buffer n_amp_views,
-                                             py::buffer amplitudes,
-                                             int32_t data_index,
-                                             py::buffer det_data,
-                                             py::buffer intervals,
-                                             bool use_accel)
+            int64_t step_length,
+            int64_t amp_offset,
+            py::buffer n_amp_views,
+            py::buffer amplitudes,
+            int32_t data_index,
+            py::buffer det_data,
+            py::buffer intervals,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -58,52 +57,55 @@ void init_template_offset(py::module &m)
             }
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
                 double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
 
-// Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
+                    }
+                }
 
-#pragma omp target data map(to : n_view,     \
-                                n_samp,      \
-                                data_index,  \
-                                step_length, \
-                                amp_offset,  \
-                                amp_view_off[0 : n_view])
-{
-#pragma omp target teams distribute parallel for collapse(2)
-    for (int64_t iview = 0; iview < n_view; iview++) {
-        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
-            // Adjust for the actual start of the interval
-            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
+                # pragma omp target data map(to : n_view, \
+                n_samp,                                   \
+                data_index,                               \
+                step_length,                              \
+                amp_offset,                               \
+                amp_view_off[0 : n_view])
+                {
+                    # pragma omp target teams distribute parallel for collapse(2)
+                    for (int64_t iview = 0; iview < n_view; iview++) {
+                        for (int64_t isamp = 0; isamp < max_interval_size; isamp++) {
+                            // Adjust for the actual start of the interval
+                            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-            // Check if the value is out of range for the current interval
-            if (adjusted_isamp > dev_intervals[iview].last) {
-                continue;
-            }
+                            // Check if the value is out of range for the current
+                            // interval
+                            if (adjusted_isamp > dev_intervals[iview].last) {
+                                continue;
+                            }
 
-            int64_t d = data_index * n_samp + adjusted_isamp;
-            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
-                (adjusted_isamp - dev_intervals[iview].first) / step_length
-            );
-            dev_det_data[d] += dev_amplitudes[amp];
-        }
-    }
-}
+                            int64_t d = data_index * n_samp + adjusted_isamp;
+                            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
+                                (adjusted_isamp - dev_intervals[iview].first) /
+                                step_length
+                            );
+                            dev_det_data[d] += dev_amplitudes[amp];
+                        }
+                    }
+                }
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                    #pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
                         isamp <= raw_intervals[iview].last;
@@ -120,21 +122,22 @@ for (int64_t iview = 0; iview < n_view; iview++) {
 
             delete amp_view_off;
 
-            return; });
+            return;
+        });
 
     m.def(
         "template_offset_project_signal", [](
-                                              int32_t data_index,
-                                              py::buffer det_data,
-                                              int32_t flag_index,
-                                              py::buffer flag_data,
-                                              uint8_t flag_mask,
-                                              int64_t step_length,
-                                              int64_t amp_offset,
-                                              py::buffer n_amp_views,
-                                              py::buffer amplitudes,
-                                              py::buffer intervals,
-                                              bool use_accel)
+            int32_t data_index,
+            py::buffer det_data,
+            int32_t flag_index,
+            py::buffer flag_data,
+            uint8_t flag_mask,
+            int64_t step_length,
+            int64_t amp_offset,
+            py::buffer n_amp_views,
+            py::buffer amplitudes,
+            py::buffer intervals,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -180,72 +183,78 @@ for (int64_t iview = 0; iview < n_view; iview++) {
             }
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_det_data = omgr.device_ptr(raw_det_data);
                 uint8_t * dev_det_flags = omgr.device_ptr(raw_det_flags);
                 Interval * dev_intervals = omgr.device_ptr(raw_intervals);
                 double * dev_amplitudes = omgr.device_ptr(raw_amplitudes);
 
-// Calculate the maximum interval size on the CPU
-int64_t max_interval_size = 0;
-for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
-    if (interval_size > max_interval_size) {
-        max_interval_size = interval_size;
-    }
-}
-
-#pragma omp target data map(to : n_view,                  \
-                                n_samp,                   \
-                                data_index,               \
-                                flag_index,               \
-                                step_length,              \
-                                amp_offset,               \
-                                amp_view_off[0 : n_view], \
-                                use_flags)
-{
-                // TODO the paralelism can likely be improved on this function
-#pragma omp target teams distribute collapse(2)
-    for (int64_t iview = 0; iview < n_view; iview++) {
-        for (int64_t isamp = 0; isamp < max_interval_size; isamp += step_length) {
-            // Adjust for the actual start of the interval
-            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
-
-            // Check if the value is out of range for the current interval
-            if (adjusted_isamp > dev_intervals[iview].last) {
-                continue;
-            }
-
-            // Insure we do not go out of the current interval
-            int64_t max_step_length = std::min(step_length, dev_intervals[iview].last - adjusted_isamp + 1);
-
-            // Reduce on a chunk of `step_length` samples.
-            double contrib = 0.0;
-#pragma omp parallel for reduction(+ : contrib)
-            for (int64_t i = 0; i < max_step_length; i++) {
-                int64_t d = data_index * n_samp + adjusted_isamp + i;
-                if (use_flags) {
-                    int64_t f = flag_index * n_samp + adjusted_isamp + i;
-                    uint8_t check = dev_det_flags[f] & flag_mask;
-                    if (check == 0) {
-                        contrib += dev_det_data[d];
+                // Calculate the maximum interval size on the CPU
+                int64_t max_interval_size = 0;
+                for (int64_t iview = 0; iview < n_view; iview++) {
+                    int64_t interval_size = raw_intervals[iview].last -
+                                            raw_intervals[iview].first + 1;
+                    if (interval_size > max_interval_size) {
+                        max_interval_size = interval_size;
                     }
-                } else {
-                    contrib += dev_det_data[d];
                 }
-            }
 
-            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(isamp / step_length);
-            dev_amplitudes[amp] += contrib;
-        }
-    }
-}
+                # pragma omp target data map(to : n_view, \
+                n_samp,                                   \
+                data_index,                               \
+                flag_index,                               \
+                step_length,                              \
+                amp_offset,                               \
+                amp_view_off[0 : n_view],                 \
+                use_flags)
+                {
+                    // TODO the paralelism can likely be improved on this function
+                    # pragma omp target teams distribute collapse(2)
+                    for (int64_t iview = 0; iview < n_view; iview++) {
+                        for (int64_t isamp = 0; isamp < max_interval_size;
+                             isamp += step_length) {
+                            // Adjust for the actual start of the interval
+                            int64_t adjusted_isamp = isamp + dev_intervals[iview].first;
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                            // Check if the value is out of range for the current
+                            // interval
+                            if (adjusted_isamp > dev_intervals[iview].last) {
+                                continue;
+                            }
+
+                            // Insure we do not go out of the current interval
+                            int64_t max_step_length =
+                                std::min(step_length,
+                                         dev_intervals[iview].last - adjusted_isamp + 1);
+
+                            // Reduce on a chunk of `step_length` samples.
+                            double contrib = 0.0;
+                            # pragma omp parallel for reduction(+ : contrib)
+                            for (int64_t i = 0; i < max_step_length; i++) {
+                                int64_t d = data_index * n_samp + adjusted_isamp + i;
+                                if (use_flags) {
+                                    int64_t f = flag_index * n_samp + adjusted_isamp + i;
+                                    uint8_t check = dev_det_flags[f] & flag_mask;
+                                    if (check == 0) {
+                                        contrib += dev_det_data[d];
+                                    }
+                                } else {
+                                    contrib += dev_det_data[d];
+                                }
+                            }
+
+                            int64_t amp = amp_offset + amp_view_off[iview] +
+                                          (int64_t)(isamp / step_length);
+                            dev_amplitudes[amp] += contrib;
+                        }
+                    }
+                }
+
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
                 for (int64_t iview = 0; iview < n_view; iview++) {
-#pragma omp parallel for default(shared)
+                    #pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
                         isamp <= raw_intervals[iview].last;
@@ -265,20 +274,21 @@ for (int64_t iview = 0; iview < n_view; iview++) {
                         } else {
                             contrib = raw_det_data[d];
                         }
-#pragma omp atomic update
+                        #pragma omp atomic update
                         raw_amplitudes[amp] += contrib;
                     }
                 }
             }
             delete amp_view_off;
-            return; });
+            return;
+        });
 
     m.def(
         "template_offset_apply_diag_precond", [](
-                                                  py::buffer offset_var,
-                                                  py::buffer amplitudes_in,
-                                                  py::buffer amplitudes_out,
-                                                  bool use_accel)
+            py::buffer offset_var,
+            py::buffer amplitudes_in,
+            py::buffer amplitudes_out,
+            bool use_accel)
         {
             auto & omgr = OmpManager::get();
             int dev = omgr.get_device();
@@ -301,30 +311,31 @@ for (int64_t iview = 0; iview < n_view; iview++) {
             );
 
             if (offload) {
-#ifdef HAVE_OPENMP_TARGET
+                #ifdef HAVE_OPENMP_TARGET
 
                 double * dev_amp_in = omgr.device_ptr(raw_amp_in);
                 double * dev_amp_out = omgr.device_ptr(raw_amp_out);
                 double * dev_offset_var = omgr.device_ptr(raw_offset_var);
 
-#pragma omp target data map(to : n_amp)
-{
-#pragma omp target teams distribute parallel for
-    for (int64_t iamp = 0; iamp < n_amp; iamp++) {
-        dev_amp_out[iamp] = dev_amp_in[iamp];
-        dev_amp_out[iamp] *= dev_offset_var[iamp];
-    }
-}
+                # pragma omp target data map(to : n_amp)
+                {
+                    # pragma omp target teams distribute parallel for
+                    for (int64_t iamp = 0; iamp < n_amp; iamp++) {
+                        dev_amp_out[iamp] = dev_amp_in[iamp];
+                        dev_amp_out[iamp] *= dev_offset_var[iamp];
+                    }
+                }
 
-#endif // ifdef HAVE_OPENMP_TARGET
+                #endif // ifdef HAVE_OPENMP_TARGET
             } else {
-#pragma omp parallel for default(shared)
+                #pragma omp parallel for default(shared)
                 for (int64_t iamp = 0; iamp < n_amp; iamp++) {
                     raw_amp_out[iamp] = raw_amp_in[iamp];
                     raw_amp_out[iamp] *= raw_offset_var[iamp];
                 }
             }
-            return; });
+            return;
+        });
 
     return;
 }

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -67,7 +67,7 @@ void init_template_offset(py::module &m)
 // Calculate the maximum interval size on the CPU
 int64_t max_interval_size = 0;
 for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = dev_intervals[iview].last - dev_intervals[iview].first + 1;
+    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
     if (interval_size > max_interval_size) {
         max_interval_size = interval_size;
     }
@@ -190,7 +190,7 @@ for (int64_t iview = 0; iview < n_view; iview++) {
 // Calculate the maximum interval size on the CPU
 int64_t max_interval_size = 0;
 for (int64_t iview = 0; iview < n_view; iview++) {
-    int64_t interval_size = dev_intervals[iview].last - dev_intervals[iview].first + 1;
+    int64_t interval_size = raw_intervals[iview].last - raw_intervals[iview].first + 1;
     if (interval_size > max_interval_size) {
         max_interval_size = interval_size;
     }

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -217,9 +217,7 @@ for (int64_t iview = 0; iview < n_view; iview++) {
             }
 
             int64_t d = data_index * n_samp + adjusted_isamp;
-            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(
-                (adjusted_isamp - dev_intervals[iview].first) / step_length
-            );
+            int64_t amp = amp_offset + amp_view_off[iview] + (int64_t)(isamp / step_length);
             double contrib = 0.0;
             if (use_flags) {
                 int64_t f = flag_index * n_samp + adjusted_isamp;


### PR DESCRIPTION
Precomputing the maximum interval size to be able to fully collapse the triple loop in most operators leaded to significantly improved computation density on the GPU.