### PR TITLE
Updating JAX

### DIFF
--- a/src/toast/jax/mutableArray.py
+++ b/src/toast/jax/mutableArray.py
@@ -101,7 +101,7 @@ class MutableJaxArray:
     """
 
     host_data: np.array
-    data: jnp.DeviceArray
+    data: jax.Array
     shape: Tuple
     size: int
     dtype: np.dtype


### PR DESCRIPTION
replaced DeviceArray with Jax.Array to comply with the [jax.Array migration](https://jax.readthedocs.io/en/latest/jax_array_migration.html#whats-going-on).