### PR TITLE
Add processing bit to non-science shared mask

### DIFF
--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -103,6 +103,7 @@ def set_default_values(values=None):
     # composite masks for convenience
     defaults["shared_mask_nonscience"] = (
         defaults["shared_mask_invalid"]
+        | defaults["shared_mask_processing"]
         | defaults["shared_mask_unstable_scanrate"]
         | defaults["shared_mask_irregular"]
     )

--- a/src/toast/pointing_utils.py
+++ b/src/toast/pointing_utils.py
@@ -159,7 +159,7 @@ def scan_range_lonlat(
     lon = list()
     lat = list()
     for idet, detquat in enumerate(detquats):
-        dquats = qa.mult(bore_quats, detquat)
+        dquats = qa.mult(bore_quats[rank_slice, :], detquat)
         det_lon, det_lat = center_offset_lonlat(
             dquats,
             center_offset=center_lonlat,


### PR DESCRIPTION
Many data reduction operators default to using the combined "non-science" masks for shared and detector flags.  The shared mask non-science mask currently does not include the processing bit.  This PR tests the inclusion of that.