### PR TITLE
Add a new, general purpose convolution function

### DIFF
--- a/src/toast/fft.py
+++ b/src/toast/fft.py
@@ -288,7 +288,7 @@ def convolve(
                 _debug_plot_tod(tdata, f"{debug}_tin_{itod}")
 
             # Forward transform
-            _ = np.fft.rfft(tdata, out=fdata, norm="backward")
+            fdata[:] = np.fft.rfft(tdata, norm="backward")
 
             if debug is not None:
                 # Plot the initial fourier domain buffer
@@ -318,7 +318,7 @@ def convolve(
                 _debug_plot_fourier(fdata, f"{debug}_fout_{itod}")
 
             # Inverse transform
-            _ = np.fft.irfft(fdata, out=tdata, norm="backward")
+            tdata[:] = np.fft.irfft(fdata, norm="backward")
 
             # Copy back to input array
             if debug is not None:

--- a/src/toast/fft.py
+++ b/src/toast/fft.py
@@ -1,8 +1,10 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import numpy as np
+from scipy.interpolate import PchipInterpolator
+from scipy.signal import windows
 
 from ._libtoast import FFTDirection, FFTPlanReal1D, FFTPlanReal1DStore, FFTPlanType
 from .utils import object_ndim
@@ -101,3 +103,314 @@ def r1d_backward(indata):
         for indx in range(count):
             ret[indx, :] = plan.tdata(indx)
         return ret
+
+
+def convolve(
+    data,
+    rate,
+    kernel_freq=None,
+    kernels=None,
+    kernel_func=None,
+    deconvolve=False,
+    algorithm="numpy",
+    debug=None,
+):
+    """Convolve timestream data with Fourier domain kernels.
+
+    If data is a 2D array, the first dimension is the number of timestreams.
+    The FFT length is chosen to be the smallest radix-2 value sufficient to store
+    twice the data length.  The input data is centered in the time-domain buffer
+    and is reflected about the endpoints to avoid discontinuities.  Any additional
+    samples on either end are zero padded.  The reflected data is further apodized
+    smoothly to zero with a Gaussian window.
+
+    If `kernels` is a 2D array, there should be one per timestream, and all
+    kernels should be specified on the same frequency grid given by `kernel_freq.
+    If `kernels` is 1D, the same kernel will be applied to all timestreams.  The
+    kernels will be interpolated in frequency space to match the FFT resolution.
+    Alternatively, if `kernel_func` is specified, it will be called with the
+    detector index and the Fourier domain frequencies.  The function should return
+    the complex kernel values at these frequencies.
+
+    The input data is modified in-place.
+
+    Args:
+        data (iterable):  Sequence of timestreams.
+        rate (float):  Sample rate in Hz.
+        kernel_freq (array):  The common frequency values for all input kernels.
+        kernels (array):  Array of Fourier domain kernels.
+        deconvolve (bool):  If True, divide by the kernel instead of multiplying.
+        use_numpy (bool):  If True, use numpy.fft instead of internal tools.
+
+    Returns:
+        None
+
+    """
+    if kernel_func is not None:
+        if kernel_freq is not None or kernels is not None:
+            msg = "Cannot specify both the kernel function and explicit kernel values"
+            raise RuntimeError(msg)
+    else:
+        if kernel_freq is None or kernels is None:
+            msg = "Must specify either the kernel function or explicit kernel values"
+            raise RuntimeError(msg)
+        if len(kernel_freq.shape) != 1:
+            msg = "kernel_freq should be the common frequencies for all kernels"
+            raise RuntimeError(msg)
+        if len(kernels.shape) == 1:
+            # Common kernel
+            if kernels.shape[0] != kernel_freq.shape[0]:
+                msg = "common kernel should have same length as frequencies"
+                raise RuntimeError(msg)
+        elif len(kernels.shape) == 2:
+            if kernels.shape[1] != kernel_freq.shape[0]:
+                msg = "kernels should have same length as frequencies"
+                raise RuntimeError(msg)
+        else:
+            msg = "kernels should be a 1D or 2D array"
+            raise RuntimeError(msg)
+
+    n_tod = len(data)
+    n_samp = len(data[0])
+    for itod in range(1, n_tod):
+        if len(data[itod]) != n_samp:
+            msg = "All detector arrays should be the same length"
+            raise RuntimeError(msg)
+
+    # Find the FFT size and frequencies
+    order = int(np.ceil(np.log(n_samp) / np.log(2)))
+    n_fft = 2 ** (order + 1)
+    n_psd = n_fft // 2 + 1
+    freq = np.fft.rfftfreq(n_fft, d=1.0 / rate)
+    n_buffer = (n_fft - n_samp) // 2
+    n_reflect = min(n_buffer, n_samp)
+
+    # Apodization of reflected extension
+    apodize = windows.general_gaussian(
+        n_reflect * 2,
+        3.0,
+        (n_reflect // 2),
+        sym=True,
+    )[:n_reflect]
+
+    def _interpolate_kernel(kern):
+        """Helper function to interpolate a single kernel.
+
+        Only used when interpolating an explicit kernel.  Not used with a kernel.
+        function.
+        """
+        # If we are deconvolving, ensure that zero-values are set to something
+        # reasonable and small.
+        if kernel_freq is None:
+            raise RuntimeError("Should never get here- input kernel_freq is None")
+        kern_mag = np.absolute(kern)
+        kern_ang = np.angle(kern)
+        if deconvolve:
+            kern_extent = np.max(kern_mag)
+            kern_limit = 1.0e-5 * kern_extent
+            safe_mag = np.array(kern_mag)
+            safe_mag[kern_mag < kern_limit] = kern_limit
+        else:
+            safe_mag = kern_mag
+        mag_interp = PchipInterpolator(kernel_freq, safe_mag, extrapolate=True)
+        ang_interp = PchipInterpolator(kernel_freq, kern_ang, extrapolate=True)
+        mag_out = mag_interp(freq)
+        ang_out = ang_interp(freq)
+        out = mag_out * np.exp(1j * ang_out)
+        return out
+
+    def _set_input(td, hndl):
+        """Helper function to populate the time domain buffer."""
+        td[:] = 0
+        td[n_buffer - n_reflect : n_buffer] = hndl[n_reflect - 1 :: -1]
+        td[n_buffer : n_buffer + n_samp] = hndl[:]
+        td[n_buffer + n_samp : n_buffer + n_samp + n_reflect] = hndl[
+            -1 : -(n_reflect + 1) : -1
+        ]
+        td[n_buffer - n_reflect : n_buffer] *= apodize
+        td[n_buffer + n_samp + n_reflect - 1 : n_buffer + n_samp - 1 : -1] *= apodize
+
+    def _debug_plot_fourier(fdata, plotroot):
+        """Helper function to plot fourier domain data."""
+        import matplotlib.pyplot as plt
+
+        for frange in [(0, len(fdata)), (0, 32), (-32, len(fdata))]:
+            plotfile = f"{plotroot}_{frange[0]}-{frange[1]}.pdf"
+            pslc = slice(frange[0], frange[1], 1)
+            fig = plt.figure(figsize=(12, 16), dpi=72)
+            ax = fig.add_subplot(2, 1, 1, aspect="auto")
+            ax.plot(freq[pslc], np.real(fdata[pslc]))
+            ax.set_title("Fourier Domain Real Part")
+            ax.set_xlabel("Frequency")
+            ax.set_ylabel("Amplitude")
+            ax = fig.add_subplot(2, 1, 2, aspect="auto")
+            ax.plot(freq[pslc], np.imag(fdata[pslc]))
+            ax.set_title("Fourier Domain Imaginary Part")
+            ax.set_xlabel("Frequency")
+            ax.set_ylabel("Amplitude")
+            plt.savefig(plotfile)
+            plt.close()
+
+    def _debug_plot_tod(tdata, plotroot):
+        """Helper function to plot time domain data."""
+        import matplotlib.pyplot as plt
+
+        for frange in [(0, len(tdata)), (0, 500), (-500, len(tdata))]:
+            plotfile = f"{plotroot}_{frange[0]}-{frange[1]}.pdf"
+            pslc = slice(frange[0], frange[1], 1)
+            fig = plt.figure(figsize=(12, 8), dpi=72)
+            ax = fig.add_subplot(1, 1, 1, aspect="auto")
+            ax.plot(np.arange(n_fft)[pslc], tdata[pslc])
+            ax.set_title("Time Domain Data")
+            ax.set_xlabel("Sample")
+            ax.set_ylabel("Amplitude")
+            plt.savefig(plotfile)
+            plt.close()
+
+    common_kernel = None
+    if kernel_func is None and len(kernels.shape) == 1:
+        # We have a common kernel, interpolate it now
+        common_kernel = _interpolate_kernel(kernels)
+        if debug is not None:
+            _debug_plot_fourier(common_kernel, f"{debug}_kernel_common")
+
+    if algorithm == "numpy":
+        # Buffers we will re-use
+        tdata = np.empty(n_fft)
+        fdata = np.empty(n_psd, dtype=np.complex128)
+
+        # Loop over FFTs.
+        for itod in range(n_tod):
+            handle = data[itod]
+            _set_input(tdata, handle)
+            if debug is not None:
+                # Plot the initial time domain buffer
+                _debug_plot_tod(tdata, f"{debug}_tin_{itod}")
+
+            # Forward transform
+            _ = np.fft.rfft(tdata, out=fdata, norm="backward")
+
+            if debug is not None:
+                # Plot the initial fourier domain buffer
+                _debug_plot_fourier(fdata, f"{debug}_fin_{itod}")
+
+            if common_kernel is None:
+                if kernel_func is None:
+                    krn = _interpolate_kernel(kernels[itod])
+                else:
+                    krn = kernel_func(itod, freq)
+                if debug is not None:
+                    _debug_plot_fourier(krn, f"{debug}_kernel_{itod}")
+            else:
+                krn = common_kernel
+
+            # Convolve with kernel
+            if deconvolve:
+                fdata[:] /= krn
+            else:
+                fdata[:] *= krn
+            # For a real transform, the nyquist frequency element is real
+            fdata.imag[-1] = 0
+            # Remove DC level
+            fdata[0] = 0
+            if debug is not None:
+                # Plot the final fourier domain buffer
+                _debug_plot_fourier(fdata, f"{debug}_fout_{itod}")
+
+            # Inverse transform
+            _ = np.fft.irfft(fdata, out=tdata, norm="backward")
+
+            # Copy back to input array
+            if debug is not None:
+                # Plot the final time domain buffer
+                _debug_plot_tod(tdata, f"{debug}_tout_{itod}")
+            handle[:] = tdata[n_buffer : n_buffer + n_samp]
+    elif algorithm == "internal":
+        # We are using the internal FFT tools, so we batch-process all transforms
+        store = FFTPlanReal1DStore.get()
+        fplan = store.forward(n_fft, n_tod)
+        rplan = store.backward(n_fft, n_tod)
+
+        # Copy input into buffers
+        for itod in range(n_tod):
+            td = fplan.tdata(itod)
+            handle = data[itod]
+            _set_input(td, handle)
+            if debug is not None:
+                # Plot the initial time domain buffer
+                _debug_plot_tod(td, f"{debug}_tin_{itod}")
+
+        # Forward transform
+        fplan.exec()
+
+        # Convolve with kernels
+        for itod in range(n_tod):
+            rplan.fdata(itod)[:] = fplan.fdata(itod)
+            fd = rplan.fdata(itod)
+
+            if debug is not None:
+                # Plot the initial fourier domain buffer
+                fcomplex = np.zeros(n_psd, dtype=np.complex128)
+                fcomplex.real[:] = fd[:n_psd]
+                fcomplex.imag[1:-1] = fd[-1 : n_psd - 1 : -1]
+                _debug_plot_fourier(fcomplex, f"{debug}_fin_{itod}")
+
+            if common_kernel is None:
+                if kernel_func is None:
+                    krn = _interpolate_kernel(kernels[itod])
+                else:
+                    krn = kernel_func(itod, freq)
+                if debug is not None:
+                    _debug_plot_fourier(krn, f"{debug}_kernel_{itod}")
+            else:
+                krn = common_kernel
+            # The real and imaginary parts of the input and kernel,
+            # excluding the zero and nyquist frequencies.
+            kre = np.real(krn[1:-1])
+            kim = np.imag(krn[1:-1])
+            fre = np.array(fd[1 : n_psd - 1])
+            fim = np.array(fd[-1 : n_psd - 1 : -1])
+            nyq = fd[n_psd - 1]
+            # We handle the zero and nyquist frequencies separately
+            if deconvolve:
+                denom = kre**2 + kim**2
+                # Real values
+                fd[1 : n_psd - 1] = (fre * kre + fim * kim) / denom
+                # Nyquist
+                fd[n_psd - 1] = (nyq * krn.real[-1]) / (krn.real[-1] ** 2)
+                # Imaginary values
+                fd[-1 : n_psd - 1 : -1] = (kre * fim - fre * kim) / denom
+            else:
+                # Real values
+                fd[1 : n_psd - 1] = fre * kre - fim * kim
+                # Nyquist
+                fd[n_psd - 1] = nyq * krn.real[-1]
+                # Imaginary values
+                fd[-1 : n_psd - 1 : -1] = kre * fim + fre * kim
+            # Remove DC level
+            fd[0] = 0
+            if debug is not None:
+                # Plot the final fourier domain buffer
+                fcomplex = np.zeros(n_psd, dtype=np.complex128)
+                fcomplex.real[:] = fd[:n_psd]
+                fcomplex.imag[1:-1] = fd[-1 : n_psd - 1 : -1]
+                _debug_plot_fourier(fcomplex, f"{debug}_fout_{itod}")
+
+        # Reverse transform
+        rplan.exec()
+
+        # Copy out data
+        for itod in range(n_tod):
+            td = rplan.tdata(itod)
+            if debug is not None:
+                # Plot the final time domain buffer
+                _debug_plot_tod(td, f"{debug}_tout_{itod}")
+            handle = data[itod]
+            handle[:] = td[n_buffer : n_buffer + n_samp]
+
+        # Save memory by clearing the fft plans
+        store.clear()
+    else:
+        msg = f"Unknown algorithm choice '{algorithm}'.  Should"
+        msg += " be one of 'numpy' or 'internal'."
+        raise RuntimeError(msg)

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -38,7 +38,8 @@ class DetDataView(MutableMapping):
             if len(value) != len(vw):
                 msg = "when assigning to a view, you must have one value or one value for each view interval"
                 raise RuntimeError(msg)
-            vw[:] = value
+            for iv, v in enumerate(vw):
+                v[:] = value[iv]
 
     def __iter__(self):
         return iter(self.slices)
@@ -62,7 +63,7 @@ class SharedView(MutableMapping):
     # Mapping methods
 
     def __getitem__(self, key):
-        vw = [self.obj.shared[key][x] for x in self.slices]
+        vw = [np.array(self.obj.shared[key].data[x], copy=False) for x in self.slices]
         return vw
 
     def __delitem__(self, key):

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -358,9 +358,10 @@ class PolyFilter2D(Operator):
                         sample_flags *= dets_in_group
                         for isample in range(nsample):
                             if np.all(coeff[isample, igroup] == 0):
-                                temp_ob.detdata[self.det_flags][
-                                    detectors, view.first + isample
-                                ] |= sample_flags
+                                for idet, det in enumerate(detectors):
+                                    temp_ob.detdata[self.det_flags][
+                                        det, view.first + isample
+                                    ] |= sample_flags[idet]
 
                 gt.stop("Poly2D:  Update detector flags")
 

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -325,7 +325,9 @@ class SaveHDF5(Operator):
                             detectors=ob.detdata[fld].detectors,
                             units=ob.detdata[fld].units,
                         )
-                        original.detdata[fld][:] = ob.detdata[fld][:].astype(np.float32)
+                        original.detdata[fld].data[:] = (
+                            ob.detdata[fld].data[:].astype(np.float32)
+                        )
                 else:
                     # Duplicate detdata
                     original = ob.duplicate(

--- a/src/toast/scripts/toast_timing_plot.py
+++ b/src/toast/scripts/toast_timing_plot.py
@@ -49,7 +49,8 @@ def main():
             if mat is not None:
                 # this is a function timer
                 trace = mat.group(1)
-                value = float(row[7])
+                # Get the maximum time, since only some processes might be doing work
+                value = float(row[5])
                 if trace == "main":
                     # special case
                     continue

--- a/src/toast/tests/fft.py
+++ b/src/toast/tests/fft.py
@@ -5,9 +5,11 @@
 import os
 
 import numpy as np
+import scipy.signal
 
-from ..fft import r1d_backward, r1d_forward
+from ..fft import r1d_backward, r1d_forward, convolve
 from ..rng import random
+from ..vis import set_matplotlib_backend
 from ._helpers import create_outdir
 from .mpi import MPITestCase
 
@@ -24,6 +26,14 @@ class FFTTest(MPITestCase):
         for b in range(self.nbatch):
             self.input_batch[b, :] = random(self.length, counter=[0, 0], key=[0, b])
         self.compare_batch = np.array(self.input_batch)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
 
     def test_roundtrip(self):
         output = r1d_forward(self.input_one)
@@ -52,6 +62,7 @@ class FFTTest(MPITestCase):
 
         if (self.comm is None) or (self.comm.rank == 0):
             # One process dumps debugging info
+            set_matplotlib_backend()
             import matplotlib.pyplot as plt
 
             for b in range(self.nbatch):
@@ -78,3 +89,452 @@ class FFTTest(MPITestCase):
 
         np.testing.assert_array_almost_equal(check, self.compare_batch)
         return
+
+    def _conv_create_kernel(self, rate, order, kfreqs, delay_freqs):
+        b, a = scipy.signal.butter(
+            order, rate / 10, btype="low", analog=True, output="ba"
+        )
+        _, kvals = scipy.signal.freqs(b, a, worN=kfreqs)
+        _, delay = scipy.signal.group_delay((b, a), w=delay_freqs, fs=rate)
+        return kvals, delay
+
+    def _conv_plot_kernel(self, kfreqs, kvals, outfile):
+        set_matplotlib_backend()
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure(figsize=(12, 8), dpi=72)
+        ax = fig.add_subplot(1, 1, 1, aspect="auto")
+        ax.semilogx(kfreqs, kvals)
+        ax.set_title("Butterworth filter frequency response")
+        ax.set_xlabel("Frequency")
+        ax.set_ylabel("Amplitude")
+        ax.margins(0, 0.1)
+        ax.grid(which="both", axis="both")
+        plt.savefig(outfile)
+        plt.close()
+
+    def _conv_plot_signals(self, data, outfile, plot_start, plot_stop):
+        set_matplotlib_backend()
+        import matplotlib.pyplot as plt
+
+        pslc = slice(plot_start, plot_stop, 1)
+        fig = plt.figure(figsize=(12, 8), dpi=72)
+        ax = fig.add_subplot(1, 1, 1, aspect="auto")
+        for label, times, vals in data:
+            ax.plot(times[pslc], vals[pslc], label=label)
+        ax.set_title("Signal Timestream")
+        ax.set_xlabel("Time [seconds]")
+        ax.set_ylabel("Amplitude")
+        ax.legend(loc="best")
+        plt.savefig(outfile)
+        plt.close()
+
+    def _conv_create_signals(self, rate, n_tod, n_samp, flow, fhigh):
+        t = (1 / rate) * np.arange(n_samp)
+        lowf = np.sin(2 * np.pi * flow * t)
+        highf = np.sin(2 * np.pi * fhigh * t)
+        sig = lowf + highf
+        return (
+            np.tile(sig, n_tod).reshape((n_tod, -1)),
+            np.tile(lowf, n_tod).reshape((n_tod, -1)),
+        )
+
+    def test_convolve_common(self):
+        rate = 200.0
+        n_samp = 12345
+        n_tod = 5
+        filter_order = 4
+        fftorder = int(np.ceil(np.log(n_samp) / np.log(2)))
+        n_fft = 2 ** (fftorder + 1)
+        kfreqs = np.fft.rfftfreq(n_fft, d=1.0 / rate)
+
+        # Timestamps
+        times = (1 / rate) * np.arange(n_samp)
+
+        # Make some signals consisting of a sine wave above and below
+        # the cutoff.
+        flow = 5.0
+        fhigh = 50.0
+        original, lowf = self._conv_create_signals(rate, n_tod, n_samp, flow, fhigh)
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 500)]:
+                savefile = os.path.join(
+                    self.outdir, f"conv_common_in_{prange[0]}-{prange[1]}.pdf"
+                )
+                self._conv_plot_signals(
+                    [("Input", times, original[0])],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+        # Build a lowpass kernel
+        kvals, sample_shift = self._conv_create_kernel(
+            rate,
+            filter_order,
+            kfreqs,
+            np.array([flow]),
+        )
+
+        if (self.comm is None) or (self.comm.rank == 0):
+            savefile = os.path.join(self.outdir, "conv_common_kernel.pdf")
+            self._conv_plot_kernel(kfreqs, kvals, savefile)
+
+        # The butterworth lowpass introduces a phase shift.  Compute the expected
+        # magnitude of this sample shift at our low frequency for later comparision.
+        times_shifted = times[:] + (sample_shift[0] / rate)
+
+        # Make a finely-sampled time grid to interpolate the input and phase-shift
+        # corrected outputs to in order to compare.
+        times_compare = np.linspace(times[100], times[200], num=1000)
+        lowf_compare = np.zeros((n_tod, len(times_compare)))
+        for itod in range(n_tod):
+            lowf_compare[itod] = np.interp(times_compare, times, lowf[itod])
+
+        # Convolve
+        signals = dict()
+        signals_compare = dict()
+        for algo in ["numpy", "internal"]:
+            signals[algo] = np.array(original)
+            signals_compare[algo] = np.zeros((n_tod, len(times_compare)))
+            debug_root = None
+            if self.make_plots:
+                debug_root = os.path.join(self.outdir, f"conv_common_interp_{algo}")
+            convolve(
+                signals[algo],
+                rate,
+                kernel_freq=kfreqs,
+                kernels=kvals,
+                algorithm=algo,
+                debug=debug_root,
+            )
+
+            # Remove the sample shift in the output, for easier comparison with
+            # the input.
+            for itod in range(n_tod):
+                signals_compare[algo][itod] = np.interp(
+                    times_compare, times_shifted, signals[algo][itod]
+                )
+
+            # Check result
+            for itod in range(n_tod):
+                diff = signals_compare[algo][itod] - lowf_compare[itod]
+                passed = np.all(np.absolute(diff) < 0.2)
+                if not passed:
+                    print(f"{algo} fail: max diff = {np.amax(np.absolute(diff))}")
+                    self.assertTrue(False)
+
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 500)]:
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_common_compare_output_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times, lowf[0]),
+                        ("Numpy", times, signals["numpy"][0]),
+                        ("Internal", times, signals["internal"][0]),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_common_compare_diff_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        (
+                            "Numpy - Internal",
+                            times,
+                            signals["numpy"][0] - signals["internal"][0],
+                        ),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_common_compare_shifted_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times_compare, lowf_compare[0]),
+                        (
+                            "Numpy, Shift Removed",
+                            times_compare,
+                            signals_compare["numpy"][0],
+                        ),
+                        (
+                            "Internal, Shift Removed",
+                            times_compare,
+                            signals_compare["internal"][0],
+                        ),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+    def test_convolve_kfunc(self):
+        rate = 200.0
+        n_samp = 12345
+        n_tod = 5
+        filter_order = 4
+        fftorder = int(np.ceil(np.log(n_samp) / np.log(2)))
+        n_fft = 2 ** (fftorder + 1)
+        freqs = np.fft.rfftfreq(n_fft, d=1.0 / rate)
+
+        # Timestamps
+        times = (1 / rate) * np.arange(n_samp)
+
+        # Create a function which generates a kernel on demand
+        def _kernel_func(indx, kfreqs):
+            """Function which generates a kernel on demand.
+
+            `indx` is ignored- the same kernel is always returned.
+            """
+            b, a = scipy.signal.butter(
+                filter_order, rate / 10, btype="low", analog=True, output="ba"
+            )
+            _, kvals = scipy.signal.freqs(b, a, worN=kfreqs)
+            return kvals
+
+        # Make some signals consisting of a sine wave above and below
+        # the cutoff.
+        flow = 5.0
+        fhigh = 50.0
+        original, lowf = self._conv_create_signals(rate, n_tod, n_samp, flow, fhigh)
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 500)]:
+                savefile = os.path.join(
+                    self.outdir, f"conv_kfunc_in_{prange[0]}-{prange[1]}.pdf"
+                )
+                self._conv_plot_signals(
+                    [("Input", times, original[0])],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+        # The butterworth lowpass introduces a phase shift.  Compute the expected
+        # magnitude of this sample shift at our low frequency for later comparision.
+        temp_kvals, sample_shift = self._conv_create_kernel(
+            rate,
+            filter_order,
+            freqs,
+            np.array([flow]),
+        )
+        times_shifted = times[:] + (sample_shift[0] / rate)
+
+        # Make a finely-sampled time grid to interpolate the input and phase-shift
+        # corrected outputs to in order to compare.
+        times_compare = np.linspace(times[100], times[200], num=1000)
+        lowf_compare = np.zeros((n_tod, len(times_compare)))
+        for itod in range(n_tod):
+            lowf_compare[itod] = np.interp(times_compare, times, lowf[itod])
+
+        # Convolve
+        signals = dict()
+        signals_compare = dict()
+        for algo in ["numpy", "internal"]:
+            signals[algo] = np.array(original)
+            signals_compare[algo] = np.zeros((n_tod, len(times_compare)))
+            debug_root = None
+            if self.make_plots:
+                debug_root = os.path.join(self.outdir, f"conv_kfunc_interp_{algo}")
+            convolve(
+                signals[algo],
+                rate,
+                kernel_func=_kernel_func,
+                algorithm=algo,
+                debug=debug_root,
+            )
+
+            # Remove the sample shift in the output, for easier comparison with
+            # the input.
+            for itod in range(n_tod):
+                signals_compare[algo][itod] = np.interp(
+                    times_compare, times_shifted, signals[algo][itod]
+                )
+
+            # Check result
+            for itod in range(n_tod):
+                diff = signals_compare[algo][itod] - lowf_compare[itod]
+                passed = np.all(np.absolute(diff) < 0.2)
+                if not passed:
+                    print(f"{algo} fail: max diff = {np.amax(np.absolute(diff))}")
+                    self.assertTrue(False)
+
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 500)]:
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_kfunc_compare_output_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times, lowf[0]),
+                        ("Numpy", times, signals["numpy"][0]),
+                        ("Internal", times, signals["internal"][0]),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_kfunc_compare_shifted_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times_compare, lowf_compare[0]),
+                        (
+                            "Numpy, Shift Removed",
+                            times_compare,
+                            signals_compare["numpy"][0],
+                        ),
+                        (
+                            "Internal, Shift Removed",
+                            times_compare,
+                            signals_compare["internal"][0],
+                        ),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+    def test_convolve_deconvolve(self):
+        rate = 200.0
+        n_samp = 12345
+        n_tod = 5
+        filter_order = 4
+
+        # Timestamps
+        times = (1 / rate) * np.arange(n_samp)
+
+        # Create a function which generates a kernel on demand
+        def _kernel_func(indx, kfreqs):
+            """Function which just attenuates all frequencies"""
+            kvals = np.ones(len(kfreqs), dtype=np.complex128)
+            kvals.imag[1:-1] = 1.0
+            kvals *= 0.5
+            return kvals
+
+        # Make some gaussian noise
+        original = np.empty((n_tod, n_samp), dtype=np.float64)
+        for itod in range(n_tod):
+            np.random.seed(itod * n_samp + 12345)
+            original[itod] = np.random.normal(loc=0, scale=1.0, size=n_samp)
+
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 100)]:
+                savefile = os.path.join(
+                    self.outdir, f"conv_roundtrip_in_{prange[0]}-{prange[1]}.pdf"
+                )
+                self._conv_plot_signals(
+                    [("Input", times, original[0])],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+        # Convolve
+        signals = dict()
+        for algo in ["numpy", "internal"]:
+            signals[algo] = np.array(original)
+            debug_root = None
+            if self.make_plots:
+                debug_root = os.path.join(self.outdir, f"conv_roundtrip_interp1_{algo}")
+            convolve(
+                signals[algo],
+                rate,
+                kernel_func=_kernel_func,
+                deconvolve=False,
+                algorithm=algo,
+                debug=debug_root,
+            )
+
+        # Deconvolve
+        signals_compare = dict()
+        for algo in ["numpy", "internal"]:
+            signals_compare[algo] = np.array(signals[algo])
+            debug_root = None
+            if self.make_plots:
+                debug_root = os.path.join(self.outdir, f"conv_roundtrip_interp2_{algo}")
+            convolve(
+                signals_compare[algo],
+                rate,
+                kernel_func=_kernel_func,
+                deconvolve=True,
+                algorithm=algo,
+                debug=debug_root,
+            )
+
+        if (self.comm is None) or (self.comm.rank == 0):
+            for prange in [(0, n_samp), (0, 100)]:
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_roundtrip_compare_convolved_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times, original[0]),
+                        ("Numpy", times, signals["numpy"][0]),
+                        ("Internal", times, signals["internal"][0]),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_roundtrip_compare_deconvolved_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Input", times, original[0]),
+                        ("Numpy", times, signals_compare["numpy"][0]),
+                        ("Internal", times, signals_compare["internal"][0]),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+                savefile = os.path.join(
+                    self.outdir,
+                    f"conv_roundtrip_compare_resid_{prange[0]}-{prange[1]}.pdf",
+                )
+                self._conv_plot_signals(
+                    [
+                        ("Numpy", times, (signals_compare["numpy"][0] - original[0])),
+                        (
+                            "Internal",
+                            times,
+                            (signals_compare["internal"][0] - original[0]),
+                        ),
+                    ],
+                    savefile,
+                    prange[0],
+                    prange[1],
+                )
+
+        # Check result
+        for algo in ["numpy", "internal"]:
+            for itod in range(n_tod):
+                cslc = slice(50, -50, 1)
+                orig = original[itod][cslc]
+                comp = signals_compare[algo][itod][cslc]
+                bad = np.absolute(orig) < 0.001
+                absdiff = np.absolute(comp - orig)
+                absdiff[bad] = 0
+                if np.amax(absdiff) > 0.1:
+                    print(
+                        f"{algo}[{itod}] fail: max absdiff = {np.amax(absdiff)}",
+                        flush=True,
+                    )
+                    self.assertTrue(False)

--- a/src/toast/vis.py
+++ b/src/toast/vis.py
@@ -310,8 +310,10 @@ def plot_projected_quats(
 
     qdang = None
     if qdet is not None:
-        qdang = np.zeros((qdet.shape[0], 3, qdet.shape[1]), dtype=np.float64)
-        for det in range(qdet.shape[0]):
+        n_qdet = len(qdet)
+        n_samp = len(qdet[0])
+        qdang = np.zeros((n_qdet, 3, n_samp), dtype=np.float64)
+        for det in range(n_qdet):
             qdang[det, 0], qdang[det, 1], qdang[det, 2] = qa.to_lonlat_angles(qdet[det])
             qdang[det, 0] *= 180.0 / np.pi
             qdang[det, 1] *= 180.0 / np.pi


### PR DESCRIPTION
In several places throughout the code we perform Fourier domain convolution and use a variety of techniques.  This work aims to have a common function for some of these use cases which carefully handles the symmetric extension of data in the Fourier domain buffer and is unit tested.  Changes include:

- New toast.fft.convolve function that can take precomputed kernels or use a callback function to generate the kernels.  Unit tests verify roundtrip and expected sample phase shift introduced by a Butterworth filter.

- Porting of the timeconstant deconvolution operator to this new function.

- Small unrelated fix to toast timing plots

- Unrelated fixes to DetectorData indexing.  In a couple places we were triggering data copying by using numpy "advanced indexing".