### PR TITLE
Allow data distributions where some processes have no data.

### DIFF
--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -172,20 +172,22 @@ class DistDetSamp(object):
 
         self.det_indices = list()
         for ds in self.dets:
-            dfirst = self.det_index[ds[0]]
-            dlast = self.det_index[ds[-1]]
-            self.det_indices.append(DistRange(dfirst, dlast - dfirst + 1))
+            if len(ds) > 0:
+                # At least one detector on this process
+                dfirst = self.det_index[ds[0]]
+                dlast = self.det_index[ds[-1]]
+                self.det_indices.append(DistRange(dfirst, dlast - dfirst + 1))
 
         if self.comm.group_rank == 0:
             # check that all processes have some data, otherwise print warning
             for i, ds in enumerate(self.dets):
                 if len(ds) == 0:
                     msg = f"Process {i} has no detectors assigned."
-                    log.warning(msg)
+                    log.verbose(msg)
             for i, ss in enumerate(self.samps):
                 if ss[1] == 0:
                     msg = f"Process {i} has no samples assigned."
-                    log.warning(msg)
+                    log.verbose(msg)
 
     def __eq__(self, other):
         log = Logger.get()
@@ -195,7 +197,7 @@ class DistDetSamp(object):
             log.verbose(f"  process_rows {self.process_rows} != {other.process_rows}")
         if not comm_equivalent(self.comm.comm_group, other.comm.comm_group):
             fail = 1
-            log.verbose(f"  obs group comm not equivalent")
+            log.verbose("  obs group comm not equivalent")
         # If the group comms are equivalent, then we know that the row / col
         # comms are equivalent, since they come from the same cache for a given
         # value of process_rows.
@@ -223,7 +225,7 @@ class DistDetSamp(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        s = f"<DistDetSamp "
+        s = "<DistDetSamp "
         s += f"P_row {self.comm_row_rank}/{self.comm_row_size} "
         s += f"P_col {self.comm_col_rank}/{self.comm_col_size} "
         s += "dets=["

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -339,7 +339,9 @@ class Demodulate(Operator):
                 obs.clear()
 
             log.debug_rank(
-                "Demodulated observation in", comm=data.comm.comm_group, timer=timer
+                f"Demodulated observation {obs.name} in",
+                comm=data.comm.comm_group,
+                timer=timer,
             )
         if self.purge:
             data.clear()
@@ -459,8 +461,8 @@ class Demodulate(Operator):
                             plocal.append(d)
                     if len(plocal) == 0:
                         msg = f"obs {obs.name}, process row {iprow} has no"
-                        msg += " unflagged detectors.  This may cause an error."
-                        log.warning(msg)
+                        msg += " good detectors.  This is inefficient..."
+                        log.debug(msg)
                     detsets.append(plocal)
             detsets = obs.comm_col.bcast(detsets, root=0)
 

--- a/src/toast/tests/dist.py
+++ b/src/toast/tests/dist.py
@@ -159,6 +159,29 @@ class DataTest(MPITestCase):
                     f.write("{:04d} = ({}, {})\n".format(indx, d[0], d[1]))
                     indx += 1
 
+    def test_overdist(self):
+        sizes = [100, 100]
+        groups = 4
+        dist = distribute_discrete(sizes, groups)
+        self.assertTrue(dist[0].offset == 0)
+        self.assertTrue(dist[0].n_elem == 1)
+        self.assertTrue(dist[1].offset == 1)
+        self.assertTrue(dist[1].n_elem == 1)
+        self.assertTrue(dist[2].offset == 2)
+        self.assertTrue(dist[2].n_elem == 0)
+        self.assertTrue(dist[3].offset == 2)
+        self.assertTrue(dist[3].n_elem == 0)
+
+        dist = distribute_uniform(2, 4)
+        self.assertTrue(dist[0].offset == 0)
+        self.assertTrue(dist[0].n_elem == 1)
+        self.assertTrue(dist[1].offset == 1)
+        self.assertTrue(dist[1].n_elem == 1)
+        self.assertTrue(dist[2].offset == 2)
+        self.assertTrue(dist[2].n_elem == 0)
+        self.assertTrue(dist[3].offset == 2)
+        self.assertTrue(dist[3].n_elem == 0)
+
     def test_view(self):
         data = create_satellite_data(
             self.comm, obs_per_group=1, obs_time=10.0 * u.minute

--- a/src/toast/tests/helpers/__init__.py
+++ b/src/toast/tests/helpers/__init__.py
@@ -5,7 +5,11 @@
 # Namespace imports
 
 from .flags import fake_flags
-from .ground import create_ground_data, create_ground_telescope
+from .ground import (
+    create_ground_data,
+    create_ground_telescope,
+    create_overdistributed_data,
+)
 from .hwp import fake_hwpss, fake_hwpss_data
 from .sky import (
     create_fake_beam_alm,

--- a/src/toast/tests/helpers/ground.py
+++ b/src/toast/tests/helpers/ground.py
@@ -204,3 +204,113 @@ def create_ground_data(
             ob.update_local_detector_flags(det_flags)
 
     return data
+
+
+def create_overdistributed_data(
+    mpicomm,
+    sample_rate=60.0 * u.Hz,
+    hwp_rpm=59.0,
+    fp_width=5.0 * u.degree,
+    temp_dir=None,
+    el_nod=False,
+    el_nods=[-1 * u.degree, 1 * u.degree],
+    fknee=None,
+    freqs=None,
+    turnarounds_invalid=False,
+    single_group=False,
+):
+    """Create a data object with more detectors than processes.
+
+    Use the specified MPI communicator to attempt to create 2 process groups.  Create
+    a fake telescope and run the ground sim to make some observations for each
+    group.  The number of detectors in the telescope is set to half the group size.
+
+    Args:
+        mpicomm (MPI.Comm): the MPI communicator (or None).
+        sample_rate (Quantity): the sample rate.
+
+    Returns:
+        toast.Data: the distributed data with named observations.
+
+    """
+    toastcomm = create_comm(mpicomm, single_group=single_group)
+    data = Data(toastcomm)
+
+    # Create telescope with one pixel per process.
+    tele = create_ground_telescope(
+        toastcomm.group_size,
+        sample_rate=sample_rate,
+        pixel_per_process=1,
+        fknee=fknee,
+        freqs=freqs,
+        width=fp_width,
+    )
+
+    # Modify the focalplane "pixel" key so that each pixel has 4
+    # detectors.  When we use the detset key below, there will be
+    # half as many detsets as processes.
+    fp_table = tele.focalplane.detector_data
+    old_pixels = np.array(fp_table["pixel"])
+    for idet in range(len(old_pixels)):
+        new_pix = old_pixels[idet // 4]
+        fp_table["pixel"][idet] = new_pix
+
+    # Create a schedule.
+
+    schedule = None
+
+    if mpicomm is None or mpicomm.rank == 0:
+        tdir = temp_dir
+        if tdir is None:
+            tdir = tempfile.mkdtemp()
+
+        sch_file = os.path.join(tdir, "ground_schedule.txt")
+        run_scheduler(
+            opts=[
+                "--site-name",
+                tele.site.name,
+                "--telescope",
+                tele.name,
+                "--site-lon",
+                "{}".format(tele.site.earthloc.lon.to_value(u.degree)),
+                "--site-lat",
+                "{}".format(tele.site.earthloc.lat.to_value(u.degree)),
+                "--site-alt",
+                "{}".format(tele.site.earthloc.height.to_value(u.meter)),
+                "--patch",
+                "small_patch,1,40,-40,44,-44",
+                "--start",
+                "2020-01-01 00:00:00",
+                "--stop",
+                "2020-01-01 06:00:00",
+                "--out",
+                sch_file,
+            ]
+        )
+        schedule = GroundSchedule()
+        schedule.read(sch_file)
+        if temp_dir is None:
+            shutil.rmtree(tdir)
+    if mpicomm is not None:
+        schedule = mpicomm.bcast(schedule, root=0)
+
+    sim_ground = ops.SimGround(
+        name="sim_ground",
+        telescope=tele,
+        schedule=schedule,
+        hwp_angle=defaults.hwp_angle,
+        hwp_rpm=hwp_rpm,
+        weather="atacama",
+        median_weather=True,
+        detset_key="pixel",
+        elnod_start=el_nod,
+        elnods=el_nods,
+        scan_accel_az=3 * u.degree / u.second**2,
+    )
+    if turnarounds_invalid:
+        sim_ground.turnaround_mask = 1 + 2
+    else:
+        sim_ground.turnaround_mask = 2
+    sim_ground.apply(data)
+
+    return data


### PR DESCRIPTION
This situation may occur when demodulating data with cut detectors or situations where having many processes is useful for simulation operations that are independent of the number of detectors.  Specific changes include:

- In distribute_discrete(), lift the restriction on having more groups than work units.

- In the DetectorData class, handle the case where there are no local detectors.

- Remove various warning / errors for this situation

- Add unit tests that test this "over distribution" of data with more processes than detectors.