### PR TITLE
Jump finder fix

### DIFF
--- a/src/toast/ops/simple_deglitch.py
+++ b/src/toast/ops/simple_deglitch.py
@@ -150,7 +150,7 @@ class SimpleDeglitch(Operator):
             views = ob.intervals[self.view]
             focalplane = ob.telescope.focalplane
 
-            local_dets = ob.select_local_detectors(flagmask=defaults.det_mask_invalid)
+            local_dets = ob.select_local_detectors(flagmask=self.det_mask)
             shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
             for name in local_dets:
                 sig = ob.detdata[self.det_data][name]

--- a/src/toast/ops/simple_deglitch.py
+++ b/src/toast/ops/simple_deglitch.py
@@ -32,7 +32,7 @@ class SimpleDeglitch(Operator):
     det_data = Unicode(defaults.det_data, help="Observation detdata key to analyze")
 
     det_mask = Int(
-        defaults.det_mask_nonscience,
+        defaults.det_mask_invalid,
         help="Bit mask value for per-detector flagging",
     )
 
@@ -43,7 +43,7 @@ class SimpleDeglitch(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_nonscience,
+        defaults.det_mask_invalid,
         help="Bit mask value for detector sample flagging",
     )
 

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -208,10 +208,9 @@ class SimpleJumpCorrect(Operator):
 
         sigmas = []
         nn = len(toi)
-        for start in range(tol, nn - tol, 2 * tol):
+        # Ignore tol samples at the edge
+        for start in range(tol, nn - 3*tol + 1, 2*tol):
             stop = start + 2 * tol
-            if stop > nn - tol:
-                break
             ind = slice(start, stop)
             x = toi[ind][full_flag[ind] == 0]
             if len(x) != 0:

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -234,10 +234,13 @@ class SimpleJumpCorrect(Operator):
 
         """
         corrected_signal = signal.copy()
+        nsample = len(signal)
         flag_out = flag.copy()
         for peak, _, amplitude in peaks:
             corrected_signal[peak:] -= amplitude
-            flag_out[peak - int(tol) : peak + int(tol)] = True
+            pstart = max(0, peak - tol)
+            pstop = min(nsample, peak + tol)
+            flag_out[pstart : pstop] = True
         return corrected_signal, flag_out
 
     @function_timer

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -251,7 +251,7 @@ class SimpleJumpCorrect(Operator):
             views = ob.intervals[self.view]
             focalplane = ob.telescope.focalplane
 
-            local_dets = ob.select_local_detectors(flagmask=defaults.det_mask_invalid)
+            local_dets = ob.select_local_detectors(flagmask=self.det_mask)
             shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
             for name in local_dets:
                 sig = ob.detdata[self.det_data][name]

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -7,7 +7,7 @@ import copy
 import numpy as np
 import traitlets
 from astropy import units as u
-from scipy.signal import fftconvolve
+from scipy.signal import convolve
 
 from .. import qarray as qa
 from ..intervals import IntervalList
@@ -268,7 +268,7 @@ class SimpleJumpCorrect(Operator):
                     sig_view = sig[ind].copy()
                     bad_view = bad[ind]
                     bad_view_out = bad_view.copy()
-                    sig_filtered = fftconvolve(sig_view, stepfilter, mode="same")
+                    sig_filtered = convolve(sig_view, stepfilter, mode="same")
                     peaks = self._find_peaks(
                         sig_filtered,
                         bad_view,

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -163,6 +163,7 @@ class SimpleJumpCorrect(Operator):
         """
         peaks = []
         mytoi = np.ma.masked_array(toi)
+        nsample = len(mytoi)
         # Do not accept jumps at the ends due to boundary effects
         lbound = tol
         rbound = tol
@@ -186,7 +187,7 @@ class SimpleJumpCorrect(Operator):
 
             # mask out the vicinity not to have false detections near the peak
             istart = max(0, imax - tol)
-            istop = min(len(mytoi), imax + tol)
+            istop = min(nsample, imax + tol)
             mytoi[istart:istop] = np.ma.masked
             flag_out[istart:istop] = True
             # Excessive flagging is a sign of false detection

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -32,7 +32,7 @@ class SimpleJumpCorrect(Operator):
     det_data = Unicode(defaults.det_data, help="Observation detdata key to analyze")
 
     det_mask = Int(
-        defaults.det_mask_nonscience,
+        defaults.det_mask_invalid,
         help="Bit mask value for per-detector flagging",
     )
 
@@ -43,7 +43,7 @@ class SimpleJumpCorrect(Operator):
     )
 
     det_flag_mask = Int(
-        defaults.det_mask_nonscience,
+        defaults.det_mask_invalid,
         help="Bit mask value for detector sample flagging",
     )
 

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -94,12 +94,6 @@ class SimpleJumpCorrect(Operator):
         help="Minimum number of good samples in an interval",
     )
 
-    medfilt_kernel_size = Int(
-        101,
-        help="Median filter kernel width.  Either 0 (full interval) "
-        "or a positive odd number",
-    )
-
     @traitlets.validate("det_mask")
     def _check_det_mask(self, proposal):
         check = proposal["value"]
@@ -119,15 +113,6 @@ class SimpleJumpCorrect(Operator):
         check = proposal["value"]
         if check < 0:
             raise traitlets.TraitError("Det flag mask should be a positive integer")
-        return check
-
-    @traitlets.validate("medfilt_kernel_size")
-    def _check_medfilt_kernel_size(self, proposal):
-        check = proposal["value"]
-        if check < 0:
-            raise traitlets.TraitError("medfilt_kernel_size cannot be negative")
-        if check > 0 and check % 2 == 0:
-            raise traitlets.TraitError("medfilt_kernel_size cannot be even")
         return check
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
- Fix jump finder that only finds the maximum jump.
- Replace `scipy.signal.fftconvolve` with `scipy.signal.convolve`. `scipy.signal.convolve` could auto select/guess best convolve method (direct calculation or FFT).
- Simplify for loop in `_get_sigma` function.