### PR TITLE
Change HWP deflection of detector pointing to not alter polarization

### DIFF
--- a/src/toast/qarray.py
+++ b/src/toast/qarray.py
@@ -283,8 +283,12 @@ def rotation(axis, angle):
     if np.shape(axis)[-1] != 3:
         raise RuntimeError("axis is not a 3D vector")
     axin = ensure_buffer_f64(axis)
+    nax = len(axin) // 3
     angin = ensure_buffer_f64(angle)
-    out = AlignedF64(4 * len(angin))
+    if nax > len(angin):
+        out = AlignedF64(4 * nax)
+    else:
+        out = AlignedF64(4 * len(angin))
     qa_from_axisangle(axin, angin, out)
     if len(out) == 4:
         if (object_ndim(axis) == 2) or (object_ndim(angle) == 1):

--- a/src/toast/tests/ops_pointing_detector.py
+++ b/src/toast/tests/ops_pointing_detector.py
@@ -14,8 +14,12 @@ from .._libtoast import pixels_healpix, stokes_weights_IQU
 from ..accelerator import ImplementationType, accel_enabled
 from ..intervals import IntervalList, interval_dtype
 from ..observation import default_values as defaults
+from ..vis import plot_projected_quats
 from ._helpers import (
-    close_data, create_outdir, create_satellite_data, create_ground_data
+    close_data,
+    create_outdir,
+    create_satellite_data,
+    create_ground_data,
 )
 from .mpi import MPITestCase
 
@@ -24,6 +28,14 @@ class PointingDetectorTest(MPITestCase):
     def setUp(self):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
         self.outdir = create_outdir(self.comm, fixture_name)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
 
     def test_detector_pointing_simple(self):
         # Create a fake satellite data set for testing
@@ -48,11 +60,12 @@ class PointingDetectorTest(MPITestCase):
 
         handle = None
         if rank == 0:
-            handle = open(os.path.join(self.outdir, "out_test_detpointing_simple_info"), "w")
+            handle = open(
+                os.path.join(self.outdir, "out_test_detpointing_simple_info"), "w"
+            )
         data.info(handle=handle)
         if rank == 0:
             handle.close()
-
         close_data(data)
 
     def test_detector_pointing_hwp_deflect(self):
@@ -82,7 +95,53 @@ class PointingDetectorTest(MPITestCase):
                 theta2, phi2, psi2 = qa.to_iso_angles(quats2[idet])
                 rms_theta = np.degrees(np.std(theta1 - theta2))
                 rms_phi = np.degrees(np.std(phi1 - phi2))
-                self.assertTrue(rms_theta > .5 and rms_theta < 1.5)
-                self.assertTrue(rms_phi > .5 and rms_phi < 1.5)
+                self.assertTrue(rms_theta > 0.5 and rms_theta < 1.5)
+                self.assertTrue(rms_phi > 0.5 and rms_phi < 1.5)
+        close_data(data)
 
+    def test_detector_pointing_hwp_deflect_plot(self):
+        # Create fake observing.
+        data = create_ground_data(self.comm, sample_rate=30.0 * u.Hz, hwp_rpm=60.0)
+
+        # Regular pointing in Az/El
+        detpointing1 = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_azel,
+        )
+        detpointing1.apply(data)
+
+        # Pointing with deflection in Az/El
+        detpointing2 = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_azel,
+            hwp_angle=defaults.hwp_angle,
+            hwp_angle_offset=0 * u.deg,
+            # hwp_angle_offset=45 * u.deg,
+            hwp_deflection_radius=2.0 * u.deg,
+            quats="deflected",
+        )
+        detpointing2.apply(data)
+
+        # Plot pointing.  We take the first detector (which will be at the
+        # boresight) for the nominal and deflected cases and verify that
+        # the motion makes sense.
+        if data.comm.world_rank == 0 and self.make_plots:
+            n_debug = 30
+            n_skip = 1
+            start = 150
+            slc = slice(start, start + n_debug * n_skip, n_skip)
+            bquat = np.array(data.obs[0].shared[defaults.boresight_azel].data[slc, :])
+            dquat = np.zeros((2, n_debug, 4), dtype=np.float64)
+            dquat[0] = data.obs[0].detdata[detpointing1.quats][0, slc, :]
+            dquat[1] = data.obs[0].detdata[detpointing2.quats][0, slc, :]
+            invalid = np.array(data.obs[0].shared[defaults.shared_flags][slc])
+            invalid &= defaults.shared_mask_invalid
+            valid = np.logical_not(invalid)
+            outfile = os.path.join(self.outdir, "pointing_deflection.pdf")
+            plot_projected_quats(
+                outfile,
+                qbore=bquat,
+                qdet=dquat,
+                valid=valid,
+                scale=2.0,
+                equal_aspect=False,
+            )
         close_data(data)


### PR DESCRIPTION
* Modify deflection code so that the overall detector polarization direction stays fixed (i.e. the deflection is a translation)

* Add a unit test which makes plots of the detector pointing

* Small fixes to the plotting utility

* Small fix for case where quaternions are constructed from an array of axes.

Here is a plot comparing the existing code's behavior with the changes in this PR.  Note how the old code rotates the detector frame as well as deflecting it.  Old code:

![pointing_deflection_old](https://github.com/user-attachments/assets/584be1a2-6131-402b-97e1-cb82309b156d)

And the code in this PR:

![pointing_deflection_new](https://github.com/user-attachments/assets/a0de9567-f17e-4339-ae20-64d9e083d45b)
