### PR TITLE
Improvements to AzimuthIntervals

### DIFF
--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -69,15 +69,18 @@ class IntervalList(Sequence, AcceleratorObject):
                 raise RuntimeError(
                     "If constructing from intervals, other spans should be None"
                 )
-            timespans = [(x.start, x.stop) for x in intervals]
-            indices = self._find_indices(timespans)
-            self.data = np.array(
-                [
-                    (self.timestamps[x[0]], self.timestamps[x[1]], x[0], x[1])
-                    for x in indices
-                ],
-                dtype=interval_dtype,
-            ).view(np.recarray)
+            if len(intervals) == 0:
+                self.data = np.zeros(0, dtype=interval_dtype).view(np.recarray)
+            else:
+                timespans = [(x.start, x.stop) for x in intervals]
+                indices = self._find_indices(timespans)
+                self.data = np.array(
+                    [
+                        (self.timestamps[x[0]], self.timestamps[x[1]], x[0], x[1])
+                        for x in indices
+                    ],
+                    dtype=interval_dtype,
+                ).view(np.recarray)
         elif timespans is not None:
             if samplespans is not None:
                 raise RuntimeError("Cannot construct from both time and sample spans")

--- a/src/toast/ops/CMakeLists.txt
+++ b/src/toast/ops/CMakeLists.txt
@@ -8,6 +8,7 @@ install(FILES
     delete.py
     copy.py
     reset.py
+    fill_gaps.py
     arithmetic.py
     memory_counter.py
     simple_deglitch.py

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -15,6 +15,7 @@ from .crosslinking import CrossLinking
 from .delete import Delete
 from .demodulation import Demodulate, StokesWeightsDemod
 from .elevation_noise import ElevationNoise
+from .fill_gaps import FillGaps
 from .filterbin import FilterBin, combine_observation_matrix
 from .flag_intervals import FlagIntervals
 from .flag_sso import FlagSSO

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -519,9 +519,9 @@ class AzimuthIntervals(Operator):
         flag_intervals.apply(data, detectors=None)
 
     def _find_turnaround(self, vel):
-        """Fit a quadratic polynomial and find the turnaround sample."""
+        """Fit a polynomial and find the turnaround sample."""
         x = np.arange(len(vel))
-        fit_poly = np.polynomial.polynomial.Polynomial.fit(x, vel, 4)
+        fit_poly = np.polynomial.polynomial.Polynomial.fit(x, vel, 5)
         fit_vel = fit_poly(x)
         vel_switch = np.where(fit_vel[:-1] * fit_vel[1:] < 0)[0]
         if len(vel_switch) != 1:

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -576,6 +576,7 @@ class AzimuthIntervals(Operator):
         while igrp < nfgroup:
             grp = flag_groups[igrp]
             if len(grp) == 0:
+                igrp += 1
                 continue
             first = grp[0]
             last = grp[-1] + 1

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -309,18 +309,13 @@ class Demodulate(Operator):
             self.demod_data.obs.append(demod_obs)
 
             if self.purge:
-                if self.shared_flags is not None:
-                    del obs.shared[self.shared_flags]
-                for det_data in self.det_data.split(";"):
-                    del obs.detdata[det_data]
-                if self.det_flags is not None:
-                    del obs.detdata[self.det_flags]
-                if self.noise_model is not None:
-                    del obs[self.noise_model]
+                obs.clear()
 
             log.debug_rank(
                 "Demodulated observation in", comm=data.comm.comm_group, timer=timer
             )
+        if self.purge:
+            data.clear()
 
         return
 

--- a/src/toast/ops/fill_gaps.py
+++ b/src/toast/ops/fill_gaps.py
@@ -1,0 +1,178 @@
+# Copyright (c) 2024-2024 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+import os
+
+import numpy as np
+import traitlets
+from astropy import units as u
+
+from ..observation import default_values as defaults
+from ..timing import Timer, function_timer
+from ..traits import Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, flagged_noise_fill
+from .operator import Operator
+
+
+@trait_docs
+class FillGaps(Operator):
+    """Operator that fills flagged samples with noise.
+
+    Currently this operator just fills flagged samples with a simple polynomial
+    plus white noise.  It is mostly used for visualization.  No attempt is made
+    yet to fill the gaps with a constrained noise realization.
+
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
+    det_data = Unicode(
+        defaults.det_data,
+        help="Observation detdata key",
+    )
+
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid,
+        help="Bit mask value for optional shared flagging",
+    )
+
+    det_flags = Unicode(
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
+    )
+
+    det_flag_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for detector sample flagging",
+    )
+
+    buffer = Quantity(
+        1.0 * u.s,
+        help="Buffer of time on either side of each gap",
+    )
+
+    poly_order = Int(
+        1,
+        help="Order of the polynomial to fit across each gap",
+    )
+
+    @traitlets.validate("poly_order")
+    def _check_poly_order(self, proposal):
+        check = proposal["value"]
+        if check <= 0:
+            raise traitlets.TraitError("poly_order should be >= 1")
+        return check
+
+    @traitlets.validate("det_mask")
+    def _check_det_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Det mask should be a positive integer")
+        return check
+
+    @traitlets.validate("det_flag_mask")
+    def _check_det_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Flag mask should be a positive integer")
+        return check
+
+    @traitlets.validate("shared_flag_mask")
+    def _check_shared_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Flag mask should be a positive integer")
+        return check
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        env = Environment.get()
+        log = Logger.get()
+
+        for ob in data.obs:
+            timer = Timer()
+            timer.start()
+
+            # Sample rate for this observation
+            rate = ob.telescope.focalplane.sample_rate.to_value(u.Hz)
+
+            # The buffer size in samples
+            buf_samp = int(self.buffer.to_value(u.second) * rate)
+
+            # Check that parameters make sense
+            if self.poly_order > buf_samp + 1:
+                msg = f"Cannot fit an order {self.poly_order} polynomial "
+                msg += f"to {buf_samp} samples"
+                raise RuntimeError(msg)
+
+            if buf_samp > ob.n_local_samples // 4:
+                msg = f"Using {buf_samp} samples of buffer around gaps is"
+                msg += f" not reasonable for an observation with {ob.n_local_samples}"
+                msg += " local samples"
+                raise RuntimeError(msg)
+
+            # Local detectors we are considering
+            local_dets = ob.select_local_detectors(flagmask=self.det_mask)
+            n_dets = len(local_dets)
+
+            # The shared flags
+            if self.shared_flags is None:
+                shared_flags = np.zeros(ob.n_local_samples, dtype=np.uint8)
+            else:
+                shared_flags = np.array(ob.shared[self.shared_flags].data)
+                shared_flags &= self.shared_flag_mask
+
+            for idet, det in enumerate(local_dets):
+                flags = np.array(shared_flags)
+                if self.det_flags is not None:
+                    flags |= ob.detdata[self.det_flags][det, :] & self.det_flag_mask
+                flagged_noise_fill(
+                    ob.detdata[self.det_data],
+                    flags,
+                    buf_samp,
+                    poly_order=self.poly_order,
+                )
+            msg = f"FillGaps {ob.name}: completed in"
+            log.debug_rank(msg, comm=data.comm.comm_group, timer=timer)
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        # Note that the hwp_angle is not strictly required- this
+        # is just a no-op.
+        req = {
+            "shared": [self.times],
+            "detdata": [self.det_data],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        if self.det_flags is not None:
+            req["detdata"].append(self.det_flags)
+        return req
+
+    def _provides(self):
+        prov = {
+            "meta": [],
+            "detdata": [self.det_data],
+        }
+        return prov

--- a/src/toast/ops/fill_gaps.py
+++ b/src/toast/ops/fill_gaps.py
@@ -144,9 +144,9 @@ class FillGaps(Operator):
             for idet, det in enumerate(local_dets):
                 flags = np.array(shared_flags)
                 if self.det_flags is not None:
-                    flags |= ob.detdata[self.det_flags][det, :] & self.det_flag_mask
+                    flags[:] |= ob.detdata[self.det_flags][det, :] & self.det_flag_mask
                 flagged_noise_fill(
-                    ob.detdata[self.det_data],
+                    ob.detdata[self.det_data][det],
                     flags,
                     buf_samp,
                     poly_order=self.poly_order,

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -105,10 +105,15 @@ class FlagIntervals(Operator):
             if ob.comm_col_rank == 0:
                 new_flags = np.array(ob.shared[self.shared_flags])
                 for vname, vmask in self.view_mask:
-                    views = ob.view[vname]
-                    for vw in views:
-                        # Note that a View acts like a slice
-                        new_flags[vw] |= vmask
+                    if vname in ob.intervals:
+                        views = ob.view[vname]
+                        for vw in views:
+                            # Note that a View acts like a slice
+                            new_flags[vw] |= vmask
+                    else:
+                        msg = f"Intervals '{vname}' does not exist in {ob.name}"
+                        msg += " skipping flagging"
+                        log.warning(msg)
             ob.shared[self.shared_flags].set(new_flags, offset=(0,), fromrank=0)
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -335,8 +335,8 @@ class HWPSynchronousModel(Operator):
                     ob.detdata[self.det_data][det][good] -= dc
                 if self.fill_gaps:
                     rate = ob.telescope.focalplane.sample_rate.to_value(u.Hz)
-                    # 2 second buffer
-                    buffer = 2 * int(rate)
+                    # 1 second buffer
+                    buffer = int(rate)
                     flagged_noise_fill(
                         ob.detdata[self.det_data][det],
                         det_flags[det],

--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -335,12 +335,13 @@ class HWPSynchronousModel(Operator):
                     ob.detdata[self.det_data][det][good] -= dc
                 if self.fill_gaps:
                     rate = ob.telescope.focalplane.sample_rate.to_value(u.Hz)
-                    buffer = int(rate)  # approximately one second buffer on either side
+                    # 2 second buffer
+                    buffer = 2 * int(rate)
                     flagged_noise_fill(
                         ob.detdata[self.det_data][det],
                         det_flags[det],
                         buffer,
-                        poly_order=3,
+                        poly_order=1,
                     )
                 if self.relcal_continuous is not None:
                     ob.detdata[self.relcal_continuous][det, :] = cal_center / det_mag

--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -19,7 +19,7 @@ from ..mpi import MPI, flatten
 from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
 from ..traits import Bool, Int, Quantity, Unicode, Float, trait_docs
-from ..utils import Environment, Logger
+from ..utils import Environment, Logger, flagged_noise_fill
 from .operator import Operator
 
 
@@ -126,7 +126,7 @@ class HWPSynchronousModel(Operator):
 
     time_drift = Bool(False, help="If True, include time drift terms in the model")
 
-    fill_gaps = Bool(False, help="If True, fit a simple line across gaps")
+    fill_gaps = Bool(False, help="If True, fill gaps with a simple noise model")
 
     debug = Unicode(
         None,
@@ -334,7 +334,14 @@ class HWPSynchronousModel(Operator):
                     dc = np.mean(ob.detdata[self.det_data][det][good])
                     ob.detdata[self.det_data][det][good] -= dc
                 if self.fill_gaps:
-                    self._fill_gaps(ob, det, det_flags[det])
+                    rate = ob.telescope.focalplane.sample_rate.to_value(u.Hz)
+                    buffer = int(rate)  # approximately one second buffer on either side
+                    flagged_noise_fill(
+                        ob.detdata[self.det_data][det],
+                        det_flags[det],
+                        buffer,
+                        poly_order=3,
+                    )
                 if self.relcal_continuous is not None:
                     ob.detdata[self.relcal_continuous][det, :] = cal_center / det_mag
 
@@ -924,33 +931,6 @@ class HWPSynchronousModel(Operator):
         unstable = np.absolute(hvel - nominal) > 1.0e-3 * nominal
         stopped = np.array(unstable, dtype=np.uint8)
         return stopped
-
-    def _fill_gaps(self, obs, det, flags):
-        # Fill gaps with a line, just to kill large artifacts in flagged
-        # regions after removal of the HWPSS.  This is mostly just for visualization.
-        # Downstream codes should ignore these flagged samples anyway.
-        sig = obs.detdata[self.det_data][det]
-        flag_indx = np.arange(len(flags), dtype=np.int64)[np.nonzero(flags)]
-        flag_groups = np.split(flag_indx, np.where(np.diff(flag_indx) != 1)[0] + 1)
-        for grp in flag_groups:
-            if len(grp) == 0:
-                continue
-            bad_first = grp[0]
-            bad_last = grp[-1]
-            if bad_first == 0:
-                # Starting bad samples
-                sig[: bad_last + 1] = sig[bad_last + 1]
-            elif bad_last == len(flags) - 1:
-                # Ending bad samples
-                sig[bad_first:] = sig[bad_first - 1]
-            else:
-                int_first = bad_first - 1
-                int_last = bad_last + 1
-                sig[bad_first : bad_last + 1] = np.interp(
-                    np.arange(bad_first, bad_last + 1, 1, dtype=np.int32),
-                    [int_first, int_last],
-                    [sig[int_first], sig[int_last]],
-                )
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -289,7 +289,7 @@ class SimpleJumpCorrect(Operator):
                 )
                 if self.apply_jumps is not None:
                     corrected_signal, flag_out = self._remove_jumps(
-                        sig, bad, ob[self.apply_jumps], self.jump_radius
+                        sig, bad, ob[self.apply_jumps][name], self.jump_radius
                     )
                     sig[:] = corrected_signal
                     det_flags[flag_out] |= self.jump_mask

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -80,5 +80,6 @@ install(FILES
     ops_loader.py
     accelerator.py
     ops_example_ground.py
+    ops_fill_gaps.py
     DESTINATION ${PYTHON_SITE}/toast/tests
 )

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ install(FILES
     ops_yield_cut.py
     ops_elevation_noise.py
     ops_signal_diff_noise.py
+    ops_azimuth_intervals.py
     ops_loader.py
     accelerator.py
     ops_example_ground.py

--- a/src/toast/tests/ops_azimuth_intervals.py
+++ b/src/toast/tests/ops_azimuth_intervals.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2024-2024 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+from datetime import datetime
+
+import numpy as np
+from astropy import units as u
+
+from .. import ops as ops
+from ..data import Data
+from ..instrument import Focalplane, GroundSite, Telescope
+from ..instrument_sim import fake_hexagon_focalplane
+from ..mpi import MPI, Comm
+from ..observation import Observation
+from ..observation import default_values as defaults
+from ..pixels_io_healpix import write_healpix_fits
+from ..schedule import GroundSchedule
+from ..schedule_sim_ground import run_scheduler
+from ..vis import set_matplotlib_backend
+from ..ops.sim_ground_utils import scan_between
+
+from ._helpers import close_data, create_comm, create_outdir, create_ground_telescope
+from .mpi import MPITestCase
+
+
+class AzimuthIntervalsTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+
+    def create_fake_data(self):
+        # Just one group with all processes
+        toastcomm = create_comm(self.comm, single_group=True)
+
+        rate = 100.0 * u.Hz
+
+        telescope = create_ground_telescope(
+            toastcomm.group_size,
+            sample_rate=rate,
+            pixel_per_process=1,
+            fknee=None,
+            freqs=None,
+            width=5.0 * u.degree,
+        )
+
+        data = Data(toastcomm)
+
+        # 8 minutes
+        n_samp = int(8 * 60 * rate.to_value(u.Hz))
+        n_parked = int(0.1 * n_samp)
+        n_scan = int(0.12 * n_samp)
+
+        ob = Observation(toastcomm, telescope, n_samples=n_samp, name="aztest")
+        # Create shared objects for timestamps, common flags, boresight, position,
+        # and velocity.
+        ob.shared.create_column(
+            defaults.times,
+            shape=(ob.n_local_samples,),
+            dtype=np.float64,
+        )
+        ob.shared.create_column(
+            defaults.shared_flags,
+            shape=(ob.n_local_samples,),
+            dtype=np.uint8,
+        )
+        ob.shared.create_column(
+            defaults.azimuth,
+            shape=(ob.n_local_samples,),
+            dtype=np.float64,
+        )
+        ob.shared.create_column(
+            defaults.elevation,
+            shape=(ob.n_local_samples,),
+            dtype=np.float64,
+        )
+
+        # Rank zero of each grid column creates the data
+        stamps = None
+        azimuth = None
+        elevation = None
+        flags = None
+        if ob.comm_col_rank == 0:
+            start_time = 0.0 + float(ob.local_index_offset) / rate.to_value(u.Hz)
+            stop_time = start_time + float(ob.n_local_samples - 1) / rate.to_value(u.Hz)
+            stamps = np.linspace(
+                start_time,
+                stop_time,
+                num=ob.n_local_samples,
+                endpoint=True,
+                dtype=np.float64,
+            )
+
+            scans = (n_samp - n_parked) // n_scan
+            sim_scans = scans + 1
+
+            azimuth = np.zeros(ob.n_local_samples, dtype=np.float64)
+            elevation = np.radians(45.0) * np.ones(ob.n_local_samples, dtype=np.float64)
+
+            azimuth[:n_parked] = np.pi / 4
+
+            for iscan in range(sim_scans):
+                first_samp = iscan * n_scan + n_parked
+                if iscan % 2 == 0:
+                    azstart = np.pi / 4
+                    azstop = 3 * np.pi / 4
+                else:
+                    azstart = 3 * np.pi / 4
+                    azstop = np.pi / 4
+                _, az, el = scan_between(
+                    stamps[first_samp],
+                    azstart,
+                    np.pi / 4,
+                    azstop,
+                    np.pi / 4,
+                    np.radians(1.0),  # rad / s
+                    np.radians(0.25),  # rad / s^2
+                    np.radians(1.0),  # rad / s
+                    np.radians(0.25),  # rad / s^2
+                    nstep=n_scan,
+                )
+                if iscan == scans:
+                    azimuth[first_samp:] = az[: n_samp - first_samp]
+                    elevation[first_samp:] = el[: n_samp - first_samp]
+                else:
+                    azimuth[first_samp : first_samp + n_scan] = az
+                    elevation[first_samp : first_samp + n_scan] = el
+
+            # Add some noise
+            scale = 0.0005
+            azimuth[:] += np.random.normal(loc=0, scale=scale, size=ob.n_local_samples)
+            elevation[:] += np.random.normal(
+                loc=0, scale=scale, size=ob.n_local_samples
+            )
+
+            # Periodic flagged samples.  Add garbage spikes there.
+            flags = np.zeros(ob.n_local_samples, dtype=np.uint8)
+            for fspan in range(5):
+                flags[:: 1000 + fspan] = defaults.shared_mask_invalid
+            bad_samps = flags != 0
+            azimuth[bad_samps] = 10.0
+            elevation[bad_samps] = -10.0
+
+        ob.shared[defaults.times].set(stamps, offset=(0,), fromrank=0)
+        ob.shared[defaults.azimuth].set(azimuth, offset=(0,), fromrank=0)
+        ob.shared[defaults.elevation].set(elevation, offset=(0,), fromrank=0)
+        ob.shared[defaults.shared_flags].set(flags, offset=(0,), fromrank=0)
+        data.obs.append(ob)
+        return data, scans
+
+    def test_exec(self):
+        data, num_scans = self.create_fake_data()
+
+        azint = ops.AzimuthIntervals(
+            debug_root=os.path.join(self.outdir, "az_intervals"),
+            window_seconds=5.0,
+        )
+        azint.apply(data)
+
+        for ob in data.obs:
+            n_scans = len(ob.intervals[defaults.scanning_interval])
+            if n_scans != num_scans + 1:
+                msg = f"Found {n_scans} scanning intervals instead of {num_scans}"
+                print(msg, flush=True)
+                self.assertTrue(False)
+
+        close_data(data)

--- a/src/toast/tests/ops_azimuth_intervals.py
+++ b/src/toast/tests/ops_azimuth_intervals.py
@@ -31,6 +31,7 @@ class AzimuthIntervalsTest(MPITestCase):
         self.outdir = create_outdir(self.comm, fixture_name)
 
     def create_fake_data(self):
+        np.random.seed(123456)
         # Just one group with all processes
         toastcomm = create_comm(self.comm, single_group=True)
 
@@ -129,7 +130,7 @@ class AzimuthIntervalsTest(MPITestCase):
                     elevation[first_samp : first_samp + n_scan] = el
 
             # Add some noise
-            scale = 0.0005
+            scale = 0.00005
             azimuth[:] += np.random.normal(loc=0, scale=scale, size=ob.n_local_samples)
             elevation[:] += np.random.normal(
                 loc=0, scale=scale, size=ob.n_local_samples

--- a/src/toast/tests/ops_azimuth_intervals.py
+++ b/src/toast/tests/ops_azimuth_intervals.py
@@ -81,6 +81,7 @@ class AzimuthIntervalsTest(MPITestCase):
         azimuth = None
         elevation = None
         flags = None
+        scans = None
         if ob.comm_col_rank == 0:
             start_time = 0.0 + float(ob.local_index_offset) / rate.to_value(u.Hz)
             stop_time = start_time + float(ob.n_local_samples - 1) / rate.to_value(u.Hz)
@@ -141,6 +142,9 @@ class AzimuthIntervalsTest(MPITestCase):
             bad_samps = flags != 0
             azimuth[bad_samps] = 10.0
             elevation[bad_samps] = -10.0
+
+        if ob.comm_col is not None:
+            scans = ob.comm_col.bcast(scans, root=0)
 
         ob.shared[defaults.times].set(stamps, offset=(0,), fromrank=0)
         ob.shared[defaults.azimuth].set(azimuth, offset=(0,), fromrank=0)

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -113,7 +113,7 @@ class DemodulateTest(MPITestCase):
         # Demodulate
 
         downsample = 3
-        demod = ops.Demodulate(stokes_weights=weights, nskip=downsample, purge=True)
+        demod = ops.Demodulate(stokes_weights=weights, nskip=downsample, purge=False)
         demod_data = demod.apply(data)
 
         # Map again

--- a/src/toast/tests/ops_fill_gaps.py
+++ b/src/toast/tests/ops_fill_gaps.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2024-2024 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+from astropy import units as u
+
+from .. import ops as ops
+from ..observation import default_values as defaults
+from ._helpers import (
+    close_data,
+    create_ground_data,
+    create_outdir,
+    fake_flags,
+)
+from .mpi import MPITestCase
+
+
+class FillGapsTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, fixture_name)
+        np.random.seed(123456)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
+
+    def test_gap_fill(self):
+        # Create some test data.  Disable HWPSS, since we are not demodulating
+        # in this example.
+        data, input_rms = self.create_test_data()
+
+        # Make a copy for later comparison
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        # Linear fit plus noise
+        filler = ops.FillGaps(
+            shared_flag_mask=defaults.shared_mask_nonscience,
+            buffer=1.0 * u.s,
+            poly_order=1,
+        )
+        filler.apply(data)
+
+        # Diagnostic plots of one detector on each process.
+        if self.make_plots:
+            import matplotlib.pyplot as plt
+
+            for ob in data.obs:
+                det = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)[
+                    0
+                ]
+                n_all_samp = ob.n_all_samples
+                n_plot = 2
+                fig_height = 6 * n_plot
+                pltsamp = 200
+
+                for first, last in [
+                    (0, n_all_samp),
+                    (n_all_samp // 2 - pltsamp, n_all_samp // 2 + pltsamp),
+                ]:
+                    plot_slc = slice(first, last, 1)
+                    outfile = os.path.join(
+                        self.outdir,
+                        f"filled_{ob.name}_{det}_{first}-{last}.pdf",
+                    )
+
+                    times = ob.shared[defaults.times].data
+                    samp_indx = np.arange(n_all_samp)
+                    input = ob.detdata["input"][det]
+                    signal = ob.detdata[defaults.det_data][det]
+                    detflags = ob.detdata[defaults.det_flags][det]
+                    shflags = ob.shared[defaults.shared_flags].data
+
+                    fig = plt.figure(figsize=(12, fig_height), dpi=72)
+                    ax = fig.add_subplot(n_plot, 1, 1, aspect="auto")
+                    # Plot signal
+                    ax.plot(
+                        samp_indx[plot_slc],
+                        input[plot_slc],
+                        color="black",
+                        label=f"{det} Input",
+                    )
+                    ax.plot(
+                        samp_indx[plot_slc],
+                        signal[plot_slc],
+                        color="red",
+                        label=f"{det} Filled",
+                    )
+                    ax.legend(loc="best")
+                    # Plot flags
+                    ax = fig.add_subplot(n_plot, 1, 2, aspect="auto")
+                    ax.plot(
+                        samp_indx[plot_slc],
+                        shflags[plot_slc],
+                        color="blue",
+                        label="Shared Flags",
+                    )
+                    ax.plot(
+                        samp_indx[plot_slc],
+                        detflags[plot_slc],
+                        color="red",
+                        label=f"{det} Flags",
+                    )
+                    ax.legend(loc="best")
+                    fig.suptitle(f"Obs {ob.name}: {first} - {last}")
+                    fig.savefig(outfile)
+                    plt.close(fig)
+
+        close_data(data)
+
+    def create_test_data(self):
+        # Slightly slower than 0.5 Hz
+        hwp_rpm = 29.0
+        hwp_rate = 2 * np.pi * hwp_rpm / 60.0  # rad/s
+
+        sample_rate = 30 * u.Hz
+        ang_per_sample = hwp_rate / sample_rate.to_value(u.Hz)
+
+        # Create a fake ground observations set for testing.
+        data = create_ground_data(
+            self.comm,
+            sample_rate=sample_rate,
+            hwp_rpm=hwp_rpm,
+            pixel_per_process=1,
+            single_group=True,
+            fp_width=5.0 * u.degree,
+        )
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate fake instrumental noise
+        sim_noise = ops.SimNoise(noise_model="noise_model")
+        sim_noise.apply(data)
+
+        # Create flagged samples
+        fake_flags(data)
+
+        # Now we will increase the noise amplitude of flagged samples to
+        # make it easier to check that we have filled gaps with something
+        # reasonable.
+        rms = dict()
+        for ob in data.obs:
+            for det in ob.local_detectors:
+                input = np.std(ob.detdata[defaults.det_data][det])
+                rms[det] = input
+                flags = np.array(ob.shared[defaults.shared_flags].data)
+                flags[:] |= ob.detdata[defaults.det_flags][det, :]
+                bad = flags != 0
+                ob.detdata[defaults.det_data][det, bad] *= 20
+
+        return data, rms

--- a/src/toast/tests/ops_hwpss_model.py
+++ b/src/toast/tests/ops_hwpss_model.py
@@ -372,8 +372,7 @@ class HWPModelTest(MPITestCase):
             harmonics=n_harmonics,
             relcal_fixed="calibration",
             subtract_model=True,
-            # fill_gaps=True,
-            fill_gaps=False,
+            fill_gaps=True,
             debug=debug,
         )
         hwpss_model.apply(data)
@@ -391,7 +390,7 @@ class HWPModelTest(MPITestCase):
                 good = ob.detdata[defaults.det_flags][det] == 0
                 original_rms = np.std(ob.detdata["original"][det][good])
                 filtered_rms = np.std(ob.detdata[defaults.det_data][det][good])
-                print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
+                # print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
                 self.assertTrue(filtered_rms < original_rms)
         close_data(data)
 
@@ -453,8 +452,7 @@ class HWPModelTest(MPITestCase):
             # chunk_view="scanning",
             chunk_time=60 * u.second,
             subtract_model=True,
-            # fill_gaps=True,
-            fill_gaps=False,
+            fill_gaps=True,
             debug=debug,
         )
         hwpss_model.apply(data)
@@ -477,6 +475,6 @@ class HWPModelTest(MPITestCase):
                 good = ob.detdata[defaults.det_flags][det] == 0
                 original_rms = np.std(ob.detdata["original"][det][good])
                 filtered_rms = np.std(ob.detdata[defaults.det_data][det][good])
-                print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
+                # print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
                 self.assertTrue(filtered_rms < original_rms)
         close_data(data)

--- a/src/toast/tests/ops_hwpss_model.py
+++ b/src/toast/tests/ops_hwpss_model.py
@@ -372,7 +372,8 @@ class HWPModelTest(MPITestCase):
             harmonics=n_harmonics,
             relcal_fixed="calibration",
             subtract_model=True,
-            fill_gaps=True,
+            # fill_gaps=True,
+            fill_gaps=False,
             debug=debug,
         )
         hwpss_model.apply(data)
@@ -390,7 +391,7 @@ class HWPModelTest(MPITestCase):
                 good = ob.detdata[defaults.det_flags][det] == 0
                 original_rms = np.std(ob.detdata["original"][det][good])
                 filtered_rms = np.std(ob.detdata[defaults.det_data][det][good])
-                # print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
+                print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
                 self.assertTrue(filtered_rms < original_rms)
         close_data(data)
 
@@ -452,7 +453,8 @@ class HWPModelTest(MPITestCase):
             # chunk_view="scanning",
             chunk_time=60 * u.second,
             subtract_model=True,
-            fill_gaps=True,
+            # fill_gaps=True,
+            fill_gaps=False,
             debug=debug,
         )
         hwpss_model.apply(data)
@@ -475,6 +477,6 @@ class HWPModelTest(MPITestCase):
                 good = ob.detdata[defaults.det_flags][det] == 0
                 original_rms = np.std(ob.detdata["original"][det][good])
                 filtered_rms = np.std(ob.detdata[defaults.det_data][det][good])
-                # print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
+                print(f"{ob.name}[{det}]:  {filtered_rms} <? {original_rms}")
                 self.assertTrue(filtered_rms < original_rms)
         close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -26,6 +26,7 @@ from . import io_hdf5 as test_io_hdf5
 from . import math_misc as test_math_misc
 from . import noise as test_noise
 from . import observation as test_observation
+from . import ops_azimuth_intervals as test_ops_azimuth_intervals
 from . import ops_cadence_map as test_ops_cadence_map
 from . import ops_common_mode_noise as test_ops_common_mode_noise
 from . import ops_crosslinking as test_ops_crosslinking
@@ -183,6 +184,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_dist))
         suite.addTest(loader.loadTestsFromModule(test_config))
 
+        suite.addTest(loader.loadTestsFromModule(test_ops_azimuth_intervals))
         suite.addTest(loader.loadTestsFromModule(test_ops_sim_satellite))
         suite.addTest(loader.loadTestsFromModule(test_ops_sim_ground))
         suite.addTest(loader.loadTestsFromModule(test_ops_memory_counter))

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -33,6 +33,7 @@ from . import ops_crosslinking as test_ops_crosslinking
 from . import ops_demodulate as test_ops_demodulate
 from . import ops_elevation_noise as test_ops_elevation_noise
 from . import ops_example_ground as test_ops_example_ground
+from . import ops_fill_gaps as test_ops_fill_gaps
 from . import ops_filterbin as test_ops_filterbin
 from . import ops_flag_sso as test_ops_flag_sso
 from . import ops_gainscrambler as test_ops_gainscrambler
@@ -213,6 +214,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_ops_gainscrambler))
         suite.addTest(loader.loadTestsFromModule(test_ops_sim_gaindrifts))
         suite.addTest(loader.loadTestsFromModule(test_ops_polyfilter))
+        suite.addTest(loader.loadTestsFromModule(test_ops_fill_gaps))
         suite.addTest(loader.loadTestsFromModule(test_ops_groundfilter))
         suite.addTest(loader.loadTestsFromModule(test_ops_hwpfilter))
         suite.addTest(loader.loadTestsFromModule(test_ops_hwpss_model))


### PR DESCRIPTION
- Use a more robust technique for computing the scan velocity and acceleration in the presence of noise and flags
- Use a fit to the velocity for finding turnarounds
- Add a unit test to generate plots and check that the expected number of scans is found

Example plot of scan properties found in the unit tests:
![az_intervals](https://github.com/user-attachments/assets/03b57143-7951-4e66-8fe8-914dc7a1ac57)

