### PR TITLE
Jax interval map

### DIFF
--- a/src/toast/jax/CMakeLists.txt
+++ b/src/toast/jax/CMakeLists.txt
@@ -4,6 +4,7 @@
 install(FILES
     __init__.py
     intervals.py
+    maps.py
     mutableArray.py
     device.py 
     DESTINATION ${PYTHON_SITE}/toast/jax

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -5,6 +5,12 @@ from copy import deepcopy
 from types import EllipsisType
 from inspect import Signature, Parameter
 
+# TODO: common error that should be caught with a nice error message
+# - passing the wrong number of arguments to the functions (missing some)
+#
+# can I catch:
+# - errors with the order of inputs?
+
 #----------------------------------------------------------------------------------------
 # PYTREE FUNCTIONS
 

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -1,0 +1,535 @@
+import jax
+from jax import vmap, lax
+from jax import numpy as jnp
+from copy import deepcopy
+from types import EllipsisType
+from inspect import Signature, Parameter
+
+#----------------------------------------------------------------------------------------
+# PYTREE FUNCTIONS
+
+def is_pytree_leaf(structure):
+    """
+    Determines if the given structure is a leaf of a pytree.
+    
+    Args:
+        structure: The structure to check.
+    
+    Returns:
+        True if the structure is a leaf, False otherwise.
+    """
+    if isinstance(structure, jax.Array):
+        # An array is considered a leaf
+        return True
+    if isinstance(structure, list):
+        # A list with no sublists, dictionaries, or tuples is a leaf
+        return not any(isinstance(elem, (list, dict, tuple)) for elem in structure)
+    # All other types are not leaves
+    return False
+
+def map_pytree_leaves(func, structure, func_single_values=lambda v: v):
+    """
+    Applies a function to all leaves in the pytree.
+    
+    Args:
+        func: The function to apply to the leaves.
+        structure: The pytree to apply the function to.
+        func_single_values: The function to apply to single values (non-pytree elements).
+    
+    Returns:
+        The transformed pytree.
+    """
+    if is_pytree_leaf(structure):
+        return func(structure)
+    elif isinstance(structure, dict):
+        return {k: map_pytree_leaves(func, v, func_single_values) for k, v in structure.items()}
+    elif isinstance(structure, list):
+        return [map_pytree_leaves(func, v, func_single_values) for v in structure]
+    elif isinstance(structure, tuple):
+        return tuple(map_pytree_leaves(func, v, func_single_values) for v in structure)
+    else:
+        return func_single_values(structure)
+
+def map2_pytree_leaves(func, pytree1, pytree2, func_single_values=lambda v1, v2: v1):
+    """
+    Applies a function to corresponding leaves of two pytrees.
+
+    Args:
+        func: The function to apply to the leaves.
+        pytree1: The first pytree.
+        pytree2: The second pytree.
+        func_single_values: The function to apply to single values (non-pytree elements).
+
+    Returns:
+        The transformed pytree.
+    """
+    if is_pytree_leaf(pytree1):
+        return func(pytree1, pytree2)
+    elif isinstance(pytree1, dict):
+        return {k: map2_pytree_leaves(func, v1, v2, func_single_values) 
+                for ((k, v1), v2) in zip(pytree1.items(), pytree2.values())}
+    elif isinstance(pytree1, list):
+        return [map2_pytree_leaves(func, v1, v2, func_single_values) 
+                for v1, v2 in zip(pytree1, pytree2)]
+    elif isinstance(pytree1, tuple):
+        return tuple(map2_pytree_leaves(func, v1, v2, func_single_values) 
+                     for v1, v2 in zip(pytree1, pytree2))
+    else:
+        return func_single_values(pytree1, pytree2)
+
+def pytree_to_string(pytree):
+    """
+    Converts a pytree to a string representation.
+
+    Args:
+        pytree: The pytree to convert.
+
+    Returns:
+        A string representation of the pytree.
+    """
+    if is_pytree_leaf(pytree) and isinstance(pytree, list):
+        items = ", ".join(pytree_to_string(item) for item in pytree)
+        return f"Array[{items}]"
+    elif isinstance(pytree, dict):
+        items = ", ".join(f"{k}: {pytree_to_string(v)}" for k, v in pytree.items())
+        return f"{{{items}}}"
+    elif isinstance(pytree, list):
+        items = ", ".join(pytree_to_string(item) for item in pytree)
+        return f"[{items}]"
+    elif isinstance(pytree, tuple):
+        items = ", ".join(pytree_to_string(item) for item in pytree)
+        return f"({items})"
+    elif isinstance(pytree, str):
+        return pytree  # Return string without quotes
+    elif isinstance(pytree, EllipsisType):
+        return "..."
+    elif isinstance(pytree, type):
+        return pytree.__name__
+    else:
+        return str(pytree)  # Fallback for other types
+
+#------------------------------------------------
+
+def check_pytree_axis(data, axis, info=""):
+    """
+    Checks that the data's shape is concordant with the given axis.
+
+    Args:
+        data: The data to check.
+        axis: The axis to check against.
+        info: Additional info to include in error messages.
+
+    Raises:
+        AssertionError: If the data's shape does not match the given axis.
+    """
+    if is_pytree_leaf(axis):
+        assert len(axis) == data.ndim, f"{info} axis ({axis}) != {data.shape}"
+    elif isinstance(axis, dict):
+        assert len(axis) == len(data), f"{info} axis ({axis}) != len(data) ({len(data)})"
+        data_items = data.values() if isinstance(data, dict) else data
+        for d, (k, a) in zip(data_items, axis.items()):
+            check_pytree_axis(d, a, f"{info} {k}:")
+    elif isinstance(axis, (list, tuple)):
+        assert len(axis) == len(data), f"{info} axis ({axis}) != len(data) ({len(data)})"
+        for d, a in zip(data, axis):
+            check_pytree_axis(d, a, info)
+    # we do not cover the case of single values as they are ssumed to be matching
+
+def find_in_pytree(condition, structure):
+    """
+    Returns the first element in a pytree for which a condition is True.
+
+    Args:
+        condition: A function that evaluates to True or False for a given value.
+        structure: The pytree to search through.
+
+    Returns:
+        The first element that meets the condition, or None if no such element is found.
+    """
+    if is_pytree_leaf(structure):
+        # Check if the leaf contains a matching element
+        for value in structure:
+            if condition(value):
+                return value
+    elif isinstance(structure, (list, tuple, dict)):
+        # Check if the container has a matching sub-container
+        data = structure.values() if isinstance(structure, dict) else structure
+        for element in data:
+            result = find_in_pytree(condition, element)
+            if result is not None:
+                return result
+    # No match found
+    return None
+
+def map_pytree(func, structure):
+    """
+    Applies a function to all elements in the leaves of the pytree.
+
+    Args:
+        func: The function to apply.
+        structure: The pytree to apply the function to.
+
+    Returns:
+        The pytree with the function applied to each element in its leaves.
+    """
+    def map_leaf(leaf):
+        return [func(v) for v in leaf]
+
+    return map_pytree_leaves(map_leaf, structure, func)
+
+def filter_pytree(condition, structure):
+    """
+    Filters elements in the leaves of a pytree based on a condition.
+
+    Args:
+        condition: A function that returns True for elements to keep.
+        structure: The pytree to filter.
+
+    Returns:
+        A new pytree with only the elements that satisfy the condition.
+    """
+    def filter_leaf(leaf):
+        return [v for v in leaf if condition(v)]
+
+    return map_pytree_leaves(filter_leaf, structure)
+
+def index_in_pytree(value, structure):
+    """
+    Finds the index of a value in all leaves of a pytree.
+
+    Args:
+        value: The value to search for.
+        structure: The pytree to search within.
+
+    Returns:
+        The pytree structure with indices of the value in its leaves, or None where the value is not present.
+    """
+    def index_leaf(leaf):
+        return leaf.index(value) if value in leaf else None
+
+    # Applies the function to all leaves, mapping single non-leaf values to None
+    return map_pytree_leaves(index_leaf, structure, lambda x: None)
+
+def replace_in_pytree(value, new_value, structure):
+    """
+    Replaces all instances of a specified value in the leaves of a pytree with a new value.
+
+    Args:
+        value: The value to be replaced.
+        new_value: The new value to replace with. Can be a single value or a tuple of values.
+        structure: The pytree in which to perform the replacement.
+
+    Returns:
+        The pytree with the value replaced.
+    """
+    new_values = list(new_value) if isinstance(new_value, tuple) else [new_value]
+
+    def replace_leaf(leaf):
+        new_leaf = []
+        for v in leaf:
+            if v == value:
+                new_leaf.extend(new_values)
+            else:
+                new_leaf.append(v)
+        return new_leaf
+
+    return map_pytree_leaves(replace_leaf, structure)
+
+#----------------------------------------------------------------------------------------
+# INDEXING
+
+# Full slice, equivalent to `:` in `[:]`.
+ALL = slice(None, None, None)
+
+def is_valid_key(key):
+    """
+    Determines if a key is valid for indexing in a pytree.
+
+    Args:
+        key: The key to validate.
+
+    Returns:
+        True if the key is valid, False otherwise.
+    """
+    return isinstance(key, (tuple, int, jax.Array))
+
+def get_from_pytree(data, key):
+    """
+    Retrieves an element from a pytree using a key, equivalent to `data[key]`.
+
+    Args:
+        data: The pytree from which to retrieve the element.
+        key: The key for indexing.
+
+    Returns:
+        The element from the pytree corresponding to the given key.
+    """
+    def get_leaf(data_leaf, key_leaf):
+        return data_leaf[key_leaf] if is_valid_key(key_leaf) else data_leaf
+
+    return map2_pytree_leaves(get_leaf, data, key)
+
+def set_in_pytree(data, key, value):
+    """
+    Sets an element in a pytree using a key, equivalent to `data[key] = value`.
+
+    Args:
+        data: The pytree in which to set the value.
+        key: The key for indexing.
+        value: The value to set.
+
+    Returns:
+        The pytree with the specified value set at the specified key.
+    """
+    value_keys = map2_pytree_leaves(lambda v, k: (v, k), value, key)
+
+    def set_leaf(data_leaf, vk_leaf):
+        value_leaf, key_leaf = vk_leaf
+        return data_leaf.at[key_leaf].set(value_leaf) if is_valid_key(key_leaf) else data_leaf
+
+    return map2_pytree_leaves(set_leaf, data, value_keys)
+def get_index_from_pytree(data, data_axes, index, index_axis):
+    """
+    Generates a key by setting the index_axis to index, and retrieves the corresponding element from the pytree.
+
+    Args:
+        data: The pytree to index into.
+        data_axes: The axes specification of the pytree.
+        index: The index to retrieve.
+        index_axis: The axis along which to index.
+
+    Returns:
+        The element from the pytree at the specified index and axis.
+    """
+    def list_to_key(axes):
+        return tuple(index if a == index_axis else ALL for a in axes)
+
+    key = map_pytree_leaves(list_to_key, data_axes)
+    return get_from_pytree(data, key)
+
+def set_index_in_pytree(data, data_axes, index, index_axis, value):
+    """
+    Generates a key by setting the index_axis to index and sets the corresponding element in the pytree.
+
+    Args:
+        data: The pytree in which to set the value.
+        data_axes: The axes specification of the pytree.
+        index: The index to set.
+        index_axis: The axis along which to set the value.
+        value: The value to set.
+
+    Returns:
+        The pytree with the specified value set at the specified index and axis.
+    """
+    def list_to_key(axes):
+        return tuple(index if a == index_axis else ALL for a in axes)
+
+    key = map_pytree_leaves(list_to_key, data_axes)
+    return set_in_pytree(data, key, value)
+
+#----------------------------------------------------------------------------------------
+# FUNCTION WRAPING
+
+def args_to_kwargs(args, keys):
+    """
+    Converts a list of arguments into a dictionary of keyword arguments.
+
+    Args:
+        args: A list of arguments.
+        keys: A list of keys corresponding to the arguments.
+
+    Returns:
+        A dictionary where keys are from 'keys' and values are from 'args'.
+    """
+    if len(args) != len(keys):
+        raise ValueError("The number of arguments and keys must be the same")
+
+    return dict(zip(keys, args))
+
+def kwargs_to_args(kwargs):
+    """
+    Converts a dictionary of keyword arguments into a list of values.
+
+    Args:
+        kwargs: The dictionary of keyword arguments.
+
+    Returns:
+        A list of values from the dictionary.
+    """
+    return list(kwargs.values())
+
+def runtime_check_axis(func, in_axes, out_axes):
+    """
+    Wraps a function to check its axes against a specification at runtime.
+
+    Args:
+        func: The function to wrap.
+        in_axes: The input axes specification.
+        out_axes: The output axes specification.
+
+    Returns:
+        The wrapped function.
+    """
+    def wrapped_func(*args):
+        check_pytree_axis(args, in_axes, info="INPUT:")
+        output = func(*args)
+        check_pytree_axis(output, out_axes, info="OUTPUT:")
+        return output
+
+    return wrapped_func
+
+def set_documentation(func, in_axes, out_axes, reference_func=None):
+    """
+    Adds documentation to a function following the axis specification.
+
+    Args:
+        func: The function to document.
+        in_axes: The input axes specification.
+        out_axes: The output axes specification.
+        reference_func: The reference function for documentation. If None, 'func' is used.
+
+    Returns:
+        The function with added documentation.
+    """
+    reference_func = reference_func or func
+    doc = f"Original documentation of {reference_func.__name__}:\n{reference_func.__doc__}\n"
+    doc += '\nArgs:\n'
+    for key, val in in_axes.items():
+        doc += f"    {key}: {pytree_to_string(val)}\n"
+    doc += '\nReturns:\n' + '    ' +  pytree_to_string(out_axes)
+    func.__doc__ = doc
+
+    parameters = [Parameter(name, Parameter.POSITIONAL_OR_KEYWORD) for name in in_axes.keys()]
+    func.__signature__ = Signature(parameters)
+    return func
+#----------------------------------------------------------------------------------------
+# XMAP
+
+def recursive_xmap(f, in_axes, out_axes):
+    """
+    Implements 'xmap' by applying 'vmap' recursively.
+
+    Args:
+        f: The function to be mapped.
+        in_axes: The input axes mappings for 'f'.
+        out_axes: The output axes mappings for 'f'.
+
+    Returns:
+        The transformed function.
+    """
+    # Finds the first named output axis
+    named_output_axis = find_in_pytree(lambda a: isinstance(a, str), out_axes)
+
+    # If no more named output axes, return the function with runtime axis check
+    if named_output_axis is None:
+        named_input_axis = find_in_pytree(lambda a: isinstance(a, str), in_axes)
+        assert named_input_axis is None, f"Unused input axis: {named_input_axis}. Check output axes."
+        return runtime_check_axis(f, in_axes, out_axes)
+
+    # Remove axis from inputs and outputs
+    filtered_in_axes = filter_pytree(lambda a: a != named_output_axis, in_axes)
+    filtered_out_axes = filter_pytree(lambda a: a != named_output_axis, out_axes)
+
+    # Recursively map over the remaining axes
+    f_batched = recursive_xmap(f, filtered_in_axes, filtered_out_axes)
+
+    # Get indices of the axis in inputs and outputs
+    in_axes_indices = index_in_pytree(named_output_axis, list(in_axes.values()))
+    out_axes_indices = index_in_pytree(named_output_axis, out_axes)
+
+    # Apply vmap to remove the current axis
+    f_result = vmap(f_batched, in_axes=in_axes_indices, out_axes=out_axes_indices)
+    return runtime_check_axis(f_result, in_axes, out_axes)
+
+def xmap(f, in_axes, out_axes):
+    """
+    A wrapper function for applying 'xmap' to a given function.
+
+    Args:
+        f: The function to apply 'xmap' to.
+        in_axes: The input axes mappings.
+        out_axes: The output axes mappings.
+
+    Returns:
+        The batched and documented version of 'f'.
+    """
+    # TODO run assertions to insure that inputs are correct
+
+    # Batch the function
+    f_batched = recursive_xmap(f, in_axes, out_axes)
+
+    # Add documentation
+    return set_documentation(f_batched, in_axes, out_axes, reference_func=f)
+
+#----------------------------------------------------------------------------------------
+# IMAP
+
+def imap(f, in_axes, interval_axis, interval_starts, interval_ends, interval_max_length,
+         output_name, output_as_input=False):
+    """
+    Extends xmap to handle intervals with padding and reshaping.
+
+    Args:
+        f (callable): The function to be mapped.
+        in_axes (dict): The axes mappings for the input of `f`.
+        interval_axis (str): Axis name used for the interval.
+        interval_starts (str): Input name containing the starts of the interval.
+        interval_ends (str): Input name containing the ends (exclusive) of the interval.
+        interval_max_length (str): Input name containing the max length of the interval (static if jitted).
+        output_name (str): Input name containing the output value.
+        output_as_input (bool): Whether the output value should be used as an input to f.
+
+    Returns:
+        callable: The transformed function.
+    """
+    out_axes = in_axes[output_name]
+    interval_length_axis = f"{interval_axis}_length"
+    num_intervals_axis = in_axes[interval_starts][0]
+
+    in_axes_inner = filter_pytree(lambda a: isinstance(a, EllipsisType) or a == interval_axis, in_axes)
+    in_axes_inner[interval_max_length] = []
+    out_axes_inner_interval = filter_pytree(lambda a: isinstance(a, EllipsisType) or a == interval_axis, out_axes)
+    out_axes_inner = filter_pytree(lambda a: isinstance(a, EllipsisType), out_axes)
+
+    def inner_function(*args):
+        kwargs = args_to_kwargs(args, in_axes_inner.keys())
+        start, end = kwargs[interval_starts], kwargs[interval_ends]
+        absolute_index, output_data = kwargs[interval_max_length], kwargs[output_name]
+        index = start + absolute_index
+
+        def compute_within_interval():
+            input_at_index = get_index_from_pytree(kwargs, in_axes_inner, index, interval_axis)
+            for key in [interval_starts, interval_ends, interval_max_length]:
+                input_at_index.pop(key, None)
+            if not output_as_input:
+                input_at_index.pop(output_name, None)
+            return f(*kwargs_to_args(input_at_index))
+
+        def compute_outside_interval():
+            return get_index_from_pytree(output_data, out_axes_inner_interval, index, interval_axis)
+
+        output_at_index = lax.cond(index < end, compute_within_interval, compute_outside_interval)
+        return output_at_index
+
+    inner_function = runtime_check_axis(inner_function, in_axes_inner, out_axes_inner)
+
+    in_axes_batched = replace_in_pytree(interval_axis, (...), in_axes)
+    in_axes_batched[interval_max_length] = [interval_length_axis]
+    out_axes_batched = replace_in_pytree(interval_axis, (num_intervals_axis, interval_length_axis), out_axes)
+    batched_function = xmap(inner_function, in_axes_batched, out_axes_batched)
+
+    in_axes_outer = deepcopy(in_axes)
+    out_axes_outer = deepcopy(out_axes)
+
+    def outer_function(*args):
+        kwargs = args_to_kwargs(args, in_axes_outer.keys())
+        max_length, starts, output = kwargs[interval_max_length], kwargs[interval_starts], kwargs[output_name]
+        kwargs[interval_max_length] = jnp.arange(max_length)
+
+        output_interval = batched_function(*kwargs_to_args(kwargs))
+        indices_interval = starts[:, None] + jnp.arange(max_length)
+        output = set_index_in_pytree(output, out_axes_outer, indices_interval, interval_axis, output_interval)
+        return output
+
+    outer_function = runtime_check_axis(outer_function, in_axes_outer, out_axes_outer)
+    return set_documentation(outer_function, in_axes, out_axes, reference_func=f)

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -453,7 +453,7 @@ def xmap(f, in_axes, out_axes):
         out_axes: The output axes mappings.
 
     Returns:
-        The batched and documented version of 'f'.
+        callable: The batched and documented version of 'f'.
     """
     # TODO run assertions to insure that inputs are correct
 

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -9,7 +9,7 @@ from inspect import Signature, Parameter
 # - passing the wrong number of arguments to the functions (missing some)
 #
 # can I catch:
-# - errors with the order of inputs?
+# - errors with the order of inputs? -> we can at least catch inputs with incorect shape / type
 
 #----------------------------------------------------------------------------------------
 # PYTREE FUNCTIONS

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -525,7 +525,8 @@ def imap(f, in_axes, interval_axis,
             # Retrieves existing output data for indices outside the interval.
             return get_index_from_pytree(output_data, out_axes_inner_interval, index, interval_axis)
 
-        output_at_index = lax.cond(index < end, compute_within_interval, compute_outside_interval)
+        # NOTE: <= because toast intervals are inclusive
+        output_at_index = lax.cond(index <= end, compute_within_interval, compute_outside_interval)
         return output_at_index
     inner_function = runtime_check_axis(inner_function, in_axes_inner, out_axes_inner)
 

--- a/src/toast/jax/maps.py
+++ b/src/toast/jax/maps.py
@@ -8,6 +8,9 @@ from inspect import Signature, Parameter
 # TODO: common error that should be caught with a nice error message
 # - passing the wrong number of arguments to the functions (missing some)
 #
+# set f"{interval_axis}_length" to the iterval_max_length axis name for easier use?
+# (used int he template offset operator)
+#
 # can I catch:
 # - errors with the order of inputs? -> we can at least catch inputs with incorect shape / type
 

--- a/src/toast/ops/mapmaker_utils/kernels_jax.py
+++ b/src/toast/ops/mapmaker_utils/kernels_jax.py
@@ -368,7 +368,4 @@ def cov_accum_diag_invnpp_jax(
 
 
 # To test:
-# python -c 'import toast.tests; toast.tests.run("ops_mapmaker_utils"); toast.tests.run("covariance");'
-
-# To test:
-# python -c 'import toast.tests; toast.tests.run("ops_sim_tod_conviqt", "ops_mapmaker_utils", "ops_mapmaker_binning", "ops_sim_tod_dipole", "ops_demodulate");'
+# export TOAST_GPU_JAX=true; export TOAST_GPU_HYBRID_PIPELINES=true; export TOAST_LOGLEVEL=DEBUG; python -c 'import toast.tests; toast.tests.run("ops_sim_tod_conviqt"); toast.tests.run("ops_mapmaker_utils"); toast.tests.run("covariance"); toast.tests.run("ops_mapmaker_binning"); toast.tests.run("ops_sim_tod_dipole"); toast.tests.run("ops_demodulate");'

--- a/src/toast/ops/mapmaker_utils/kernels_jax.py
+++ b/src/toast/ops/mapmaker_utils/kernels_jax.py
@@ -4,10 +4,10 @@
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.maps import xmap as jax_xmap
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import ALL, INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.maps import imap
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import AlignedF64, AlignedI64, Logger
 

--- a/src/toast/ops/noise_weight/kernels_jax.py
+++ b/src/toast/ops/noise_weight/kernels_jax.py
@@ -6,7 +6,8 @@ import jax
 import jax.numpy as jnp
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.maps import imap
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
 

--- a/src/toast/ops/noise_weight/kernels_jax.py
+++ b/src/toast/ops/noise_weight/kernels_jax.py
@@ -6,10 +6,39 @@ import jax
 import jax.numpy as jnp
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX
 from ...jax.maps import imap
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
+
+def noise_weight_inner(det_data, detector_weights):
+    """
+    multiplies det_data by the weighs in detector_weights
+
+    Args:
+        det_data (float)
+        detector_weights (double): The weight to be used for the detector
+
+    Returns:
+        det_data
+    """
+    return det_data * detector_weights
+
+
+# maps over intervals and detectors
+noise_weight_inner = imap(noise_weight_inner, 
+                    in_axes={
+                        'det_data': ["n_det","n_samp"],
+                        'detector_weights': ["n_det"],
+                        'interval_starts': ["n_intervals"],
+                        'interval_ends': ["n_intervals"],
+                        'intervals_max_length': int
+                    },
+                    interval_axis='n_samp', 
+                    interval_starts='interval_starts', 
+                    interval_ends='interval_ends', 
+                    interval_max_length='intervals_max_length', 
+                    output_name='det_data', output_as_input=True)
 
 
 def noise_weight_interval(
@@ -38,24 +67,15 @@ def noise_weight_interval(
     log = Logger.get()
     log.debug(f"noise_weight: jit-compiling.")
 
-    # extract interval slice
-    intervals = JaxIntervals(
-        interval_starts, interval_ends + 1, intervals_max_length
-    )  # end+1 as the interval is inclusive
-    det_data_interval = JaxIntervals.get(
-        det_data, (det_data_index, intervals)
-    )  # det_data[det_data_index, intervals]
+    # extract indexes
+    det_data_indexed = det_data[det_data_index,:]
 
     # does the computation
-    new_det_data_interval = (
-        det_data_interval * detector_weights[:, jnp.newaxis, jnp.newaxis]
-    )
+    new_det_data_indexed = noise_weight_inner(det_data_indexed, detector_weights,
+                                              interval_starts, interval_ends, intervals_max_length)
 
     # updates results and returns
-    # det_data[det_data_index, intervals] = new_det_data_interval
-    det_data = JaxIntervals.set(
-        det_data, (det_data_index, intervals), new_det_data_interval
-    )
+    det_data = det_data.at[det_data_index,:].set(new_det_data_indexed)
     return det_data
 
 

--- a/src/toast/ops/pixels_healpix/kernels_jax.py
+++ b/src/toast/ops/pixels_healpix/kernels_jax.py
@@ -125,7 +125,7 @@ def pixels_healpix_interval(
 
     # uses out of index submap indices for out of interval values
     dummy_sub_map = jnp.ones_like(pixels_indexed) * (hit_submaps.size+1) # purposefully illegal index, jax will ignore it
-    dummy_hit_submaps = jnp.zeros_like(dummy_sub_map, dtype=hit_submaps.dtype)
+    dummy_hit_submaps = jnp.empty_like(dummy_sub_map, dtype=hit_submaps.dtype)
 
     # does the computation
     outputs = (pixels_indexed, dummy_sub_map, dummy_hit_submaps)

--- a/src/toast/ops/pixels_healpix/kernels_jax.py
+++ b/src/toast/ops/pixels_healpix/kernels_jax.py
@@ -6,55 +6,70 @@ import jax
 import jax.numpy as jnp
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX
 from ...jax.maps import imap
 from ...jax.math import healpix, qarray
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
 
 
-def pixels_healpix_inner(hpix, quats, nest):
+def pixels_healpix_inner(quats, flag, flag_mask, hit_submaps, n_pix_submap, hpix, nest):
     """
     Compute the healpix pixel indices for the detectors.
 
     Args:
-        hpix (HPIX_JAX): Healpix projection object.
         quats (array, float64): Detector quaternion (size 4).
+        flag (uint8): 
+        flag_mask (uint8): integer used to select flags (not necesarely a boolean)
+        hit_submaps (array, uint8): The pointing flags (size ???).
+        n_pix_submap (int):
+        hpix (HPIX_JAX): Healpix projection object.
         nest (bool): If True, then use NESTED ordering, else RING.
 
     Returns:
-        pixels (array, int64): The detector pixel indices to store the result.
+        (pixel,submap,hit_submap) (int64,int64): The detector pixel indices to store the result.
     """
-    # initialize dir
-    dir = qarray.rotate_zaxis(quats)
-
     # pixel computation
+    dir = qarray.rotate_zaxis(quats)
     (phi, region, z, rtz) = healpix.vec2zphi(dir)
     if nest:
         pixel = healpix.zphi2nest(hpix, phi, region, z, rtz)
     else:
         pixel = healpix.zphi2ring(hpix, phi, region, z, rtz)
 
-    return pixel
+    # extract hit submap
+    sub_map = pixel // n_pix_submap
+    hit_submap = hit_submaps[sub_map]
+
+    # applies the flags
+    is_flagged = (flag & flag_mask) != 0
+    pixel = jnp.where(is_flagged, -1, pixel)
+    hit_submap = jnp.where(is_flagged, hit_submap, 1)
+
+    return pixel, sub_map, hit_submap
 
 
 # maps over samples and detectors
-# pixels_healpix_inner = jax_xmap(pixels_healpix_inner,
-#                                 in_axes=[[...], # hpix
-#                                          ['detectors','intervals','interval_size',...], # quats
-#                                          [...]], # nest
-#                                 out_axes=['detectors','intervals','interval_size'])
-# TODO xmap is commented out for now due to a [bug with static argnum](https://github.com/google/jax/issues/10741)
-pixels_healpix_inner = jax.vmap(
-    pixels_healpix_inner, in_axes=[None, 0, None], out_axes=0
-)  # loop on interval_size
-pixels_healpix_inner = jax.vmap(
-    pixels_healpix_inner, in_axes=[None, 0, None], out_axes=0
-)  # loop on intervals
-pixels_healpix_inner = jax.vmap(
-    pixels_healpix_inner, in_axes=[None, 0, None], out_axes=0
-)  # loop on detectors
+pixels_healpix_inner = imap(pixels_healpix_inner, 
+                    in_axes={
+                        'quats': ['n_det','n_samp',...],
+                        'flags': ['n_samp'],
+                        'flag_mask':int,
+                        'hit_submaps': [...],
+                        'n_pix_submap': int,
+                        'hpix': healpix.HPIX_JAX,
+                        'nest': bool,
+                        'interval_starts': ["n_intervals"],
+                        'interval_ends': ["n_intervals"],
+                        'intervals_max_length': int,
+                        'outputs': (["n_det","n_samp"],["n_det","n_samp"],["n_det","n_samp"]),
 
+                    },
+                    interval_axis='n_samp', 
+                    interval_starts='interval_starts', 
+                    interval_ends='interval_ends', 
+                    interval_max_length='intervals_max_length', 
+                    output_name='outputs')
 
 def pixels_healpix_interval(
     quat_index,
@@ -96,52 +111,31 @@ def pixels_healpix_interval(
     log = Logger.get()
     log.debug(f"pixels_healpix: jit-compiling.")
 
-    # flag
-    n_samp = pixels.shape[1]
-    use_flags = (flag_mask != 0) and (flags.size == n_samp)
-
-    # used to extract interval slices
-    intervals = JaxIntervals(
-        interval_starts, interval_ends + 1, intervals_max_length
-    )  # end+1 as the interval is inclusive
-
-    # computes the pixels and submap
+    # create hpix object
     hpix = healpix.HPIX_JAX(nside)
-    quats_interval = JaxIntervals.get(
-        quats, (quat_index, intervals, ALL)
-    )  # quats[quat_index,intervals,:]
-    pixels_interval = pixels_healpix_inner(hpix, quats_interval, nest)
-    sub_map = jnp.ravel(
-        pixels_interval // n_pix_submap
-    )  # flattened to index into the 1D hit_submaps
-    previous_hit_submaps_unflattened = jnp.reshape(
-        hit_submaps[sub_map], newshape=pixels_interval.shape
-    )  # unflattened to apply a 2D mask
 
-    # applies the flags
-    if use_flags:
-        # we pad with 1 such that values out of the interval will be flagged
-        flags_interval = JaxIntervals.get(
-            flags, intervals, padding_value=1
-        )  # flags[intervals]
-        is_flagged = (flags_interval & flag_mask) != 0
-        pixels_interval = jnp.where(is_flagged, -1, pixels_interval)
-        #
-        new_hit_submap_unflattened = jnp.where(
-            is_flagged, previous_hit_submaps_unflattened, 1
-        )
-    else:
-        # masks the padded values in sub_map
-        new_hit_submap_unflattened = jnp.where(
-            intervals.mask, previous_hit_submaps_unflattened, 1
-        )
-    new_hit_submap = jnp.ravel(new_hit_submap_unflattened)
+    # extract indexes
+    quats_indexed = quats[quat_index,:,:]
+    pixels_indexed = pixels[pixel_index,:]
+
+    # cancels flagging if flags is not of the proper size
+    n_samp = pixels.shape[1]
+    if (flags.size != n_samp):
+        flags = jnp.zeros(shape=(n_samp,))
+
+    # uses out of index submap indices for out of interval values
+    dummy_sub_map = jnp.ones_like(pixels_indexed) * (hit_submaps.size+1) # purposefully illegal index, jax will ignore it
+    dummy_hit_submaps = jnp.zeros_like(dummy_sub_map, dtype=hit_submaps.dtype)
+
+    # does the computation
+    outputs = (pixels_indexed, dummy_sub_map, dummy_hit_submaps)
+    new_pixels_indexed, sub_map, new_hit_submaps = pixels_healpix_inner(quats_indexed, flags, flag_mask, hit_submaps, n_pix_submap, hpix, nest,
+                                              interval_starts, interval_ends, intervals_max_length,
+                                              outputs)
 
     # updates results and returns
-    hit_submaps = hit_submaps.at[sub_map].set(new_hit_submap)
-    pixels = JaxIntervals.set(
-        pixels, (pixel_index, intervals), pixels_interval
-    )  # pixels[pixel_index,intervals] = pixels_interval
+    pixels = pixels.at[pixel_index,:].set(new_pixels_indexed)
+    hit_submaps = hit_submaps.at[sub_map].set(new_hit_submaps)
     return pixels, hit_submaps
 
 
@@ -228,4 +222,4 @@ def pixels_healpix_jax(
 
 
 # To test:
-# python -c 'import toast.tests; toast.tests.run("ops_pointing_healpix", "ops_sim_ground", "ops_sim_satellite", "ops_demodulate");'
+# export TOAST_GPU_JAX=true; export TOAST_GPU_HYBRID_PIPELINES=true; export TOAST_LOGLEVEL=DEBUG; python -c 'import toast.tests; toast.tests.run("ops_pointing_healpix"); toast.tests.run("ops_sim_ground"); toast.tests.run("ops_sim_satellite"); toast.tests.run("ops_demodulate");'

--- a/src/toast/ops/pixels_healpix/kernels_jax.py
+++ b/src/toast/ops/pixels_healpix/kernels_jax.py
@@ -6,7 +6,8 @@ import jax
 import jax.numpy as jnp
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import ALL, INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.maps import imap
 from ...jax.math import healpix, qarray
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger

--- a/src/toast/ops/pointing_detector/kernels_jax.py
+++ b/src/toast/ops/pointing_detector/kernels_jax.py
@@ -4,10 +4,9 @@
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.maps import xmap as jax_xmap
-
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import ALL, INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX
+from ...jax.maps import imap
 from ...jax.math import qarray
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
@@ -31,31 +30,23 @@ def pointing_detector_inner(focalplane, boresight, flag, mask):
     )
     return quats
 
-
 # maps over intervals and detectors
-# pointing_detector_inner = jax_xmap(
-#    pointing_detector_inner,
-#    in_axes=[
-#        ["detectors", ...],  # focalplane
-#        ["intervals", "interval_size", ...],  # boresight
-#        ["intervals", "interval_size"],  # flags
-#        [...],
-#    ],  # mask
-#    out_axes=["detectors", "intervals", "interval_size", ...],
-# )
-# using vmap as the static arguments triggers the following error:
-# "ShardingContext cannot be used with xmap"
-# TODO revisit once this issue is solved [bug with static argnum](https://github.com/google/jax/issues/10741)
-pointing_detector_inner = jax.vmap(
-    pointing_detector_inner, in_axes=[None, 0, 0, None], out_axes=0
-)  # interval_size
-pointing_detector_inner = jax.vmap(
-    pointing_detector_inner, in_axes=[None, 0, 0, None], out_axes=0
-)  # intervals
-pointing_detector_inner = jax.vmap(
-    pointing_detector_inner, in_axes=[0, None, None, None], out_axes=0
-)  # detectors
-
+pointing_detector_inner = imap(pointing_detector_inner, 
+                               in_axes={
+                                   'focalplane': ["n_det", ...],
+                                   'boresight': ["n_samp", ...],
+                                   'quats': ["n_det", "n_samp", ...],
+                                   'flag': ["n_samp"],
+                                   'mask': int,
+                                   'interval_starts': ["n_intervals"],
+                                   'interval_ends': ["n_intervals"],
+                                   'intervals_max_length': int
+                               },
+                               interval_axis='n_samp', 
+                               interval_starts='interval_starts', 
+                               interval_ends='interval_ends', 
+                               interval_max_length='intervals_max_length', 
+                               output_name='quats')
 
 def pointing_detector_interval(
     focalplane,
@@ -89,24 +80,15 @@ def pointing_detector_interval(
     log = Logger.get()
     log.debug(f"pointing_detector: jit-compiling.")
 
-    # extract interval slices
-    intervals = JaxIntervals(
-        interval_starts, interval_ends + 1, intervals_max_length
-    )  # end+1 as the interval is inclusive
-    boresight_interval = JaxIntervals.get(
-        boresight, (intervals, ALL)
-    )  # boresight[intervals,:]
-    shared_flags_interval = JaxIntervals.get(
-        shared_flags, intervals
-    )  # shared_flags[intervals]
+    # indexes quats
+    quats_indexed = quats[quat_index,:,:]
 
-    # process the interval then updates quats in place
-    new_quats_interval = pointing_detector_inner(
-        focalplane, boresight_interval, shared_flags_interval, shared_flag_mask
-    )
-    quats = JaxIntervals.set(
-        quats, (quat_index, intervals, ALL), new_quats_interval
-    )  # quats[quat_index,intervals,:] = new_quats_interval
+    # process the intervals
+    new_quats_indexed = pointing_detector_inner(focalplane, boresight, quats_indexed, shared_flags, shared_flag_mask,
+                                              interval_starts, interval_ends, intervals_max_length)
+
+    # updates quats at the index
+    quats = quats.at[quat_index,:,:].set(new_quats_indexed)
     return quats
 
 

--- a/src/toast/ops/polyfilter/kernels_jax.py
+++ b/src/toast/ops/polyfilter/kernels_jax.py
@@ -60,6 +60,7 @@ def filter_poly2D_coeffs(ngroup, det_groups, templates, signals, masks):
         coeff (numpy array, float64):  The N_sample x N_group x N_mode output coefficients.
     """
     # batch on group and sample dimenssions
+    # TODO port to our xmap
     filter_poly2D_sample_group_batched = jax_xmap(
         filter_poly2D_sample_group,
         in_axes=[
@@ -193,7 +194,7 @@ def filter_polynomial_jax(order, flags, signals_list, starts, stops, use_accel):
     signals = np.array(signals_list).T  # n*nsignal
 
     # loop over intervals, this is fine as long as there are only few intervals
-    # TODO port to JaxIntervals, could be done with vmap and setting padding of flags_interval to 1
+    # TODO port to imap
     for start, stop in zip(starts, stops):
         # validates interval
         start = np.maximum(0, start)

--- a/src/toast/ops/scan_map/kernels_jax.py
+++ b/src/toast/ops/scan_map/kernels_jax.py
@@ -6,7 +6,8 @@ import jax
 import jax.numpy as jnp
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import ALL, INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX
+from ...jax.maps import imap
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
 
@@ -16,16 +17,16 @@ def global_to_local(global_pixels, npix_submap, global2local):
     Convert global pixel indices to local submaps and pixels within the submap.
 
     Args:
-        global_pixels (array):  The global pixel indices (size nsamples).
+        global_pixels (int):  The global pixel indice.
         npix_submap (int):  The number of pixels in each submap.
         global2local (array, int64):  The local submap for each global submap.
 
     Returns:
-        (tuple of array):  The (local submap, pixel within submap) for each global pixel (each of size nsamples).
+        (local_submaps, local_pixels) (int,int): (local submap, pixel within submap) for each global pixel.
     """
     quotient, remainder = jnp.divmod(global_pixels, npix_submap)
-    local_pixels = jnp.where(global_pixels < 0, -1, remainder)
-    local_submaps = jnp.where(global_pixels < 0, -1, global2local[quotient])
+    local_pixels = jnp.where(global_pixels < 0, -1, remainder.astype(int))
+    local_submaps = jnp.where(global_pixels < 0, -1, global2local[quotient.astype(int)])
     return (local_submaps, local_pixels)
 
 
@@ -33,9 +34,9 @@ def scan_map_inner(
     mapdata,
     npix_submap,
     global2local,
+    det_data,
     pixels,
     weights,
-    det_data,
     data_scale,
     should_zero,
     should_subtract,
@@ -48,16 +49,16 @@ def scan_map_inner(
         mapdata (array, ?):  The local piece of the map (size ?*npix_submap*nmap).
         npix_submap (int):  The number of pixels in each submap.
         global2local (array, int64):  The local submap for each global submap.
-        pixels (array, int): pixels (size nsample)
-        weights (array, float64):  The pointing matrix weights (size: nsample*nmap).
-        det_data (array, float64):  The timestream on which to accumulate the map values (size nsample).
+        det_data (float64):  The timestream on which to accumulate the map values.
+        pixels (int): pixels
+        weights (array, float64):  The pointing matrix weights (size: nmap).
         data_scale (float): unit rescaling
         should_zero (bool): should we zero det_data
         should_subtract (bool): should we subtract from det_data
         should_scale (bool): should we scale the detector data by the map values
 
     Returns:
-        det_data
+        det_data (float64)
     """
     # Get local submap and pixels
     submap, subpix = global_to_local(pixels, npix_submap, global2local)
@@ -65,8 +66,10 @@ def scan_map_inner(
     mapdata = mapdata[submap, subpix, :]
 
     # computes the update term
-    update = jnp.sum(mapdata * weights, axis=1) * data_scale
+    update = jnp.sum(mapdata * weights) * data_scale
 
+    # removes potentially useless dimension inroduced by imap
+    det_data = jnp.squeeze(det_data)
     # updates det_data
     if should_zero:
         det_data = jnp.zeros_like(det_data)
@@ -83,29 +86,27 @@ def scan_map_inner(
 
 
 # maps over intervals and detectors
-# scan_map_inner = jax_xmap(scan_map_inner,
-#                              in_axes=[[...], # mapdata
-#                                       [...], # npix_submap
-#                                       [...], # global2local
-#                                       ['detectors','intervals',...], # pixels
-#                                       ['detectors','intervals',...], # weights
-#                                       ['detectors','intervals',...], # det_data
-#                                       [...], # data_scale
-#                                       [...], # should_zero
-#                                       [...]], # should_subtract
-#                                       [...]], # should_scale
-#                              out_axes=['detectors','intervals',...])
-# TODO xmap is commented out for now due to a [bug with static argnum](https://github.com/google/jax/issues/10741)
-scan_map_inner = jax.vmap(
-    scan_map_inner,
-    in_axes=[None, None, None, 0, 0, 0, None, None, None, None],
-    out_axes=0,
-)  # loop on intervals
-scan_map_inner = jax.vmap(
-    scan_map_inner,
-    in_axes=[None, None, None, 0, 0, 0, None, None, None, None],
-    out_axes=0,
-)  # loop on detectors
+scan_map_inner = imap(scan_map_inner, 
+                    in_axes={
+                        'mapdata': [..., ..., ...],
+                        'npix_submap': int,
+                        'global2local': [...],
+                        'det_data': ["n_det","n_samp"],
+                        'pixels': ["n_det","n_samp"],
+                        'weights': ["n_det","n_samp",...],
+                        'data_scale': float,
+                        'should_zero': bool,
+                        'should_subtract': bool,
+                        'should_scale': bool,
+                        'interval_starts': ["n_intervals"],
+                        'interval_ends': ["n_intervals"],
+                        'intervals_max_length': int
+                    },
+                    interval_axis='n_samp', 
+                    interval_starts='interval_starts', 
+                    interval_ends='interval_ends', 
+                    interval_max_length='intervals_max_length', 
+                    output_name='det_data', output_as_input=True)
 
 
 def scan_map_interval(
@@ -154,46 +155,24 @@ def scan_map_interval(
     log = Logger.get()
     log.debug(f"scan_map: jit-compiling.")
 
-    # extract interval slices
-    intervals = JaxIntervals(
-        interval_starts, interval_ends + 1, intervals_max_length
-    )  # end+1 as the interval is inclusive
-    pixels_interval = JaxIntervals.get(
-        pixels, (pixels_index, intervals)
-    )  # pixels[pixels_index, intervals]
-    det_data_interval = JaxIntervals.get(
-        det_data, (det_data_index, intervals)
-    )  # det_data[det_data_index, intervals]
+    # extract indexes
+    pixels_indexed = pixels[pixels_index,:]
+    det_data_indexed = det_data[det_data_index,:]
     if weight_index is None:
-        weights_interval = jnp.ones_like(pixels_interval)
+        weights_indexed = jnp.ones_like(pixels_indexed)[:,:,jnp.newaxis]
     elif weights.ndim == 2:
-        weights_interval = JaxIntervals.get(
-            weights, (weight_index, intervals, jnp.newaxis)
-        )  # weights[weight_index, intervals, np.newaxis]
+        weights_indexed = weights[weight_index,:,jnp.newaxis]
     else:
-        weights_interval = JaxIntervals.get(
-            weights, (weight_index, intervals, ALL)
-        )  # weights[weight_index, intervals, :]
+        weights_indexed = weights[weight_index,:,:]
 
     # does the computation
-    new_det_data_interval = scan_map_inner(
-        mapdata,
-        npix_submap,
-        global2local,
-        pixels_interval,
-        weights_interval,
-        det_data_interval,
-        data_scale,
-        should_zero,
-        should_subtract,
-        should_scale,
-    )
+    new_det_data_indexed = scan_map_inner(mapdata, npix_submap, global2local, 
+                                          det_data_indexed, pixels_indexed, weights_indexed,
+                                          data_scale, should_zero, should_subtract, should_scale,
+                                          interval_starts, interval_ends, intervals_max_length)
 
     # updates results and returns
-    # det_data[det_data_index, intervals] = new_det_data_interval
-    det_data = JaxIntervals.set(
-        det_data, (det_data_index, intervals), new_det_data_interval
-    )
+    det_data = det_data.at[det_data_index,:].set(new_det_data_indexed)
     return det_data
 
 

--- a/src/toast/ops/scan_map/kernels_jax.py
+++ b/src/toast/ops/scan_map/kernels_jax.py
@@ -267,4 +267,5 @@ def scan_map_jax(
 
 
 # To test:
-# python -c 'import toast.tests; toast.tests.run("ops_mapmaker_solve", "ops_scan_map")'
+# export TOAST_GPU_JAX=true; export TOAST_GPU_HYBRID_PIPELINES=true; export TOAST_LOGLEVEL=DEBUG; python -c 'import toast.tests; toast.tests.run("ops_mapmaker_solve"); toast.tests.run("ops_scan_map");'
+

--- a/src/toast/ops/stokes_weights/kernels_jax.py
+++ b/src/toast/ops/stokes_weights/kernels_jax.py
@@ -300,4 +300,4 @@ def stokes_weights_I_jax(weight_index, weights, intervals, cal, use_accel):
 
 
 # To test:
-# python -c 'import toast.tests; toast.tests.run("ops_pointing_healpix"); toast.tests.run("ops_sim_tod_dipole"); toast.tests.run("ops_stokes_weights")'
+# export TOAST_GPU_JAX=true; export TOAST_GPU_HYBRID_PIPELINES=true; export TOAST_LOGLEVEL=DEBUG; python -c 'import toast.tests; toast.tests.run("ops_pointing_healpix"); toast.tests.run("ops_sim_tod_dipole"); toast.tests.run("ops_stokes_weights");'

--- a/src/toast/ops/stokes_weights/kernels_jax.py
+++ b/src/toast/ops/stokes_weights/kernels_jax.py
@@ -4,10 +4,10 @@
 
 import jax
 import jax.numpy as jnp
-from jax.experimental.maps import xmap as jax_xmap
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import ALL, INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.maps import imap
 from ...jax.math import qarray
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger

--- a/src/toast/templates/offset/kernels_jax.py
+++ b/src/toast/templates/offset/kernels_jax.py
@@ -366,4 +366,4 @@ def offset_apply_diag_precond_jax(offset_var, amplitudes_in, amplitudes_out, use
 
 
 # To test:
-# python -c 'import toast.tests; toast.tests.run("template_offset"); toast.tests.run("ops_mapmaker_solve"); toast.tests.run("ops_mapmaker")'
+# export TOAST_GPU_JAX=true; export TOAST_GPU_HYBRID_PIPELINES=true; export TOAST_LOGLEVEL=DEBUG; python -c 'import toast.tests; toast.tests.run("template_offset"); toast.tests.run("ops_mapmaker_solve"); toast.tests.run("ops_mapmaker");'

--- a/src/toast/templates/offset/kernels_jax.py
+++ b/src/toast/templates/offset/kernels_jax.py
@@ -4,10 +4,10 @@
 
 import jax
 import jax.numpy as jnp
-import numpy as np
 
 from ...accelerator import ImplementationType, kernel
-from ...jax.intervals import INTERVALS_JAX, JaxIntervals
+from ...jax.intervals import INTERVALS_JAX, ALL, JaxIntervals
+from ...jax.maps import imap
 from ...jax.mutableArray import MutableJaxArray
 from ...utils import Logger
 


### PR DESCRIPTION
Introduced `imap`, an extension of `xmap` able to deal with JAX (variable size) intervals. It simplifies the code used to write the intervals.

TODO:
- rerun all tests with JAX on,
- remove previous interval type from the codebase,
- clean-up implementation details.