### PR TITLE
Implement a new mapmaking template for periodic signals

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -305,6 +305,12 @@ conf["install_requires"] = [
 conf["extras_require"] = {
     "mpi": ["mpi4py>=3.0"],
     "totalconvolve": ["ducc0"],
+    "interactive": [
+        "wurlitzer",
+        "ipywidgets",
+        "plotly",
+        "plotly-resampler",
+    ]
 }
 conf["packages"] = find_packages(
     "src",

--- a/src/toast/coordinates.py
+++ b/src/toast/coordinates.py
@@ -95,9 +95,11 @@ def _ephem_transform(site, t):
     quat = qa.norm(np.array([b, c, d, a]))
     return quat
 
+
 def _qpoint_transform(site, t, quats_azel):
     """Get the Az/El -> Ra/Dec conversion quaternion for boresight."""
     import qpoint
+
     qp = qpoint.QPoint(
         accuracy="high",
         fast_math=True,

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -783,6 +783,8 @@ class CommonModeFilter(Operator):
             for value in values:
                 local_dets = []
                 for idet, det in enumerate(temp_ob.local_detectors):
+                    if temp_ob.local_detector_flags[det] & self.det_flag_mask:
+                        continue
                     if pat.match(det) is None:
                         continue
                     if (

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -176,7 +176,7 @@ class SaveHDF5(Operator):
     detdata_in_place = Bool(
         False,
         help="If True, all compressed detector data will be decompressed and written "
-        "over the input data."
+        "over the input data.",
     )
 
     compress_detdata = Bool(False, help="If True, use FLAC to compress detector signal")
@@ -244,11 +244,14 @@ class SaveHDF5(Operator):
                         detdata_fields[ifield] = (field, {"type": "gzip"})
                     else:
                         # Everything else is FLAC-compressed
-                        detdata_fields[ifield] = (field, {
-                            "type": "flac",
-                            "level": 5,
-                            "precision": self.compress_precision,
-                        })
+                        detdata_fields[ifield] = (
+                            field,
+                            {
+                                "type": "flac",
+                                "level": 5,
+                                "precision": self.compress_precision,
+                            },
+                        )
 
             outpath = save_hdf5(
                 ob,

--- a/src/toast/templates/CMakeLists.txt
+++ b/src/toast/templates/CMakeLists.txt
@@ -6,6 +6,7 @@ install(FILES
     template.py
     amplitudes.py
     fourier2d.py
+    periodic.py
     subharmonic.py
     gaintemplate.py
     DESTINATION ${PYTHON_SITE}/toast/templates

--- a/src/toast/templates/__init__.py
+++ b/src/toast/templates/__init__.py
@@ -8,5 +8,6 @@ from .amplitudes import Amplitudes, AmplitudesMap
 from .fourier2d import Fourier2D
 from .gaintemplate import GainTemplate
 from .offset import Offset
+from .periodic import Periodic
 from .subharmonic import SubHarmonic
 from .template import Template

--- a/src/toast/templates/offset/__init__.py
+++ b/src/toast/templates/offset/__init__.py
@@ -4,4 +4,4 @@
 
 # Namespace imports
 
-from .offset import Offset
+from .offset import Offset, plot

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -829,7 +829,7 @@ class Offset(Template):
 
         for iob, ob in enumerate(self.data.obs):
             obs_local_amps = obs_det_amps[ob.name]
-            if self.data.comm.group_size == 0:
+            if self.data.comm.group_size == 1:
                 all_obs_amps = [obs_local_amps]
             else:
                 all_obs_amps = self.data.comm.comm_group.gather(obs_local_amps, root=0)

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -424,7 +424,7 @@ class Periodic(Template):
                 }
                 amp_offset += nbins
 
-        if self.data.comm.world_size == 0:
+        if self.data.comm.world_size == 1:
             all_obs_dets_amps = [obs_det_amps]
         else:
             all_obs_dets_amps = self.data.comm.comm_world.gather(obs_det_amps, root=0)

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -1,0 +1,543 @@
+# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import ast
+import json
+from collections import OrderedDict
+
+import h5py
+import numpy as np
+
+from ..data import Data
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from ..vis import set_matplotlib_backend
+from .amplitudes import Amplitudes
+from .template import Template
+
+
+@trait_docs
+class Periodic(Template):
+    """This template represents amplitudes which are periodic in time.
+
+    The template amplitudes are modeled as a value for each detector of each
+    observation in a "bin" of the specified data values.  The min / max values
+    of the periodic data are computed for each observation, and the binning
+    between these min / max values is set by either the n_bins trait or by
+    specifying the increment in the value to use for each bin.
+
+    Although the data values used do not have to be strictly periodic, this
+    template works best if the values are varying in a regular way such that
+    each bin has approximately the same number of hits.
+
+    The periodic quantity to consider can be either a shared or detdata field.
+
+    """
+
+    # Notes:  The TraitConfig base class defines a "name" attribute.  The Template
+    # class (derived from TraitConfig) defines the following traits already:
+    #    data             : The Data instance we are working with
+    #    view             : The timestream view we are using
+    #    det_data         : The detector data key with the timestreams
+    #    det_data_units   : The units of the detector data
+    #    det_flags        : Optional detector solver flags
+    #    det_flag_mask    : Bit mask for detector solver flags
+    #
+
+    is_detdata_key = Bool(
+        False,
+        help="If True, the periodic data and flags are detector fields, not shared",
+    )
+
+    key = Unicode(
+        None, allow_none=True, help="Observation data key for the periodic quantity"
+    )
+
+    flags = Unicode(
+        None,
+        allow_none=True,
+        help="Observation data key for flags to use",
+    )
+
+    flag_mask = Int(0, help="Bit mask value for flags")
+
+    bins = Int(
+        10,
+        allow_none=True,
+        help="Number of bins between min / max values of data key",
+    )
+
+    increment = Float(
+        None,
+        allow_none=True,
+        help="The increment of the data key for each bin",
+    )
+
+    minimum_bin_hits = Int(3, help="Minimum number of samples per amplitude bin")
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _initialize(self, new_data):
+        log = Logger.get()
+        if self.key is None:
+            msg = "You must set key before initializing"
+            raise RuntimeError(msg)
+
+        if self.bins is not None and self.increment is not None:
+            msg = "Only one of bins and increment can be specified"
+            raise RuntimeError(msg)
+
+        # Use this as an "Ordered Set".  We want the unique detectors on this process,
+        # but sorted in order of occurrence.
+        all_dets = OrderedDict()
+
+        # Find the binning for each observation and the total detectors on this
+        # process.
+        self._obs_min = list()
+        self._obs_max = list()
+        self._obs_incr = list()
+        self._obs_nbins = list()
+        for ob in new_data.obs:
+            if self.is_detdata_key:
+                if self.key not in ob.detdata:
+                    continue
+            else:
+                if self.key not in ob.shared:
+                    continue
+            omin = None
+            omax = None
+            for vw in ob.intervals[self.view].data:
+                vw_slc = slice(vw.first, vw.last + 1, 1)
+                good = slice(None)
+                if self.is_detdata_key:
+                    vw_data = ob.detdata[self.key].data[vw_slc]
+                    if self.flags is not None:
+                        # We have some flags
+                        bad = ob.detdata[self.flags].data[vw_slc] & self.flag_mask
+                        good = np.logical_not(bad)
+                else:
+                    vw_data = ob.shared[self.key].data[vw_slc]
+                    if self.flags is not None:
+                        # We have some flags
+                        bad = ob.shared[self.flags].data[vw_slc] & self.flag_mask
+                        good = np.logical_not(bad)
+                vmin = np.amin(vw_data[good])
+                vmax = np.amax(vw_data[good])
+                if omin is None:
+                    omin = vmin
+                    omax = vmax
+                else:
+                    omin = min(omin, vmin)
+                    omax = max(omax, vmax)
+
+            if omin == omax:
+                msg = f"Periodic data {self.key} is constant for observation "
+                msg += f"{ob.name}"
+                raise RuntimeError(msg)
+            self._obs_min.append(omin)
+            self._obs_max.append(omax)
+            if self.bins is not None:
+                obins = int(self.bins)
+                oincr = (omax - omin) / obins
+            else:
+                oincr = float(self.increment)
+                obins = int((omax - omin) / oincr)
+            self._obs_nbins.append(obins)
+            self._obs_incr.append(oincr)
+            # Build up detector list
+            for d in ob.local_detectors:
+                if d not in all_dets:
+                    all_dets[d] = None
+
+        self._all_dets = list(all_dets.keys())
+
+        # During application of the template, we will be looping over detectors
+        # in the outer loop.  So we pack the amplitudes by detector and then by
+        # observation.  Compute the per-detector offsets into the amplitudes.
+
+        self._det_offset = dict()
+
+        offset = 0
+        for det in self._all_dets:
+            self._det_offset[det] = offset
+            for iob, ob in enumerate(new_data.obs):
+                if self.is_detdata_key:
+                    if self.key not in ob.detdata:
+                        continue
+                else:
+                    if self.key not in ob.shared:
+                        continue
+                offset += self._obs_nbins[iob]
+
+        # Now we know the total number of local amplitudes.
+
+        if offset == 0:
+            # This means that no observations included the shared key
+            # we are using.
+            msg = f"Data has no observations with key '{self.key}'."
+            msg += "  You should disable this template."
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        self._n_local = offset
+        if new_data.comm.comm_world is None:
+            self._n_global = self._n_local
+        else:
+            self._n_global = new_data.comm.comm_world.allreduce(
+                self._n_local, op=MPI.SUM
+            )
+
+        # Go through all the data and compute the number of hits per amplitude
+        # bin and the flagging of bins.
+
+        # Boolean flags
+        self._amp_flags = np.zeros(self._n_local, dtype=bool)
+
+        # Hits
+        self._amp_hits = np.zeros(self._n_local, dtype=np.int32)
+
+        self._obs_bin_hits = list()
+        for det in self._all_dets:
+            amp_offset = self._det_offset[det]
+            for iob, ob in enumerate(self.data.obs):
+                if self.is_detdata_key:
+                    if self.key not in ob.detdata:
+                        continue
+                else:
+                    if self.key not in ob.shared:
+                        continue
+
+                if det not in ob.local_detectors:
+                    continue
+                nbins = self._obs_nbins[iob]
+                det_indx = ob.detdata[self.det_data].indices([det])[0]
+                amp_hits = self._amp_hits[amp_offset : amp_offset + nbins]
+                amp_flags = self._amp_flags[amp_offset : amp_offset + nbins]
+                for vw in ob.intervals[self.view].data:
+                    vw_slc = slice(vw.first, vw.last + 1, 1)
+                    if self.is_detdata_key:
+                        vw_data = ob.detdata[self.key].data[vw_slc]
+                    else:
+                        vw_data = ob.shared[self.key].data[vw_slc]
+                    good, amp_indx = self._view_flags_and_index(
+                        det_indx,
+                        iob,
+                        ob,
+                        vw,
+                        det_flags=True,
+                    )
+                    np.add.at(
+                        amp_hits,
+                        amp_indx,
+                        np.ones(len(vw_data[good]), dtype=np.int32),
+                    )
+                    flag_thresh = amp_hits < self.minimum_bin_hits
+                    amp_flags[flag_thresh] = True
+                amp_offset += nbins
+        return
+
+    def _detectors(self):
+        return self._all_dets
+
+    def _zeros(self):
+        z = Amplitudes(self.data.comm, self._n_global, self._n_local)
+        z.local_flags[:] = np.where(self._amp_flags, 1, 0)
+        return z
+
+    def _view_flags_and_index(self, det_indx, ob_indx, ob, view, det_flags=False):
+        """Get the flags and amplitude indices for one detector and view."""
+        vw_slc = slice(view.first, view.last + 1, 1)
+        vw_len = view.last - view.first + 1
+        incr = self._obs_incr[ob_indx]
+        # Determine good samples
+        if self.is_detdata_key:
+            vw_data = ob.detdata[self.key].data[vw_slc]
+            if self.flags is not None:
+                # We have some flags
+                bad = ob.detdata[self.flags].data[vw_slc] & self.flag_mask
+            else:
+                bad = np.zeros(vw_len, dtype=bool)
+        else:
+            vw_data = ob.shared[self.key].data[vw_slc]
+            if self.flags is not None:
+                # We have some flags
+                bad = ob.shared[self.flags].data[vw_slc] & self.flag_mask
+            else:
+                bad = np.zeros(vw_len, dtype=bool)
+        if det_flags and self.det_flags is not None:
+            # We have some det flags
+            bad |= ob.detdata[self.det_flags][det_indx, vw_slc] & self.det_flag_mask
+        good = np.logical_not(bad)
+
+        # Find the amplitude index for every good sample
+        amp_indx = np.array(
+            ((vw_data[good] - self._obs_min[ob_indx]) / incr),
+            dtype=np.int32,
+        )
+        overflow = amp_indx >= self._obs_nbins[ob_indx]
+        amp_indx[overflow] = self._obs_nbins[ob_indx] - 1
+
+        return good, amp_indx
+
+    def _add_to_signal(self, detector, amplitudes, **kwargs):
+        amp_offset = self._det_offset[detector]
+        for iob, ob in enumerate(self.data.obs):
+            if self.is_detdata_key:
+                if self.key not in ob.detdata:
+                    continue
+            else:
+                if self.key not in ob.shared:
+                    continue
+
+            if detector not in ob.local_detectors:
+                continue
+            nbins = self._obs_nbins[iob]
+            det_indx = ob.detdata[self.det_data].indices([detector])[0]
+            amps = amplitudes.local[amp_offset : amp_offset + nbins]
+            for vw in ob.intervals[self.view].data:
+                vw_slc = slice(vw.first, vw.last + 1, 1)
+                good, amp_indx = self._view_flags_and_index(
+                    det_indx,
+                    iob,
+                    ob,
+                    vw,
+                    det_flags=False,
+                )
+                # Accumulate to timestream
+                ob.detdata[self.det_data][det_indx, vw_slc][good] += amps[amp_indx]
+            amp_offset += nbins
+
+    def _project_signal(self, detector, amplitudes, **kwargs):
+        amp_offset = self._det_offset[detector]
+        for iob, ob in enumerate(self.data.obs):
+            if self.is_detdata_key:
+                if self.key not in ob.detdata:
+                    continue
+            else:
+                if self.key not in ob.shared:
+                    continue
+
+            if detector not in ob.local_detectors:
+                continue
+            nbins = self._obs_nbins[iob]
+            det_indx = ob.detdata[self.det_data].indices([detector])[0]
+            amps = amplitudes.local[amp_offset : amp_offset + nbins]
+            for vw in ob.intervals[self.view].data:
+                vw_slc = slice(vw.first, vw.last + 1, 1)
+                good, amp_indx = self._view_flags_and_index(
+                    det_indx,
+                    iob,
+                    ob,
+                    vw,
+                    det_flags=True,
+                )
+                # Accumulate to amplitudes
+                np.add.at(
+                    amps,
+                    amp_indx,
+                    ob.detdata[self.det_data][det_indx, vw_slc][good],
+                )
+            amp_offset += nbins
+
+    def _add_prior(self, amplitudes_in, amplitudes_out, **kwargs):
+        # No prior for this template, nothing to accumulate to output.
+        return
+
+    def _apply_precond(self, amplitudes_in, amplitudes_out, **kwargs):
+        # Apply weights based on the number of samples hitting each
+        # amplitude bin.
+        for det in self._all_dets:
+            amp_offset = self._det_offset[det]
+            for iob, ob in enumerate(self.data.obs):
+                if self.is_detdata_key:
+                    if self.key not in ob.detdata:
+                        continue
+                else:
+                    if self.key not in ob.shared:
+                        continue
+
+                if det not in ob.local_detectors:
+                    continue
+                nbins = self._obs_nbins[iob]
+                amps_in = amplitudes_in.local[amp_offset : amp_offset + nbins]
+                amps_out = amplitudes_out.local[amp_offset : amp_offset + nbins]
+                amp_flags = amplitudes_in.local_flags[amp_offset : amp_offset + nbins]
+                amp_hits = self._amp_hits[amp_offset : amp_offset + nbins]
+                amp_good = amp_flags == 0
+
+                amps_out[amp_good] = amps_in[amp_good] * amp_hits[amp_good]
+
+                amp_offset += nbins
+
+    @function_timer
+    def write(self, amplitudes, out):
+        """Write out amplitude values.
+
+        This stores the amplitudes to a file for debugging / plotting.
+
+        Args:
+            amplitudes (Amplitudes):  The amplitude data.
+            out (str):  The output file.
+
+        Returns:
+            None
+
+        """
+        # By definition, when solving for something that is periodic for
+        # a given detector in a single observation, we (should) have many
+        # fewer template amplitudes than timestream samples.  Because of
+        # this we assume we can make several copies for extracting the
+        # amplitudes and gathering them for writing.
+
+        obs_det_amps = dict()
+
+        for det in self._all_dets:
+            amp_offset = self._det_offset[det]
+            for iob, ob in enumerate(self.data.obs):
+                if self.is_detdata_key:
+                    if self.key not in ob.detdata:
+                        continue
+                else:
+                    if self.key not in ob.shared:
+                        continue
+
+                if det not in ob.local_detectors:
+                    continue
+                if ob.name not in obs_det_amps:
+                    obs_det_amps[ob.name] = dict()
+                nbins = self._obs_nbins[iob]
+                amp_data = amplitudes.local[amp_offset : amp_offset + nbins]
+                amp_hits = self._amp_hits[amp_offset : amp_offset + nbins]
+                amp_flags = self._amp_flags[amp_offset : amp_offset + nbins]
+                obs_det_amps[ob.name][det] = {
+                    "amps": amp_data,
+                    "hits": amp_hits,
+                    "flags": amp_flags,
+                    "min": self._obs_min[iob],
+                    "max": self._obs_max[iob],
+                    "incr": self._obs_incr[iob],
+                }
+                amp_offset += nbins
+
+        if self.data.comm.world_size == 0:
+            all_obs_dets_amps = [obs_det_amps]
+        else:
+            all_obs_dets_amps = self.data.comm.comm_world.gather(obs_det_amps, root=0)
+
+        if self.data.comm.world_rank == 0:
+            obs_det_amps = dict()
+            for pdata in all_obs_dets_amps:
+                for obname in pdata.keys():
+                    if obname not in obs_det_amps:
+                        obs_det_amps[obname] = dict()
+                    obs_det_amps[obname].update(pdata[obname])
+            del all_obs_dets_amps
+            with h5py.File(out, "w") as hf:
+                for obname, obamps in obs_det_amps.items():
+                    n_det = len(obamps)
+                    det_list = list(sorted(obamps.keys()))
+                    det_indx = {y: x for x, y in enumerate(det_list)}
+                    indx_to_det = {det_indx[x]: x for x in det_list}
+                    n_amp = len(obamps[det_list[0]]["amps"])
+                    amp_min = [obamps[x]["min"] for x in det_list]
+                    amp_max = [obamps[x]["max"] for x in det_list]
+                    amp_incr = [obamps[x]["incr"] for x in det_list]
+
+                    # Create datasets for this observation
+                    hg = hf.create_group(obname)
+                    hg.attrs["detectors"] = json.dumps(det_list)
+                    hg.attrs["min"] = json.dumps(amp_min)
+                    hg.attrs["max"] = json.dumps(amp_max)
+                    hg.attrs["incr"] = json.dumps(amp_incr)
+                    hamps = hg.create_dataset(
+                        "amplitudes",
+                        (n_det, n_amp),
+                        dtype=np.float64,
+                    )
+                    hhits = hg.create_dataset(
+                        "hits",
+                        (n_det, n_amp),
+                        dtype=np.int32,
+                    )
+                    hflags = hg.create_dataset(
+                        "flags",
+                        (n_det, n_amp),
+                        dtype=np.uint8,
+                    )
+
+                    # Write data
+                    for idet in range(n_det):
+                        det = indx_to_det[idet]
+                        dprops = obamps[det]
+                        hslice = (slice(idet, idet + 1, 1), slice(0, n_amp, 1))
+                        dslice = (slice(0, n_amp, 1),)
+                        hamps.write_direct(dprops["amps"], dslice, hslice)
+                        hhits.write_direct(dprops["hits"], dslice, hslice)
+                        hflags.write_direct(dprops["flags"], dslice, hslice)
+
+
+def plot(amp_file, out_root=None):
+    """Plot an amplitude dump file.
+
+    This loads an amplitude file and makes a set of plots.
+
+    Args:
+        amp_file (str):  The path to the input file of amplitudes.
+        out_root (str):  The root of the output files.
+
+    Returns:
+        None
+
+    """
+
+    if out_root is not None:
+        set_matplotlib_backend(backend="pdf")
+
+    import matplotlib.pyplot as plt
+
+    figdpi = 100
+
+    with h5py.File(amp_file, "r") as hf:
+        for obname, obgrp in hf.items():
+            det_list = json.loads(obgrp.attrs["detectors"])
+            amp_min = list(ast.literal_eval(obgrp.attrs["min"]))
+            amp_max = list(ast.literal_eval(obgrp.attrs["max"]))
+            amp_incr = list(ast.literal_eval(obgrp.attrs["incr"]))
+
+            hamps = obgrp["amplitudes"]
+            hhits = obgrp["hits"]
+            hflags = obgrp["flags"]
+            n_bin = hamps.shape[1]
+
+            for idet, det in enumerate(det_list):
+                outfile = f"{out_root}_{obname}_{det}.pdf"
+                xdata = amp_min[idet] + amp_incr[idet] * np.arange(
+                    n_bin, dtype=np.float64
+                )
+                fig = plt.figure(dpi=figdpi, figsize=(8, 12))
+                ax = fig.add_subplot(3, 1, 1)
+                ax.step(xdata, hamps[idet], where="post", label=f"{det}")
+                ax.set_xlabel("Shared Data Value")
+                ax.set_ylabel("Amplitude")
+                ax.legend(loc="best")
+                ax = fig.add_subplot(3, 1, 2)
+                ax.step(xdata, hflags[idet], where="post", label=f"{det}")
+                ax.set_xlabel("Shared Data Value")
+                ax.set_ylabel("Flags")
+                ax.legend(loc="best")
+                ax = fig.add_subplot(3, 1, 3)
+                ax.step(xdata, hhits[idet], where="post", label=f"{det}")
+                ax.set_xlabel("Shared Data Value")
+                ax.set_ylabel("Hits")
+                ax.legend(loc="best")
+                if out_root is None:
+                    # Interactive
+                    plt.show()
+                else:
+                    plt.savefig(outfile, dpi=figdpi, bbox_inches="tight", format="pdf")
+                    plt.close()

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ install(FILES
     ops_scan_wcs.py
     ops_madam.py
     ops_gainscrambler.py
+    template_periodic.py
     template_amplitudes.py
     template_offset.py
     template_fourier2d.py

--- a/src/toast/tests/io_compression.py
+++ b/src/toast/tests/io_compression.py
@@ -26,7 +26,7 @@ from ..io.compression_flac import (
 from ..mpi import Comm
 from ..observation import default_values as defaults
 from ..observation_data import DetectorData
-from ..ops import SaveHDF5, LoadHDF5
+from ..ops import LoadHDF5, SaveHDF5
 from ..timing import Timer
 from ..utils import AlignedI32, AlignedU8
 from ._helpers import close_data, create_ground_data, create_outdir
@@ -311,7 +311,9 @@ class IoCompressionTest(MPITestCase):
             new_detdata_quanta = decompress_detdata(*comp_data_quanta)
 
             rms_float32 = np.std(ob.detdata[key].data - new_detdata_float32.data)
-            rms_precision = np.std(new_detdata_float32.data - new_detdata_precision.data)
+            rms_precision = np.std(
+                new_detdata_float32.data - new_detdata_precision.data
+            )
             rms_quanta = np.std(new_detdata_float32.data - new_detdata_quanta.data)
 
             # print(f"RMS (in) = {rms_in}")
@@ -320,7 +322,7 @@ class IoCompressionTest(MPITestCase):
             # print(f"RMS (quanta) = {rms_quanta} abs, {rms_quanta / rms_in} rel")
 
             check = np.allclose(
-                new_detdata_precision[:], new_detdata_quanta[:], rtol=10**(-precision)
+                new_detdata_precision[:], new_detdata_quanta[:], rtol=10 ** (-precision)
             )
             if not check:
                 print(f"RMS (in) = {rms_in}")
@@ -329,8 +331,10 @@ class IoCompressionTest(MPITestCase):
                 print(f"Quanta = {quanta}:  {new_detdata_quanta}")
                 self.assertTrue(False)
 
-            if rms_in / rms_precision < .9 * 10**precision:
-                print(f"RMS(in) / RMS(precision) = {rms_in / rms_precision} but precision = {precision}")
+            if rms_in / rms_precision < 0.9 * 10**precision:
+                print(
+                    f"RMS(in) / RMS(precision) = {rms_in / rms_precision} but precision = {precision}"
+                )
                 self.assertTrue(False)
 
         close_data(data)

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -845,6 +845,7 @@ class MapmakerTest(MPITestCase):
         pars["precond_width_max"] = 10
         pars["use_cgprecond"] = "T"
         pars["use_fprecond"] = "F"
+        pars["info"] = 3
         pars["path_output"] = testdir
 
         madam = ops.Madam(

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -72,6 +72,7 @@ from . import template_amplitudes as test_template_amplitudes
 from . import template_fourier2d as test_template_fourier2d
 from . import template_gain as test_template_gain
 from . import template_offset as test_template_offset
+from . import template_periodic as test_template_periodic
 from . import template_subharmonic as test_template_subharmonic
 from . import timing as test_timing
 from . import weather as test_weather
@@ -214,6 +215,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_covariance))
 
         suite.addTest(loader.loadTestsFromModule(test_template_amplitudes))
+        suite.addTest(loader.loadTestsFromModule(test_template_periodic))
         suite.addTest(loader.loadTestsFromModule(test_template_offset))
         suite.addTest(loader.loadTestsFromModule(test_template_fourier2d))
         suite.addTest(loader.loadTestsFromModule(test_template_subharmonic))

--- a/src/toast/tests/template_periodic.py
+++ b/src/toast/tests/template_periodic.py
@@ -37,6 +37,14 @@ class TemplatePeriodicTest(MPITestCase):
         self.outdir = create_outdir(self.comm, fixture_name)
         self.nside = 64
         np.random.seed(123456)
+        if not (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
 
     def fake_hwpss(self, data, field, scale):
         # Create a fake HWP synchronous signal
@@ -518,7 +526,7 @@ class TemplatePeriodicTest(MPITestCase):
         hwpss_tmpl.write(pamps, pfile)
 
         # Plot some results
-        if data.comm.world_rank == 0:
+        if data.comm.world_rank == 0 and self.make_plots:
             perplot(pfile, out_root=pplot_root)
             for ob in data.obs:
                 offplot(
@@ -717,7 +725,7 @@ class TemplatePeriodicTest(MPITestCase):
         hwpss_tmpl.write(pamps, pfile)
 
         # Plot some results
-        if data.comm.world_rank == 0:
+        if data.comm.world_rank == 0 and self.make_plots:
             perplot(pfile, out_root=pplot_root)
             for ob in data.obs:
                 offplot(

--- a/src/toast/tests/template_periodic.py
+++ b/src/toast/tests/template_periodic.py
@@ -1,0 +1,770 @@
+# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+import numpy.testing as nt
+from astropy import units as u
+
+from .. import ops
+from ..accelerator import ImplementationType, accel_enabled
+from ..atm import available_atm
+from ..observation import default_values as defaults
+from ..pixels_io_healpix import write_healpix_fits
+from ..pixels_io_wcs import write_wcs_fits
+from ..templates import Fourier2D, Offset, Periodic
+from ..templates.offset import plot as offplot
+from ..templates.periodic import plot as perplot
+from ..utils import rate_from_times
+from ..vis import plot_noise_estim
+from ._helpers import (
+    close_data,
+    create_fake_sky,
+    create_ground_data,
+    create_outdir,
+    create_satellite_data,
+    plot_healpix_maps,
+    plot_wcs_maps,
+)
+from .mpi import MPITestCase
+
+
+class TemplatePeriodicTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+        self.nside = 64
+        np.random.seed(123456)
+
+    def fake_hwpss(self, data, field, scale):
+        # Create a fake HWP synchronous signal
+        # (harmonic, cos amplitude, sin amplitude)
+        model = [
+            (1, 1.0 * scale, 0.5 * scale),
+            (2, 0.5 * scale, 1.0 * scale),
+            (3, 0.2 * scale, 0.1 * scale),
+            (4, 0.001 * scale, 0.002 * scale),
+            (5, 0.001 * scale, 0.0005 * scale),
+        ]
+        for ob in data.obs:
+            hwpss = np.zeros(ob.n_local_samples, dtype=np.float64)
+            for harmonic, camp, samp in model:
+                ang = harmonic * ob.shared[defaults.hwp_angle].data
+                hwpss[:] += camp * np.cos(ang) + samp * np.sin(ang)
+            if field not in ob.detdata:
+                ob.detdata.create(field, units=defaults.det_data_units)
+            for det in ob.local_detectors:
+                ob.detdata[field][det, :] += hwpss
+
+    def plot_compare(self, outdir, data, prefix, comps=list(), full=False):
+        import matplotlib.pyplot as plt
+
+        for ob in data.obs:
+            n_samp = ob.n_local_samples
+            if full:
+                plot_dets = ob.local_detectors
+            else:
+                plot_dets = [ob.local_detectors[0]]
+            for det in plot_dets:
+                for ns in [500, n_samp]:
+                    plot_slc = slice(0, ns, 1)
+                    savefile = os.path.join(
+                        outdir,
+                        f"{prefix}-compare_{ob.name}_{det}_{ns}.pdf",
+                    )
+                    n_comp = len(comps)
+                    n_plot = n_comp + 3
+                    fig_height = 6 * n_plot
+
+                    # Find the data range of the input
+                    dmin = np.amin(ob.detdata["input"][det, plot_slc])
+                    dmax = np.amax(ob.detdata["input"][det, plot_slc])
+                    dhalf = (dmax - dmin) / 2
+
+                    fig = plt.figure(figsize=(12, fig_height), dpi=72)
+                    for icomp, comp in enumerate(comps):
+                        ax = fig.add_subplot(n_plot, 1, icomp + 1, aspect="auto")
+                        ax.plot(
+                            ob.shared[defaults.times].data[plot_slc],
+                            ob.detdata[comp][det, plot_slc],
+                            c="blue",
+                            label=f"Component '{comp}'",
+                        )
+                        ax.legend(loc="best")
+                        plt.title(f"Obs {ob.name}, det {det}")
+
+                    ax = fig.add_subplot(n_plot, 1, n_plot - 2, aspect="auto")
+                    ax.plot(
+                        ob.shared[defaults.times].data[plot_slc],
+                        ob.detdata["input"][det, plot_slc],
+                        c="blue",
+                        label=f"Total Input Signal",
+                    )
+                    ax.set_ylim(bottom=dmin, top=dmax)
+                    ax.legend(loc="best")
+                    plt.title(f"Obs {ob.name}, det {det}")
+
+                    ax = fig.add_subplot(n_plot, 1, n_plot - 1, aspect="auto")
+                    ax.plot(
+                        ob.shared[defaults.times].data[plot_slc],
+                        ob.detdata[defaults.det_data][det, plot_slc],
+                        c="red",
+                        label="Template Cleaned",
+                    )
+                    ax.plot(
+                        ob.shared[defaults.times].data[plot_slc],
+                        ob.detdata["sky"][det, plot_slc],
+                        c="black",
+                        label="Input Sky",
+                    )
+                    # ax.set_ylim(bottom=dmin, top=dmax)
+                    ax.legend(loc="best")
+                    plt.title(f"Obs {ob.name}, det {det}")
+
+                    resid = (
+                        ob.detdata[defaults.det_data][det, plot_slc]
+                        - ob.detdata["sky"][det, plot_slc]
+                    )
+                    pmean = np.mean(resid)
+                    ax = fig.add_subplot(n_plot, 1, n_plot, aspect="auto")
+                    ax.plot(
+                        ob.shared[defaults.times].data[plot_slc],
+                        resid,
+                        c="green",
+                        label="Residual",
+                    )
+                    ax.set_ylim(bottom=pmean - dhalf, top=pmean + dhalf)
+                    ax.legend(loc="best")
+                    plt.title(f"Obs {ob.name}, det {det}")
+
+                    plt.savefig(savefile)
+                    plt.close()
+
+    def create_satellite_sim(self, outdir, sky_nside):
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(
+            self.comm,
+            sample_rate=10.0 * u.Hz,
+            obs_per_group=6,
+            pixel_per_process=7,
+            single_group=True,
+        )
+
+        # Create detector data for the combined input signal
+        for ob in data.obs:
+            ob.detdata.create("input", units=defaults.det_data_units)
+
+        # Create a default noise model
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Generate a fake "sky" and scan into timestreams.  We
+        # create a temporary pointing matrix and then clean up
+        # temporary data objects afterwards.
+
+        detpointing = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            quats="temp_quats",
+        )
+        detpointing.apply(data)
+
+        pixels = ops.PixelsHealpix(
+            nside=sky_nside,
+            detector_pointing=detpointing,
+            pixels="temp_pix",
+        )
+        pix_dist = ops.BuildPixelDistribution(
+            pixel_dist="sky_pixel_dist",
+            pixel_pointing=pixels,
+        )
+        pix_dist.apply(data)
+
+        create_fake_sky(data, "sky_pixel_dist", "fake_map")
+
+        outfile = os.path.join(outdir, f"sky_{self.nside}_input.fits")
+        write_healpix_fits(data["fake_map"], outfile, nest=True)
+        if data.comm.world_rank == 0:
+            plot_healpix_maps(mapfile=outfile)
+
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            weights="temp_weights",
+            detector_pointing=detpointing,
+        )
+
+        scanner = ops.Pipeline(
+            operators=[
+                pixels,
+                weights,
+                ops.ScanMap(
+                    det_data="sky",
+                    pixels=pixels.pixels,
+                    weights=weights.weights,
+                    map_key="fake_map",
+                    det_data_units=defaults.det_data_units,
+                ),
+            ],
+            detsets=["SINGLE"],
+        )
+        scanner.apply(data)
+
+        ops.Combine(
+            op="add",
+            first="sky",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        del data["fake_map"]
+        del data["sky_pixel_dist"]
+        for ob in data.obs:
+            del ob.detdata["temp_weights"]
+            del ob.detdata["temp_pix"]
+            del ob.detdata["temp_quats"]
+
+        # Simulate some noise
+        sim_noise = ops.SimNoise(
+            det_data="noise",
+            noise_model=default_model.noise_model,
+            det_data_units=defaults.det_data_units,
+        )
+        sim_noise.apply(data)
+        ops.Combine(
+            op="add",
+            first="noise",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        return data
+
+    def create_ground_sim(self, outdir, width, sky_proj, sky_res):
+        # Create a fake ground data set for testing
+        data = create_ground_data(
+            self.comm,
+            sample_rate=122.0 * u.Hz,
+            pixel_per_process=7,
+            single_group=True,
+            fp_width=width,
+        )
+
+        # Create detector data for the combined input signal
+        for ob in data.obs:
+            ob.detdata.create("input", units=defaults.det_data_units)
+
+        # Create a default noise model
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Az/El detector pointing
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_azel, quats="quats_azel"
+        )
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model=default_model.noise_model,
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Generate a fake "sky" and scan into timestreams.  We
+        # create a temporary pointing matrix and then clean up
+        # temporary data objects afterwards.
+
+        detpointing = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            quats="temp_quats",
+        )
+        detpointing.apply(data)
+
+        pixels = ops.PixelsWCS(
+            projection=sky_proj,
+            resolution=(sky_res, sky_res),
+            detector_pointing=detpointing,
+            pixels="temp_pix",
+            use_astropy=True,
+            auto_bounds=True,
+        )
+        pix_dist = ops.BuildPixelDistribution(
+            pixel_dist="sky_pixel_dist",
+            pixel_pointing=pixels,
+        )
+        pix_dist.apply(data)
+
+        create_fake_sky(data, "sky_pixel_dist", "fake_map")
+
+        outfile = os.path.join(
+            outdir, f"sky_{sky_proj}_{sky_res.to_value(u.arcmin)}_input.fits"
+        )
+        write_wcs_fits(data["fake_map"], outfile)
+        if data.comm.world_rank == 0:
+            plot_wcs_maps(mapfile=outfile)
+
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            weights="temp_weights",
+            detector_pointing=detpointing,
+        )
+
+        scanner = ops.Pipeline(
+            operators=[
+                pixels,
+                weights,
+                ops.ScanMap(
+                    det_data="sky",
+                    pixels=pixels.pixels,
+                    weights=weights.weights,
+                    map_key="fake_map",
+                    det_data_units=defaults.det_data_units,
+                ),
+            ],
+            detsets=["SINGLE"],
+        )
+        scanner.apply(data)
+
+        ops.Combine(
+            op="add",
+            first="sky",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        del data["fake_map"]
+        del data["sky_pixel_dist"]
+        for ob in data.obs:
+            del ob.detdata["temp_weights"]
+            del ob.detdata["temp_pix"]
+            del ob.detdata["temp_quats"]
+
+        # Simulate some noise
+        sim_noise = ops.SimNoise(
+            det_data="noise",
+            noise_model=el_model.out_model,
+            det_data_units=defaults.det_data_units,
+        )
+        sim_noise.apply(data)
+        ops.Combine(
+            op="add",
+            first="noise",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        # Simulate atmosphere
+        sim_atm_coarse = ops.SimAtmosphere(
+            name="sim_atmosphere_coarse",
+            det_data="atm",
+            detector_pointing=detpointing_azel,
+            add_loading=False,
+            lmin_center=300 * u.m,
+            lmin_sigma=30 * u.m,
+            lmax_center=10000 * u.m,
+            lmax_sigma=1000 * u.m,
+            # Use lower resolution for faster run time
+            # xstep=50 * u.m,
+            # ystep=50 * u.m,
+            # zstep=50 * u.m,
+            xstep=100 * u.m,
+            ystep=100 * u.m,
+            zstep=100 * u.m,
+            zmax=2000 * u.m,
+            nelem_sim_max=30000,
+            gain=6e-4,
+            realization=1000000,
+            wind_dist=10000 * u.m,
+            det_data_units=defaults.det_data_units,
+        )
+        sim_atm_coarse.apply(data)
+        sim_atm = ops.SimAtmosphere(
+            name="sim_atmosphere",
+            det_data="atm",
+            detector_pointing=detpointing_azel,
+            add_loading=True,
+            lmin_center=0.001 * u.m,
+            lmin_sigma=0.0001 * u.m,
+            lmax_center=1 * u.m,
+            lmax_sigma=0.1 * u.m,
+            # Use lower resolution for faster run time
+            # xstep=5 * u.m,
+            # ystep=5 * u.m,
+            # zstep=5 * u.m,
+            xstep=50 * u.m,
+            ystep=50 * u.m,
+            zstep=50 * u.m,
+            zmax=200 * u.m,
+            gain=6e-5,
+            wind_dist=3000 * u.m,
+            det_data_units=defaults.det_data_units,
+        )
+        sim_atm.apply(data)
+
+        ops.Combine(
+            op="add",
+            first="atm",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        return data
+
+    def test_satellite_hwp(self):
+        testdir = os.path.join(self.outdir, "satellite_hwp")
+        if self.comm is None or self.comm.rank == 0:
+            if not os.path.isdir(testdir):
+                os.mkdir(testdir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        # Create a fake satellite data set for testing
+        data = self.create_satellite_sim(testdir, self.nside)
+
+        # Add HWPSS and make a copy for plotting
+        hwpss_scale = 20.0
+        tod_rms = np.std(data.obs[0].detdata["input"][0])
+        self.fake_hwpss(data, "hwpss", hwpss_scale * tod_rms)
+        ops.Combine(
+            op="add",
+            first="hwpss",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        # Copy the input data into the default field
+        ops.Copy(detdata=[("input", defaults.det_data)]).apply(data)
+
+        # Create a default noise model
+        default_model = ops.DefaultNoiseModel()
+        default_model.apply(data)
+
+        # Pointing
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=self.nside,
+            detector_pointing=detpointing,
+        )
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+
+        # Set up binning operator for solving
+        binner = ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        # Set up template with 2-degree bins.
+        hwpss_tmpl = Periodic(
+            name="hwpss_template",
+            key=defaults.hwp_angle,
+            flags=defaults.shared_flags,
+            flag_mask=defaults.shared_mask_invalid,
+            bins=64,
+        )
+
+        # Simple offset template
+        offset_tmpl = Offset(
+            name="offset_template",
+            times=defaults.times,
+            noise_model=default_model.noise_model,
+            step_time=2.0 * u.second,
+            use_noise_prior=False,
+            precond_width=1,
+        )
+
+        tmatrix = ops.TemplateMatrix(templates=[offset_tmpl, hwpss_tmpl])
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="satellite_hwp",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-1,
+            write_hits=True,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=False,
+            keep_final_products=False,
+            save_cleaned=True,
+            overwrite_cleaned=True,
+            output_dir=testdir,
+        )
+
+        # Make the map
+        mapper.apply(data)
+
+        # Write offset amplitudes
+        oamps = data[f"{mapper.name}_solve_amplitudes"][offset_tmpl.name]
+        # print(f"Offset amps = {oamps}")
+        oroot = os.path.join(testdir, f"{mapper.name}_offset")
+        offset_tmpl.write(oamps, oroot)
+
+        # Dump out the periodic template amplitudes
+        pamps = data[f"{mapper.name}_solve_amplitudes"][hwpss_tmpl.name]
+        pfile = os.path.join(testdir, f"{mapper.name}_hwpss.h5")
+        pplot_root = os.path.join(testdir, f"{mapper.name}_hwpss-template")
+        hwpss_tmpl.write(pamps, pfile)
+
+        # Plot some results
+        if data.comm.world_rank == 0:
+            perplot(pfile, out_root=pplot_root)
+            for ob in data.obs:
+                offplot(
+                    f"{oroot}_{ob.name}.h5",
+                    compare={x: ob.detdata["input"][x, :] for x in ob.local_detectors},
+                    out=f"{oroot}_{ob.name}",
+                )
+            self.plot_compare(
+                testdir, data, mapper.name, comps=["sky", "noise", "hwpss"]
+            )
+            hit_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
+            map_file = os.path.join(testdir, f"{mapper.name}_map.fits")
+            binmap_file = os.path.join(testdir, f"{mapper.name}_binmap.fits")
+            truth_file = os.path.join(testdir, f"sky_{self.nside}_input.fits")
+            plot_healpix_maps(
+                hitfile=hit_file,
+                mapfile=map_file,
+                truth=truth_file,
+                range_I=(-2, 2),
+                range_Q=(-0.5, 0.5),
+                range_U=(-0.5, 0.5),
+            )
+            plot_healpix_maps(
+                hitfile=hit_file,
+                mapfile=binmap_file,
+                truth=truth_file,
+                range_I=(-2, 2),
+                range_Q=(-0.5, 0.5),
+                range_U=(-0.5, 0.5),
+            )
+
+        # Compare the cleaned timestreams to the original
+        for ob in data.obs:
+            for det in ob.local_detectors:
+                dof = np.sqrt(ob.n_local_samples)
+                in_rms = np.std(ob.detdata["input"][det])
+                thresh = hwpss_scale * (in_rms / dof)
+                out_rms = np.std(ob.detdata[defaults.det_data][det])
+                print(f"Using threshold {thresh}, input rms = {in_rms}")
+                if out_rms > thresh:
+                    print(f"{ob.name}:{det} output rms = {out_rms} exceeds threshold")
+                    raise RuntimeError("Failed satellite hwpss template regression")
+
+        close_data(data)
+
+    def test_ground_hwp_narrow(self):
+        # Skip this time intensive test for now
+        return
+        if not available_atm:
+            print(
+                "TOAST was compiled without atmosphere support, skipping ground tests"
+            )
+            return
+
+        testdir = os.path.join(self.outdir, "ground_hwp_narrow")
+        if self.comm is None or self.comm.rank == 0:
+            if not os.path.isdir(testdir):
+                os.mkdir(testdir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        proj = "CAR"
+        res = 0.2 * u.degree
+        data = self.create_ground_sim(testdir, 5.0 * u.degree, proj, res)
+
+        # Add HWPSS and make a copy for plotting
+        hwpss_scale = 2.0
+        tod_rms = np.std(data.obs[0].detdata["input"][0])
+        self.fake_hwpss(data, "hwpss", hwpss_scale * tod_rms)
+        ops.Combine(
+            op="add",
+            first="hwpss",
+            second="input",
+            result="input",
+        ).apply(data)
+
+        # Copy the input data into the default field
+        ops.Copy(detdata=[("input", defaults.det_data)]).apply(data)
+
+        # Pointing matrix
+
+        detpointing_radec = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec, quats="quats_radec"
+        )
+        pixels = ops.PixelsWCS(
+            detector_pointing=detpointing_radec,
+            projection=proj,
+            resolution=(res, res),
+            auto_bounds=True,
+            use_astropy=True,
+        )
+        weights = ops.StokesWeights(
+            mode="IQU",
+            detector_pointing=detpointing_radec,
+            hwp_angle=defaults.hwp_angle,
+        )
+
+        # Estimate noise
+        estim = ops.NoiseEstim(
+            det_data=defaults.det_data,
+            out_model="noise_est",
+            lagmax=2048,
+            nbin_psd=64,
+            nsum=1,
+            naverage=64,
+        )
+        estim.apply(data)
+
+        fit_estim = ops.FitNoiseModel(
+            noise_model="noise_est",
+            out_model="noise_fit",
+        )
+        fit_estim.apply(data)
+
+        for ob in data.obs:
+            for det in ob.local_detectors:
+                fplot = os.path.join(testdir, f"noise_est_{det}.pdf")
+                plot_noise_estim(
+                    fplot,
+                    ob[estim.out_model].freq(det),
+                    ob[estim.out_model].psd(det),
+                    fit_freq=ob[fit_estim.out_model].freq(det),
+                    fit_psd=ob[fit_estim.out_model].psd(det),
+                    semilog=False,
+                )
+
+        # Set up binning operator for solving and final binning
+        binner = ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model="noise_fit",
+            view="scanning",
+        )
+
+        # Set up template for HWPSS
+        hwpss_tmpl = Periodic(
+            name="hwpss_template",
+            key=defaults.hwp_angle,
+            flags=defaults.shared_flags,
+            flag_mask=defaults.shared_mask_invalid,
+            bins=64,
+        )
+
+        # Simple offset template
+        offset_tmpl = Offset(
+            name="offset_template",
+            times=defaults.times,
+            noise_model="noise_fit",
+            step_time=2.0 * u.second,
+            use_noise_prior=False,
+            precond_width=1,
+        )
+
+        tmatrix = ops.TemplateMatrix(
+            templates=[
+                hwpss_tmpl,
+                offset_tmpl,
+            ],
+            view="scanning",
+        )
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="ground_hwp",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-3,
+            write_hits=True,
+            write_map=True,
+            write_binmap=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=True,
+            keep_final_products=False,
+            save_cleaned=True,
+            overwrite_cleaned=True,
+            output_dir=testdir,
+        )
+
+        # Make the map
+        mapper.apply(data)
+
+        # Write offset amplitudes
+        oamps = data[f"{mapper.name}_solve_amplitudes"][offset_tmpl.name]
+        # print(f"Offset amps = {oamps}")
+        oroot = os.path.join(testdir, f"{mapper.name}_offset")
+        offset_tmpl.write(oamps, oroot)
+
+        # Dump out the periodic template amplitudes
+        pamps = data[f"{mapper.name}_solve_amplitudes"][hwpss_tmpl.name]
+        pfile = os.path.join(testdir, f"{mapper.name}_hwpss.h5")
+        pplot_root = os.path.join(testdir, f"{mapper.name}_hwpss-template")
+        hwpss_tmpl.write(pamps, pfile)
+
+        # Plot some results
+        if data.comm.world_rank == 0:
+            perplot(pfile, out_root=pplot_root)
+            for ob in data.obs:
+                offplot(
+                    f"{oroot}_{ob.name}.h5",
+                    compare={x: ob.detdata["input"][x, :] for x in ob.local_detectors},
+                    out=f"{oroot}_{ob.name}",
+                )
+            self.plot_compare(
+                testdir, data, mapper.name, comps=["sky", "noise", "atm", "hwpss"]
+            )
+            # self.plot_compare(data, mapper.name, comps=["sky", "noise", "atm"])
+            hit_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
+            map_file = os.path.join(testdir, f"{mapper.name}_map.fits")
+            binmap_file = os.path.join(testdir, f"{mapper.name}_binmap.fits")
+            truth_file = os.path.join(
+                testdir, f"sky_{proj}_{res.to_value(u.arcmin)}_input.fits"
+            )
+            plot_wcs_maps(hitfile=hit_file)
+            plot_wcs_maps(
+                hitfile=hit_file,
+                mapfile=map_file,
+                truth=truth_file,
+                range_I=(-2, 2),
+                range_Q=(-0.5, 0.5),
+                range_U=(-0.5, 0.5),
+            )
+            plot_wcs_maps(
+                hitfile=hit_file,
+                mapfile=binmap_file,
+                truth=truth_file,
+                range_I=(-2, 2),
+                range_Q=(-0.5, 0.5),
+                range_U=(-0.5, 0.5),
+            )
+
+        # Compare the cleaned timestreams to the original
+        for ob in data.obs:
+            for det in ob.local_detectors:
+                dof = np.sqrt(ob.n_local_samples)
+                in_rms = np.std(ob.detdata["input"][det])
+                thresh = hwpss_scale * (in_rms / dof)
+                out_rms = np.std(ob.detdata[defaults.det_data][det])
+                print(f"Using threshold {thresh}, input rms = {in_rms}")
+                if out_rms > thresh:
+                    print(f"{ob.name}:{det} output rms = {out_rms} exceeds threshold")
+                    # This failure is expected until a more sophisticated template
+                    # is implemented for atmosphere removal.
+                    # raise RuntimeError("Failed ground hwpss template regression")
+
+        close_data(data)


### PR DESCRIPTION
This adds a new template that regresses components of detector data that are correlated with a shared data field whose values are periodic (HWP angle, Azimuth, etc). The values of the periodic field are binned and a
different set of template amplitudes are solved for each detector and each observation.  Additional changes:

* Unit test for fake HWPSS removal in satellite and ground simulations.

* Unit test helper for healpix map plotting, similar to the helper function for WCS plotting.

* Added functions to the Offset template to support writing and plotting solved amplitudes.

* Small improvement to noise model fitting.

* Run format_source.sh

Below are some plots from the unit tests, showing the removal of fake HWPSS in the template-cleaned timestream prior to final binning.
[satellite_hwp-compare_test_000005_2023-02-23T00:50+00:00_1677113400_D0A-150_500.pdf](https://github.com/hpc4cmb/toast/files/12332207/satellite_hwp-compare_test_000005_2023-02-23T00.50%2B00.00_1677113400_D0A-150_500.pdf)
[satellite_hwp-compare_test_000005_2023-02-23T00:50+00:00_1677113400_D0A-150_6000.pdf](https://github.com/hpc4cmb/toast/files/12332208/satellite_hwp-compare_test_000005_2023-02-23T00.50%2B00.00_1677113400_D0A-150_6000.pdf)
