### PR TITLE
Mss3

### DIFF
--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -242,7 +242,7 @@ class IntervalList(Sequence, AcceleratorObject):
             return
         neg = list()
         # Handle range before first interval
-        if not np.isclose(self.timestamps[0], self.data[0].start):
+        if not np.isclose(self.timestamps[0], self.data[0].start, rtol=1e-12):
             neg.append((self.timestamps[0], self.data[0].start, 0, self.data[0].first))
         for i in range(len(self.data) - 1):
             # Handle gaps between intervals
@@ -254,7 +254,7 @@ class IntervalList(Sequence, AcceleratorObject):
                 # There are some samples in between
                 neg.append((cur_stop, next_start, cur_last, next_first))
         # Handle range after last interval
-        if not np.isclose(self.timestamps[-1], self.data[-1].stop):
+        if not np.isclose(self.timestamps[-1], self.data[-1].stop, rtol=1e-12):
             neg.append(
                 (
                     self.data[-1].stop,
@@ -273,9 +273,8 @@ class IntervalList(Sequence, AcceleratorObject):
             raise RuntimeError(
                 "Cannot do AND operation on intervals with different timestamps"
             )
-        if not np.isclose(self.timestamps[0], other.timestamps[0]) or not np.isclose(
-            self.timestamps[-1], other.timestamps[-1]
-        ):
+        if not np.isclose(self.timestamps[0], other.timestamps[0], rtol=1e-12) \
+           or not np.isclose(self.timestamps[-1], other.timestamps[-1], rtol=1e-12):
             raise RuntimeError(
                 "Cannot do AND operation on intervals with different timestamps"
             )
@@ -308,9 +307,8 @@ class IntervalList(Sequence, AcceleratorObject):
             raise RuntimeError(
                 "Cannot do OR operation on intervals with different timestamps"
             )
-        if not np.isclose(self.timestamps[0], other.timestamps[0]) or not np.isclose(
-            self.timestamps[-1], other.timestamps[-1]
-        ):
+        if not np.isclose(self.timestamps[0], other.timestamps[0], rtol=1e-12) \
+           or not np.isclose(self.timestamps[-1], other.timestamps[-1], rtol=1e-12):
             raise RuntimeError(
                 "Cannot do OR operation on intervals with different timestamps"
             )

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -91,13 +91,19 @@ class SharedView(MutableMapping):
 class View(Sequence):
     """Class representing a list of views into any of the local observation data."""
 
-    def __init__(self, obj, key):
+    def __init__(self, obj, key, inverse=False):
         self.obj = obj
         self.key = key
         # Compute a list of slices for these intervals
-        self.slices = [slice(x.first, x.last, 1) for x in self.obj.intervals[key]]
+        if inverse:
+            self.slices = [slice(x.first, x.last, 1) for x in ~self.obj.intervals[key]]
+        else:
+            self.slices = [slice(x.first, x.last, 1) for x in self.obj.intervals[key]]
         self.detdata = DetDataView(obj, self.slices)
         self.shared = SharedView(obj, self.slices)
+
+    def __invert__(self):
+        return View(self.obj, self.key, inverse=True)
 
     def __getitem__(self, key):
         return self.slices[key]
@@ -137,22 +143,32 @@ class ViewManager(MutableMapping):
     # Mapping methods
 
     def __getitem__(self, key):
-        view_name = key
-        if view_name is None:
+        if key is None:
             # Make sure the fake internal intervals are created
             trigger = self.obj.intervals[None]
             view_name = self.obj.intervals.all_name
+            inverse = False
+        else:
+            if key.startswith("~"):
+                key = key[1:]
+                inverse = True
+            else:
+                inverse = False
+            view_name = key
         if view_name not in self.obj._views:
             # View does not yet exist, create it.
             if key is not None and key not in self.obj.intervals:
                 raise KeyError(
-                    "Observation does not have interval list named '{}'".format(key)
+                    f"Observation does not have interval list named '{key}'"
                 )
             self.obj._views[view_name] = View(self.obj, key)
             # Register deleter callback
             if key is not None:
                 self.obj.intervals.register_delete_callback(key, self.__delitem__)
-        return self.obj._views[view_name]
+        if inverse:
+            return ~self.obj._views[view_name]
+        else:
+            return self.obj._views[view_name]
 
     def __delitem__(self, key):
         del self.obj._views[key]

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -8,6 +8,8 @@ from collections.abc import Mapping, MutableMapping, Sequence
 
 import numpy as np
 
+from .utils import Logger
+
 
 class DetDataView(MutableMapping):
     """Class that applies views to a DetDataManager instance."""
@@ -92,6 +94,7 @@ class View(Sequence):
     """Class representing a list of views into any of the local observation data."""
 
     def __init__(self, obj, key, inverse=False):
+        self.inverted_counter = 0
         self.obj = obj
         self.key = key
         # Compute a list of slices for these intervals
@@ -103,6 +106,18 @@ class View(Sequence):
         self.shared = SharedView(obj, self.slices)
 
     def __invert__(self):
+        """Return a new view that is the complement of the current view.
+
+        Repeatedly calling __invert__() and resynthesizing the inverse view is
+        inefficient.  Rather, the calling code should construct and save it.
+        """
+        self.inverted_counter += 1
+        if self.inverted_counter > 100:
+            log = Logger.get()
+            msg = f"The '{self.key}' view has been inverted {self.inverted_counter}"
+            msg += " times.  The calling code should probably store and reuse"
+            msg += " the view instead of synthesizing it repeatedly."
+            log.warning(msg)
         return View(self.obj, self.key, inverse=True)
 
     def __getitem__(self, key):

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -1427,6 +1427,7 @@ class FilterBin(Operator):
             write_map = self.write_map
             write_noiseweighted_map = self.write_noiseweighted_map
         keep_final = self.keep_final_products
+        keep_cov = self.keep_final_products or self.write_obs_matrix
         for key, write, keep, force, rootname in [
             (hits_name, self.write_hits and binned, keep_final, False, self.name),
             (rcond_name, self.write_rcond and binned, keep_final, False, self.name),
@@ -1439,7 +1440,7 @@ class FilterBin(Operator):
             ),
             (map_name, write_map, keep_final, True, mc_root),
             (invcov_name, self.write_invcov and binned, keep_final, False, self.name),
-            (cov_name, self.write_cov and binned, keep_final, False, self.name),
+            (cov_name, self.write_cov and binned, keep_cov, False, self.name),
         ]:
             if write:
                 product = key.replace(f"{self.name}_", "")

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -1426,19 +1426,20 @@ class FilterBin(Operator):
         else:
             write_map = self.write_map
             write_noiseweighted_map = self.write_noiseweighted_map
+        keep_final = self.keep_final_products
         for key, write, keep, force, rootname in [
-            (hits_name, self.write_hits and binned, False, False, self.name),
-            (rcond_name, self.write_rcond and binned, False, False, self.name),
+            (hits_name, self.write_hits and binned, keep_final, False, self.name),
+            (rcond_name, self.write_rcond and binned, keep_final, False, self.name),
             (
                 noiseweighted_map_name,
                 write_noiseweighted_map,
-                False,
+                keep_final,
                 True,
                 mc_root,
             ),
-            (map_name, write_map, False, True, mc_root),
-            (invcov_name, self.write_invcov and binned, False, False, self.name),
-            (cov_name, self.write_cov and binned, True, False, self.name),
+            (map_name, write_map, keep_final, True, mc_root),
+            (invcov_name, self.write_invcov and binned, keep_final, False, self.name),
+            (cov_name, self.write_cov and binned, keep_final, False, self.name),
         ]:
             if write:
                 product = key.replace(f"{self.name}_", "")

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -7,7 +7,7 @@ import traitlets
 
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Int, List, Unicode, trait_docs
+from ..traits import Int, List, Unicode, trait_docs, Bool
 from ..utils import Environment, Logger
 from .operator import Operator
 
@@ -20,7 +20,8 @@ class FlagIntervals(Operator):
     with shared flags.  The view_mask trait is a list of tuples.  Each tuple contains
     the name of the view (i.e. interval) to apply and the bitmask to use for that
     view.  For each interval view, flag values in the shared_flags object are bitwise-
-    OR'd with the specified mask for samples in the view.
+    OR'd with the specified mask for samples in the view.  If the name of the view is
+    prefixed with '~' or '-', the bitmask is applied to all samples outside the view.
     """
 
     # Class traits
@@ -37,6 +38,10 @@ class FlagIntervals(Operator):
 
     shared_flag_bytes = Int(
         1, help="If creating shared key, use this many bytes per sample"
+    )
+
+    reset = Bool(
+        False, help="If True, flag bits are first set to 0 for the entire observation"
     )
 
     @traitlets.validate("shared_flag_bytes")
@@ -104,14 +109,16 @@ class FlagIntervals(Operator):
             new_flags = None
             if ob.comm_col_rank == 0:
                 new_flags = np.array(ob.shared[self.shared_flags])
+                if self.reset:
+                    for vname, vmask in self.view_mask:
+                        new_flags &= ~vmask
                 for vname, vmask in self.view_mask:
-                    if vname in ob.intervals:
-                        views = ob.view[vname]
-                        for vw in views:
+                    try:
+                        for vw in ob.view[vname]:
                             # Note that a View acts like a slice
                             new_flags[vw] |= vmask
-                    else:
-                        msg = f"Intervals '{vname}' does not exist in {ob.name}"
+                    except KeyError as e:
+                        msg = f"{e}; Intervals '{vname}' does not exist in {ob.name}"
                         msg += " skipping flagging"
                         log.warning(msg)
             ob.shared[self.shared_flags].set(new_flags, offset=(0,), fromrank=0)

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -21,7 +21,7 @@ class FlagIntervals(Operator):
     the name of the view (i.e. interval) to apply and the bitmask to use for that
     view.  For each interval view, flag values in the shared_flags object are bitwise-
     OR'd with the specified mask for samples in the view.  If the name of the view is
-    prefixed with '~' or '-', the bitmask is applied to all samples outside the view.
+    prefixed with '~' the bitmask is applied to all samples outside the view.
     """
 
     # Class traits

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -176,8 +176,8 @@ class BuildHitMap(Operator):
                 shared_flgs = [None for x in pix]
 
             # Process every data view
-            for pview, fview, shared_fview in zip(pix, flgs, shared_flgs):
-                for det in dets:
+            for det in dets:
+                for pview, fview, shared_fview in zip(pix, flgs, shared_flgs):
                     # Get local submap and pixels
                     local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
 
@@ -464,8 +464,8 @@ class BuildInverseCovariance(Operator):
                 shared_flgs = [None for x in wts]
 
             # Process every data view
-            for pview, wview, fview, shared_fview in zip(pix, wts, flgs, shared_flgs):
-                for det in dets:
+            for det in dets:
+                for pview, wview, fview, shared_fview in zip(pix, wts, flgs, shared_flgs):
                     # We require that the pointing matrix has the same number of
                     # non-zero elements for every detector and every observation.
                     # We check that here.

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -175,8 +175,8 @@ class BuildHitMap(Operator):
             else:
                 shared_flgs = [None for x in pix]
 
-            # Process every data view
             for det in dets:
+                # Process every data view
                 for pview, fview, shared_fview in zip(pix, flgs, shared_flgs):
                     # Get local submap and pixels
                     local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
@@ -463,8 +463,8 @@ class BuildInverseCovariance(Operator):
             else:
                 shared_flgs = [None for x in wts]
 
-            # Process every data view
             for det in dets:
+                # Process every data view
                 for pview, wview, fview, shared_fview in zip(pix, wts, flgs, shared_flgs):
                     # We require that the pointing matrix has the same number of
                     # non-zero elements for every detector and every observation.

--- a/src/toast/schedule.py
+++ b/src/toast/schedule.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2019-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -87,8 +87,11 @@ class GroundScan(Scan):
         start = self.start.isoformat(timespec="seconds")
         val = f"<GroundScan '{self.name}' "
         val += f"at {start} with El = {self.el}, Az {self.az_min} -- {self.az_max}, "
-        val += f"RA = {self.ra_min:.1f} < {self.ra_mean:.1f} < {self.ra_max:.1f}, "
-        val += f"Dec {self.dec_min:.1f} < {self.dec_mean:.1f} < {self.dec_max:.1f}>"
+        if self.ra_min is None:
+            val += f"RA, Dec = None, None>"
+        else:
+            val += f"RA = {self.ra_min:.1f} < {self.ra_mean:.1f} < {self.ra_max:.1f}, "
+            val += f"Dec {self.dec_min:.1f} < {self.dec_mean:.1f} < {self.dec_max:.1f}>"
         return val
 
     @function_timer

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ install(FILES
     dist.py
     instrument.py
     intervals.py
+    ops_flag_intervals.py
     rng.py
     math_misc.py
     qarray.py

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -152,6 +152,25 @@ class IntervalTest(MPITestCase):
         ninterval12 = len(intervals12)
         assert ninterval1 + ninterval2 == ninterval12
 
+    def test_inverse(self):
+        # Form an interval list and its inverse and confirm that together
+        # they cover the entire observation
+        n = 100
+        stamps = np.arange(n, dtype=np.float64)
+        breaks = stamps[::10]
+        nbreak = len(breaks)
+        times1 = [(breaks[2 * i], breaks[2 * i + 1]) for i in range(nbreak // 2)]
+        intervals0 = IntervalList(stamps, timespans=times1)
+        intervals1 = ~intervals0
+        intervals2 = ~intervals1
+        included = np.zeros(n, dtype=int)
+        for ival in intervals1:
+            included[ival.first : ival.last] += 1
+        assert not np.all(included)
+        for ival in intervals2:
+            included[ival.first : ival.last] += 1
+        assert np.all(included == 1)
+
     # def test_tochunks(self):
     #     intrvls = regular_intervals(
     #         self.nint, self.start, self.first, self.rate, self.duration, self.gap

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -437,6 +437,11 @@ class ObservationTest(MPITestCase):
                     np.testing.assert_equal(ob.detdata[dd][:, slc], vw[:])
                 for vw, slc in zip(ob.view["bad"].detdata[dd], bad_slices):
                     np.testing.assert_equal(ob.detdata[dd][:, slc], vw[:])
+                # Test inverting views
+                for vw1, vw2 in zip(
+                        ob.view["good"].detdata[dd], ob.view["~bad"].detdata[dd]
+                ):
+                    np.testing.assert_equal(vw1[:], vw2[:])
 
             for sh in ["boresight_azel", "boresight_radec", "flags", "timestamps"]:
                 for vw, slc in zip(ob.view["good"].shared[sh], good_slices):

--- a/src/toast/tests/ops_flag_intervals.py
+++ b/src/toast/tests/ops_flag_intervals.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import glob
+import os
+import sys
+
+import healpy as hp
+import numpy as np
+import numpy.testing as nt
+import scipy.sparse
+from astropy import units as u
+from astropy.table import Column
+
+from toast import ObsMat
+
+from .. import ops as ops
+from ..mpi import MPI, Comm
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..pixels import PixelData, PixelDistribution
+from ..pixels_io_healpix import read_healpix
+from ..vis import set_matplotlib_backend
+from .helpers import (
+    close_data,
+    create_ground_data,
+    create_outdir,
+    fake_flags,
+)
+from .mpi import MPITestCase
+
+
+class FlagIntervalsTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+
+    def test_flag_intervals(self):
+        # Create a fake ground data set for testing
+        data = create_ground_data(self.comm, turnarounds_invalid=True)
+
+        mask1 = np.uint8(128)
+        nflagged0 = 0
+        ntot = 0
+        for ob in data.obs:
+            flags = ob.shared[defaults.shared_flags].data
+            ntot += flags.size
+            nflagged0 += np.sum(flags & mask1 != 0)
+        assert nflagged0 == 0
+
+        # Flag all samples in the leftright interval
+        
+        flag_intervals = ops.FlagIntervals(
+            view_mask=[(defaults.scan_leftright_interval, mask1)],
+            reset=True,
+        )
+        flag_intervals.apply(data)
+
+        nflagged1 = 0
+        for ob in data.obs:
+            flags = ob.shared[defaults.shared_flags].data
+            nflagged1 += np.sum(flags & mask1 != 0)
+        assert nflagged1 != 0
+
+        # Flag all samples outside the leftright interval
+
+        mask2 = np.uint8(64)
+        flag_intervals = ops.FlagIntervals(
+            view_mask=[(f"~{defaults.scan_leftright_interval}", mask2)],
+            reset=True,
+        )
+        flag_intervals.apply(data)
+
+        # Compare the two sets
+
+        for iob, ob in enumerate(data.obs):
+            flags = ob.shared[defaults.shared_flags].data
+            flagged1 = flags & mask1 != 0
+            flagged2 = flags & mask2 != 0
+            # Test completeness
+            assert not np.any(flagged1 + flagged2 == 0)
+            # Test overlap
+            assert not np.any(flagged1 + flagged2 == 2)
+
+        close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -22,6 +22,7 @@ from . import footprint as test_footprint
 from . import healpix as test_healpix
 from . import instrument as test_instrument
 from . import intervals as test_intervals
+from . import ops_flag_intervals as test_ops_flag_intervals
 from . import io_compression as test_io_compression
 from . import io_hdf5 as test_io_hdf5
 from . import math_misc as test_math_misc
@@ -180,6 +181,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_qarray))
         suite.addTest(loader.loadTestsFromModule(test_noise))
         suite.addTest(loader.loadTestsFromModule(test_intervals))
+        suite.addTest(loader.loadTestsFromModule(test_ops_flag_intervals))
         suite.addTest(loader.loadTestsFromModule(test_instrument))
         suite.addTest(loader.loadTestsFromModule(test_pixels))
         suite.addTest(loader.loadTestsFromModule(test_weather))


### PR DESCRIPTION
A bucket of tweaks needed to facilitate the MSS3 simulations:
- improve compatibility between the `FilterBin` operator and `sotodlib` `Splits` operator
- fix a bug in producing the string representation of a `Scan` object when the Celestial coordinates are not yet calculated
- Add support for flagging the inverse of a given view
- Add a unit test for `FlagIntervals`
- Fix more interval time stamp comparison issues. The default relative tolerance is completely inadequate.