### PR TITLE
Create an all-inclusive example unit test for ground-based data.

### DIFF
--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -1156,7 +1156,10 @@ def plot(amp_file, compare=dict(), out=None):
             fig = plt.figure(dpi=fig_dpi, figsize=(fig_width, fig_height))
             ax = fig.add_subplot(1, 1, 1)
             if det in compare:
-                ax.plot(x_samples, compare[det], color="black", label=f"{det} Data")
+                dc = np.mean(compare[det])
+                ax.plot(
+                    x_samples, compare[det] - dc, color="black", label=f"{det} Data"
+                )
             ax.step(
                 amp_first[:],
                 hamps[idet],

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -552,10 +552,12 @@ def plot(amp_file, out_root=None):
             amp_max = list(ast.literal_eval(obgrp.attrs["max"]))
             amp_incr = list(ast.literal_eval(obgrp.attrs["incr"]))
 
-            hamps = obgrp["amplitudes"]
-            hhits = obgrp["hits"]
-            hflags = obgrp["flags"]
+            hamps = np.array(obgrp["amplitudes"])
+            hhits = np.array(obgrp["hits"])
+            hflags = np.array(obgrp["flags"])
             n_bin = hamps.shape[1]
+            bad = hflags != 0
+            hamps[bad] = np.nan
 
             for idet, det in enumerate(det_list):
                 outfile = f"{out_root}_{obname}_{det}.pdf"

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -78,5 +78,6 @@ install(FILES
     ops_signal_diff_noise.py
     ops_loader.py
     accelerator.py
+    ops_example_ground.py
     DESTINATION ${PYTHON_SITE}/toast/tests
 )

--- a/src/toast/tests/_helpers.py
+++ b/src/toast/tests/_helpers.py
@@ -15,9 +15,11 @@ from astropy import units as u
 from astropy.table import Column, QTable, Table
 from astropy.table import vstack as table_vstack
 from astropy.wcs import WCS
+from scipy.ndimage import gaussian_filter
 
 from .. import ops as ops
 from .. import qarray as qa
+from .. import rng
 from ..data import Data
 from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
 from ..instrument_sim import fake_boresight_focalplane, fake_hexagon_focalplane
@@ -25,7 +27,8 @@ from ..mpi import Comm
 from ..observation import DetectorData, Observation
 from ..observation import default_values as defaults
 from ..pixels import PixelData
-from ..pixels_io_healpix import write_healpix_fits
+from ..pixels_io_healpix import write_healpix_fits, read_healpix_fits
+from ..pixels_io_wcs import read_wcs_fits
 from ..schedule import GroundSchedule
 from ..schedule_sim_ground import run_scheduler
 from ..schedule_sim_satellite import create_satellite_schedule
@@ -525,79 +528,306 @@ def create_healpix_ring_satellite(
     return data
 
 
-def create_fake_sky(data, dist_key, map_key, hpix_out=None):
-    np.random.seed(987654321)
-    dist = data[dist_key]
-    pix_data = PixelData(dist, np.float64, n_value=3, units=defaults.det_data_units)
-    # Just replicate the fake data across all local submaps
+def create_fake_healpix_file(
+    out_file,
+    nside,
+    fwhm=10.0 * u.arcmin,
+    lmax=256,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
+    units=u.K,
+):
+    """Generate a fake sky map on disk with one process.
+
+    This should only be called on a single process!
+
+    Args:
+        out_file (str):  The output FITS map.
+        nside (int):  The NSIDE value.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        lmax (int):  The ell_max of the expansion for smoothing.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        units (Unit):  The map units to write to the file.
+
+    Returns:
+        None
+
+    """
+    npix = 12 * nside**2
     off = 0
-    for submap in range(dist.n_submap):
-        I_data = 0.3 * np.random.normal(size=dist.n_pix_submap)
-        Q_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
-        U_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
-        if submap in dist.local_submaps:
-            pix_data.data[off, :, 0] = I_data
-            pix_data.data[off, :, 1] = Q_data
-            pix_data.data[off, :, 2] = U_data
-            off += 1
-    data[map_key] = pix_data
-    if hpix_out is not None:
-        write_healpix_fits(
-            pix_data,
-            hpix_out,
-            nest=True,
-            comm_bytes=10000000,
-            report_memory=False,
-            single_precision=False,
+    maps = list()
+    for scale in [I_scale, Q_scale, U_scale]:
+        vals = np.array(
+            rng.random(
+                npix,
+                key=(12345, 6789),
+                counter=(0, off),
+                sampler="gaussian",
+            ),
+            dtype=np.float64,
         )
+        vals = hp.smoothing(vals, fwhm=fwhm.to_value(u.radian), lmax=lmax)
+        maps.append(scale * vals)
+        off += npix
+    del vals
+    unit_str = f"{units}"
+    hp.write_map(
+        out_file,
+        maps,
+        nest=True,
+        fits_IDL=False,
+        coord="C",
+        column_units=unit_str,
+        dtype=np.float32,
+    )
+    del maps
 
 
-def create_fake_sky_tod(
+def create_fake_wcs_file(
+    out_file,
+    wcs,
+    wcs_shape,
+    fwhm=10.0 * u.arcmin,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
+    units=u.K,
+):
+    """Generate a fake sky map on disk with one process.
+
+    This should only be called on a single process!
+
+    Args:
+        out_file (str):  The output FITS map.
+        wcs (astropy.wcs.WCS):  The WCS structure.
+        wcs_shape (tuple):  The image dimensions in longitude, latitude.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        units (Unit):  The map units to write to the file.
+
+    Returns:
+        None
+
+    """
+    # Image dimensions
+    lon_dim = wcs_shape[0]
+    lat_dim = wcs_shape[1]
+    # Get the smoothing kernel FWHM in terms of pixels
+    lon_res_deg = np.absolute(wcs.wcs.cdelt[0])
+    lat_res_deg = np.absolute(wcs.wcs.cdelt[1])
+    lon_fwhm = fwhm.to_value(u.degree) / lon_res_deg
+    lat_fwhm = fwhm.to_value(u.degree) / lat_res_deg
+
+    image_shape = (3, lat_dim, lon_dim)
+    image = np.zeros(image_shape, dtype=np.float64)
+
+    np.random.seed(987654321)
+    for imap, scale in enumerate([I_scale, Q_scale, U_scale]):
+        temp = np.random.normal(loc=0.0, scale=scale, size=(lat_dim, lon_dim))
+        image[imap, :, :] = gaussian_filter(temp, sigma=(lat_fwhm, lon_fwhm))
+
+    # Basic wcs header
+    header = wcs.to_header(relax=True)
+    # Add map dimensions
+    header["NAXIS"] = image.ndim
+    for i, n in enumerate(image.shape[::-1]):
+        header[f"NAXIS{i+1}"] = n
+    # Add units
+    header["BUNIT"] = str(units)
+    hdus = af.HDUList([af.PrimaryHDU(image.astype(np.float32), header)])
+    hdus.writeto(out_file)
+    del hdus
+    del image
+
+
+def create_fake_healpix_map(
+    out_file,
+    pixel_dist,
+    fwhm=10.0 * u.arcmin,
+    lmax=256,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
+    units=u.K,
+):
+    """Create and load a healpix map into a PixelData object.
+
+    This starts from a pre-made PixelDistribution and uses that to determine
+    the Healpix NSIDE.  It then creates a map on disk and loads it into a
+    distributed PixelData object.
+
+    Args:
+        out_file (str):  The generated FITS map.
+        pixel_dist (PixelDistribution):  The pixel distribution to use.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        lmax (int):  The ell_max of the expansion for smoothing.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        units (Unit):  The map units to write to the file.
+
+    Returns:
+        (PixelData):  The distributed map.
+
+    """
+    comm = pixel_dist.comm
+    if comm is None:
+        rank = 0
+    else:
+        rank = comm.rank
+    npix = pixel_dist.n_pix
+    nside = hp.npix2nside(npix)
+    if rank == 0:
+        create_fake_healpix_file(
+            out_file,
+            nside,
+            fwhm=fwhm,
+            lmax=lmax,
+            I_scale=I_scale,
+            Q_scale=Q_scale,
+            U_scale=U_scale,
+            units=units,
+        )
+    if comm is not None:
+        comm.barrier()
+    pix = PixelData(pixel_dist, np.float64, n_value=3, units=units)
+    read_healpix_fits(pix, out_file, nest=True)
+    return pix
+
+
+def create_fake_wcs_map(
+    out_file,
+    pixel_dist,
+    wcs,
+    wcs_shape,
+    fwhm=10.0 * u.arcmin,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
+    units=u.K,
+):
+    """Create and load a WCS map into a PixelData object.
+
+    This starts from a pre-made PixelDistribution and WCS information (from,
+    for example, a PixelsWCS instance).  It then creates a map on disk and loads
+    it into a distributed PixelData object.
+
+    Args:
+        out_file (str):  The generated FITS map.
+        pixel_dist (PixelDistribution):  The pixel distribution to use.
+        wcs (astropy.wcs.WCS):  The WCS structure.
+        wcs_shape (tuple):  The image dimensions in longitude, latitude.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        units (Unit):  The map units to write to the file.
+
+    Returns:
+        (PixelData):  The distributed map.
+
+    """
+    comm = pixel_dist.comm
+    if comm is None:
+        rank = 0
+    else:
+        rank = comm.rank
+    if rank == 0:
+        create_fake_wcs_file(
+            out_file,
+            wcs,
+            wcs_shape,
+            fwhm=fwhm,
+            I_scale=I_scale,
+            Q_scale=Q_scale,
+            U_scale=U_scale,
+            units=units,
+        )
+    if comm is not None:
+        comm.barrier()
+    pix = PixelData(pixel_dist, np.float64, n_value=3, units=units)
+    read_wcs_fits(pix, out_file)
+    return pix
+
+
+def create_fake_healpix_scanned_tod(
     data,
     pixel_pointing,
     stokes_weights,
-    map_vals=(1.0, 1.0, 1.0),
+    out_file,
+    pixel_dist,
+    map_key="fake_sky",
+    fwhm=10.0 * u.arcmin,
+    lmax=256,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
     det_data=defaults.det_data,
-    randomize=False,
 ):
-    """Fake sky signal with constant I/Q/U"""
-    np.random.seed(987654321)
+    """Create a fake healpix map and scan this into detector timestreams.
 
-    # Build the pixel distribution
-    build_dist = ops.BuildPixelDistribution(
-        pixel_dist="fake_map_dist",
-        pixel_pointing=pixel_pointing,
+    The pixel distribution is created if it does not exist.  The map is created
+    on disk and then loaded into a PixelData object.  The pointing expansion and
+    map scanning are pipelined so that detector pointing does not need to be stored
+    persistently.
+
+    Args:
+        data (Data):  The data container.
+        pixel_pointing (Operator):  The healpix pixelization operator.
+        stokes_weights (Operator):  The detector weights operator.
+        out_file (str):  The generated FITS map.
+        pixel_dist (PixelDistribution):  The pixel distribution to use.
+        map_key (str):  The data key to hold the generated map in memory.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        lmax (int):  The ell_max of the expansion for smoothing.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        det_data (str):  The detdata name of the output scanned signal.
+
+    Returns:
+        None
+
+    """
+    if pixel_dist not in data:
+        # Build the pixel distribution
+        build_dist = ops.BuildPixelDistribution(
+            pixel_dist=pixel_dist,
+            pixel_pointing=pixel_pointing,
+        )
+        build_dist.apply(data)
+
+    if map_key in data:
+        msg = f"Generated map '{map_key}' already exists in data"
+        raise RuntimeError(msg)
+
+    # Use detector data units for the map, if it exists.
+    first_obs = data.obs[0]
+    if det_data in first_obs.detdata:
+        units = first_obs.detdata[det_data].units
+    else:
+        units = u.K
+
+    # Create and load the map
+    data[map_key] = create_fake_healpix_map(
+        out_file,
+        data[pixel_dist],
+        fwhm=fwhm,
+        lmax=lmax,
+        I_scale=I_scale,
+        Q_scale=Q_scale,
+        U_scale=U_scale,
+        units=units,
     )
-    build_dist.apply(data)
-
-    # Create a fake sky
-    map_key = "fake_map"
-    dist_key = build_dist.pixel_dist
-    dist = data[dist_key]
-    pix_data = PixelData(dist, np.float64, n_value=3, units=u.K)
-    off = 0
-    for submap in range(dist.n_submap):
-        if submap in dist.local_submaps:
-            if randomize:
-                pix_data.data[off, :, 0] = map_vals[0] * np.random.normal(
-                    size=dist.n_pix_submap
-                )
-                pix_data.data[off, :, 1] = map_vals[1] * np.random.normal(
-                    size=dist.n_pix_submap
-                )
-                pix_data.data[off, :, 2] = map_vals[2] * np.random.normal(
-                    size=dist.n_pix_submap
-                )
-            else:
-                pix_data.data[off, :, 0] = map_vals[0]
-                pix_data.data[off, :, 1] = map_vals[1]
-                pix_data.data[off, :, 2] = map_vals[2]
-            off += 1
-    data[map_key] = pix_data
 
     # Scan map into timestreams
     scanner = ops.ScanMap(
-        det_data=defaults.det_data,
+        det_data=det_data,
         pixels=pixel_pointing.pixels,
         weights=stokes_weights.weights,
         map_key=map_key,
@@ -611,7 +841,254 @@ def create_fake_sky_tod(
         ],
     )
     scan_pipe.apply(data)
-    return map_key
+
+    # Cleanup, to avoid any conflicts with the calling code.
+    for ob in data.obs:
+        for buf in [
+            pixel_pointing.pixels,
+            stokes_weights.weights,
+            pixel_pointing.detector_pointing.quats,
+        ]:
+            if buf in ob:
+                del ob[buf]
+
+
+def create_fake_wcs_scanned_tod(
+    data,
+    pixel_pointing,
+    stokes_weights,
+    out_file,
+    pixel_dist,
+    map_key="fake_sky",
+    fwhm=10.0 * u.arcmin,
+    I_scale=1.0,
+    Q_scale=1.0,
+    U_scale=1.0,
+    det_data=defaults.det_data,
+):
+    """Create a fake WCS map and scan this into detector timestreams.
+
+    The pixel distribution is created if it does not exist.  The map is created
+    on disk and then loaded into a PixelData object.  The pointing expansion and
+    map scanning are pipelined so that detector pointing does not need to be stored
+    persistently.
+
+    Args:
+        data (Data):  The data container.
+        pixel_pointing (Operator):  The healpix pixelization operator.
+        stokes_weights (Operator):  The detector weights operator.
+        out_file (str):  The generated FITS map.
+        pixel_dist (PixelDistribution):  The pixel distribution to use.
+        map_key (str):  The data key to hold the generated map in memory.
+        fwhm (Quantity):  The beam smoothing FWHM.
+        I_scale (float):  The overall scaling factor of the intensity map.
+        Q_scale (float):  The overall scaling factor of the Stokes Q map.
+        U_scale (float):  The overall scaling factor of the Stokes U map.
+        det_data (str):  The detdata name of the output scanned signal.
+
+    Returns:
+        None
+
+    """
+    if pixel_dist not in data:
+        # Build the pixel distribution
+        build_dist = ops.BuildPixelDistribution(
+            pixel_dist=pixel_dist,
+            pixel_pointing=pixel_pointing,
+        )
+        build_dist.apply(data)
+
+    if map_key in data:
+        msg = f"Generated map '{map_key}' already exists in data"
+        raise RuntimeError(msg)
+
+    # Use detector data units for the map, if it exists.
+    first_obs = data.obs[0]
+    if det_data in first_obs.detdata:
+        units = first_obs.detdata[det_data].units
+    else:
+        units = u.K
+
+    # Get the WCS info from the pixel operator
+    wcs = pixel_pointing.wcs
+    wcs_shape = pixel_pointing.wcs_shape
+
+    # Create and load the map
+    data[map_key] = create_fake_wcs_map(
+        out_file,
+        data[pixel_dist],
+        wcs,
+        wcs_shape,
+        fwhm=fwhm,
+        I_scale=I_scale,
+        Q_scale=Q_scale,
+        U_scale=U_scale,
+        units=units,
+    )
+
+    # Scan map into timestreams
+    scanner = ops.ScanMap(
+        det_data=det_data,
+        pixels=pixel_pointing.pixels,
+        weights=stokes_weights.weights,
+        map_key=map_key,
+    )
+    scan_pipe = ops.Pipeline(
+        detector_sets=["SINGLE"],
+        operators=[
+            pixel_pointing,
+            stokes_weights,
+            scanner,
+        ],
+    )
+    scan_pipe.apply(data)
+
+    # Cleanup, to avoid any conflicts with the calling code.
+    for ob in data.obs:
+        for buf in [
+            pixel_pointing.pixels,
+            stokes_weights.weights,
+            pixel_pointing.detector_pointing.quats,
+        ]:
+            if buf in ob:
+                del ob[buf]
+
+
+# def create_fake_sky(data, dist_key, map_key, hpix_out=None):
+#     np.random.seed(987654321)
+#     dist = data[dist_key]
+#     pix_data = PixelData(dist, np.float64, n_value=3, units=defaults.det_data_units)
+#     # Just replicate the fake data across all local submaps
+#     off = 0
+#     for submap in range(dist.n_submap):
+#         I_data = 0.3 * np.random.normal(size=dist.n_pix_submap)
+#         Q_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
+#         U_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
+#         if submap in dist.local_submaps:
+#             pix_data.data[off, :, 0] = I_data
+#             pix_data.data[off, :, 1] = Q_data
+#             pix_data.data[off, :, 2] = U_data
+#             off += 1
+#     data[map_key] = pix_data
+#     if hpix_out is not None:
+#         write_healpix_fits(
+#             pix_data,
+#             hpix_out,
+#             nest=True,
+#             comm_bytes=10000000,
+#             report_memory=False,
+#             single_precision=False,
+#         )
+
+
+# def create_fake_healpix_sky(
+#     data,
+#     dist_key,
+#     map_key,
+#     fwhm=10.0 * u.arcmin,
+#     lmax=256,
+#     hpix_out=None,
+# ):
+#     npix = data[dist_key].npix
+#     map_vals = np.array(
+#         rng.random(
+#             npix,
+#             key=(12345, 6789),
+#             counter=(0, 0),
+#             sampler="gaussian",
+#         ),
+#         dtype=np.float64,
+#     )
+#     map_vals = hp.smoothing(
+#         map_vals, fwhm=self.fwhm.to_value(u.radian), lmax=self.lmax
+#     ).astype(dtype)
+#     sss_map /= np.std(sss_map)
+
+#     dist = data[dist_key]
+#     pix_data = PixelData(dist, np.float64, n_value=3, units=defaults.det_data_units)
+#     # Just replicate the fake data across all local submaps
+#     off = 0
+#     for submap in range(dist.n_submap):
+#         I_data = 0.3 * np.random.normal(size=dist.n_pix_submap)
+#         Q_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
+#         U_data = 0.03 * np.random.normal(size=dist.n_pix_submap)
+#         if submap in dist.local_submaps:
+#             pix_data.data[off, :, 0] = I_data
+#             pix_data.data[off, :, 1] = Q_data
+#             pix_data.data[off, :, 2] = U_data
+#             off += 1
+#     data[map_key] = pix_data
+#     if hpix_out is not None:
+#         write_healpix_fits(
+#             pix_data,
+#             hpix_out,
+#             nest=True,
+#             comm_bytes=10000000,
+#             report_memory=False,
+#             single_precision=False,
+#         )
+
+
+# def create_fake_sky_tod(
+#     data,
+#     pixel_pointing,
+#     stokes_weights,
+#     map_vals=(1.0, 1.0, 1.0),
+#     det_data=defaults.det_data,
+#     randomize=False,
+# ):
+#     """Fake sky signal with constant I/Q/U"""
+#     np.random.seed(987654321)
+
+#     # Build the pixel distribution
+#     build_dist = ops.BuildPixelDistribution(
+#         pixel_dist="fake_map_dist",
+#         pixel_pointing=pixel_pointing,
+#     )
+#     build_dist.apply(data)
+
+#     # Create a fake sky
+#     map_key = "fake_map"
+#     dist_key = build_dist.pixel_dist
+#     dist = data[dist_key]
+#     pix_data = PixelData(dist, np.float64, n_value=3, units=u.K)
+#     off = 0
+#     for submap in range(dist.n_submap):
+#         if submap in dist.local_submaps:
+#             if randomize:
+#                 pix_data.data[off, :, 0] = map_vals[0] * np.random.normal(
+#                     size=dist.n_pix_submap
+#                 )
+#                 pix_data.data[off, :, 1] = map_vals[1] * np.random.normal(
+#                     size=dist.n_pix_submap
+#                 )
+#                 pix_data.data[off, :, 2] = map_vals[2] * np.random.normal(
+#                     size=dist.n_pix_submap
+#                 )
+#             else:
+#                 pix_data.data[off, :, 0] = map_vals[0]
+#                 pix_data.data[off, :, 1] = map_vals[1]
+#                 pix_data.data[off, :, 2] = map_vals[2]
+#             off += 1
+#     data[map_key] = pix_data
+
+#     # Scan map into timestreams
+#     scanner = ops.ScanMap(
+#         det_data=defaults.det_data,
+#         pixels=pixel_pointing.pixels,
+#         weights=stokes_weights.weights,
+#         map_key=map_key,
+#     )
+#     scan_pipe = ops.Pipeline(
+#         detector_sets=["SINGLE"],
+#         operators=[
+#             pixel_pointing,
+#             stokes_weights,
+#             scanner,
+#         ],
+#     )
+#     scan_pipe.apply(data)
+#     return map_key
 
 
 def create_fake_mask(data, dist_key, mask_key):

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -18,7 +18,7 @@ from ._helpers import (
     close_data,
     create_ground_data,
     create_outdir,
-    create_fake_sky_tod,
+    create_fake_healpix_scanned_tod,
 )
 
 from .mpi import MPITestCase
@@ -52,12 +52,21 @@ class DemodulateTest(MPITestCase):
             detector_pointing=detpointing,
         )
 
-        map_values = (10.0, 2.0, 0.0)
-        map_key = create_fake_sky_tod(
+        sky_file = os.path.join(self.outdir, "fake_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
             data,
             pixels,
             weights,
-            map_vals=map_values,
+            sky_file,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
         )
 
         # Simulate noise
@@ -184,6 +193,7 @@ class DemodulateTest(MPITestCase):
 
             map_mod = hp.read_map(fname_mod, None)
             map_demod = hp.read_map(fname_demod, None)
+            map_input = hp.read_map(sky_file, None)
 
             fig = plt.figure(figsize=[18, 12])
             nrow, ncol = 2, 3
@@ -191,7 +201,7 @@ class DemodulateTest(MPITestCase):
             reso = 5
 
             for i, m in enumerate(map_mod):
-                value = map_values[i]
+                value = map_input[i]
                 good = m != 0
                 rms = np.sqrt(np.mean((m[good] - value) ** 2))
                 m[m == 0] = hp.UNSEEN
@@ -209,7 +219,7 @@ class DemodulateTest(MPITestCase):
                 )
 
             for i, m in enumerate(map_demod):
-                value = map_values[i]
+                value = map_input[i]
                 good = m != 0
                 rms = np.sqrt(np.mean((m[good] - value) ** 2))
                 m[m == 0] = hp.UNSEEN

--- a/src/toast/tests/ops_example_ground.py
+++ b/src/toast/tests/ops_example_ground.py
@@ -1,0 +1,603 @@
+# Copyright (c) 2024-2024 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+import numpy.testing as nt
+from astropy import units as u
+from astropy.table import Column
+
+from .. import ops as ops
+from .. import templates as templates
+from ..intervals import IntervalList
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..vis import (
+    set_matplotlib_backend,
+    plot_healpix_maps,
+    plot_wcs_maps,
+    plot_noise_estim,
+)
+from ._helpers import (
+    close_data,
+    create_ground_data,
+    create_outdir,
+    fake_flags,
+    fake_hwpss,
+    create_fake_healpix_scanned_tod,
+)
+from .mpi import MPITestCase
+
+
+class ExampleGroundTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+        np.random.seed(123456)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
+
+    def test_example(self):
+        testdir = os.path.join(self.outdir, "example")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create some test data.  Disable HWPSS, since we are not demodulating
+        # in this example.
+        data = self.create_test_data(
+            testdir,
+            sky=True,
+            atm=True,
+            noise=True,
+            hwpss=False,
+            azss=True,
+            flags=True,
+        )
+
+        # Make a copy for later comparison
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        # Diagnostic plots of one detector on each process.  This is useful for
+        # plotting the "input" data before doing any operations.
+        for ob in data.obs:
+            self.plot_obs(
+                testdir,
+                "input",
+                ob,
+                defaults.det_data,
+                dets=None,
+                det_mask=defaults.det_mask_nonscience,
+                interval_name="scanning",
+            )
+
+        # -----------------------------------------------------------------------------
+        # Here is where we could do something to the timestream values.  For example,
+        # filtering, flagging, etc.  This depends on what new thing we are testing.
+        # If we are processing the timestream in some way, we could instantiate our
+        # operator here and apply it to the data.
+        # -----------------------------------------------------------------------------
+
+        for ob in data.obs:
+            # -------------------------------------------------------------------------
+            # Here is where we could do some kind of testing of generated timestream
+            # values or the results of some timestream operation.  In this example
+            # we just check that detector data has some good samples.
+            # -------------------------------------------------------------------------
+
+            selected_dets = ob.select_local_detectors(
+                flagmask=defaults.det_mask_invalid
+            )
+            for det in selected_dets:
+                # Unflagged detector should have at least some good data
+                rms = np.std(ob.detdata[defaults.det_data][det])
+                self.assertTrue(rms > 0)
+
+            # Diagnostic plots of one detector on each process
+            self.plot_obs(
+                testdir,
+                "processed",
+                ob,
+                defaults.det_data,
+                dets=None,
+                det_mask=defaults.det_mask_nonscience,
+                interval_name="scanning",
+            )
+
+        # Mapmaking.  Not all tests need to make a map!  Some tests are just examining
+        # the results of timestream processing.  Other tests of mapmaking operations
+        # might simulate data and go straight to map-domain tests.
+
+        # Detector pointing
+        detpointing = ops.PointingDetectorSimple()
+
+        # Pointing matrix for Mapmaking.  We can use either Healpix or WCS projections.
+        # We save that choice so that we can use it later for diagnostic plots.
+        use_healpix = True
+
+        if use_healpix:
+            # Healpix pixelization
+            pixels = ops.PixelsHealpix(
+                nside=256,
+                detector_pointing=detpointing,
+            )
+        else:
+            # WCS in one of the supported projections (CAR, TAN, etc)
+            pixels = ops.PixelsWCS(
+                detector_pointing=detpointing,
+                projection="CAR",
+                resolution=(0.05 * u.degree, 0.05 * u.degree),
+                dimensions=(),
+                auto_bounds=True,
+            )
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+
+        # Noise estimation.  Our simulated data has many contributions to the "noise",
+        # including atmosphere.  The input instrument noise model does not accurately
+        # represent the data.  For mapmaking we could either estimate the white noise
+        # level with sample differences or we could fit a full 1/f noise model spectrum.
+
+        # Estimate noise using sample differences
+        noise_estim = ops.SignalDiffNoiseModel(noise_model="noise_estimate")
+        noise_estim.apply(data)
+
+        # # Estimate full 1/f noise model.
+        # noise_estim = ops.NoiseEstim(
+        #     name="estimate_model",
+        #     # output_dir=testdir, # Enable this to dump out the model into FITS files
+        #     out_model="raw_noise_estimate",
+        #     lagmax=512,
+        #     nbin_psd=64,
+        #     nsum=1,
+        #     naverage=64,
+        # )
+        # noise_estim.apply(data)
+
+        # # Compute a 1/f fit to this
+        # noise_fit = ops.FitNoiseModel(
+        #     noise_model=noise_estim.out_model,
+        #     out_model="noise_estimate",
+        # )
+        # noise_fit.apply(data)
+
+        # Plot the noise estimates.  Just the first detector of each obs
+        # on each process.
+        if self.make_plots:
+            for ob in data.obs:
+                det = ob.local_detectors[0]
+                if "raw_noise_estimate" in ob:
+                    # We have both a raw and fit noise model
+                    est_freq = ob["raw_noise_estimate"].freq(det)
+                    est_psd = ob["raw_noise_estimate"].psd(det)
+                    fit_freq = ob["noise_estimate"].freq(det)
+                    fit_psd = ob["noise_estimate"].psd(det)
+                else:
+                    # Just a sample diff estimate
+                    est_freq = ob["noise_estimate"].freq(det)
+                    est_psd = ob["noise_estimate"].psd(det)
+                    fit_freq = None
+                    fit_psd = None
+                fname = os.path.join(testdir, f"{ob.name}_{det}_noise_estimate.png")
+                plot_noise_estim(
+                    fname,
+                    est_freq,
+                    est_psd,
+                    fit_freq=fit_freq,
+                    fit_psd=fit_psd,
+                    semilog=False,
+                )
+
+        # Set up binning operator for solving and final binning
+        binner = ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model="noise_estimate",
+            view="scanning",
+        )
+
+        # Simple offset template (i.e. classic destriping "baselines")
+        offset_tmpl = templates.Offset(
+            name="offset_template",
+            times=defaults.times,
+            noise_model="noise_estimate",
+            step_time=1.0 * u.second,
+            use_noise_prior=False,
+            precond_width=1,
+        )
+
+        # Template for scan synchronous signal
+        azss_tmpl = templates.Periodic(
+            name="azss_template",
+            key=defaults.azimuth,
+            flags=defaults.shared_flags,
+            flag_mask=defaults.shared_mask_invalid,
+            bins=10,
+        )
+
+        # Build the template matrix
+        tmatrix = ops.TemplateMatrix(
+            templates=[
+                azss_tmpl,
+                offset_tmpl,
+            ],
+            view="scanning",
+        )
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="example",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-3,
+            write_hits=True,
+            write_map=True,
+            write_binmap=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=True,
+            keep_final_products=False,
+            save_cleaned=True,
+            overwrite_cleaned=True,
+            output_dir=testdir,
+        )
+
+        # Make the map
+        mapper.apply(data)
+
+        # Write offset amplitudes
+        oamps = data[f"{mapper.name}_solve_amplitudes"][offset_tmpl.name]
+        oroot = os.path.join(testdir, f"{mapper.name}_template-offset")
+        offset_tmpl.write(oamps, oroot)
+
+        # Dump out the Az synchronous signal template amplitudes
+        pamps = data[f"{mapper.name}_solve_amplitudes"][azss_tmpl.name]
+        pfile = os.path.join(testdir, f"{mapper.name}_template-azss.h5")
+        pplot_root = os.path.join(testdir, f"{mapper.name}_template-azss")
+        azss_tmpl.write(pamps, pfile)
+
+        # Plot some results
+        if data.comm.world_rank == 0 and self.make_plots:
+            hit_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
+            map_file = os.path.join(testdir, f"{mapper.name}_map.fits")
+            binmap_file = os.path.join(testdir, f"{mapper.name}_binmap.fits")
+            I_range = (-2, 2)
+            P_range = (-0.5, 0.5)
+            if use_healpix:
+                plot_healpix_maps(hitfile=hit_file, gnomview=True, gnomres=0.5)
+                plot_healpix_maps(
+                    hitfile=hit_file,
+                    mapfile=map_file,
+                    range_I=I_range,
+                    range_Q=P_range,
+                    range_U=P_range,
+                    gnomview=True,
+                    gnomres=0.5,
+                )
+                plot_healpix_maps(
+                    hitfile=hit_file,
+                    mapfile=binmap_file,
+                    range_I=I_range,
+                    range_Q=P_range,
+                    range_U=P_range,
+                    gnomview=True,
+                    gnomres=0.5,
+                )
+            else:
+                plot_wcs_maps(hitfile=hit_file)
+                plot_wcs_maps(
+                    hitfile=hit_file,
+                    mapfile=map_file,
+                    range_I=I_range,
+                    range_Q=P_range,
+                    range_U=P_range,
+                )
+                plot_wcs_maps(
+                    hitfile=hit_file,
+                    mapfile=binmap_file,
+                    range_I=I_range,
+                    range_Q=P_range,
+                    range_U=P_range,
+                )
+            templates.periodic.plot(pfile, out_root=pplot_root)
+            for ob in data.obs:
+                templates.offset.plot(
+                    f"{oroot}_{ob.name}.h5",
+                    compare={x: ob.detdata["input"][x, :] for x in ob.local_detectors},
+                    out=f"{oroot}_{ob.name}",
+                )
+
+        # -------------------------------------------------------------------------
+        # Here is where we could evaluate map-domain quantities.  For example, we
+        # could load the input map and compare values, etc.  For now, just check
+        # that the destriped / template-regressed timestreams have a smaller RMS
+        # than the inputs.
+        # -------------------------------------------------------------------------
+
+        # Compare the cleaned timestreams to the original
+        for ob in data.obs:
+            self.plot_obs(
+                testdir,
+                "cleaned",
+                ob,
+                defaults.det_data,
+                dets=None,
+                det_mask=defaults.det_mask_nonscience,
+                interval_name="scanning",
+            )
+            for det in ob.local_detectors:
+                dof = np.sqrt(ob.n_local_samples)
+                in_rms = np.std(ob.detdata["input"][det])
+                out_rms = np.std(ob.detdata[defaults.det_data][det])
+                if out_rms > in_rms:
+                    msg = f"{ob.name} det {det} cleaned rms ({out_rms}) greater than "
+                    msg += f"input ({in_rms})"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+
+        # This deletes ALL data, including external communicators that are not normally
+        # destroyed by doing "del data".
+        close_data(data)
+
+    def plot_obs(
+        self,
+        out_dir,
+        prefix,
+        obs,
+        detdata_name,
+        dets=None,
+        det_mask=defaults.det_mask_nonscience,
+        interval_name=None,
+    ):
+        if not self.make_plots:
+            return
+        import matplotlib.pyplot as plt
+        import matplotlib.patches as mpatches
+
+        # Every process will plot its first local detector
+        selected_dets = obs.select_local_detectors(selection=dets, flagmask=det_mask)
+
+        # If the helper function for flagging samples has been applied, we will have
+        # the first half of the samples flagged.  Plot the full observation and also
+        # a range of samples near the center.
+        n_all_samp = obs.n_all_samples
+        plot_ranges = list()
+        plot_files = list()
+        n_plot = 2
+        fig_height = 6 * n_plot
+        axes = dict()
+        pltsamp = 400
+        det = selected_dets[0]
+        for first, last in [
+            (0, n_all_samp),
+            (n_all_samp // 2 - pltsamp, n_all_samp // 2 + pltsamp),
+        ]:
+            rangestr = f"{first}-{last}"
+            axes[rangestr] = dict()
+            axes[rangestr]["range"] = (first, last)
+            axes[rangestr]["file"] = os.path.join(
+                out_dir,
+                f"{obs.name}_{det}_{first}-{last}.pdf",
+            )
+            axes[rangestr]["fig"] = plt.figure(figsize=(12, fig_height), dpi=72)
+            axes[rangestr]["ax"] = list()
+            for pl in range(n_plot):
+                axes[rangestr]["ax"].append(
+                    axes[rangestr]["fig"].add_subplot(n_plot, 1, pl + 1, aspect="auto")
+                )
+
+        times = obs.shared[defaults.times].data
+        signal = obs.detdata[detdata_name][det]
+        detflags = obs.detdata[defaults.det_flags][det]
+        shflags = obs.shared[defaults.shared_flags].data
+
+        for rangestr, props in axes.items():
+            rg = props["range"]
+            file = props["file"]
+            fig = props["fig"]
+            ax = props["ax"]
+            props["legend"] = list()
+            plot_slc = slice(rg[0], rg[1], 1)
+            # Plot signal
+            ax[0].plot(
+                times[plot_slc],
+                signal[plot_slc],
+                color="black",
+                label=f"{det} '{detdata_name}'",
+            )
+            handles, labels = ax[0].get_legend_handles_labels()
+            props["legend"].append(handles)
+            # Plot flags
+            ax[1].plot(
+                times[plot_slc],
+                shflags[plot_slc],
+                color="blue",
+                label="Shared Flags",
+            )
+            ax[1].plot(
+                times[plot_slc],
+                detflags[plot_slc],
+                color="red",
+                label=f"{det} Flags",
+            )
+            handles, labels = ax[1].get_legend_handles_labels()
+            # Plot Intervals
+            if interval_name is not None:
+                plt_intervals = IntervalList(
+                    timestamps=times, samplespans=[(rg[0], rg[1])]
+                )
+                overlap = plt_intervals & obs.intervals[interval_name]
+                for intr in overlap:
+                    ax[1].axvspan(
+                        times[intr.first], times[intr.last], color="gray", alpha=0.1
+                    )
+                # Add a legend entry for the intervals
+                patch = mpatches.Patch(
+                    color="gray", alpha=0.1, label=f"Intervals '{interval_name}'"
+                )
+                handles.append(patch)
+            props["legend"].append(handles)
+
+        for rangestr, props in axes.items():
+            rg = props["range"]
+            file = props["file"]
+            fig = props["fig"]
+            ax = props["ax"]
+            handles = props["legend"]
+            for a, handle in zip(ax, handles):
+                a.legend(handles=handle, loc="best")
+            fig.suptitle(f"Obs {obs.name}:{rangestr}")
+            fig.savefig(file)
+            plt.close(fig)
+
+    def create_test_data(
+        self,
+        outdir,
+        sky=False,
+        atm=False,
+        noise=False,
+        hwpss=False,
+        azss=False,
+        flags=False,
+    ):
+        # Slightly slower than 0.5 Hz
+        hwp_rpm = 29.0
+        hwp_rate = 2 * np.pi * hwp_rpm / 60.0  # rad/s
+
+        sample_rate = 30 * u.Hz
+        ang_per_sample = hwp_rate / sample_rate.to_value(u.Hz)
+
+        # Create a fake ground observations set for testing.  We add more detectors
+        # than the default to create a denser focalplane for more cross linking.
+        data = create_ground_data(
+            self.comm,
+            sample_rate=sample_rate,
+            hwp_rpm=hwp_rpm,
+            pixel_per_process=7,
+            single_group=True,
+            fp_width=5.0 * u.degree,
+        )
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Detector pointing in RA/DEC and Az/El
+        detpointing_radec = ops.PointingDetectorSimple(shared_flag_mask=0)
+        detpointing_azel = ops.PointingDetectorSimple(
+            shared_flag_mask=0,
+            boresight=defaults.boresight_azel,
+        )
+
+        # Make an elevation-dependent noise model
+        el_model = ops.ElevationNoise(
+            noise_model=default_model.noise_model,
+            out_model="el_weighted",
+            detector_pointing=detpointing_azel,
+        )
+        el_model.apply(data)
+
+        # Create some fake sky signal.  Here we generate a random map and scan
+        # it into timestreams.
+        if sky:
+            # Healpix pointing matrix
+            pixels = ops.PixelsHealpix(
+                nside=256,
+                detector_pointing=detpointing_radec,
+            )
+            weights = ops.StokesWeights(
+                mode="IQU",
+                hwp_angle=defaults.hwp_angle,
+                detector_pointing=detpointing_radec,
+            )
+            skyfile = os.path.join(outdir, f"sky_input.fits")
+            create_fake_healpix_scanned_tod(
+                data,
+                pixels,
+                weights,
+                skyfile,
+                "input_sky_dist",
+                map_key="input_sky",
+                fwhm=30.0 * u.arcmin,
+                lmax=3 * pixels.nside,
+                I_scale=0.001,
+                Q_scale=0.0001,
+                U_scale=0.0001,
+                det_data=defaults.det_data,
+            )
+            if self.make_plots:
+                if data.comm.world_rank == 0:
+                    plot_healpix_maps(mapfile=skyfile)
+
+        # Atmosphere
+        if atm:
+            sim_atm = ops.SimAtmosphere(
+                detector_pointing=detpointing_azel,
+                zmax=1000 * u.m,
+                gain=1.0e-4,
+                xstep=100 * u.m,
+                ystep=100 * u.m,
+                zstep=100 * u.m,
+                add_loading=True,
+                lmin_center=300 * u.m,
+                lmin_sigma=30 * u.m,
+                lmax_center=10000 * u.m,
+                lmax_sigma=1000 * u.m,
+                # lmin_center=0.001 * u.m,
+                # lmin_sigma=0.0001 * u.m,
+                # lmax_center=1 * u.m,
+                # lmax_sigma=0.1 * u.m,
+            )
+            sim_atm.apply(data)
+
+        # Create Az synchronous signal
+        if azss:
+            sss = ops.SimScanSynchronousSignal(
+                detector_pointing=detpointing_azel,
+                nside=1024,
+                scale=1.0 * u.mK,
+            )
+            sss.apply(data)
+
+        # Create HWPSS
+        if hwpss:
+            hwpss_scale = 10.0
+            # Just get an approximate rms, based on the input optical
+            # power simulated so far.
+            tod_rms = np.std(data.obs[0].detdata[defaults.det_data][0])
+            coeff = fake_hwpss(data, defaults.det_data, hwpss_scale * tod_rms)
+
+        # Simulate elevation-weighted instrumental noise
+        if noise:
+            sim_noise = ops.SimNoise(noise_model="el_weighted")
+            sim_noise.apply(data)
+
+        # Create flagged samples
+        if flags:
+            fake_flags(data)
+
+        # Cleanup any temporary data objects used in this function, just so that
+        # the returned data object is clean.
+        for ob in data.obs:
+            for buf in [
+                detpointing_azel.quats,
+                detpointing_radec.quats,
+            ]:
+                if buf in ob:
+                    del ob[buf]
+
+        return data

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -24,7 +24,6 @@ from ..pixels_io_healpix import read_healpix
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
     create_ground_data,
     create_outdir,
     fake_flags,

--- a/src/toast/tests/ops_interpolate_healpix.py
+++ b/src/toast/tests/ops_interpolate_healpix.py
@@ -15,7 +15,7 @@ from ..pixels_io_healpix import write_healpix_fits, write_healpix_hdf5
 from ._helpers import (
     close_data,
     create_fake_mask,
-    create_fake_sky,
+    create_fake_healpix_scanned_tod,
     create_outdir,
     create_satellite_data,
 )
@@ -47,28 +47,25 @@ class InterpolateHealpixTest(MPITestCase):
         )
         weights.apply(data)
 
+        # Create fake polarized sky signal
         hpix_file = os.path.join(self.outdir, "fake.fits")
-        if data.comm.comm_world is None or data.comm.comm_world.rank == 0:
-            # Create a smooth sky
-            lmax = 3 * pixels.nside
-            cls = np.ones([4, lmax + 1])
-            np.random.seed(98776)
-            fake_sky = hp.synfast(cls, pixels.nside, fwhm=np.radians(30))
-            # Write this to a file
-            hp.write_map(hpix_file, fake_sky)
-
-        # Scan the map from the file
-
-        scan_hpix = ops.ScanHealpixMap(
-            file=hpix_file,
-            det_data="scan_data",
-            pixel_pointing=pixels,
-            stokes_weights=weights,
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            hpix_file,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.degree,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
         )
-        scan_hpix.apply(data)
 
         # Interpolate the map from the file
-
         interp_hpix = ops.InterpolateHealpixMap(
             file=hpix_file,
             det_data="interp_data",

--- a/src/toast/tests/ops_madam.py
+++ b/src/toast/tests/ops_madam.py
@@ -15,7 +15,7 @@ from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
+    create_fake_healpix_scanned_tod,
     create_outdir,
     create_satellite_data,
     fake_flags,
@@ -52,17 +52,23 @@ class MadamTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(self.outdir, "input_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # if data.comm.world_rank == 0:
         #     set_matplotlib_backend()

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -20,7 +20,12 @@ from ..timing import GlobalTimers
 from ..timing import dump as dump_timers
 from ..timing import gather_timers
 from ..vis import set_matplotlib_backend
-from ._helpers import close_data, create_fake_sky, create_outdir, create_satellite_data
+from ._helpers import (
+    close_data,
+    create_fake_healpix_scanned_tod,
+    create_outdir,
+    create_satellite_data,
+)
 from .mpi import MPITestCase
 
 
@@ -66,17 +71,23 @@ class MapmakerTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Now clear the pointing and reset things for use with the mapmaking test later
         delete_pointing = ops.Delete(
@@ -196,17 +207,23 @@ class MapmakerTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Now clear the pointing and reset things for use with the mapmaking test later
         delete_pointing = ops.Delete(
@@ -521,22 +538,23 @@ class MapmakerTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
             data,
+            pixels,
+            weights,
+            skyfile,
             "pixel_dist",
-            "fake_map",
-            hpix_out=os.path.join(testdir, "input_map.fits"),
-        )
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Now clear the pointing and reset things for use with the mapmaking test later
         delete_pointing = ops.Delete(detdata=[pixels.pixels, weights.weights])
@@ -790,22 +808,23 @@ class MapmakerTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
             data,
+            pixels,
+            weights,
+            skyfile,
             "pixel_dist",
-            "fake_map",
-            hpix_out=os.path.join(testdir, "input_map.fits"),
-        )
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Now clear the pointing and reset things for use with the mapmaking test later
         delete_pointing = ops.Delete(

--- a/src/toast/tests/ops_noise_estim.py
+++ b/src/toast/tests/ops_noise_estim.py
@@ -19,7 +19,7 @@ from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
+    create_fake_healpix_scanned_tod,
     create_ground_data,
     create_outdir,
     create_satellite_data,
@@ -367,25 +367,22 @@ class NoiseEstimTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
-            det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
-        )
-        scanner.apply(data)
-
-        # Write map to a file
+        # Create fake polarized sky pixel values
         map_file = os.path.join(self.outdir, "fake_map.fits")
-        write_healpix_fits(data["fake_map"], map_file, nest=pixels.nest)
-
-        # Create an uncorrelated noise model from focalplane detector properties
-        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
-        default_model.apply(data)
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            map_file,
+            "pixel_dist",
+            map_key="fake_map",
+            fwhm=60.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
+        )
 
         # Simulate noise from this model
         sim_noise = ops.SimNoise(noise_model="noise_model")

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -18,7 +18,7 @@ from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
+    create_fake_healpix_scanned_tod,
     create_ground_data,
     create_outdir,
     create_satellite_data,
@@ -54,17 +54,23 @@ class PolyFilterTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(self.outdir, "input_sky_polyfilter.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Create an uncorrelated noise model from focalplane detector properties
         default_model = ops.DefaultNoiseModel(noise_model="noise_model")
@@ -145,17 +151,23 @@ class PolyFilterTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(self.outdir, "input_sky_polyfilter_trend.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Create an uncorrelated noise model from focalplane detector properties
         default_model = ops.DefaultNoiseModel(noise_model="noise_model")
@@ -283,17 +295,23 @@ class PolyFilterTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(self.outdir, "input_sky_polyfilter2D.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Add 2D polynomial modes.
         coeff = np.arange(norder**2)
@@ -462,17 +480,23 @@ class PolyFilterTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Scan map into timestreams
-        scanner = ops.ScanMap(
+        # Create fake polarized sky signal
+        skyfile = os.path.join(self.outdir, "input_sky_common_mode.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
             det_data=defaults.det_data,
-            pixels=pixels.pixels,
-            weights=weights.weights,
-            map_key="fake_map",
         )
-        scanner.apply(data)
 
         # Make fake flags
         fake_flags(data)

--- a/src/toast/tests/ops_scan_wcs.py
+++ b/src/toast/tests/ops_scan_wcs.py
@@ -15,7 +15,7 @@ from ..pixels_io_wcs import write_wcs_fits
 from ._helpers import (
     close_data,
     create_fake_mask,
-    create_fake_sky,
+    create_fake_wcs_map,
     create_ground_data,
     create_outdir,
 )
@@ -58,19 +58,26 @@ class ScanWCSTest(MPITestCase):
         )
         weights.apply(data)
 
-        # Create fake polarized sky pixel values locally
-        create_fake_sky(data, "pixel_dist", "fake_map")
-
-        # Write this to a file
+        # Create fake polarized sky signal
         input_file = os.path.join(self.outdir, "fake.fits")
-        write_wcs_fits(data["fake_map"], input_file)
+        map_key = "fake_map"
+        data[map_key] = create_fake_wcs_map(
+            input_file,
+            "pixel_dist",
+            fwhm=10.0 * u.arcmin,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
+        )
+        map_data = data[map_key]
 
         # Scan map into timestreams
         scanner = ops.ScanMap(
             det_data=defaults.det_data,
             pixels=pixels.pixels,
             weights=weights.weights,
-            map_key="fake_map",
+            map_key=map_key,
         )
         scanner.apply(data)
 

--- a/src/toast/tests/ops_sim_cosmic_rays.py
+++ b/src/toast/tests/ops_sim_cosmic_rays.py
@@ -14,7 +14,6 @@ from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,

--- a/src/toast/tests/ops_sim_crosstalk.py
+++ b/src/toast/tests/ops_sim_crosstalk.py
@@ -13,7 +13,6 @@ from ..pixels import PixelData, PixelDistribution
 from ..pixels_io_healpix import write_healpix_fits
 from ._helpers import (
     close_data,
-    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,

--- a/src/toast/tests/ops_sim_gaindrifts.py
+++ b/src/toast/tests/ops_sim_gaindrifts.py
@@ -16,7 +16,6 @@ from ..pixels_io_healpix import write_healpix_fits
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
     create_outdir,
     create_satellite_data,
     create_satellite_data_big,

--- a/src/toast/tests/ops_time_constant.py
+++ b/src/toast/tests/ops_time_constant.py
@@ -16,7 +16,6 @@ from ..pixels import PixelData, PixelDistribution
 from ..vis import set_matplotlib_backend
 from ._helpers import (
     close_data,
-    create_fake_sky,
     create_outdir,
     create_satellite_data,
     fake_flags,

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -31,6 +31,7 @@ from . import ops_common_mode_noise as test_ops_common_mode_noise
 from . import ops_crosslinking as test_ops_crosslinking
 from . import ops_demodulate as test_ops_demodulate
 from . import ops_elevation_noise as test_ops_elevation_noise
+from . import ops_example_ground as test_ops_example_ground
 from . import ops_filterbin as test_ops_filterbin
 from . import ops_flag_sso as test_ops_flag_sso
 from . import ops_gainscrambler as test_ops_gainscrambler

--- a/src/toast/tests/template_periodic.py
+++ b/src/toast/tests/template_periodic.py
@@ -21,7 +21,8 @@ from ..utils import rate_from_times
 from ..vis import plot_noise_estim
 from ._helpers import (
     close_data,
-    create_fake_sky,
+    create_fake_healpix_scanned_tod,
+    create_fake_wcs_scanned_tod,
     create_ground_data,
     create_outdir,
     create_satellite_data,
@@ -191,13 +192,6 @@ class TemplatePeriodicTest(MPITestCase):
         )
         pix_dist.apply(data)
 
-        create_fake_sky(data, "sky_pixel_dist", "fake_map")
-
-        outfile = os.path.join(outdir, f"sky_{self.nside}_input.fits")
-        write_healpix_fits(data["fake_map"], outfile, nest=True)
-        if data.comm.world_rank == 0:
-            plot_healpix_maps(mapfile=outfile)
-
         weights = ops.StokesWeights(
             mode="IQU",
             hwp_angle=defaults.hwp_angle,
@@ -205,21 +199,26 @@ class TemplatePeriodicTest(MPITestCase):
             detector_pointing=detpointing,
         )
 
-        scanner = ops.Pipeline(
-            operators=[
-                pixels,
-                weights,
-                ops.ScanMap(
-                    det_data="sky",
-                    pixels=pixels.pixels,
-                    weights=weights.weights,
-                    map_key="fake_map",
-                    det_data_units=defaults.det_data_units,
-                ),
-            ],
-            detsets=["SINGLE"],
+        # Create fake polarized sky signal
+        skyfile = os.path.join(outdir, f"sky_{self.nside}_input.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "sky_pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data="sky",
         )
-        scanner.apply(data)
+
+        if data.comm.world_rank == 0:
+            plot_healpix_maps(mapfile=skyfile)
 
         ops.Combine(
             op="add",
@@ -307,15 +306,6 @@ class TemplatePeriodicTest(MPITestCase):
         )
         pix_dist.apply(data)
 
-        create_fake_sky(data, "sky_pixel_dist", "fake_map")
-
-        outfile = os.path.join(
-            outdir, f"sky_{sky_proj}_{sky_res.to_value(u.arcmin)}_input.fits"
-        )
-        write_wcs_fits(data["fake_map"], outfile)
-        if data.comm.world_rank == 0:
-            plot_wcs_maps(mapfile=outfile)
-
         weights = ops.StokesWeights(
             mode="IQU",
             hwp_angle=defaults.hwp_angle,
@@ -323,21 +313,25 @@ class TemplatePeriodicTest(MPITestCase):
             detector_pointing=detpointing,
         )
 
-        scanner = ops.Pipeline(
-            operators=[
-                pixels,
-                weights,
-                ops.ScanMap(
-                    det_data="sky",
-                    pixels=pixels.pixels,
-                    weights=weights.weights,
-                    map_key="fake_map",
-                    det_data_units=defaults.det_data_units,
-                ),
-            ],
-            detsets=["SINGLE"],
+        outfile = os.path.join(
+            outdir, f"sky_{sky_proj}_{sky_res.to_value(u.arcmin)}_input.fits"
         )
-        scanner.apply(data)
+        create_fake_wcs_scanned_tod(
+            data,
+            pixels,
+            weights,
+            outfile,
+            "sky_pixel_dist",
+            map_key="fake_map",
+            fwhm=10.0 * u.arcmin,
+            I_scale=1.0,
+            Q_scale=1.0,
+            U_scale=1.0,
+            det_data="sky",
+        )
+
+        if data.comm.world_rank == 0:
+            plot_wcs_maps(mapfile=outfile)
 
         ops.Combine(
             op="add",


### PR DESCRIPTION
This work aims to solve two problems:

- Lack of an example unit test for ground telescope data which can be used as a starting point (by removing various things) for future unit tests.

- Inconsistent techniques for "scanning from a map" across many unit tests.  Basically I have removed ad-hoc code for generating fake sky signal and scanning into timestreams and centralized that in several unit test helper functions.