### PR TITLE
Minor fixes to noise estimation work

### DIFF
--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -656,6 +656,7 @@ class Observation(MutableMapping):
             sample_sets=self.all_sample_sets,
             process_rows=self.dist.process_rows,
         )
+        new_obs.set_local_detector_flags(self.local_detector_flags)
         for k, v in self._internal.items():
             if meta is None or k in meta:
                 new_obs[k] = copy.deepcopy(v)
@@ -817,6 +818,7 @@ class Observation(MutableMapping):
         self.intervals = new_intervals_manager
 
         # Restore detector flags for our new local detectors
+        self._detflags = {x: int(0) for x in self.dist.dets[self.dist.comm.group_rank]}
         self.set_local_detector_flags(
             {x: all_det_flags[x] for x in self.local_detectors}
         )

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -917,4 +917,9 @@ def redistribute_data(
             glb = global_intervals[field]
         new_intervals_manager.create(field, glb, new_shared_manager[times], fromrank=0)
 
-    return new_shared_manager, new_detdata_manager, new_intervals_manager, global_intervals
+    return (
+        new_shared_manager,
+        new_detdata_manager,
+        new_intervals_manager,
+        global_intervals,
+    )

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -402,7 +402,7 @@ class NoiseEstimTest(MPITestCase):
             shared_flag_mask=1,
             # view="scanning",
             output_dir=self.outdir,
-            lagmax=1000,
+            lagmax=200,
             nbin_psd=300,
         )
         estim.apply(data)
@@ -417,7 +417,7 @@ class NoiseEstimTest(MPITestCase):
             stokes_weights=weights,
             # view="scanning",
             output_dir=self.outdir,
-            lagmax=1000,
+            lagmax=200,
             nbin_psd=300,
         )
         estim.apply(data)
@@ -490,7 +490,7 @@ class NoiseEstimTest(MPITestCase):
             name="estimate_model",
             output_dir=self.outdir,
             out_model="noise_estimate",
-            lagmax=1000,
+            lagmax=200,
             nbin_psd=128,
             nsum=4,
         )


### PR DESCRIPTION
Some small fixes, discovered with unit tests and batch jobs with 8 or 16 processes per group:

* When duplicating an observation, also duplicate per-detector flags.

* When redistributing an observation, reset per-detector flags before setting.

* Make the common mode removal an option (default True) prior to noise estimation.  This is useful if the data has already had the common mode removed prior to this operator.

* When high-pass filtering data that is distributed by time slices there may be some chunks that are fully flagged.  This should not be an error.  Instead, the flagged timestream is set to zero.

* When communicating overlaps, ensure that the span used (lagmax
  + half_average) is less than the number of samples.