### PR TITLE
Do not redistribute data unless computing cross spectra.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           sudo rm -rf /usr/share/miniconda \
             && sudo rm -rf /usr/local/miniconda \
-            && curl -SL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh \
+            && curl -SL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${{ matrix.arch }}.sh \
             && bash miniforge.sh -b -f -p ~/conda \
             && source ~/conda/etc/profile.d/conda.sh \
             && conda activate base \

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -179,7 +179,7 @@ class NoiseEstim(Operator):
         None, allow_none=True, help="When set, PSDs are measured over averaged TODs"
     )
 
-    remove_common_mode = Bool(True, help="Remove common mode signal before estimation")
+    remove_common_mode = Bool(False, help="Remove common mode signal before estimation")
 
     @traitlets.validate("detector_pointing")
     def _check_detector_pointing(self, proposal):
@@ -235,7 +235,15 @@ class NoiseEstim(Operator):
         log = Logger.get()
         timer = Timer()
         timer.start()
-        if obs.comm_col is not None and obs.comm_col.size > 1:
+        if (
+            (
+                len(self.pairs) > 0 or 
+                (not self.nocross)
+            ) and (
+                obs.comm_col is not None and 
+                obs.comm_col.size > 1
+            )
+        ):
             self.redistribute = True
             # Redistribute the data so each process has all detectors
             # for some sample range

--- a/src/toast/vis.py
+++ b/src/toast/vis.py
@@ -459,12 +459,11 @@ def plot_healpix_maps(
         )
         mlon = np.mean(lon)
         mlat = np.mean(lat)
-        mlon_deg = 180 * mlon / np.pi
-        mlat_deg = 180 * mlat / np.pi
-        gnomres = (np.amax(lat) - np.amin(lat)) / xsize
-        gnomres *= 180 * 60 / np.pi
+        gnomres = 1.1 * (np.amax(lat) - np.amin(lat)) / xsize
+        gnomres *= 60
         if gnomview:
-            gnomrot = (mlon_deg, mlat_deg, 0.0)
+            gnomrot = (mlon, mlat, 0.0)
+        print(f"gnomres = {gnomres} arcmin, gnomrot = {gnomrot}", flush=True)
         plot_single(
             hitdata,
             0,


### PR DESCRIPTION
When estimating the noise PSDs, computing autospectra does not require redistribution.  Also apply a small fix to one of the plotting routines.