### PR TITLE
Add a more helpful error message for missing dependency

### DIFF
--- a/src/toast/scripts/toast_timing_plot.py
+++ b/src/toast/scripts/toast_timing_plot.py
@@ -17,6 +17,12 @@ import plotly.express as px
 import plotly.io as pio
 
 
+if pio.kaleido.scope is None:
+    # Missing kaleido causes cryptic error messages
+    msg = "toast_timing_plot requires plotly with kaleido"
+    raise ImportError(msg)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Plot a timing dump.")
 


### PR DESCRIPTION
Trivial fix to add a more helpful error message to an error condition I have met more than once.