### PR TITLE
Fix intervals

### DIFF
--- a/src/libtoast/src/toast_tod_filter.cpp
+++ b/src/libtoast/src/toast_tod_filter.cpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -40,9 +40,9 @@ void toast::filter_polynomial(int64_t order, size_t n, uint8_t * flags,
         int64_t start = starts[iscan];
         int64_t stop = stops[iscan];
         if (start < 0) start = 0;
-        if (stop > n - 1) stop = n - 1;
+        if (stop > n) stop = n;
         if (stop < start) continue;
-        int scanlen = stop - start + 1;
+        int scanlen = stop - start;
 
         int ngood = 0;
         for (size_t i = 0; i < scanlen; ++i) {

--- a/src/toast/_libtoast/ops_mapmaker_utils.cpp
+++ b/src/toast/_libtoast/ops_mapmaker_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -212,7 +212,7 @@ void init_ops_mapmaker_utils(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -258,7 +258,7 @@ void init_ops_mapmaker_utils(py::module & m) {
 
                                 // Check if the value is out of range for the current
                                 // interval
-                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                if (adjusted_isamp >= dev_intervals[iview].last) {
                                     continue;
                                 }
 
@@ -311,7 +311,7 @@ void init_ops_mapmaker_utils(py::module & m) {
                         for (int64_t iview = 0; iview < n_view; iview++) {
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                isamp < raw_intervals[iview].last;
                                 isamp++
                             ) {
                                 int32_t w_indx = raw_weight_index[idet];

--- a/src/toast/_libtoast/ops_noise_weight.cpp
+++ b/src/toast/_libtoast/ops_noise_weight.cpp
@@ -54,7 +54,7 @@ void init_ops_noise_weight(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -84,7 +84,7 @@ void init_ops_noise_weight(py::module & m) {
 
                                 // Check if the value is out of range for the current
                                 // interval
-                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                if (adjusted_isamp >= dev_intervals[iview].last) {
                                     continue;
                                 }
 
@@ -103,7 +103,7 @@ void init_ops_noise_weight(py::module & m) {
                         #pragma omp parallel for default(shared) schedule(static)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
-                            isamp <= raw_intervals[iview].last;
+                            isamp < raw_intervals[iview].last;
                             isamp++
                         ) {
                             int32_t d_indx = raw_data_index[idet];

--- a/src/toast/_libtoast/ops_noise_weight.cpp
+++ b/src/toast/_libtoast/ops_noise_weight.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+// Copyright (c) 2023-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 

--- a/src/toast/_libtoast/ops_pixels_healpix.cpp
+++ b/src/toast/_libtoast/ops_pixels_healpix.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -1241,7 +1241,7 @@ void init_ops_pixels_healpix(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -1282,7 +1282,7 @@ void init_ops_pixels_healpix(py::module & m) {
 
                                     // Check if the value is out of range for the
                                     // current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                    if (adjusted_isamp >= dev_intervals[iview].last) {
                                         continue;
                                     }
 
@@ -1326,7 +1326,7 @@ void init_ops_pixels_healpix(py::module & m) {
 
                                     // Check if the value is out of range for the
                                     // current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                    if (adjusted_isamp >= dev_intervals[iview].last) {
                                         continue;
                                     }
 
@@ -1360,7 +1360,7 @@ void init_ops_pixels_healpix(py::module & m) {
                             #pragma omp parallel for default(shared) schedule(static)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                isamp < raw_intervals[iview].last;
                                 isamp++
                             ) {
                                 pixels_healpix_nest_inner(
@@ -1389,7 +1389,7 @@ void init_ops_pixels_healpix(py::module & m) {
                             #pragma omp parallel for default(shared) schedule(static)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                isamp < raw_intervals[iview].last;
                                 isamp++
                             ) {
                                 pixels_healpix_ring_inner(

--- a/src/toast/_libtoast/ops_pointing_detector.cpp
+++ b/src/toast/_libtoast/ops_pointing_detector.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -141,7 +141,7 @@ void init_ops_pointing_detector(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -175,7 +175,7 @@ void init_ops_pointing_detector(py::module & m) {
 
                                 // Check if the value is out of range for the current
                                 // interval
-                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                if (adjusted_isamp >= dev_intervals[iview].last) {
                                     continue;
                                 }
 
@@ -203,7 +203,7 @@ void init_ops_pointing_detector(py::module & m) {
                         #pragma omp parallel for default(shared) schedule(static)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
-                            isamp <= raw_intervals[iview].last;
+                            isamp < raw_intervals[iview].last;
                             isamp++
                         ) {
                             pointing_detector_inner(

--- a/src/toast/_libtoast/ops_scan_map.cpp
+++ b/src/toast/_libtoast/ops_scan_map.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2023 by the parties listed in the AUTHORS file.
+// Copyright (c) 2023-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -174,7 +174,7 @@ void register_ops_scan_map(py::module & m, char const * name) {
                   int64_t max_interval_size = 0;
                   for (int64_t iview = 0; iview < n_view; iview++) {
                       int64_t interval_size = raw_intervals[iview].last -
-                                              raw_intervals[iview].first + 1;
+                                              raw_intervals[iview].first;
                       if (interval_size > max_interval_size) {
                           max_interval_size = interval_size;
                       }
@@ -216,7 +216,7 @@ void register_ops_scan_map(py::module & m, char const * name) {
 
                                   // check if the value is out of range for the current
                                   // interval
-                                  if (adjusted_isamp > dev_intervals[iview].last) {
+                                  if (adjusted_isamp >= dev_intervals[iview].last) {
                                       continue;
                                   }
 
@@ -251,7 +251,7 @@ void register_ops_scan_map(py::module & m, char const * name) {
                           #pragma omp parallel for default(shared) schedule(static)
                           for (
                               int64_t isamp = raw_intervals[iview].first;
-                              isamp <= raw_intervals[iview].last;
+                              isamp < raw_intervals[iview].last;
                               isamp++
                           ) {
                               scan_map_inner <T> (

--- a/src/toast/_libtoast/ops_stokes_weights.cpp
+++ b/src/toast/_libtoast/ops_stokes_weights.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -234,7 +234,7 @@ void init_ops_stokes_weights(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -272,7 +272,7 @@ void init_ops_stokes_weights(py::module & m) {
 
                                     // check if the value is out of range for the
                                     // current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                    if (adjusted_isamp >= dev_intervals[iview].last) {
                                         continue;
                                     }
 
@@ -311,7 +311,7 @@ void init_ops_stokes_weights(py::module & m) {
 
                                     // check if the value is out of range for the
                                     // current interval
-                                    if (adjusted_isamp > dev_intervals[iview].last) {
+                                    if (adjusted_isamp >= dev_intervals[iview].last) {
                                         continue;
                                     }
 
@@ -344,7 +344,7 @@ void init_ops_stokes_weights(py::module & m) {
                             #pragma omp parallel for default(shared) schedule(static)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                isamp < raw_intervals[iview].last;
                                 isamp++
                             ) {
                                 stokes_weights_IQU_inner(
@@ -369,7 +369,7 @@ void init_ops_stokes_weights(py::module & m) {
                             #pragma omp parallel for default(shared) schedule(static)
                             for (
                                 int64_t isamp = raw_intervals[iview].first;
-                                isamp <= raw_intervals[iview].last;
+                                isamp < raw_intervals[iview].last;
                                 isamp++
                             ) {
                                 stokes_weights_IQU_inner_hwp(
@@ -442,7 +442,7 @@ void init_ops_stokes_weights(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -472,7 +472,7 @@ void init_ops_stokes_weights(py::module & m) {
 
                                 // Check if the value is out of range for the current
                                 // interval
-                                if (adjusted_isamp > dev_intervals[iview].last) {
+                                if (adjusted_isamp >= dev_intervals[iview].last) {
                                     continue;
                                 }
 
@@ -491,7 +491,7 @@ void init_ops_stokes_weights(py::module & m) {
                         #pragma omp parallel for default(shared) schedule(static)
                         for (
                             int64_t isamp = raw_intervals[iview].first;
-                            isamp <= raw_intervals[iview].last;
+                            isamp < raw_intervals[iview].last;
                             isamp++
                         ) {
                             int32_t w_indx = raw_weight_index[idet];

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -73,7 +73,7 @@ void init_template_offset(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -102,7 +102,7 @@ void init_template_offset(py::module & m) {
 
                             // Check if the value is out of range for the current
                             // interval
-                            if (adjusted_isamp > dev_intervals[iview].last) {
+                            if (adjusted_isamp >= dev_intervals[iview].last) {
                                 continue;
                             }
 
@@ -124,7 +124,7 @@ void init_template_offset(py::module & m) {
                     #pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
-                        isamp <= raw_intervals[iview].last;
+                        isamp < raw_intervals[iview].last;
                         isamp++
                     ) {
                         int64_t d = data_index * n_samp + isamp;
@@ -218,7 +218,7 @@ void init_template_offset(py::module & m) {
                 int64_t max_interval_size = 0;
                 for (int64_t iview = 0; iview < n_view; iview++) {
                     int64_t interval_size = raw_intervals[iview].last -
-                                            raw_intervals[iview].first + 1;
+                                            raw_intervals[iview].first;
                     if (interval_size > max_interval_size) {
                         max_interval_size = interval_size;
                     }
@@ -255,14 +255,14 @@ void init_template_offset(py::module & m) {
 
                             // Check if the value is out of range for the current
                             // interval
-                            if (adjusted_isamp > dev_intervals[iview].last) {
+                            if (adjusted_isamp >= dev_intervals[iview].last) {
                                 continue;
                             }
 
                             // Insure we do not go out of the current interval
                             int64_t max_step_length = std::min(
                                 step_length,
-                                dev_intervals[iview].last - adjusted_isamp + 1
+                                dev_intervals[iview].last - adjusted_isamp
                             );
 
                             int64_t amp = amp_offset + amp_view_off[iview] +
@@ -298,7 +298,7 @@ void init_template_offset(py::module & m) {
                     #pragma omp parallel for default(shared)
                     for (
                         int64_t isamp = raw_intervals[iview].first;
-                        isamp <= raw_intervals[iview].last;
+                        isamp < raw_intervals[iview].last;
                         isamp++
                     ) {
                         int64_t d = data_index * n_samp + isamp;

--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -141,7 +141,7 @@ class IntervalList(Sequence, AcceleratorObject):
 
     def _find_indices(self, timespans):
         # Each interval covers all samples where the sample time meets:
-        # interval.start <= self.timestamps AND self.timestamps < self.timestamps
+        # interval.start <= self.timestamps AND self.timestamps < interval.stop
         # (open-ended interval)
         # with one exception: if the interval ends at the last timestamp, the
         # corresponding sample is included (closed interval)

--- a/src/toast/intervals.py
+++ b/src/toast/intervals.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -65,6 +65,7 @@ class IntervalList(Sequence, AcceleratorObject):
         super().__init__()
         self.timestamps = timestamps
         if intervals is not None:
+            # Construct intervals using timespans from the provided intervals
             if timespans is not None or samplespans is not None:
                 raise RuntimeError(
                     "If constructing from intervals, other spans should be None"
@@ -73,39 +74,43 @@ class IntervalList(Sequence, AcceleratorObject):
                 self.data = np.zeros(0, dtype=interval_dtype).view(np.recarray)
             else:
                 timespans = [(x.start, x.stop) for x in intervals]
-                indices = self._find_indices(timespans)
+                indices, times = self._find_indices(timespans)
                 self.data = np.array(
                     [
-                        (self.timestamps[x[0]], self.timestamps[x[1]], x[0], x[1])
-                        for x in indices
+                        (time[0], time[1], ind[0], ind[1])
+                        for (time, ind) in zip(times, indices)
                     ],
                     dtype=interval_dtype,
                 ).view(np.recarray)
         elif timespans is not None:
+            # Construct intervals using provided timespans
             if samplespans is not None:
                 raise RuntimeError("Cannot construct from both time and sample spans")
             if len(timespans) == 0:
                 self.data = np.zeros(0, dtype=interval_dtype).view(np.recarray)
             else:
-                # Construct intervals from time ranges
+                timespans = np.vstack(timespans)
                 for i in range(len(timespans) - 1):
+                    if np.isclose(timespans[i][1], timespans[i + 1][0], rtol=1e-12):
+                        # Force nearly equal timestamps to match
+                        timespans[i][1] = timespans[i + 1][0]
                     if timespans[i][1] > timespans[i + 1][0]:
                         raise RuntimeError("Timespans must be sorted and disjoint")
-                indices = self._find_indices(timespans)
+                indices, times = self._find_indices(timespans)
                 self.data = np.array(
                     [
-                        (self.timestamps[x[0]], self.timestamps[x[1]], x[0], x[1])
-                        for x in indices
+                        (time[0], time[1], ind[0], ind[1])
+                        for (time, ind) in zip(times, indices)
                     ],
                     dtype=interval_dtype,
                 ).view(np.recarray)
         elif samplespans is not None:
+            # Construct intervals from sample ranges
             if len(samplespans) == 0:
                 self.data = np.zeros(0, dtype=interval_dtype).view(np.recarray)
             else:
-                # Construct intervals from sample ranges
                 for i in range(len(samplespans) - 1):
-                    if samplespans[i][1] >= samplespans[i + 1][0]:
+                    if samplespans[i][1] > samplespans[i + 1][0]:
                         raise RuntimeError("Sample spans must be sorted and disjoint")
                 builder = list()
                 for first, last in samplespans:
@@ -113,33 +118,53 @@ class IntervalList(Sequence, AcceleratorObject):
                         continue
                     if first < 0:
                         first = 0
-                    if last >= len(self.timestamps):
-                        last = len(self.timestamps) - 1
-                    builder.append((timestamps[first], timestamps[last], first, last))
+                    if last > len(self.timestamps):
+                        last = len(self.timestamps)
+                    builder.append(
+                        (self._sample_time(first), self._sample_time(last), first, last)
+                    )
                 self.data = np.array(builder, dtype=interval_dtype).view(np.recarray)
         else:
             # No data yet
             self.data = np.zeros(0, dtype=interval_dtype).view(np.recarray)
 
+    def _sample_time(self, sample):
+        nsample = len(self.timestamps)
+        if sample < 0 or sample > nsample:
+            msg = f"Invalid sample index: {sample} not in [0, {nsample}]"
+            raise RuntimeError(msg)
+        if sample == nsample:
+            # Handle the end of the timestamps differently
+            return self.timestamps[sample - 1]
+        else:
+            return self.timestamps[sample]
+
     def _find_indices(self, timespans):
-        start_indx = np.searchsorted(
-            self.timestamps, [x[0] for x in timespans], side="left"
+        # Each interval covers all samples where the sample time meets:
+        # interval.start <= self.timestamps AND self.timestamps < self.timestamps
+        # (open-ended interval)
+        # with one exception: if the interval ends at the last timestamp, the
+        # corresponding sample is included (closed interval)
+        start_time, stop_time = np.vstack(timespans).T
+        # Cut out timespans that do not overlap with the available timestamps
+        good = np.logical_and(
+            start_time < self.timestamps[-1], stop_time > self.timestamps[0]
         )
-        stop_indx = np.searchsorted(
-            self.timestamps, [x[1] for x in timespans], side="right"
-        )
-        stop_indx -= 1
-        # Remove accidental overlap caused by timespan boundary occurring
-        # exactly over a time stamp.
-        for i in range(start_indx.size - 1):
-            if stop_indx[i] == start_indx[i + 1]:
-                stop_indx[i] -= 1
-        out = list()
-        for start, stop in zip(start_indx, stop_indx):
-            if stop < 0 or start >= len(self.timestamps):
-                continue
-            out.append((start, stop))
-        return out
+        start_time = start_time[good]
+        stop_time = stop_time[good]
+        start_indx = np.searchsorted(self.timestamps, start_time, side="left")
+        stop_indx = np.searchsorted(self.timestamps, stop_time, side="left")
+        # Include the last sample where the stop time matches the last time stamp
+        nsample = len(self.timestamps)
+        stop_indx[stop_indx == nsample - 1] = nsample
+        times = list()
+        samples = list()
+        for start, stop, first, last in zip(
+                start_time, stop_time, start_indx, stop_indx
+        ):
+            times.append((start, stop))
+            samples.append((first, last))
+        return samples, times
 
     def __getitem__(self, key):
         return self.data[key]
@@ -168,9 +193,10 @@ class IntervalList(Sequence, AcceleratorObject):
             return False
         if len(self.timestamps) != len(other.timestamps):
             return False
-        if not np.isclose(self.timestamps[0], other.timestamps[0]) or not np.isclose(
-            self.timestamps[-1], other.timestamps[-1]
-        ):
+        # Comparing timestamps with default tolerances to np.isclose
+        # is always True.  Must use sufficiently tight tolerances
+        if not np.isclose(self.timestamps[0], other.timestamps[0], rtol=1e-12) \
+           or not np.isclose( self.timestamps[-1], other.timestamps[-1], rtol=1e-12):
             return False
         for s, o in zip(self.data, other.data):
             if s.first != o.first:
@@ -188,20 +214,25 @@ class IntervalList(Sequence, AcceleratorObject):
         propose = list()
         first = self.data[0].first
         last = self.data[0].last
+        start = self.data[0].start
+        stop = self.data[0].stop
         for i in range(1, len(self.data)):
             cur_first = self.data[i].first
             cur_last = self.data[i].last
-            if cur_first == last + 1:
+            cur_start = self.data[i].start
+            cur_stop = self.data[i].stop
+            if cur_first == last:
                 # This interval is contiguous with the previous one
                 last = cur_last
+                stop = cur_stop
             else:
                 # There is a gap
-                propose.append(
-                    (self.timestamps[first], self.timestamps[last], first, last)
-                )
+                propose.append((start, stop, first, last))
                 first = cur_first
                 last = cur_last
-        propose.append((self.timestamps[first], self.timestamps[last], first, last))
+                start = cur_start
+                stop = cur_stop
+        propose.append((start, stop, first, last))
         if len(propose) < len(self.data):
             # Need to update
             self.data = np.array(propose, dtype=interval_dtype).view(np.recarray)
@@ -212,31 +243,24 @@ class IntervalList(Sequence, AcceleratorObject):
         neg = list()
         # Handle range before first interval
         if not np.isclose(self.timestamps[0], self.data[0].start):
-            last = self.data[0].first - 1
-            neg.append((self.timestamps[0], self.timestamps[last], 0, last))
+            neg.append((self.timestamps[0], self.data[0].start, 0, self.data[0].first))
         for i in range(len(self.data) - 1):
             # Handle gaps between intervals
             cur_last = self.data[i].last
+            cur_stop = self.data[i].stop
             next_first = self.data[i + 1].first
+            next_start = self.data[i + 1].start
             if next_first != cur_last + 1:
                 # There are some samples in between
-                neg.append(
-                    (
-                        self.timestamps[cur_last + 1],
-                        self.timestamps[next_first - 1],
-                        cur_last + 1,
-                        next_first - 1,
-                    )
-                )
+                neg.append((cur_stop, next_start, cur_last, next_first))
         # Handle range after last interval
         if not np.isclose(self.timestamps[-1], self.data[-1].stop):
-            first = self.data[-1].last + 1
             neg.append(
                 (
-                    self.timestamps[first],
+                    self.data[-1].stop,
                     self.timestamps[-1],
-                    first,
-                    len(self.timestamps) - 1,
+                    self.data[-1].last,
+                    len(self.timestamps),
                 )
             )
         return IntervalList(
@@ -263,11 +287,13 @@ class IntervalList(Sequence, AcceleratorObject):
 
         # Walk both sequences, building up the intersection.
         while (curself < len(self.data)) and (curother < len(other)):
-            low = max(self.data[curself].first, other[curother].first)
-            high = min(self.data[curself].last, other[curother].last)
-            if low <= high:
-                result.append((self.timestamps[low], self.timestamps[high], low, high))
-            if self.data[curself].last < other[curother].last:
+            start = max(self.data[curself].start, other[curother].start)
+            stop = min(self.data[curself].stop, other[curother].stop)
+            if start < stop:
+                low = max(self.data[curself].first, other[curother].first)
+                high = min(self.data[curself].last, other[curother].last)
+                result.append((start, stop, low, high))
+            if self.data[curself].stop < other[curother].stop:
                 curself += 1
             else:
                 curother += 1
@@ -296,6 +322,8 @@ class IntervalList(Sequence, AcceleratorObject):
         result = list()
         res_first = None
         res_last = None
+        res_start = None
+        res_stop = None
         curself = 0
         curother = 0
 
@@ -303,19 +331,19 @@ class IntervalList(Sequence, AcceleratorObject):
         done_self = False
         done_other = False
         while (not done_self) or (not done_other):
-            next = None
+            next_ = None
             if done_self:
-                next = other[curother]
+                next_ = other[curother]
                 curother += 1
             elif done_other:
-                next = self.data[curself]
+                next_ = self.data[curself]
                 curself += 1
             else:
                 if self.data[curself].first < other[curother].first:
-                    next = self.data[curself]
+                    next_ = self.data[curself]
                     curself += 1
                 else:
-                    next = other[curother]
+                    next_ = other[curother]
                     curother += 1
             if curself >= len(self.data):
                 done_self = True
@@ -323,33 +351,36 @@ class IntervalList(Sequence, AcceleratorObject):
                 done_other = True
 
             if res_first is None:
-                res_first = next.first
-                res_last = next.last
+                res_first = next_.first
+                res_last = next_.last
+                res_start = next_.start
+                res_stop = next_.stop
             else:
                 # We use '<' here instead of '<=', so that intervals which are next to
                 # each other (but not overlapping) are not combined.  If the combination
                 # is desired, the simplify() method can be used.
-                if next.first < res_last + 1:
+                if next_.first < res_last:
                     # We overlap last interval
-                    if next.last > res_last:
+                    if next_.last > res_last:
                         # This interval extends beyond the last interval
-                        res_last = next.last
+                        res_last = next_.last
+                        res_stop = next_.stop
                 else:
                     # We have a break, close out previous interval and start a new one
                     result.append(
                         (
-                            self.timestamps[res_first],
-                            self.timestamps[res_last],
+                            res_start,
+                            res_stop,
                             res_first,
                             res_last,
                         )
                     )
-                    res_first = next.first
-                    res_last = next.last
+                    res_first = next_.first
+                    res_last = next_.last
+                    res_start = next_.start
+                    res_stop = next_.stop
         # Close out final interval
-        result.append(
-            (self.timestamps[res_first], self.timestamps[res_last], res_first, res_last)
-        )
+        result.append((res_start, res_stop, res_first, res_last))
 
         return IntervalList(
             self.timestamps,
@@ -456,13 +487,13 @@ def regular_intervals(n, start, first, rate, duration, gap):
 
     for i in range(n):
         ifirst = first + i * totsamples
-        ilast = ifirst + dursamples - 1
+        ilast = ifirst + dursamples
         # The time span between interval starts (the first sample of one
         # interval to the first sample of the next) includes the one extra
         # sample time.
         istart = start + i * (totsamples * invrate)
-        # The stop time is the timestamp of the last valid sample (thus the -1).
-        istop = istart + ((dursamples - 1) * invrate)
+        # The stop time is the timestamp of the last sample
+        istop = istart + (dursamples * invrate)
         intervals.append((istart, istop, ifirst, ilast))
 
     return np.array(intervals, dtype=interval_dtype).view(np.recarray)

--- a/src/toast/jax/intervals.py
+++ b/src/toast/jax/intervals.py
@@ -32,8 +32,7 @@ class INTERVALS_JAX:
         elif intervals.size == 0:
             return 1
         else:
-            # end+1 as TOAST intervals are inclusive
-            return 1 + np.max(intervals.last - intervals.first)
+            return np.max(intervals.last - intervals.first)
 
     @function_timer
     def to_host(self):

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -2133,7 +2133,7 @@ class IntervalsManager(MutableMapping):
                 # Create fake intervals
                 faketimes = -1.0 * np.ones(self._local_samples, dtype=np.float64)
                 self._internal[self.all_name] = IntervalList(
-                    faketimes, samplespans=[(0, self._local_samples - 1)]
+                    faketimes, samplespans=[(0, self._local_samples)]
                 )
             return self.all_name
         else:

--- a/src/toast/observation_view.py
+++ b/src/toast/observation_view.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -95,7 +95,7 @@ class View(Sequence):
         self.obj = obj
         self.key = key
         # Compute a list of slices for these intervals
-        self.slices = [slice(x.first, x.last + 1, 1) for x in self.obj.intervals[key]]
+        self.slices = [slice(x.first, x.last, 1) for x in self.obj.intervals[key]]
         self.detdata = DetDataView(obj, self.slices)
         self.shared = SharedView(obj, self.slices)
 

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2023-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -293,11 +293,11 @@ class AzimuthIntervals(Operator):
                     vel_switch = np.array(vel_switch)
 
                     stable_times = [
-                        (stamps[x[0]], stamps[x[1] - 1])
+                        (stamps[x[0]], stamps[x[1]])
                         for x in zip(begin_stable, end_stable)
                     ]
                     throw_times = [
-                        (stamps[x[0]], stamps[x[1] - 1])
+                        (stamps[x[0]], stamps[x[1]])
                         for x in zip(begin_throw, end_throw)
                     ]
 

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -792,7 +792,7 @@ class FilterBin(Operator):
             for name in self.leftright_interval, self.rightleft_interval:
                 mask = np.zeros(phase.size, dtype=bool)
                 for ival in obs.intervals[name]:
-                    mask[ival.first : ival.last + 1] = True
+                    mask[ival.first : ival.last] = True
                 masks.append(mask)
             for template in legendre_templates:
                 for mask in masks:
@@ -819,7 +819,7 @@ class FilterBin(Operator):
 
         for ival in intervals:
             istart = ival.first
-            istop = ival.last + 1
+            istop = ival.last
             # Trim flagged samples from both ends
             while istart < istop and bad[istart]:
                 istart += 1
@@ -827,7 +827,7 @@ class FilterBin(Operator):
                 istop -= 1
             if istop - istart < nfilter:
                 # Not enough samples to filter, flag this interval
-                shared_flags[ival.first : ival.last + 1] |= self.filter_flag_mask
+                shared_flags[ival.first : ival.last] |= self.filter_flag_mask
                 continue
             wbin = 2 / (istop - istart)
             phase = (np.arange(istop - istart) + 0.5) * wbin - 1

--- a/src/toast/ops/groundfilter.py
+++ b/src/toast/ops/groundfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -240,7 +240,7 @@ class GroundFilter(Operator):
             for name in self.leftright_interval, self.rightleft_interval:
                 mask = np.zeros(phase.size, dtype=bool)
                 for ival in obs.intervals[name]:
-                    mask[ival.first : ival.last + 1] = True
+                    mask[ival.first : ival.last] = True
                 masks.append(mask)
             for template in legendre_templates:
                 for mask in masks:

--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -880,13 +880,13 @@ class HWPSynchronousModel(Operator):
             # Use the specified interval list for the chunks.  Cut any
             # chunks that are tiny.
             for intr in obs.intervals[self.chunk_view]:
-                ch_size = intr.last - intr.first + 1
+                ch_size = intr.last - intr.first
                 ch_mid = intr.first + ch_size // 2
                 if ch_size > 10 * self.harmonics:
                     chunks.append(
                         {
                             "start": intr.first,
-                            "end": intr.last + 1,
+                            "end": intr.last,
                             "time": reltime[ch_mid],
                         }
                     )
@@ -909,7 +909,7 @@ class HWPSynchronousModel(Operator):
         if self.chunk_view is not None:
             not_modelled = np.ones_like(shared_flags)
             for intr in obs.intervals[self.chunk_view]:
-                not_modelled[intr.first : intr.last + 1] = 0
+                not_modelled[intr.first : intr.last] = 0
             shared_flags |= not_modelled
 
         # Per-detector flags.  We merge in the shared flags to these since the

--- a/src/toast/ops/madam.py
+++ b/src/toast/ops/madam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -596,7 +596,7 @@ class Madam(Operator):
                 # and accumulate the number of samples.
                 for intvw in ob.intervals[self.view]:
                     interval_starts.append(nsamp_valid)
-                    nsamp_valid += intvw.last - intvw.first + 1
+                    nsamp_valid += intvw.last - intvw.first
             else:
                 interval_starts.append(nsamp_valid)
                 nsamp_valid += ob.n_local_samples

--- a/src/toast/ops/mapmaker_utils/kernels_numpy.py
+++ b/src/toast/ops/mapmaker_utils/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -64,7 +64,7 @@ def build_noise_weighted_numpy(
         for interval in intervals:
             # get interval slices
             interval_start = interval.first
-            interval_end = interval.last + 1
+            interval_end = interval.last
             data_samples = det_data[d_index, interval_start:interval_end]
             pixel_samples = pixels[p_index, interval_start:interval_end]
             weights_sample = weights[w_index, interval_start:interval_end, :]

--- a/src/toast/ops/noise_weight/kernels_numpy.py
+++ b/src/toast/ops/noise_weight/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -22,6 +22,6 @@ def noise_weight_numpy(
         detector_weight = detector_weights[idet]
         for interval in intervals:
             interval_start = interval.first
-            interval_end = interval.last + 1
+            interval_end = interval.last
             # Multiply by the weight
             det_data[d_index, interval_start:interval_end] *= detector_weight

--- a/src/toast/ops/pixels_healpix/kernels_numpy.py
+++ b/src/toast/ops/pixels_healpix/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -29,7 +29,7 @@ def pixels_healpix_numpy(
         qidx = quat_index[idet]
         pidx = pixel_index[idet]
         for vw in intervals:
-            samples = slice(vw.first, vw.last + 1, 1)
+            samples = slice(vw.first, vw.last, 1)
             dir = qa.rotate(quats[qidx][samples], zaxis)
             pixels[pidx][samples] = hp.vec2pix(
                 nside,

--- a/src/toast/ops/pixels_healpix/pixels_healpix.py
+++ b/src/toast/ops/pixels_healpix/pixels_healpix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -212,7 +212,7 @@ class PixelsHealpix(Operator):
             quat_indx = ob.detdata[quats_name].indices(dets)
             pix_indx = ob.detdata[self.pixels].indices(dets)
 
-            view_slices = [slice(x.first, x.last + 1, 1) for x in ob.intervals[view]]
+            view_slices = [slice(x.first, x.last, 1) for x in ob.intervals[view]]
 
             # Do we already have pointing for all requested detectors?
             if exists:

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -499,7 +499,7 @@ class PixelsWCS(Operator):
                     self.pixels, sample_shape=(), dtype=np.int64, detectors=dets
                 )
 
-            view_slices = [slice(x.first, x.last + 1, 1) for x in ob.intervals[view]]
+            view_slices = [slice(x.first, x.last, 1) for x in ob.intervals[view]]
 
             # Do we already have pointing for all requested detectors?
             if exists:

--- a/src/toast/ops/pointing_detector/kernels_numpy.py
+++ b/src/toast/ops/pointing_detector/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -22,7 +22,7 @@ def pointing_detector_numpy(
     for idet in range(len(quat_index)):
         qidx = quat_index[idet]
         for vw in intervals:
-            samples = slice(vw.first, vw.last + 1, 1)
+            samples = slice(vw.first, vw.last, 1)
             bore = np.array(boresight[samples])
             if shared_flags is not None:
                 good = (shared_flags[samples] & shared_flag_mask) == 0

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -278,8 +278,8 @@ class PolyFilter2D(Operator):
 
             views = temp_ob.intervals[self.view]
             for iview, view in enumerate(views):
-                nsample = view.last - view.first + 1
-                vslice = slice(view.first, view.last + 1)
+                nsample = view.last - view.first
+                vslice = slice(view.first, view.last)
 
                 # Accumulate the linear regression templates
 
@@ -540,7 +540,7 @@ class PolyFilter(Operator):
                     local_stops.append(interval.last)
             else:
                 local_starts = [0]
-                local_stops = [obs.n_local_samples - 1]
+                local_stops = [obs.n_local_samples]
 
             local_starts = np.array(local_starts)
             local_stops = np.array(local_stops)
@@ -615,7 +615,7 @@ class PolyFilter(Operator):
                     shared_flags = np.array(obs.shared[self.shared_flags])
                     not_filtered = np.ones(shared_flags.size, dtype=bool)
                     for start, stop in zip(local_starts, local_stops):
-                        not_filtered[start : stop + 1] = False
+                        not_filtered[start : stop] = False
                     shared_flags[not_filtered] |= self.poly_flag_mask
                 obs.shared[self.shared_flags].set(shared_flags, fromrank=0)
             if obs.comm.comm_group is not None:

--- a/src/toast/ops/scan_map/kernels_numpy.py
+++ b/src/toast/ops/scan_map/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -32,7 +32,7 @@ def scan_map_numpy(
         wts = weights[weight_index[idet]]
         tod = det_data[det_data_index[idet]]
         for view in intervals:
-            vslice = slice(view.first, view.last + 1)
+            vslice = slice(view.first, view.last)
 
             # Get local submaps and pixel indices within each submap
             good = pix[vslice] >= 0

--- a/src/toast/ops/sim_tod_atm_observe.py
+++ b/src/toast/ops/sim_tod_atm_observe.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -566,7 +566,7 @@ class ObserveAtmosphere(Operator):
         timestamps = ob.shared[times].data
         tmin = int(timestamps[first])
         tmax = int(timestamps[last])
-        slc = slice(first, last + 1, 1)
+        slc = slice(first, last, 1)
 
         ddata = None
         if raw is not None:

--- a/src/toast/ops/simple_deglitch.py
+++ b/src/toast/ops/simple_deglitch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2024-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -162,8 +162,8 @@ class SimpleDeglitch(Operator):
                     (det_flags & self.det_flag_mask) != 0,
                 )
                 for iview, view in enumerate(views):
-                    nsample = view.last - view.first + 1
-                    ind = slice(view.first, view.last + 1)
+                    nsample = view.last - view.first
+                    ind = slice(view.first, view.last)
                     sig_view = sig[ind].copy()
                     w = self.medfilt_kernel_size
                     if w > 0 and nsample > 2 * w:

--- a/src/toast/ops/simple_jumpcorrect.py
+++ b/src/toast/ops/simple_jumpcorrect.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2024-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -295,8 +295,8 @@ class SimpleJumpCorrect(Operator):
                     det_flags[flag_out] |= self.jump_mask
                 else:
                     for iview, view in enumerate(views):
-                        nsample = view.last - view.first + 1
-                        ind = slice(view.first, view.last + 1)
+                        nsample = view.last - view.first
+                        ind = slice(view.first, view.last)
                         sig_view = sig[ind].copy()
                         bad_view = bad[ind]
                         bad_view_out = bad_view.copy()

--- a/src/toast/ops/stokes_weights/kernels_numpy.py
+++ b/src/toast/ops/stokes_weights/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -37,7 +37,7 @@ def stokes_weights_IQU_numpy(
         widx = weight_index[idet]
         eta = (1.0 - epsilon[idet]) / (1.0 + epsilon[idet])
         for vw in intervals:
-            samples = slice(vw.first, vw.last + 1, 1)
+            samples = slice(vw.first, vw.last, 1)
             vd = qa.rotate(quats[qidx][samples], zaxis)
             vo = qa.rotate(quats[qidx][samples], xaxis)
 
@@ -81,5 +81,5 @@ def stokes_weights_I_numpy(weight_index, weights, intervals, cal, use_accel):
     for idet in range(len(weight_index)):
         widx = weight_index[idet]
         for vw in intervals:
-            samples = slice(vw.first, vw.last + 1, 1)
+            samples = slice(vw.first, vw.last, 1)
             weights[widx][samples] = cal[idet]

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -542,7 +542,7 @@ class export_obs(object):
                 local_sets = list()
                 offset = 0
                 for intr in obs.intervals[self._data_export.frame_intervals]:
-                    chunk = intr.last - offset + 1
+                    chunk = intr.last - offset
                     local_sets.append([chunk])
                     offset += chunk
                 if offset != obs.n_local_samples:

--- a/src/toast/templates/hwpss.py
+++ b/src/toast/templates/hwpss.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2023-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -202,7 +202,7 @@ class Hwpss(Template):
             if self.view is not None:
                 # Flag samples outside the valid intervals
                 for vw in self._obs_outview[iob]:
-                    vw_slc = slice(vw.first, vw.last + 1, 1)
+                    vw_slc = slice(vw.first, vw.last, 1)
                     flags[vw_slc] = 1
             coeff = amplitudes.local[amp_offset : amp_offset + self._n_coeff]
             model = hwpss_build_model(
@@ -234,7 +234,7 @@ class Hwpss(Template):
             if self.view is not None:
                 # Flag samples outside the valid intervals
                 for vw in self._obs_outview[iob]:
-                    vw_slc = slice(vw.first, vw.last + 1, 1)
+                    vw_slc = slice(vw.first, vw.last, 1)
                     flags[vw_slc] = 1
             if self.det_flags is not None:
                 flags |= ob.detdata[self.det_flags][detector] & self.det_flag_mask

--- a/src/toast/templates/offset/kernels_numpy.py
+++ b/src/toast/templates/offset/kernels_numpy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -39,8 +39,8 @@ def offset_add_to_signal_numpy(
     """
     offset = amp_offset
     for interval, view_offset in zip(intervals, n_amp_views):
-        samples = slice(interval.first, interval.last + 1, 1)
-        sampidx = np.arange(0, interval.last - interval.first + 1, dtype=np.int64)
+        samples = slice(interval.first, interval.last, 1)
+        sampidx = np.arange(0, interval.last - interval.first, dtype=np.int64)
         amp_idx = sampidx // step_length
         amp_vals = np.array([amplitudes[offset + x] for x in amp_idx])
         amp_flags = np.array([amplitude_flags[offset + x] for x in amp_idx])
@@ -86,10 +86,10 @@ def offset_project_signal_numpy(
     """
     offset = amp_offset
     for interval, view_offset in zip(intervals, n_amp_views):
-        samples = slice(interval.first, interval.last + 1, 1)
+        samples = slice(interval.first, interval.last, 1)
         ampidx = (
             offset
-            + np.arange(0, interval.last - interval.first + 1, dtype=np.int64)
+            + np.arange(0, interval.last - interval.first, dtype=np.int64)
             // step_length
         )
         ddata = det_data[data_index][samples]

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -1023,13 +1023,15 @@ class Offset(Template):
                     for ivw, vw in enumerate(ob.intervals[self.view]):
                         n_amp_view = self._obs_views[iob][ivw]
                         for istep in range(n_amp_view):
-                            amp_first.append(vw.first + istep * step_length)
+                            istart = vw.first + istep * step_length
+                            amp_first.append(istart)
+                            amp_start.append(ob.shared[self.times].data[istart])
                             if istep == n_amp_view - 1:
-                                amp_last.append(vw.last)
+                                istop = vw.last
                             else:
-                                amp_last.append(vw.first + (istep + 1) * step_length)
-                            amp_start.append(ob.shared[self.times].data[amp_first[-1]])
-                            amp_stop.append(ob.shared[self.times].data[amp_last[-1]])
+                                istop = vw.first + (istep + 1) * step_length
+                            amp_last.append(istop)
+                            amp_stop.append(ob.shared[self.times].data[istop - 1])
                     props["amp_first"] = np.array(amp_first, dtype=np.int64)
                     props["amp_last"] = np.array(amp_last, dtype=np.int64)
                     props["amp_start"] = np.array(amp_start, dtype=np.float64)
@@ -1149,7 +1151,7 @@ def plot(amp_file, compare=dict(), out=None):
         fig_height = 4
         fig_dpi = 100
 
-        x_samples = np.arange(amp_first[0], amp_last[-1] + 1, 1)
+        x_samples = np.arange(amp_first[0], amp_last[-1], 1)
 
         for idet, det in enumerate(det_list):
             outfile = f"{out}_{det}.pdf"

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -117,7 +117,7 @@ class Periodic(Template):
             omin = None
             omax = None
             for vw in ob.intervals[self.view].data:
-                vw_slc = slice(vw.first, vw.last + 1, 1)
+                vw_slc = slice(vw.first, vw.last, 1)
                 good = slice(None)
                 if self.is_detdata_key:
                     vw_data = ob.detdata[self.key].data[vw_slc]
@@ -249,7 +249,7 @@ class Periodic(Template):
                 else:
                     flag_indx = None
                 for vw in ob.intervals[self.view].data:
-                    vw_slc = slice(vw.first, vw.last + 1, 1)
+                    vw_slc = slice(vw.first, vw.last, 1)
                     if self.is_detdata_key:
                         vw_data = ob.detdata[self.key].data[vw_slc]
                     else:
@@ -285,8 +285,8 @@ class Periodic(Template):
         self, det_indx, ob_indx, ob, view, flag_indx=None, det_flags=False
     ):
         """Get the flags and amplitude indices for one detector and view."""
-        vw_slc = slice(view.first, view.last + 1, 1)
-        vw_len = view.last - view.first + 1
+        vw_slc = slice(view.first, view.last, 1)
+        vw_len = view.last - view.first
         incr = self._obs_incr[ob_indx]
         # Determine good samples
         if self.is_detdata_key:
@@ -337,7 +337,7 @@ class Periodic(Template):
             det_indx = ob.detdata[self.det_data].indices([detector])[0]
             amps = amplitudes.local[amp_offset : amp_offset + nbins]
             for vw in ob.intervals[self.view].data:
-                vw_slc = slice(vw.first, vw.last + 1, 1)
+                vw_slc = slice(vw.first, vw.last, 1)
                 good, amp_indx = self._view_flags_and_index(
                     det_indx,
                     iob,
@@ -372,7 +372,7 @@ class Periodic(Template):
             else:
                 flag_indx = None
             for vw in ob.intervals[self.view].data:
-                vw_slc = slice(vw.first, vw.last + 1, 1)
+                vw_slc = slice(vw.first, vw.last, 1)
                 good, amp_indx = self._view_flags_and_index(
                     det_indx,
                     iob,

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -140,6 +140,24 @@ class IntervalTest(MPITestCase):
         # print("bit or = ", test)
         self.assertTrue(test == or_check)
 
+    def test_union(self):
+        # Construct two disjoint interval lists that together for a
+        # continuous span.  Then form a union between them and confirm
+        # that the total number of intervals is the sum of the two lists
+        # (no intervals were merged)
+        stamps = np.arange(100, dtype=np.float64)
+        breaks = stamps[::10]
+        nbreak = len(breaks)
+        times1 = [(breaks[2 * i], breaks[2 * i + 1]) for i in range(nbreak // 2)]
+        times2 = [(breaks[2 * i + 1], breaks[2 * i + 2]) for i in range(nbreak // 2 - 1)]
+        intervals1 = IntervalList(stamps, timespans=times1)
+        intervals2 = IntervalList(stamps, timespans=times2)
+        ninterval1 = len(intervals1)
+        ninterval2 = len(intervals2)
+        intervals12 = intervals1 | intervals2
+        ninterval12 = len(intervals12)
+        assert ninterval1 + ninterval2 == ninterval12
+
     # def test_tochunks(self):
     #     intrvls = regular_intervals(
     #         self.nint, self.start, self.first, self.rate, self.duration, self.gap

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -30,15 +30,15 @@ class IntervalTest(MPITestCase):
             dtype=interval_dtype,
         ).view(np.recarray)
         check_neg = [
-            (0.0, 1.0, 0, 1),
+            (0.0, 2.0, 0, 2),
         ]
         check_neg.extend(
             [
-                (float(10.0 * x + 6), float(10.0 * x + 11), (10 * x + 6), (10 * x + 11))
+                (float(10.0 * x + 5), float(10.0 * x + 12), (10 * x + 5), (10 * x + 12))
                 for x in range(9)
             ]
         )
-        check_neg.append((96.0, 99.0, 96, 99))
+        check_neg.append((95.0, 99.0, 95, 100))
         check_neg = np.array(check_neg, dtype=interval_dtype).view(np.recarray)
 
         itime = IntervalList(stamps, timespans=timespans)
@@ -57,18 +57,17 @@ class IntervalTest(MPITestCase):
     def test_simplify(self):
         stamps = np.arange(100, dtype=np.float64)
         boundaries = [10 * x for x in range(1, 9)]
-        ranges = [(x, x + 9) for x in boundaries]
-        check = np.array([(stamps[10], stamps[89], 10, 89)], dtype=interval_dtype).view(
+        ranges = [(x, x + 10) for x in boundaries]
+        check = np.array([(stamps[10], stamps[90], 10, 90)], dtype=interval_dtype).view(
             np.recarray
         )
         ival = IntervalList(stamps, samplespans=ranges)
-        # print("ival = ", ival)
         ival.simplify()
-        # print("simple ival = ", ival)
         self.assertTrue(ival[0] == check[0])
 
     def test_bitwise(self):
-        stamps = np.arange(100, dtype=np.float64)
+        nsample = 100
+        stamps = np.arange(nsample, dtype=np.float64)
         raw = np.array(
             [
                 (float(10.0 * x + 2), float(10.0 * x + 5), (10 * x + 2), (10 * x + 5))
@@ -81,15 +80,12 @@ class IntervalTest(MPITestCase):
 
         full = ival | neg
         full.simplify()
-        # print("full = ", full)
-        check = np.array([(stamps[0], stamps[-1], 0, 99)], dtype=interval_dtype).view(
+        check = np.array([(stamps[0], stamps[-1], 0, nsample)], dtype=interval_dtype).view(
             np.recarray
         )
-        # print(f"check = {check}")
         self.assertTrue(full[0] == check)
 
         empty = ival & neg
-        # print("empty = ", empty)
 
         rawshift = np.array(
             [
@@ -133,11 +129,9 @@ class IntervalTest(MPITestCase):
         )
 
         test = ival & shifted
-        # print("bit and = ", test)
         self.assertTrue(test == and_check)
 
         test = ival | shifted
-        # print("bit or = ", test)
         self.assertTrue(test == or_check)
 
     def test_union(self):
@@ -162,7 +156,7 @@ class IntervalTest(MPITestCase):
     #     intrvls = regular_intervals(
     #         self.nint, self.start, self.first, self.rate, self.duration, self.gap
     #     )
-    #     totsamp = self.nint * (intrvls[0].last - intrvls[0].first + 1)
+    #     totsamp = self.nint * (intrvls[0].last - intrvls[0].first)
     #     totsamp += self.nint * (intrvls[1].first - intrvls[0].last - 1)
     #     sizes = intervals_to_chunklist(intrvls, totsamp, startsamp=self.first + 10)
     #     # for it in intrvls:
@@ -181,7 +175,7 @@ class IntervalTest(MPITestCase):
     #
     #     for it in intrvls:
     #         # print(it.first," ",it.last," ",it.start," ",it.stop)
-    #         check += it.last - it.first + 1
+    #         check += it.last - it.first
     #
     #     nt.assert_equal(check, goodsamp)
     #     return

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -429,8 +429,8 @@ class ObservationTest(MPITestCase):
                 np.testing.assert_equal(ob.shared[sh], ob.view[None].shared[sh][0])
 
             # Test named views
-            good_slices = [slice(x.first, x.last + 1, 1) for x in ob.intervals["good"]]
-            bad_slices = [slice(x.first, x.last + 1, 1) for x in ob.intervals["bad"]]
+            good_slices = [slice(x.first, x.last, 1) for x in ob.intervals["good"]]
+            bad_slices = [slice(x.first, x.last, 1) for x in ob.intervals["bad"]]
 
             for dd in ["signal", "flags"]:
                 for vw, slc in zip(ob.view["good"].detdata[dd], good_slices):

--- a/src/toast/tests/ops_example_ground.py
+++ b/src/toast/tests/ops_example_ground.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2024-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -324,7 +324,7 @@ class ExampleGroundTest(MPITestCase):
             )
             scanning_samples = np.zeros(ob.n_local_samples, dtype=bool)
             for intr in ob.intervals["scanning"]:
-                scanning_samples[intr.first : intr.last + 1] = 1
+                scanning_samples[intr.first : intr.last] = 1
             for det in ob.select_local_detectors(flagmask=defaults.det_mask_nonscience):
                 good = np.logical_and(
                     ob.detdata[defaults.det_flags][det] == 0,

--- a/src/toast/tests/ops_groundfilter.py
+++ b/src/toast/tests/ops_groundfilter.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -109,10 +109,10 @@ class GroundFilterTest(MPITestCase):
             az = ob.shared[defaults.azimuth].data * 100
             rightgoing = np.zeros(az.size, dtype=bool)
             for ival in ob.intervals[defaults.throw_leftright_interval]:
-                rightgoing[ival.first : ival.last + 1] = True
+                rightgoing[ival.first : ival.last] = True
             leftgoing = np.zeros(az.size, dtype=bool)
             for ival in ob.intervals[defaults.throw_rightleft_interval]:
-                leftgoing[ival.first : ival.last + 1] = True
+                leftgoing[ival.first : ival.last] = True
             rms[ob.name] = dict()
             for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
                 flags = ob.shared[defaults.shared_flags].data & self.shared_flag_mask

--- a/src/toast/tests/ops_pointing_healpix.py
+++ b/src/toast/tests/ops_pointing_healpix.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2023 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -31,7 +31,7 @@ class PointingHealpixTest(MPITestCase):
         )
         nsamp = phivec.size
         faketimes = -1.0 * np.ones(nsamp, dtype=np.float64)
-        intervals = IntervalList(faketimes, samplespans=[(0, nsamp - 1)])
+        intervals = IntervalList(faketimes, samplespans=[(0, nsamp)])
 
         eps = np.array([0.0])
         gamma = np.array([0.0])
@@ -118,7 +118,7 @@ class PointingHealpixTest(MPITestCase):
         zero_index = np.array([0], dtype=np.int32)
         zero_flags = np.zeros(nsamp, dtype=np.uint8)
         faketimes = -1.0 * np.ones(nsamp, dtype=np.float64)
-        intervals = IntervalList(faketimes, samplespans=[(0, nsamp - 1)])
+        intervals = IntervalList(faketimes, samplespans=[(0, nsamp)])
 
         pix = 49103
         theta, phi = hp.pix2ang(nside, pix, nest=nest)
@@ -180,7 +180,7 @@ class PointingHealpixTest(MPITestCase):
         zero_index = np.array([0], dtype=np.int32)
         zero_flags = np.zeros(nsamp, dtype=np.uint8)
         faketimes = -1.0 * np.ones(nsamp, dtype=np.float64)
-        intervals = IntervalList(faketimes, samplespans=[(0, nsamp - 1)])
+        intervals = IntervalList(faketimes, samplespans=[(0, nsamp)])
 
         pix = 49103
         theta, phi = hp.pix2ang(nside, pix, nest=nest)
@@ -363,7 +363,7 @@ class PointingHealpixTest(MPITestCase):
             times = obs.shared[defaults.times]
             nsample = len(times)
             intervals1 = np.array(
-                [(times[0], times[-1], 0, nsample - 1)], dtype=interval_dtype
+                [(times[0], times[-1], 0, nsample)], dtype=interval_dtype
             ).view(np.recarray)
             intervals2 = np.array(
                 [(times[0], times[nsample // 2], 0, nsample // 2)], dtype=interval_dtype

--- a/src/toast/tests/ops_sim_ground.py
+++ b/src/toast/tests/ops_sim_ground.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -39,7 +39,7 @@ class SimGroundTest(MPITestCase):
             ring += 1
         self.npix = npix
         self.fp = fake_hexagon_focalplane(n_pix=npix)
-
+        
     def test_exec(self):
         # Slow sampling
         fp = fake_hexagon_focalplane(
@@ -172,7 +172,7 @@ class SimGroundTest(MPITestCase):
             plt.close()
 
         close_data(data)
-
+    
     def test_phase(self):
         # Slow sampling
         fp = fake_hexagon_focalplane(
@@ -244,9 +244,9 @@ class SimGroundTest(MPITestCase):
         good2 = np.zeros(az2.size, dtype=bool)
 
         for ival in data1.obs[0].intervals[defaults.scan_leftright_interval]:
-            good1[ival.first : ival.last + 1] = True
+            good1[ival.first : ival.last] = True
         for ival in data2.obs[0].intervals[defaults.scan_leftright_interval]:
-            good2[ival.first : ival.last + 1] = True
+            good2[ival.first : ival.last] = True
 
         step1 = np.median(np.diff(az1[good1]))
         step2 = np.median(np.diff(az2[good2]))


### PR DESCRIPTION
Current TOAST `IntervalList` class has an issue when two disjoint sets of intervals like left-going and right-going scans are combined:  if the union of the lists is continuous, the intervals get merged into one long interval.  This happens even without calling the `simplify()` method.

The problem comes from choices made on how to handle intervals that end exactly at a timestamp. Currently, that sample gets excluded, if it is also claimed by the next interval. This caused the exact span of one interval to depend on the definition of the subsequent interval.

In this PR, intervals are redefined to be open-ended.  Samples are included up-to but not including the end time stamp. `np.isclose(rtol=1e-12)` is used to compare floating point time stamps. To make the interval definition more intuitive and compatible with Numpy indexing, the sample ranges defining the interval are now also open ended. This redefinition required small changes to many source files.

Current initialization of the `IntervalList` causes the provided time spans to be rewritten in terms of the actual time stamps. This is also problematic since using the resulting `IntervalList` to initialize a new one with potentially different sampling would cause the interval time spans to repeatedly shift from their original positions.  The new code faithfully maintains the provided time spans.