### PR TITLE
Fix unit test

### DIFF
--- a/src/libtoast/include/toast/atm.hpp
+++ b/src/libtoast/include/toast/atm.hpp
@@ -1,5 +1,5 @@
 
-// Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
@@ -8,9 +8,7 @@
 
 #ifdef HAVE_CHOLMOD
 
-extern "C" {
 # include <cholmod.h>
-}
 
 namespace toast {
 // This small singleton class is used to initialize and finalize the cholmod package.

--- a/src/libtoast/tests/toast_test_polyfilter.cpp
+++ b/src/libtoast/tests/toast_test_polyfilter.cpp
@@ -1,12 +1,11 @@
 
-// Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+// Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 // All rights reserved.  Use of this source code is governed by
 // a BSD-style license that can be found in the LICENSE file.
 
 #include <toast_test.hpp>
 
 #include <cmath>
-
 
 using namespace std;
 using namespace toast;
@@ -35,7 +34,7 @@ TEST_F(TOASTpolyfilterTest, filter) {
     }
 
     int64_t starts[] = {0, n / 2};
-    int64_t stops[] = {n / 2 - 1, n - 1};
+    int64_t stops[] = {n / 2, n};
     size_t nscan = 2;
 
     double rms1start = 0, rms2start = 0, rms3start = 0;
@@ -100,7 +99,7 @@ TEST_F(TOASTpolyfilterTest, filter_with_flags) {
     }
 
     int64_t starts[] = {0, n / 2};
-    int64_t stops[] = {n / 2 - 1, n - 1};
+    int64_t stops[] = {n / 2, n};
     size_t nscan = 2;
 
     double rms1start = 0, rms2start = 0, rms3start = 0;


### PR DESCRIPTION
Fix an error in a unit test which resulted from the recent change in interval indexing.

Also add a tiny fix to facilitate gcc15 checking `extern C` more rigorously.