### PR TITLE
Add unit test for IntervalList creation from close ended intervals

### DIFF
--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -183,7 +183,9 @@ class IntervalTest(MPITestCase):
         # Time ranges are open ended *unless* they fall exactly on a sample.
         # Here we set the ending time of each span to exactly the timestamp
         # of the final sample.
-        timespans = [(stamps[x[0]], stamps[x[1] - 1]) for x in samplespans]
+        timespans = [
+            (stamps[x[0]], stamps[min(x[1], stamps.size - 1)]) for x in samplespans
+        ]
         intr_times = IntervalList(stamps, timespans=timespans)
 
         self.assertTrue(intr_samples == intr_times)

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -180,9 +180,8 @@ class IntervalTest(MPITestCase):
         samplespans = [(x * n_intr, x * n_intr + n_intr) for x in range(n_intr)]
         intr_samples = IntervalList(stamps, samplespans=samplespans)
 
-        # Time ranges are open ended *unless* they fall exactly on a sample.
-        # Here we set the ending time of each span to exactly the timestamp
-        # of the final sample.
+        # Time ranges are open ended *unless* the end time coincides
+        # with the observation end time.
         timespans = [
             (stamps[x[0]], stamps[min(x[1], stamps.size - 1)]) for x in samplespans
         ]

--- a/src/toast/tests/intervals.py
+++ b/src/toast/tests/intervals.py
@@ -171,6 +171,23 @@ class IntervalTest(MPITestCase):
             included[ival.first : ival.last] += 1
         assert np.all(included == 1)
 
+    def test_closed_time_spans(self):
+        n_samp = 100
+        n_intr = 10
+        stamps = 1000.0 * np.arange(n_samp, dtype=np.float64)
+
+        # Sample ranges are open ended
+        samplespans = [(x * n_intr, x * n_intr + n_intr) for x in range(n_intr)]
+        intr_samples = IntervalList(stamps, samplespans=samplespans)
+
+        # Time ranges are open ended *unless* they fall exactly on a sample.
+        # Here we set the ending time of each span to exactly the timestamp
+        # of the final sample.
+        timespans = [(stamps[x[0]], stamps[x[1] - 1]) for x in samplespans]
+        intr_times = IntervalList(stamps, timespans=timespans)
+
+        self.assertTrue(intr_samples == intr_times)
+
     # def test_tochunks(self):
     #     intrvls = regular_intervals(
     #         self.nint, self.start, self.first, self.rate, self.duration, self.gap


### PR DESCRIPTION
This unit test fails, but I think it should work, [based on the comments in the recently updated code](https://github.com/hpc4cmb/toast/blob/46230c8949e5be3e554da819ad3ee450bc77f6e1/src/toast/intervals.py#L143-L147).  @keskitalo can you take a look and see what you think?