### PR TITLE
Store Az min/max metadata in the AzimuthIntervals operator

### DIFF
--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -5,7 +5,7 @@
 # Import Operators into our public API
 
 from .arithmetic import Combine
-from .azimuth_intervals import AzimuthIntervals
+from .azimuth_intervals import AzimuthIntervals, AzimuthRanges
 from .cadence_map import CadenceMap
 from .calibrate import CalibrateDetectors
 from .common_mode_noise import CommonModeNoise

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -151,6 +151,8 @@ class AzimuthIntervals(Operator):
             # Smoothing window in samples
             window = int(rate * self.window_seconds)
 
+            az_min_rad = None
+            az_max_rad = None
             if obs.comm_col_rank == 0:
                 # The azimuth angle
                 azimuth = np.array(obs.shared[self.azimuth].data)
@@ -158,6 +160,11 @@ class AzimuthIntervals(Operator):
                 # The azimuth flags
                 flags = np.array(obs.shared[self.shared_flags].data)
                 flags &= self.shared_flag_mask
+
+                # The min / max Az range for this time chunk
+                good_az = flags == 0
+                az_min_rad = min(azimuth[good_az])
+                az_max_rad = max(azimuth[good_az])
 
                 # Scan velocity
                 scan_vel = self._gradient(azimuth, window, flags=flags)
@@ -447,6 +454,18 @@ class AzimuthIntervals(Operator):
                         ax.set_ylabel("Scan Acceleration")
                     plt.savefig(out_file)
                     plt.close()
+
+            # Find the global Az min / max
+            if obs.comm_col_rank == 0 and obs.comm_row is not None:
+                # Find the min / max across the top process row
+                az_min_rad = obs.comm_row.allreduce(az_min_rad, op=MPI.MIN)
+                az_max_rad = obs.comm_row.allreduce(az_max_rad, op=MPI.MAX)
+            if obs.comm_col is not None:
+                # Broadcast down the column
+                az_min_rad = obs.comm_col.bcast(az_min_rad, root=0)
+                az_max_rad = obs.comm_col.bcast(az_max_rad, root=0)
+            obs["scan_min_az"] = az_min_rad * u.radian
+            obs["scan_max_az"] = az_max_rad * u.radian
 
             # Now create the intervals across each process column
             if obs.comm_col is not None:

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -151,8 +151,6 @@ class AzimuthIntervals(Operator):
             # Smoothing window in samples
             window = int(rate * self.window_seconds)
 
-            az_min_rad = None
-            az_max_rad = None
             if obs.comm_col_rank == 0:
                 # The azimuth angle
                 azimuth = np.array(obs.shared[self.azimuth].data)
@@ -160,11 +158,6 @@ class AzimuthIntervals(Operator):
                 # The azimuth flags
                 flags = np.array(obs.shared[self.shared_flags].data)
                 flags &= self.shared_flag_mask
-
-                # The min / max Az range for this time chunk
-                good_az = flags == 0
-                az_min_rad = min(azimuth[good_az])
-                az_max_rad = max(azimuth[good_az])
 
                 # Scan velocity
                 scan_vel = self._gradient(azimuth, window, flags=flags)
@@ -455,18 +448,6 @@ class AzimuthIntervals(Operator):
                     plt.savefig(out_file)
                     plt.close()
 
-            # Find the global Az min / max
-            if obs.comm_col_rank == 0 and obs.comm_row is not None:
-                # Find the min / max across the top process row
-                az_min_rad = obs.comm_row.allreduce(az_min_rad, op=MPI.MIN)
-                az_max_rad = obs.comm_row.allreduce(az_max_rad, op=MPI.MAX)
-            if obs.comm_col is not None:
-                # Broadcast down the column
-                az_min_rad = obs.comm_col.bcast(az_min_rad, root=0)
-                az_max_rad = obs.comm_col.bcast(az_max_rad, root=0)
-            obs["scan_min_az"] = az_min_rad * u.radian
-            obs["scan_max_az"] = az_max_rad * u.radian
-
             # Now create the intervals across each process column
             if obs.comm_col is not None:
                 have_scanning = obs.comm_col.bcast(have_scanning, root=0)
@@ -526,6 +507,14 @@ class AzimuthIntervals(Operator):
                     )
                 else:
                     obs.shared[self.shared_flags].set(None, offset=(0,), fromrank=0)
+
+        # Add azimuth ranges to the observations
+        azimuth_ranges = AzimuthRanges(
+            azimuth=self.azimuth,
+            shared_flags=self.shared_flags,
+            shared_flag_mask=self.shared_flag_mask,
+        )
+        azimuth_ranges.apply(data, detectors=None)
 
         # Additionally flag turnarounds as unstable pointing
         flag_intervals = FlagIntervals(
@@ -598,3 +587,105 @@ class AzimuthIntervals(Operator):
                 self.throw_rightleft_interval,
             ]
         }
+
+
+@trait_docs
+class AzimuthRanges(Operator):
+    """Measure and record the azimuth ranges in each observation"""
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    azimuth = Unicode(defaults.azimuth, help="Observation shared key for Azimuth")
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid,
+        help="Bit mask value for bad azimuth pointing",
+    )
+
+    view = Unicode(
+        None, allow_none=True, help="Use this view of the data in all observations"
+    )
+
+    @traitlets.validate("shared_flag_mask")
+    def _check_shared_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Flag mask should be a positive integer")
+        return check
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        env = Environment.get()
+        log = Logger.get()
+
+        for obs in data.obs:
+            if obs.comm_col_rank == 0:
+                # The azimuth angle
+                azimuth = np.array(obs.shared[self.azimuth].data)
+
+                # The azimuth flags
+                flags = np.array(obs.shared[self.shared_flags].data)
+                flags &= self.shared_flag_mask
+
+                # The min / max Az range for this time chunk
+                good = flags == 0
+
+                az = []
+                for view in obs.intervals[self.view]:
+                    ind = slice(view.first, view.last)
+                    az.append(azimuth[ind][good[ind]])
+                az = np.hstack(az)
+
+            # Find the global Az min / max
+            if obs.comm_col_rank == 0 and obs.comm_row is not None:
+                # Find the min / max across the top process row
+                az = obs.comm_row.allgather(az)
+                az = np.hstack(az)
+                az = np.unwrap(az)
+                az_min_rad = np.amin(az)
+                az_max_rad = np.amax(az)
+                # Find the right branch
+                while az_min_rad < 0:
+                    az_min_rad += 2 * np.pi
+                    az_max_rad += 2 * np.pi
+                while az_min_rad > 2 * np.pi:
+                    az_min_rad -= 2 * np.pi
+                    az_max_rad -= 2 * np.pi
+                # Check if we wrap around
+                if az_max_rad - az_min_rad > 2 * np.pi:
+                    az_min_rad = 0
+                    az_max_rad = 2 * np.pi
+            else:
+                az_min_rad = 0
+                az_max_rad = 0
+            if obs.comm_col is not None:
+                # Broadcast down the column
+                az_min_rad = obs.comm_col.bcast(az_min_rad, root=0)
+                az_max_rad = obs.comm_col.bcast(az_max_rad, root=0)
+            obs["scan_min_az"] = az_min_rad * u.radian
+            obs["scan_max_az"] = az_max_rad * u.radian
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "shared": [self.azimuth],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        return req
+
+    def _provides(self):
+        return {}

--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -129,7 +129,6 @@ class AzimuthIntervals(Operator):
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
-        env = Environment.get()
         log = Logger.get()
 
         for obs in data.obs:
@@ -186,9 +185,9 @@ class AzimuthIntervals(Operator):
 
                 if len(begin_stable) == 0 or len(end_stable) == 0:
                     msg = f"Observation {obs.name} has no stable scanning"
-                    msg += f" periods.  You should cut this observation or"
-                    msg += f" change the filter window.  Flagging all samples"
-                    msg += f" as unstable pointing."
+                    msg += " periods.  You should cut this observation or"
+                    msg += " change the filter window.  Flagging all samples"
+                    msg += " as unstable pointing."
                     log.warning(msg)
                     have_scanning = False
 
@@ -220,7 +219,7 @@ class AzimuthIntervals(Operator):
                                 stable_bad = (
                                     stable_timespans < self.short_limit.to_value(u.s)
                                 )
-                            except:
+                            except Exception:
                                 # Try short limit as fraction
                                 median_stable = np.median(stable_timespans)
                                 stable_bad = (
@@ -244,7 +243,7 @@ class AzimuthIntervals(Operator):
                                 stable_bad = (
                                     stable_timespans > self.long_limit.to_value(u.s)
                                 )
-                            except:
+                            except Exception:
                                 # Try long limit as fraction
                                 median_stable = np.median(stable_timespans)
                                 stable_bad = (
@@ -626,11 +625,12 @@ class AzimuthRanges(Operator):
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
-        env = Environment.get()
-        log = Logger.get()
-
         for obs in data.obs:
+            az_min_rad = None
+            az_max_rad = None
             if obs.comm_col_rank == 0:
+                # Compute the good azimuth data along the top process row
+
                 # The azimuth angle
                 azimuth = np.array(obs.shared[self.azimuth].data)
 
@@ -647,32 +647,34 @@ class AzimuthRanges(Operator):
                     az.append(azimuth[ind][good[ind]])
                 az = np.hstack(az)
 
-            # Find the global Az min / max
-            if obs.comm_col_rank == 0 and obs.comm_row is not None:
-                # Find the min / max across the top process row
-                az = obs.comm_row.allgather(az)
-                az = np.hstack(az)
-                az = np.unwrap(az)
-                az_min_rad = np.amin(az)
-                az_max_rad = np.amax(az)
-                # Find the right branch
-                while az_min_rad < 0:
-                    az_min_rad += 2 * np.pi
-                    az_max_rad += 2 * np.pi
-                while az_min_rad > 2 * np.pi:
-                    az_min_rad -= 2 * np.pi
-                    az_max_rad -= 2 * np.pi
-                # Check if we wrap around
-                if az_max_rad - az_min_rad > 2 * np.pi:
-                    az_min_rad = 0
-                    az_max_rad = 2 * np.pi
-            else:
-                az_min_rad = 0
-                az_max_rad = 0
-            if obs.comm_col is not None:
-                # Broadcast down the column
-                az_min_rad = obs.comm_col.bcast(az_min_rad, root=0)
-                az_max_rad = obs.comm_col.bcast(az_max_rad, root=0)
+                # Gather the data to the first process and compute the range
+                # there.
+                if obs.comm_row is not None:
+                    az = np.hstack(obs.comm_row.gather(az, root=0))
+
+                if obs.comm_row_rank == 0:
+                    # Find the global min / max on one process
+                    az = np.unwrap(az)
+                    az_min_rad = np.amin(az)
+                    az_max_rad = np.amax(az)
+                    # Find the right branch
+                    while az_min_rad < 0:
+                        az_min_rad += 2 * np.pi
+                        az_max_rad += 2 * np.pi
+                    while az_min_rad > 2 * np.pi:
+                        az_min_rad -= 2 * np.pi
+                        az_max_rad -= 2 * np.pi
+                    # Check if we wrap around
+                    if az_max_rad - az_min_rad > 2 * np.pi:
+                        az_min_rad = 0
+                        az_max_rad = 2 * np.pi
+
+            # Broadcast the result to the whole group
+            if obs.comm.comm_group is not None:
+                az_min_rad = obs.comm.comm_group.bcast(az_min_rad, root=0)
+                az_max_rad = obs.comm.comm_group.bcast(az_max_rad, root=0)
+
+            # Set the metadata
             obs["scan_min_az"] = az_min_rad * u.radian
             obs["scan_max_az"] = az_max_rad * u.radian
 

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -42,6 +42,7 @@ from ..utils import (
     rate_from_times,
 )
 from ..weather import SimWeather
+from .azimuth_intervals import AzimuthRanges
 from .flag_intervals import FlagIntervals
 from .operator import Operator
 from .sim_ground_utils import (
@@ -601,10 +602,6 @@ class SimGround(Operator):
 
             # Scan limits
             ob["scan_el"] = scan.el  # Nominal elevation
-            ob["scan_min_az"] = scan_min_az * u.radian
-            ob["scan_max_az"] = scan_max_az * u.radian
-            ob["scan_min_el"] = scan_min_el * u.radian
-            ob["scan_max_el"] = scan_max_el * u.radian
 
             # Create and set shared objects for timestamps, position, velocity, and
             # boresight.
@@ -813,6 +810,14 @@ class SimGround(Operator):
             ],
         )
         flag_intervals.apply(data, detectors=None)
+
+        # Add azimuth ranges to the observations
+        azimuth_ranges = AzimuthRanges(
+            azimuth=self.azimuth,
+            shared_flags=self.shared_flags,
+            shared_flag_mask=defaults.shared_mask_invalid,
+        )
+        azimuth_ranges.apply(data, detectors=None)
 
     def _simulate_scanning(self, site, scan, n_samples, rate, comm, samp_ranks):
         """Simulate the boresight Az/El pointing for one session."""

--- a/src/toast/ops/sim_ground.py
+++ b/src/toast/ops/sim_ground.py
@@ -602,6 +602,8 @@ class SimGround(Operator):
 
             # Scan limits
             ob["scan_el"] = scan.el  # Nominal elevation
+            ob["scan_min_el"] = scan_min_el * u.radian
+            ob["scan_max_el"] = scan_max_el * u.radian
 
             # Create and set shared objects for timestamps, position, velocity, and
             # boresight.


### PR DESCRIPTION
This fixes the use of the FilterBin operator on real data, which does not have the `scan_min_az` and `scan_max_az` metadata keys generated by the SimGround operator.