### PR TITLE
When converting coordinates with qpoint, make use of weather info

### DIFF
--- a/src/toast/coordinates.py
+++ b/src/toast/coordinates.py
@@ -100,14 +100,27 @@ def _qpoint_transform(site, t, quats_azel):
     """Get the Az/El -> Ra/Dec conversion quaternion for boresight."""
     import qpoint
 
+    if hasattr(site, "weather"):
+        weather = site.weather
+        temperature = weather.air_temperature.to_value(u.Celsius)
+        pressure = weather.surface_pressure.to_value(u.mbar)
+        if hasattr(weather, "relative_humidity"):
+            humidity = weather.relative_humidity
+        else:
+            humidity = 0
+    else:
+        temperature = 0
+        pressure = 0
+        humidity = 0
+
     qp = qpoint.QPoint(
         accuracy="high",
         fast_math=True,
         mean_aber=True,
         rate_ref="always",
-        temperature=0,
-        pressure=0,
-        humidity=0,
+        temperature=temperature,
+        pressure=pressure,
+        humidity=humidity,
         update_iers=True,
         rate_dut1="always",
         rate_wobble="always",

--- a/src/toast/weather.py
+++ b/src/toast/weather.py
@@ -63,6 +63,20 @@ class Weather(object):
         self._west_wind_val = west_wind
         self._south_wind_val = south_wind
 
+    def copy(self):
+        return Weather(
+            time=self._time_val,
+            ice_water=self._ice_water_val,
+            liquid_water=self._liquid_water_val,
+            pwv=self._pwv_val,
+            humidity=self._humidity_val,
+            surface_pressure=self._surface_pressure_val,
+            surface_temperature=self._surface_temperature_val,
+            air_temperature=self._air_temperature_val,
+            west_wind=self._west_wind_val,
+            south_wind=self._south_wind_val,
+        )
+
     def __eq__(self, other):
         if self._time_val != other._time_val:
             return False


### PR DESCRIPTION
The qpoint conversion from AZ / EL to RA / DEC can make use of the temperature, pressure, and humidity of the environment.  If a weather object is associated with a site, make use of this information.