### PR TITLE
Stokes_weights fixes

### DIFF
--- a/src/toast/ops/stokes_weights/kernels_jax.py
+++ b/src/toast/ops/stokes_weights/kernels_jax.py
@@ -53,7 +53,7 @@ def stokes_weights_IQU_inner(eps, cal, gamma, pin, hwpang, IAU):
     )
     alpha_x = vm_x * vo[0] + vm_y * vo[1] + vm_z * vo[2]
     alpha = jnp.arctan2(alpha_y, alpha_x)
-    ang = 2.0 * (alpha + 2.0 * (hwpang - gamma))
+    ang = 2.0 * (2.0 * (gamma - hwpang) - alpha)
     weights = jnp.array(
         [cal, jnp.cos(ang) * eta * cal, -jnp.sin(ang) * eta * cal * IAU]
     )

--- a/src/toast/ops/stokes_weights/kernels_jax.py
+++ b/src/toast/ops/stokes_weights/kernels_jax.py
@@ -65,7 +65,7 @@ def stokes_weights_IQU_inner(eps, cal, gamma, pin, hwpang, IAU):
 #    stokes_weights_IQU_inner,
 #    in_axes=[
 #        ["detectors"],  # epsilon
-#        [...],  # cal
+#        ["detectors"],  # cal
 #        ["detectors"],  # gamma
 #        ["detectors", "intervals", "interval_size", ...],  # quats
 #        ["intervals", "interval_size"], # hwp
@@ -83,7 +83,7 @@ stokes_weights_IQU_inner = jax.vmap(
     stokes_weights_IQU_inner, in_axes=[None, None, None, 0, 0, None], out_axes=0
 )  # intervals
 stokes_weights_IQU_inner = jax.vmap(
-    stokes_weights_IQU_inner, in_axes=[0, None, 0, 0, None, None], out_axes=0
+    stokes_weights_IQU_inner, in_axes=[0, 0, 0, 0, None, None], out_axes=0
 )  # detectors
 
 
@@ -112,7 +112,7 @@ def stokes_weights_IQU_interval(
         hwp (array, float64):  The HWP angles (size n_samp).
         epsilon (array, float):  The cross polar response (size n_det).
         gamma (array, float):  The polarization orientation angle of each detector.
-        cal (array):  A constant to apply to the pointing weights.
+        cal (array, float64):  An array to apply to the pointing weights (size n_det).
         IAU (bool):  Whether to use IAU convention.
         interval_starts (array, int): size n_view
         interval_ends (array, int): size n_view
@@ -188,7 +188,7 @@ def stokes_weights_IQU_jax(
         intervals (array, Interval): The intervals to modify (size n_view)
         epsilon (array, float):  The cross polar response (size n_det).
         gamma (array, float):  The polarization orientation angle of each detector.
-        cal (array):  A constant to apply to the pointing weights.
+        cal (array, float64):  An array to apply to the pointing weights (size n_det).
         IAU (bool):  If True, use IAU convention.
         use_accel (bool): should we use the accelerator
 
@@ -237,7 +237,7 @@ def stokes_weights_I_interval(
     Args:
         weight_index (array, int): The indexes of the weights (size n_det)
         weights (array, float64): The flat packed detectors weights for the specified mode (size n_det*n_samp)
-        cal (array):  A constant to apply to the pointing weights.
+        cal (array, float64):  An array to apply to the pointing weights (size n_det).
         interval_starts (array, int): size n_view
         interval_ends (array, int): size n_view
         intervals_max_length (int): maximum length of an interval
@@ -256,9 +256,7 @@ def stokes_weights_I_interval(
 
     # updates results and returns
     # weights[weight_index,intervals] = cal
-    #
-    # FIXME: cal is an array
-    weights = JaxIntervals.set(weights, (weight_index, intervals), cal)
+    weights = JaxIntervals.set(weights, (weight_index, intervals), cal[:, jnp.newaxis, jnp.newaxis])
     return weights
 
 
@@ -279,7 +277,7 @@ def stokes_weights_I_jax(weight_index, weights, intervals, cal, use_accel):
         weight_index (array, int): The indexes of the weights (size n_det)
         weights (array, float64): The flat packed detectors weights for the specified mode (size n_det*n_samp)
         intervals (array, Interval): The intervals to modify (size n_view)
-        cal (array):  A constant to apply to the pointing weights.
+        cal (array, float64):  An array to apply to the pointing weights (size n_det).
         use_accel (bool): should we use the accelerator
 
     Returns:

--- a/src/toast/ops/stokes_weights/kernels_numpy.py
+++ b/src/toast/ops/stokes_weights/kernels_numpy.py
@@ -67,7 +67,8 @@ def stokes_weights_IQU_numpy(
             if hwp is None:
                 ang = 2.0 * alpha
             else:
-                ang = 2.0 * (alpha + 2.0 * (hwp - gamma[idet]))
+                ang = 2.0 * (2.0 * (gamma[idet] - hwp) - alpha)
+
 
             weights[widx][samples, 0] = cal[idet]
             weights[widx][samples, 1] = cal[idet] * eta * np.cos(ang)


### PR DESCRIPTION
Fixed:
* shape and use of `cal` in the `stokes_weights` kernels since it is now an array of size `ndets`,
* formula to compute `ang` in the Numpy and JAX `stokes_weights_IQU` kernels (ported the updated C++ one).