### PR TITLE
Unwrap the HWP angle before perturbing and guard against stepped HWP

### DIFF
--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -213,7 +213,14 @@ class PerturbHWP(Operator):
                     raise RuntimeError("Simulated timing error causes time travel")
 
                 # Simulate rate drift
-                nominal_rate = (hwp_angle[-1] - hwp_angle[0]) / time_delta
+                unwrapped = np.unwrap(hwp_angle)
+                median_step = np.median(np.diff(unwrapped))
+                if np.abs(median_step) < 1e-10:
+                    # This was a stepped HWP, not continuously rotating
+                    msg = f"Don't know now to perturb a stepped HWP.  "
+                    msg += f"Median step size is {np.degrees(median_step)} deg"
+                    raise ValueError(msg)
+                nominal_rate = (unwrapped[-1] - unwrapped[0]) / time_delta
                 if self.drift_sigma is None:
                     begin_rate = nominal_rate
                     accel = 0

--- a/src/toast/tests/ops_perturbhwp.py
+++ b/src/toast/tests/ops_perturbhwp.py
@@ -80,3 +80,22 @@ class PerturbHWPTest(MPITestCase):
         assert rms > 1e-6, "HWP angle does not change enough when perturbed"
 
         close_data(data)
+
+    def test_perturbhwp_stepped(self):
+        # Create fake observing of a small patch
+        data = create_ground_data(self.comm)
+
+        times = data.obs[0].shared[defaults.times].data.copy()
+        orig = data.obs[0].shared[defaults.hwp_angle]
+        orig[:] = np.round(np.linspace(0, 10, times.size)) * np.pi / 8
+
+        perturb = ops.PerturbHWP(
+            drift_sigma=0.1 / u.h,
+            time_sigma=1e-3 * u.s,
+            realization=1,
+        )
+
+        with self.assertRaises(ValueError):
+            perturb.apply(data)
+
+        close_data(data)


### PR DESCRIPTION
Handle situations where the HWP angle is not continuous.