### PR TITLE
make entry points callable as python modules

### DIFF
--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -23,6 +23,7 @@ set(ENTRY_POINTS
 foreach(pyscript ${ENTRY_POINTS})
     string(REPLACE ".py" "" outscript "${pyscript}")
     install(PROGRAMS "${pyscript}" DESTINATION bin RENAME "${outscript}")
+    install(FILES "${pyscript}" DESTINATION ${PYTHON_SITE}/toast/scripts)
 endforeach()
 
 install(FILES


### PR DESCRIPTION
such that `python -m toast.scripts.toast_ground_schedule -h` would work or we could do
```py
from toast.scripts.toast_ground_schedule import main
main(...)
```