### PR TITLE
Fully functional implementation

### DIFF
--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ENTRY_POINTS
     toast_obsmatrix_combine.py
     toast_obsmatrix_coadd.py
     toast_config_verify.py
+    toast_config_compare.py
     toast_merge_timings.py
     toast_plot_wcs.py
     toast_plot_healpix.py

--- a/src/toast/scripts/toast_config_compare.py
+++ b/src/toast/scripts/toast_config_compare.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""Load two TOAST config files and report the differences between them."""
+
+import argparse
+import re
+import sys
+import traceback
+from collections import OrderedDict
+
+from astropy.units import Quantity, Unit
+from toast.mpi import Comm, get_world
+from toast.utils import Environment, Logger, import_from_name, object_fullname
+
+import toast
+from toast.config import dump_json, dump_toml, dump_yaml, load_config
+
+
+def cropped_string(value, width):
+    """Crop long strings, Add color to select strings"""
+    try:
+        value = eval(value)
+    except (SyntaxError, NameError):
+        pass
+    # Parse Astropy quantities and units
+    # if re.match(r"^Quantity.*", value) is not None:
+    #     value = eval(value)
+    # elif re.match(r"^Unit.*", value) is not None:
+    #     value = eval(value)
+    # Convert to string
+    string = str(value)
+    # If necessary, replace the middle with "..."
+    if len(string) > width:
+        w = width // 2 - 3
+        string = string[:w] + "..." + string[-w:]
+    baselength = len(string)
+    # Use ANSI color sequences for highlighting.
+    # Will not work on Windows
+    if string == "True" or string == "ENABLED":
+        string = "\033[32m" + string + "\033[0m"
+    elif string == "False" or string == "DISABLED":
+        string = "\033[31m" + string + "\033[0m"
+    elif string == "NOT SET":
+        string = "\033[33m" + string + "\033[0m"
+    # Adding ANSI color sequences confuses Python string alignment
+    extralength = len(string) - baselength
+    return string, extralength
+
+
+def compare_dictionaries(
+    dict1,
+    dict2,
+    depth=0,
+    msg=[],
+    tab="  ",
+    width=40,
+):
+    """Recursively compare two dictionaries and print out the
+    differences
+
+    """
+    mismatched = False
+    keys = set(dict1.keys())
+    keys.update(dict2.keys())
+    for key in sorted(keys):
+        # for key, value1 in dict1.items():
+        # Special case: if operator is only enabled in one config,
+        # do not inspect any other keys
+        if (
+            "enabled" in dict1
+            and dict1["enabled"] != dict2["enabled"]
+            and key != "enabled"
+        ):
+            continue
+        # Check if the key is present in both dictionaries
+        # or just in one
+        missing = False
+        if key in dict1:
+            value1 = dict1[key]
+            if key in dict2:
+                value2 = dict2[key]
+            else:
+                missing = True
+                if value1["enabled"]["value"] == "True":
+                    value1 = "ENABLED"
+                else:
+                    value1 = "DISABLED"
+                value2 = "NOT SET"
+                msg.append(tab * depth + f"{key}")
+        else:
+            missing = True
+            if value2["enabled"]["value"] == "True":
+                value2 = "ENABLED"
+            else:
+                value2 = "DISABLED"
+            value1 = "NOT SET"
+            msg.append(tab * depth + f"{key}")
+        if isinstance(value1, OrderedDict) and not missing:
+            mismatched |= compare_dictionaries(
+                value1,
+                value2,
+                depth=depth + 1,
+                msg=msg + [tab * depth + f"{key}"],
+                tab=tab,
+                width=width,
+            )
+        else:
+            if value1 != value2:
+                if msg[-1].strip() == "enabled":
+                    # Special handling for the "enabled" key
+                    if value1 == "True":
+                        value1 = "ENABLED"
+                    else:
+                        value1 = "DISABLED"
+                    if value2 == "True":
+                        value2 = "ENABLED"
+                    else:
+                        value2 = "DISABLED"
+                    msg.pop()
+                w1, w2 = width
+                w1 -= len(msg[-1])
+                str1, extra1 = cropped_string(value1, w1)
+                str2, extra2 = cropped_string(value2, w2)
+                print("\n".join(msg) + f"{str1:>{w1+extra1}}{str2:>{w2+extra2}}")
+                mismatched = True
+        if mismatched:
+            msg = []
+    return mismatched
+
+
+def main():
+    env = Environment.get()
+    log = Logger.get()
+
+    mpiworld, procs, rank = get_world()
+    if rank != 0:
+        return
+
+    if len(sys.argv) != 3:
+        msg = f"Usage: toast_config_compare.py <config1> <config2>"
+        raise RuntimeError(msg)
+
+    path0 = sys.argv[0]
+    path1 = sys.argv[1]
+    path2 = sys.argv[2]
+
+    configs = []
+    for path in path1, path2:
+        print(f"Parsing {path}")
+        parser = argparse.ArgumentParser(description="Compare two TOAST configs")
+
+        sys.argv = [path0, "--config", path]
+        config_in, args, jobargs = toast.parse_config(parser)
+
+        # Instantiate everything and then convert back to a config.
+        # This will automatically prune stale traits, etc.
+        run = toast.create_from_config(config_in)
+        run_vars = vars(run)
+
+        config_out = OrderedDict()
+        for sect_key, sect_val in run_vars.items():
+            sect_vars = vars(sect_val)
+            obj_list = list()
+            for obj_name, obj in sect_vars.items():
+                obj_list.append(obj)
+            config_out.update(toast.config.build_config(obj_list))
+        configs.append(config_out)
+
+    w1 = 70
+    w2 = 60
+    print("Comparing")
+    print(f"{path1:>{w1}}{path2:>{w2}}")
+    compare_dictionaries(*configs, tab="  ", width=(w1, w2))
+
+    return
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()

--- a/src/toast/scripts/toast_config_compare.py
+++ b/src/toast/scripts/toast_config_compare.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 
 from astropy.units import Quantity, Unit
 from toast.mpi import Comm, get_world
+from toast.trait_utils import string_to_scalar
 from toast.utils import Environment, Logger, import_from_name, object_fullname
 
 import toast
@@ -23,14 +24,9 @@ from toast.config import dump_json, dump_toml, dump_yaml, load_config
 def cropped_string(value, width):
     """Crop long strings, Add color to select strings"""
     try:
-        value = eval(value)
+        value = string_to_scalar(value)
     except (SyntaxError, NameError):
         pass
-    # Parse Astropy quantities and units
-    # if re.match(r"^Quantity.*", value) is not None:
-    #     value = eval(value)
-    # elif re.match(r"^Unit.*", value) is not None:
-    #     value = eval(value)
     # Convert to string
     string = str(value)
     # If necessary, replace the middle with "..."


### PR DESCRIPTION
Simple script to compare two TOAST configs and print out the differences.  Only operators or templates that are enabled in both configs are compared.

Here is an example output:
```
$ toast_config_compare config_log_carlos.toml config_log_baichiang.toml
Parsing config_log_carlos.toml
Parsing config_log_baichiang.toml
Comparing
                                                config_log_carlos.toml                                   config_log_baichiang.toml
operators
  demod_noise_estim_fit                                       DISABLED                                                     ENABLED
  diff_noise_cut_flag                                         DISABLED                                                     ENABLED
  gainscrambler                                                ENABLED                                                    DISABLED
  mlmapmaker
    area   /global/cfs/projectdirs/sobs...etry_v20250306_lat_f090.fits   /home/bai-chiang/devel/pwg-...geometry_v20241015_2p0.fits
    checkpoint_interval                                              0                                                          20
    downsample                                                  [2, 1]                                                         [1]
    maxerr                                                       1e-06                                                       1e-08
    maxiter                                                 [200, 200]                                                      [1000]
    nmat_dir                                                      None   /home/bai-chiang/devel/pwg-...out/noise/LAT_f030/o6/nmats
    nmat_mode                                                    build                                                        load
    skip_existing                                                False                                                        True
    srcsamp                                                       None                               masks/psmask_LAT_f030.car.hdf
  noise_cut_fit                                               DISABLED                                                     ENABLED
  noise_cut_flag                                              DISABLED                                                     ENABLED
  noise_estim_fit                                             DISABLED                                                     ENABLED
  pixels_healpix_radec                                         ENABLED                                                    DISABLED
  pixels_wcs_radec                                            DISABLED                                                     ENABLED
  scan_detector_map                                            NOT SET                                                    DISABLED
  scan_map                                                     ENABLED                                                    DISABLED
  scan_map_pixels                                              ENABLED                                                    DISABLED
  scan_wcs_detector_map                                        NOT SET                                                    DISABLED
  sim_atmosphere                                               ENABLED                                                    DISABLED
  sim_ground
    median_weather                                                True                                                       False
    randomize_phase                                              False                                                        True
    scan_accel_az                                         3.0 deg / s2                                                1.0 deg / s2
    scan_rate_az                                           1.5 deg / s                                                 1.0 deg / s
    use_ephem                                                     True                                                       False
    use_qpoint                                                   False                                                        True
  sim_hwpss
    fname_hwpss    /global/u2/c/chervias/.l...s/data/hwpss_per_chi.pck   /home/bai-chiang/micromamba.../ops/data/hwpss_per_chi.pck
  sim_noise                                                    ENABLED                                                    DISABLED
  sim_sss                                                      ENABLED                                                    DISABLED
templates
  fourier2d                                                   DISABLED                                                     ENABLED
```