### PR TITLE
Implement Operator loader pattern on execution

### DIFF
--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ install(FILES
     ops_yield_cut.py
     ops_elevation_noise.py
     ops_signal_diff_noise.py
+    ops_loader.py
     accelerator.py
     DESTINATION ${PYTHON_SITE}/toast/tests
 )

--- a/src/toast/tests/ops_loader.py
+++ b/src/toast/tests/ops_loader.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+from datetime import datetime
+
+import healpy as hp
+import numpy as np
+import numpy.testing as nt
+from astropy import units as u
+
+from .. import ops as ops
+from ..data import Data
+from ..mpi import MPI, Comm
+from ..observation import default_values as defaults
+from ..traits import Float, trait_docs
+from ._helpers import close_data, create_outdir, create_satellite_data
+from .mpi import MPITestCase
+
+
+class RandomLoader(object):
+    """Class that generates random data."""
+
+    def __init__(self, rms=1.0):
+        self.rms = rms
+
+    def load(self, obs):
+        exists_data = obs.detdata.ensure(
+            defaults.det_data,
+            dtype=np.float64,
+            detectors=obs.local_detectors,
+            create_units=u.Kelvin,
+        )
+        for det in obs.local_detectors:
+            obs.detdata[defaults.det_data][det] = np.random.normal(
+                scale=self.rms, size=obs.n_local_samples
+            )
+        exists_flags = obs.detdata.ensure(
+            defaults.det_flags, dtype=np.uint8, detectors=obs.local_detectors
+        )
+
+    def unload(self, obs):
+        del obs.detdata[defaults.det_data]
+        del obs.detdata[defaults.det_flags]
+
+
+@trait_docs
+class CheckRMS(ops.Operator):
+    """Operator that just checks the data RMS"""
+
+    expected = Float(
+        1.0,
+        help="Expected detector rms value",
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _exec(self, data, detectors=None, **kwargs):
+        for ob in data.obs:
+            for det in ob.local_detectors:
+                rms = float(np.std(ob.detdata[defaults.det_data][det]))
+                margin = np.sqrt(self.expected**4 / (ob.n_local_samples - 1))
+                if np.absolute(rms - self.expected) > margin:
+                    msg = (
+                        f"{ob.name}[{det}]: {rms} outside {self.expected} +/- {margin}"
+                    )
+                    raise RuntimeError(msg)
+
+    def _finalize(self, data, **kwargs):
+        pass
+
+
+class LoaderTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+    def create_data(self, rms=1.0):
+        # Create a fake dataset, but delete any detector data
+        data = create_satellite_data(self.comm, obs_per_group=2, flagged_pixels=False)
+        ops.Delete(detdata=[defaults.det_data, defaults.det_flags]).apply(data)
+
+        # Create a loader instance for each observation
+        for obs in data.obs:
+            obs.loader = RandomLoader(rms=rms)
+        return data
+
+    def test_load_exec(self):
+        rms = 5.0
+        data = self.create_data(rms=rms)
+
+        # Verify that there is no data yet.
+        for obs in data.obs:
+            if defaults.det_data in obs.detdata:
+                msg = f"Detector data in obs {obs.name} exists prior to load"
+                print(msg)
+                self.assertTrue(False)
+            if defaults.det_flags in obs.detdata:
+                msg = f"Detector flags in obs {obs.name} exists prior to load"
+                print(msg)
+                self.assertTrue(False)
+
+        rms_checker = CheckRMS(expected=rms)
+        rms_checker.load_exec(data)
+        rms_checker.finalize(data)
+
+        # Verify that the data was purged
+        for obs in data.obs:
+            if defaults.det_data in obs.detdata:
+                msg = f"Detector data in obs {obs.name} was not unloaded"
+                print(msg)
+                self.assertTrue(False)
+            if defaults.det_flags in obs.detdata:
+                msg = f"Detector flags in obs {obs.name} was not unloaded"
+                print(msg)
+                self.assertTrue(False)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -36,6 +36,7 @@ from . import ops_flag_sso as test_ops_flag_sso
 from . import ops_gainscrambler as test_ops_gainscrambler
 from . import ops_groundfilter as test_ops_groundfilter
 from . import ops_hwpfilter as test_ops_hwpfilter
+from . import ops_loader as test_ops_loader
 from . import ops_madam as test_ops_madam
 from . import ops_mapmaker as test_ops_mapmaker
 from . import ops_mapmaker_binning as test_ops_mapmaker_binning
@@ -195,6 +196,7 @@ def test(name=None, verbosity=2):
 
         suite.addTest(loader.loadTestsFromModule(test_ops_flag_sso))
         suite.addTest(loader.loadTestsFromModule(test_ops_statistics))
+        suite.addTest(loader.loadTestsFromModule(test_ops_loader))
         suite.addTest(loader.loadTestsFromModule(test_ops_mapmaker_utils))
         suite.addTest(loader.loadTestsFromModule(test_ops_mapmaker_binning))
         suite.addTest(loader.loadTestsFromModule(test_ops_mapmaker_solve))


### PR DESCRIPTION
This is a small PR that is the beginning of implementing a design pattern that is useful in cases where the solved map-domain or template amplitude products require more detector data than will fit in memory.  Essentially the new `Operator.load_exec()` method loops over observations and looks for an Observation attribute containing a "Loader" class.  If that exists, it is used to "load" data prior to calling `exec()` on that observation and then used to "unload" data afterwards.  See the trivial unit test to see how this works.

Future PRs will use this feature to implement an operator that loads (or simulates) data per observation and accumulates the hits, inverse covariance, and noise weighted map.  This foundational operator can then be used in larger workflows making a binned map or solving for template amplitudes without persistent storage of all detector data.