### PR TITLE
Various small fixes

### DIFF
--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -732,7 +732,10 @@ class FlagNoiseFit(Operator):
                             if not all_good[idet]:
                                 # Already cut
                                 continue
-                            if np.absolute(fknee - fknee_mean) > fknee_std * self.sigma_fknee:
+                            if (
+                                np.absolute(fknee - fknee_mean) >
+                                fknee_std * self.sigma_fknee
+                            ):
                                 msg = f"obs {obs.name}, det {name} has f_knee "
                                 msg += f"{fknee} that is > {self.sigma_fknee} "
                                 msg += f"x {fknee_std} from {fknee_mean}"
@@ -741,8 +744,10 @@ class FlagNoiseFit(Operator):
                                 n_cut += 1
                     msg = f"pass {flag_pass}, {n_cut} detectors flagged"
                     log.debug(msg)
+                    flag_pass += 1
                 all_flags = {
-                    x: self.outlier_flag_mask for i, x in enumerate(all_names) if all_good[i]
+                    x: self.outlier_flag_mask for i, x in enumerate(all_names)
+                    if not all_good[i]
                 }
                 msg = f"obs {obs.name}: flagged {len(all_flags)} / {len(all_names)}"
                 msg += " outlier detectors"

--- a/src/toast/scripts/toast_plot_healpix.py
+++ b/src/toast/scripts/toast_plot_healpix.py
@@ -14,8 +14,8 @@ from toast.vis import plot_healpix_maps
 
 def main():
     parser = argparse.ArgumentParser(
-        description="This program plots output maps in WCS projections.",
-        usage="toast_plot_wcs <options>",
+        description="This program plots output healpix maps.",
+        usage="toast_plot_healpix <options>",
     )
 
     parser.add_argument(

--- a/src/toast/templates/fourier2d.py
+++ b/src/toast/templates/fourier2d.py
@@ -195,8 +195,12 @@ class Fourier2D(Template):
         # Allocate norms.  This data is the same size as a set of amplitudes,
         # so we allocate it in C memory.
 
-        self._norms_raw = AlignedF64.zeros(self._n_local)
-        self._norms = self._norms_raw.array()
+        if self._n_local == 0:
+            self._norms_raw = None
+            self._norms = None
+        else:
+            self._norms_raw = AlignedF64.zeros(self._n_local)
+            self._norms = self._norms_raw.array()
 
         def evaluate_template(theta, phi, radius):
             """Helper function to get the template values for a detector."""

--- a/src/toast/templates/hwpss.py
+++ b/src/toast/templates/hwpss.py
@@ -144,7 +144,10 @@ class Hwpss(Template):
             )
 
         # Boolean flags
-        self._amp_flags = np.zeros(self._n_local, dtype=bool)
+        if self._n_local == 0:
+            self._amp_flags = None
+        else:
+            self._amp_flags = np.zeros(self._n_local, dtype=bool)
 
         for det in self._all_dets:
             amp_offset = self._det_offset[det]
@@ -163,7 +166,8 @@ class Hwpss(Template):
 
     def _zeros(self):
         z = Amplitudes(self.data.comm, self._n_global, self._n_local)
-        z.local_flags[:] = np.where(self._amp_flags, 1, 0)
+        if self._amp_flags is not None:
+            z.local_flags[:] = np.where(self._amp_flags, 1, 0)
         return z
 
     @classmethod

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -229,8 +229,12 @@ class Offset(Template):
 
         # Here we track the variance of the offsets based on the detector noise weights
         # and the number of unflagged / good samples per offset.
-        self._offsetvar_raw = AlignedF64.zeros(self._n_local)
-        self._offsetvar = self._offsetvar_raw.array()
+        if self._n_local == 0:
+            self._offsetvar_raw = None
+            self._offsetvar = None
+        else:
+            self._offsetvar_raw = AlignedF64.zeros(self._n_local)
+            self._offsetvar = self._offsetvar_raw.array()
 
         offset = 0
         for det in self._all_dets:

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -217,10 +217,16 @@ class Periodic(Template):
         # bin and the flagging of bins.
 
         # Boolean flags
-        self._amp_flags = np.zeros(self._n_local, dtype=bool)
+        if self._n_local == 0:
+            self._amp_flags = None
+        else:
+            self._amp_flags = np.zeros(self._n_local, dtype=bool)
 
         # Hits
-        self._amp_hits = np.zeros(self._n_local, dtype=np.int32)
+        if self._n_local == 0:
+            self._amp_hits = None
+        else:
+            self._amp_hits = np.zeros(self._n_local, dtype=np.int32)
 
         self._obs_bin_hits = list()
         for det in self._all_dets:
@@ -271,7 +277,8 @@ class Periodic(Template):
 
     def _zeros(self):
         z = Amplitudes(self.data.comm, self._n_global, self._n_local)
-        z.local_flags[:] = np.where(self._amp_flags, 1, 0)
+        if self._amp_flags is not None:
+            z.local_flags[:] = np.where(self._amp_flags, 1, 0)
         return z
 
     def _view_flags_and_index(


### PR DESCRIPTION
- Fix deadlock in 1D polyfilter if a process has no good detectors

- When flagging noise model outliers, iterate until no further detectors are cut.

- In the template classes and Amplitude class, handle the case where some processes have no good detectors.