### PR TITLE
fix broken scheduling mode

### DIFF
--- a/src/toast/schedule_sim_ground.py
+++ b/src/toast/schedule_sim_ground.py
@@ -1027,6 +1027,7 @@ def attempt_scan_pole(
                 patch,
                 boresight_angle,
             )
+            el = None
             success = True
             break
         # In pole scheduling, first elevation is just below the patch
@@ -1917,29 +1918,42 @@ def add_cooler_cycle(
     moon_phase2 = moon.phase
 
     # Create an entry in the schedule
-    entry = fout_fmt.format(
-        to_UTC(t1),
-        to_UTC(t2),
-        to_MJD(t1),
-        to_MJD(t2),
-        boresight_angle,
-        patch.name,
-        az,
-        az,
-        el,
-        "R",
-        sun_el1,
-        sun_az1,
-        sun_el2,
-        sun_az2,
-        moon_el1,
-        moon_az1,
-        moon_el2,
-        moon_az2,
-        0.005 * (moon_phase1 + moon_phase2),
-        patch.hits,
-        0,
-    )
+    if args.verbose_schedule:
+        entry = fout_fmt.format(
+            to_UTC(t1),
+            to_UTC(t2),
+            to_MJD(t1),
+            to_MJD(t2),
+            boresight_angle,
+            patch.name,
+            az,
+            az,
+            el,
+            "R",
+            sun_el1,
+            sun_az1,
+            sun_el2,
+            sun_az2,
+            moon_el1,
+            moon_az1,
+            moon_el2,
+            moon_az2,
+            0.005 * (moon_phase1 + moon_phase2),
+            patch.hits,
+            0,
+        )
+    else:
+        entry = fout_fmt.format(
+            to_UTC(t1),
+            to_UTC(t2),
+            boresight_angle,
+            patch.name,
+            az,
+            az,
+            el,
+            patch.hits,
+            0,
+        )
 
     # Write the entry
     log.debug(entry)


### PR DESCRIPTION
Forgot to add the `verbose` option to Pole schedules. Clearing this out to file another change in the scheduler format.