### PR TITLE
When parsing config files, handle compatible types

### DIFF
--- a/src/toast/scripts/toast_config_verify.py
+++ b/src/toast/scripts/toast_config_verify.py
@@ -167,12 +167,15 @@ def main():
     # Instantiate everything and then convert back to a config for dumping.
     # This will automatically prune stale traits, etc.
     run = toast.create_from_config(config)
+    run_vars = vars(run)
+
     out_config = OrderedDict()
-    for sect_key, sect_val in vars(run).items():
+    for sect_key, sect_val in run_vars.items():
+        sect_vars = vars(sect_val)
         obj_list = list()
-        for obj_name, obj in vars(sect_val).items():
+        for obj_name, obj in sect_vars.items():
             obj_list.append(obj)
-        out_config[sect_key] = toast.config.build_config(obj_list)
+        out_config.update(toast.config.build_config(obj_list))
 
     # Write the final config out
     if user_args.out_toml is not None:

--- a/src/toast/scripts/toast_config_verify.py
+++ b/src/toast/scripts/toast_config_verify.py
@@ -42,12 +42,12 @@ def main():
             iop += 1
             user_opts.append(opts[iop])
             iop += 1
-        if opts[iop] == "--out_json":
+        elif opts[iop] == "--out_json":
             user_opts.append(opts[iop])
             iop += 1
             user_opts.append(opts[iop])
             iop += 1
-        if opts[iop] == "--out_yaml":
+        elif opts[iop] == "--out_yaml":
             user_opts.append(opts[iop])
             iop += 1
             user_opts.append(opts[iop])


### PR DESCRIPTION
Due to the way we are writing TOML and YAML files for user-friendly editing, the true type of traits loaded from those formats can be ambiguous.  This work adds checks to allow assignment from compatible types when merging the values loaded from config files with the current state of trait properties.