### PR TITLE
Redistribute intervals fix

### DIFF
--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -690,8 +690,11 @@ class HWPSynchronousModel(Operator):
             all_dets = dets
             all_mag = mag
         else:
-            all_dets = flatten(obs.comm_col.gather(dets, root=0))
-            all_mag = np.array(flatten(obs.comm_col.gather(mag, root=0)))
+            all_dets = obs.comm_col.gather(dets, root=0)
+            all_mag = obs.comm_col.gather(mag, root=0)
+            if obs.comm_col.rank == 0:
+                all_dets = list(flatten(all_dets))
+                all_mag = np.array(list(flatten(all_mag)))
 
         # One process does the trivial calculation
         all_flags = None

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -24,7 +24,7 @@ from .operator import Operator
 
 
 def unwrap_together(x, y, period=2 * np.pi * u.rad):
-    """ Unwrap x but apply the same branch corrections to y """
+    """Unwrap x but apply the same branch corrections to y"""
     for i in range(1, len(x)):
         while np.abs(x[i] - x[i - 1]) > np.abs(x[i] + period - x[i - 1]):
             x[i] += period
@@ -449,7 +449,6 @@ class PixelsWCS(Operator):
                     is_azimuth=is_azimuth,
                     center_offset=self.center_offset,
                 )
-            rank = data.comm.comm_world.rank  # DEBUG
             minmax = minmax.T
             # Compact observations on both sides of the zero meridian
             # can confuse this calculation.  We must unwrap the per-observation
@@ -462,9 +461,10 @@ class PixelsWCS(Operator):
             if data.comm.comm_world is not None:
                 # Zero meridian concern applies across processes
                 def gather(x):
-                    return data.comm.comm_world.allgather(
-                        x.to_value(u.radian)
-                        ) * u.radian
+                    return (
+                        data.comm.comm_world.allgather(x.to_value(u.radian)) * u.radian
+                    )
+
                 all_lonmin = gather(lonmin)
                 all_lonmax = gather(lonmax)
                 all_latmin = gather(latmin)

--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -23,6 +23,18 @@ from .delete import Delete
 from .operator import Operator
 
 
+def unwrap_together(x, y, period=2 * np.pi * u.rad):
+    """ Unwrap x but apply the same branch corrections to y """
+    for i in range(1, len(x)):
+        while np.abs(x[i] - x[i - 1]) > np.abs(x[i] + period - x[i - 1]):
+            x[i] += period
+            y[i] += period
+        while np.abs(x[i] - x[i - 1]) > np.abs(x[i] - period - x[i - 1]):
+            x[i] -= period
+            y[i] -= period
+    return
+
+
 @trait_docs
 class PixelsWCS(Operator):
     """Operator which generates detector pixel indices defined on a flat projection.
@@ -437,28 +449,31 @@ class PixelsWCS(Operator):
                     is_azimuth=is_azimuth,
                     center_offset=self.center_offset,
                 )
+            rank = data.comm.comm_world.rank  # DEBUG
             minmax = minmax.T
             # Compact observations on both sides of the zero meridian
-            # can confuse this calculation. Use np.unwrap() to find
-            # the most compact longitude range.
-            lonmin = np.amin(np.unwrap(minmax[0]))
-            lonmax = np.amax(np.unwrap(minmax[1]))
-            if lonmax < lonmin:
-                lonmax += 2 * np.pi
+            # can confuse this calculation.  We must unwrap the per-observation
+            # limits for the most compact longitude range.
+            unwrap_together(minmax[0], minmax[1])
+            lonmin = np.amin(minmax[0])
+            lonmax = np.amin(minmax[1])
             latmin = np.amin(minmax[2])
             latmax = np.amax(minmax[3])
             if data.comm.comm_world is not None:
                 # Zero meridian concern applies across processes
-                all_lonmin = data.comm.comm_world.allgather(lonmin.to_value(u.radian))
-                all_lonmax = data.comm.comm_world.allgather(lonmax.to_value(u.radian))
-                all_latmin = data.comm.comm_world.allgather(latmin.to_value(u.radian))
-                all_latmax = data.comm.comm_world.allgather(latmax.to_value(u.radian))
-                lonmin = np.amin(np.unwrap(all_lonmin)) * u.radian
-                lonmax = np.amax(np.unwrap(all_lonmax)) * u.radian
-                if lonmax < lonmin:
-                    lonmax += 2 * np.pi
-                latmin = np.amin(all_latmin) * u.radian
-                latmax = np.amax(all_latmax) * u.radian
+                def gather(x):
+                    return data.comm.comm_world.allgather(
+                        x.to_value(u.radian)
+                        ) * u.radian
+                all_lonmin = gather(lonmin)
+                all_lonmax = gather(lonmax)
+                all_latmin = gather(latmin)
+                all_latmax = gather(latmax)
+                unwrap_together(all_lonmin, all_lonmax)
+                lonmin = np.amin(all_lonmin)
+                lonmax = np.amin(all_lonmax)
+                latmin = np.amin(all_latmin)
+                latmax = np.amax(all_latmax)
             self.bounds = (
                 lonmin.to(u.degree),
                 lonmax.to(u.degree),

--- a/src/toast/tests/helpers/ground.py
+++ b/src/toast/tests/helpers/ground.py
@@ -93,6 +93,7 @@ def create_ground_data(
     turnarounds_invalid=False,
     single_group=False,
     flagged_pixels=True,
+    schedule_hours=2,
 ):
     """Create a data object with a simple ground sim.
 
@@ -137,6 +138,7 @@ def create_ground_data(
         if tdir is None:
             tdir = tempfile.mkdtemp()
 
+        sch_hours = f"{int(schedule_hours):02d}"
         sch_file = os.path.join(tdir, "ground_schedule.txt")
         run_scheduler(
             opts=[
@@ -155,7 +157,7 @@ def create_ground_data(
                 "--start",
                 "2020-01-01 00:00:00",
                 "--stop",
-                "2020-01-01 06:00:00",
+                f"2020-01-01 {sch_hours}:00:00",
                 "--out",
                 sch_file,
             ]
@@ -218,6 +220,7 @@ def create_overdistributed_data(
     freqs=None,
     turnarounds_invalid=False,
     single_group=False,
+    schedule_hours=2,
 ):
     """Create a data object with more detectors than processes.
 
@@ -264,6 +267,7 @@ def create_overdistributed_data(
         if tdir is None:
             tdir = tempfile.mkdtemp()
 
+        sch_hours = f"{int(schedule_hours):02d}"
         sch_file = os.path.join(tdir, "ground_schedule.txt")
         run_scheduler(
             opts=[
@@ -282,7 +286,7 @@ def create_overdistributed_data(
                 "--start",
                 "2020-01-01 00:00:00",
                 "--stop",
-                "2020-01-01 06:00:00",
+                f"2020-01-01 {sch_hours}:00:00",
                 "--out",
                 sch_file,
             ]

--- a/src/toast/tests/ops_hwpss_model.py
+++ b/src/toast/tests/ops_hwpss_model.py
@@ -106,7 +106,7 @@ class HWPModelTest(MPITestCase):
             weights,
             skyfile,
             "input_sky_dist",
-            map_key="input_sky",
+            map_key=map_key,
             fwhm=30.0 * u.arcmin,
             lmax=3 * pixels.nside,
             I_scale=0.001,
@@ -274,7 +274,7 @@ class HWPModelTest(MPITestCase):
             os.makedirs(testdir)
 
         data, tod_rms, coeff = self.create_test_data(testdir)
-        n_harmonics = len(coeff) // 4
+        n_harmonics = len(coeff[data.obs[0].name]) // 4
 
         # Add random DC level
         for ob in data.obs:
@@ -331,7 +331,7 @@ class HWPModelTest(MPITestCase):
             os.makedirs(testdir)
 
         data, tod_rms, coeff = self.create_test_data(testdir)
-        n_harmonics = len(coeff) // 4
+        n_harmonics = len(coeff[data.obs[0].name]) // 4
 
         # Apply a random inverse relative calibration
         np.random.seed(123456)
@@ -400,7 +400,7 @@ class HWPModelTest(MPITestCase):
             os.makedirs(testdir)
 
         data, tod_rms, coeff = self.create_test_data(testdir)
-        n_harmonics = len(coeff) // 4
+        n_harmonics = len(coeff[data.obs[0].name]) // 4
 
         # Apply a random inverse relative calibration that is time-varying
         np.random.seed(123456)


### PR DESCRIPTION
Currently, integration tests run on just two processes.  When they are launched with four processes, the problem size and data distribution changes and new unit test failures come to light.

This PR fixes an error in the interval redistribution, making necessary adjustments to the spt3g import/export facilities.

It also fixes a corner case issue in automatic WCS bounds finding.