### PR TITLE
Tweaks 12 2023

### DIFF
--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -731,6 +731,8 @@ class StokesWeightsDemod(Operator):
 
         for obs in data.obs:
             dets = obs.select_local_detectors(detectors)
+            if len(dets) == 0:
+                continue
 
             exists_weights = obs.detdata.ensure(
                 self.weights,

--- a/src/toast/ops/sim_tod_atm_generate.py
+++ b/src/toast/ops/sim_tod_atm_generate.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -370,9 +370,6 @@ class GenerateAtmosphere(Operator):
             ystep_current = u.Quantity(self.ystep) / np.sqrt(scale)**(ncone - 1)
             zstep_current = u.Quantity(self.zstep) / np.sqrt(scale)**(ncone - 1)
             counter1 = counter1start
-            # xstep_current = u.Quantity(self.xstep)
-            # ystep_current = u.Quantity(self.ystep)
-            # zstep_current = u.Quantity(self.zstep)
 
             sim_list = list()
 

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -80,6 +80,7 @@ class SimAtmTest(MPITestCase):
         # Simulate atmosphere signal and accumulate
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -136,7 +137,7 @@ class SimAtmTest(MPITestCase):
             mdata = hp.read_map(mapfile, nest=False, dtype=float)
             mdata[mdata == 0] = hp.UNSEEN
 
-            outfile = "{}.png".format(mapfile)
+            outfile = f"{mapfile}.png"
             hp.gnomview(mdata, xsize=1600, rot=(42.0, -42.0), reso=0.5, nest=False)
             plt.savefig(outfile)
             plt.close()
@@ -145,7 +146,7 @@ class SimAtmTest(MPITestCase):
             mdata = hp.read_map(mapfile, None, nest=False)
             mdata[mdata == 0] = hp.UNSEEN
 
-            outfile = "{}.png".format(mapfile)
+            outfile = f"{mapfile}.png"
             fig = plt.figure(figsize=[8 * 3, 12])
             hp.gnomview(
                 mdata[0],
@@ -180,7 +181,7 @@ class SimAtmTest(MPITestCase):
             mdata = hp.read_map(mapfile, None, nest=False)
             mdata[mdata == 0] = hp.UNSEEN
 
-            outfile = "{}.png".format(mapfile)
+            outfile = f"{mapfile}.png"
             fig = plt.figure(figsize=[8 * 3, 12])
             hp.gnomview(
                 mdata[0],
@@ -226,7 +227,7 @@ class SimAtmTest(MPITestCase):
             rank = self.comm.rank
 
         # Create fake observing of a small patch
-        data = create_ground_data(self.comm)
+        data = create_ground_data(self.comm, sample_rate=100 * u.Hz)
 
         # Simple detector pointing
         detpointing_azel = ops.PointingDetectorSimple(
@@ -240,6 +241,7 @@ class SimAtmTest(MPITestCase):
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
             det_data="full_signal",
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -248,6 +250,7 @@ class SimAtmTest(MPITestCase):
             detector_pointing=detpointing_azel,
             sample_rate=data.obs[0].telescope.focalplane.sample_rate / 4,
             det_data="interpolated_signal",
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -329,6 +332,7 @@ class SimAtmTest(MPITestCase):
             detector_weights=azel_weights,
             polarization_fraction=0.2,
             add_loading=False,  # Loading is not polarized
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -381,7 +385,7 @@ class SimAtmTest(MPITestCase):
             mdata = hp.read_map(mapfile, nest=False, dtype=float)
             mdata[mdata == 0] = hp.UNSEEN
 
-            outfile = "{}.png".format(mapfile)
+            outfile = f"{mapfile}.png"
             hp.gnomview(mdata, xsize=1600, rot=(42.0, -42.0), reso=0.5, nest=False)
             plt.savefig(outfile)
             plt.close()
@@ -390,7 +394,7 @@ class SimAtmTest(MPITestCase):
             mdata = hp.read_map(mapfile, None, nest=False)
             mdata[mdata == 0] = hp.UNSEEN
 
-            outfile = "{}.png".format(mapfile)
+            outfile = f"{mapfile}.png"
             fig = plt.figure(figsize=[8 * 3, 12])
             hp.gnomview(
                 mdata[0],
@@ -460,6 +464,7 @@ class SimAtmTest(MPITestCase):
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
             gain=0,
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -526,6 +531,7 @@ class SimAtmTest(MPITestCase):
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
             cache_dir=cache_dir,
+            zmax=200 * u.m,
         )
         sim_atm.apply(data)
 
@@ -627,6 +633,7 @@ class SimAtmTest(MPITestCase):
         sim_atm = ops.SimAtmosphere(
             detector_pointing=detpointing_azel,
             detector_weights=weights_azel,
+            zmax=200 * u.m,
         )
 
         # Build hit map and covariance


### PR DESCRIPTION
Small tweaks that didn't deserve a separate PR:
- add a short circuit for empty detector list in demodulation
- fix atmospheric snapshot output for debugging
- noise estimator will automatically create the output directory if it does not exist
and some bigger items:
- the three concentric atmospheric cones are now scaled to fit the specified `zmax` so we don't simulate useless volume elements. This change means that old and new atmospheric simulations will be incompatible.
- Volume element size (`xstep`, `ystep`, `zstep`) is now defined in terms of the largest, not the smallest concentric cone. This is more intuitive since it is the same length scale as the total simulated volume.
- fixed broken snapshot plot generation in atmospheric simulation