### PR TITLE
Improve AzimuthIntervals and other small fixes.

### DIFF
--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -400,6 +400,7 @@ class MapMaker(Operator):
                 pixel_pointing=map_binning.pixel_pointing,
                 shared_flags=map_binning.shared_flags,
                 shared_flag_mask=map_binning.shared_flag_mask,
+                save_pointing=map_binning.full_pointing,
             )
             pix_dist.apply(self._data)
             self._log.info_rank(
@@ -559,7 +560,7 @@ class MapMaker(Operator):
             map_binning.det_data = self.det_data
         else:
             map_binning.det_data = out_cleaned
-        if self.write_noiseweighted_map:
+        if self.write_noiseweighted_map or self.keep_final_products:
             map_binning.noiseweighted = self.noiseweighted_map_name
         map_binning.binned = self.map_name
 


### PR DESCRIPTION
- Modify the AzimuthIntervals operator to more robustly exclude false "throw" intervals.  Instead we first detect the stable pointing periods and then find the exact turnaround sample between those (and raise an exception if there is more than one).  This does mean that beginning of the first throw and the end of the last throw are truncated to the stable scan boundary.

- In the mapmaker, keep the noise weighted map if `keep_final_products` is True.

- In the mapmaker, if the binner is configured to compute and save full detector pointing, use that option when initially computing the pixel distribution. This avoids computing the pointing twice.

- When scanning from a map in the template solver, if we already have full detector pointing, then run that over all detectors.

- Fix typo in mapmaker from recent refactor.