### PR TITLE
Add support for HDF5 I/O of observations without detector data

### DIFF
--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -783,7 +783,7 @@ def load_hdf5(
         and (process_rows is not None)
         and (process_rows != comm.group_size)
     ):
-        msg = f"When loading observations with serial HDF5, process_rows must equal "
+        msg = "When loading observations with serial HDF5, process_rows must equal "
         msg += "the group size"
         log.error(msg)
         raise RuntimeError(msg)

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -825,9 +825,9 @@ def save_hdf5(
                     meta_group.attrs[k] = v
             except (ValueError, TypeError) as e:
                 msg = f"Failed to store obs key '{k}' = '{v}' as an attribute ({e})."
-                msg += f" Try casting it to a supported type when storing in the "
-                msg += f"observation dictionary or implement save_hdf5() and "
-                msg += f"load_hdf5() methods."
+                msg += " Try casting it to a supported type when storing in the "
+                msg += "observation dictionary or implement save_hdf5() and "
+                msg += "load_hdf5() methods."
                 log.verbose(msg)
     del meta_group
 

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -1235,6 +1235,7 @@ class DetDataManager(MutableMapping):
     def clear(self):
         for k in self._internal.keys():
             self._internal[k].clear()
+        self._internal.clear()
 
     def __repr__(self):
         val = "<DetDataManager {} local detectors, {} samples".format(

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -44,7 +44,10 @@ class LoadHDF5(Operator):
 
     meta = List([], help="Only load this list of meta objects")
 
-    detdata = List([], help="Only load this list of detdata objects")
+    detdata = List(
+        [defaults.det_data, defaults.det_flags],
+        help="Only load this list of detdata objects",
+    )
 
     shared = List([], help="Only load this list of shared objects")
 
@@ -90,9 +93,10 @@ class LoadHDF5(Operator):
         if len(self.shared) > 0:
             shared_fields = list(self.shared)
 
-        detdata_fields = None
         if len(self.detdata) > 0:
             detdata_fields = list(self.detdata)
+        else:
+            detdata_fields = list()
 
         intervals_fields = None
         if len(self.intervals) > 0:

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -159,7 +159,10 @@ class SaveHDF5(Operator):
 
     meta = List([], allow_none=True, help="Only save this list of meta objects")
 
-    detdata = List([], help="Only save this list of detdata objects")
+    detdata = List(
+        [defaults.det_data, defaults.det_flags],
+        help="Only save this list of detdata objects",
+    )
 
     shared = List([], help="Only save this list of shared objects")
 
@@ -240,7 +243,7 @@ class SaveHDF5(Operator):
             if len(self.detdata) > 0:
                 detdata_fields = list(self.detdata)
             else:
-                detdata_fields = list(ob.detdata.keys())
+                detdata_fields = list()
 
             if self.compress_detdata:
                 # Add generic compression instructions to detdata fields
@@ -293,8 +296,8 @@ class SaveHDF5(Operator):
                     else:
                         verify_fields = list(detdata_fields)
                 else:
-                    # We saved everything
-                    verify_fields = list(ob.detdata.keys())
+                    # We saved nothing
+                    verify_fields = list()
 
                 if self.detdata_float32:
                     # We want to duplicate everything *except* float64 detdata
@@ -350,7 +353,7 @@ class SaveHDF5(Operator):
                 )
 
                 if not obs_approx_equal(compare, original):
-                    msg = f"Observation HDF5 verify failed:\n"
+                    msg = "Observation HDF5 verify failed:\n"
                     msg += f"Input = {original}\n"
                     msg += f"Loaded = {compare}"
                     log.error(msg)


### PR DESCRIPTION
- The default list of detdata fields for save / load is now the standard signal and flags.

- An empty list of detdata fields is now interpreted as "no fields" rather than "all fields".

- Add a unit test to check save / load with empty detector data.