### PR TITLE
Update required language standard to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ string(REGEX REPLACE "^([0-9]+\\.[0-9]+)\\..*" "\\1" MAJMIN_VERSION "${REL_VERSI
 
 project(toast VERSION ${MAJMIN_VERSION} LANGUAGES C CXX)
 
-# Force C++11
-set(CMAKE_CXX_STANDARD 11)
+# Force C++14, needed by internal google test framework
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Set symbol visibility to hidden to be consistent with pybind11


### PR DESCRIPTION
Our bundled copy of the google test framework now requires C++14. We could relax this in the future if needed once we reorganize the compiled extension and ensure that all features are tested from the python interface.  In that scenario, we could then completely remove the compiled test runner and gtest.