### PR TITLE
Add a simple operator to apply a "counter 1/f" filter.

### DIFF
--- a/src/toast/ops/CMakeLists.txt
+++ b/src/toast/ops/CMakeLists.txt
@@ -27,6 +27,7 @@ install(FILES
     flag_intervals.py
     common_mode_noise.py
     noise_model.py
+    noise_filter.py
     signal_diff_noise_model.py
     gainscrambler.py
     pointing.py

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -38,6 +38,7 @@ from .mapmaker_utils import (
 )
 from .memory_counter import MemoryCounter
 from .noise_estimation import NoiseEstim
+from .noise_filter import NoiseFilter
 from .noise_model import DefaultNoiseModel, FitNoiseModel, FlagNoiseFit
 from .noise_weight import NoiseWeight
 from .obsmat import ObsMat, coadd_observation_matrix

--- a/src/toast/ops/noise_filter.py
+++ b/src/toast/ops/noise_filter.py
@@ -135,8 +135,8 @@ class NoiseFilter(Operator):
                     net = estimate_net(freq.value, psd)
                 else:
                     plateau_samples = np.logical_and(
-                        (freq > self.white_noise_min.to_value(u.Hz)),
-                        (freq < self.white_noise_max.to_value(u.Hz)),
+                        (freq > self.white_noise_min.to(u.Hz)),
+                        (freq < self.white_noise_max.to(u.Hz)),
                     )
                     net = np.sqrt(np.mean(psd[plateau_samples]))
 

--- a/src/toast/ops/noise_filter.py
+++ b/src/toast/ops/noise_filter.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import numpy as np
+from astropy import units as u
+
+from ..fft import convolve
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Int, Unicode, trait_docs
+from .operator import Operator
+
+
+@trait_docs
+class NoiseFilter(Operator):
+    """Apply the time domain inverse noise filter (N_tt`^-1) to timestreams.
+
+    This operator uses a specified noise model and computes the inverse time domain
+    noise covariance (1 / PSD^2).  It then applies this to the detector timestreams.
+
+    Historically this sort of operation was used to transform data to a basis where
+    the noise is white for purposes of solving a least squares problem (e.g. the
+    classic GLS mapmaking equation).  However, in the case of using a series of
+    timestream filters and making a binned map, this operation might be useful as
+    an additional filter in the stack.
+
+    NOTE:  This assumes that flagged samples have already been filled with a
+    constrained noise realization (or something similar).  See the FillGaps operator.
+
+    """
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
+    det_data = Unicode(
+        defaults.det_data,
+        help="Observation detdata key apply filtering to",
+    )
+
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid,
+        help="Bit mask value for optional shared flagging",
+    )
+
+    det_flags = Unicode(
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
+    )
+
+    det_flag_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for detector sample flagging",
+    )
+
+    noise_model = Unicode(
+        defaults.noise_model, help="Observation key containing the noise model"
+    )
+
+    debug = Unicode(
+        None,
+        allow_none=True,
+        help="Path to directory for generating debug plots",
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        for obs in data.obs:
+            dets = obs.select_local_detectors(detectors, flagmask=self.det_mask)
+            if len(dets) == 0:
+                continue
+
+            # Sample rate for this observation
+            rate = obs.telescope.focalplane.sample_rate.to_value(u.Hz)
+
+            # The signal array: this is a list of detector array references.
+            signal = obs.detdata[self.det_data][dets, :]
+
+            # Construct the N_tt'^-1 kernels for these detectors
+            kernels = list()
+            kern_freq = None
+            for d in dets:
+                nse = obs[self.noise_model]
+                freq = nse.freq(d)
+                if kern_freq is None:
+                    kern_freq = freq
+                else:
+                    if not np.allclose(kern_freq, freq):
+                        msg = "All detectors in the noise model must have the same"
+                        msg += " frequency binning"
+                        raise RuntimeError(msg)
+                psd = np.array(nse.psd(d))
+                psd_max = np.amax(psd)
+                psd_limit = 1.0e-8 * psd_max
+                cut = psd < psd_limit
+                psd[cut] = psd_limit
+                kernels.append(1.0 / psd**2)
+            kernels = np.array(kernels)
+
+            # Convolve this inverse noise covariance with the detector timestreams
+            convolve(
+                signal,
+                rate,
+                kernel_freq=kern_freq,
+                kernels=kernels,
+                algorithm="numpy",
+                debug=self.debug_root,
+            )
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "meta": [self.noise_model],
+            "detdata": [self.det_data],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        if self.det_flags is not None:
+            req["detdata"].append(self.det_flags)
+        return req
+
+    def _provides(self):
+        return dict()

--- a/src/toast/ops/noise_filter.py
+++ b/src/toast/ops/noise_filter.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
+import os
 
 import numpy as np
 from astropy import units as u
@@ -8,7 +9,8 @@ from astropy import units as u
 from ..fft import convolve
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Int, Unicode, trait_docs
+from ..traits import Int, Unicode, Quantity, trait_docs
+from .noise_model import estimate_net
 from .operator import Operator
 
 
@@ -70,6 +72,18 @@ class NoiseFilter(Operator):
         defaults.noise_model, help="Observation key containing the noise model"
     )
 
+    white_noise_min = Quantity(
+        None,
+        allow_none=True,
+        help="The minimum frequency to consider for the white noise plateau",
+    )
+
+    white_noise_max = Quantity(
+        None,
+        allow_none=True,
+        help="The maximum frequency to consider for the white noise plateau",
+    )
+
     debug = Unicode(
         None,
         allow_none=True,
@@ -81,6 +95,12 @@ class NoiseFilter(Operator):
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
+        if self.white_noise_max is not None:
+            # Ensure that the min is also set
+            if self.white_noise_min is None:
+                msg = "You must set both of the min / max values or neither of them"
+                raise RuntimeError(msg)
+
         for obs in data.obs:
             dets = obs.select_local_detectors(detectors, flagmask=self.det_mask)
             if len(dets) == 0:
@@ -95,32 +115,59 @@ class NoiseFilter(Operator):
             # Construct the N_tt'^-1 kernels for these detectors
             kernels = list()
             kern_freq = None
+            psd = None
             for d in dets:
                 nse = obs[self.noise_model]
                 freq = nse.freq(d)
                 if kern_freq is None:
                     kern_freq = freq
+                    psd = np.zeros(len(kern_freq), dtype=np.float64)
                 else:
                     if not np.allclose(kern_freq, freq):
                         msg = "All detectors in the noise model must have the same"
                         msg += " frequency binning"
                         raise RuntimeError(msg)
-                psd = np.array(nse.psd(d))
-                psd_max = np.amax(psd)
-                psd_limit = 1.0e-8 * psd_max
+                psd[:] = nse.psd(d).value
+
+                # Estimate the NET, so that we can properly treat the 1/f in the
+                # kernel.
+                if self.white_noise_max is None:
+                    net = estimate_net(freq.value, psd)
+                else:
+                    plateau_samples = np.logical_and(
+                        (freq > self.white_noise_min.to_value(u.Hz)),
+                        (freq < self.white_noise_max.to_value(u.Hz)),
+                    )
+                    net = np.sqrt(np.mean(psd[plateau_samples]))
+
+                # The white noise value sets the scale things we care about.  If
+                # other frequencies have been filtered out, make sure that these
+                # components do not blow up in the kernel.  Also normalize the
+                # kernel so that the white noise levels are not impacted.
+                net_sq = net**2
+                psd_limit = 1.0e-3 * net_sq
                 cut = psd < psd_limit
                 psd[cut] = psd_limit
-                kernels.append(1.0 / psd**2)
+                psd[:] = 1 / psd
+                norm = net_sq
+                psd *= norm
+                psd[0] = 0
+                kernels.append(psd)
             kernels = np.array(kernels)
 
             # Convolve this inverse noise covariance with the detector timestreams
+            debug_root = None
+            if self.debug is not None:
+                debug_root = os.path.join(
+                    self.debug, f"noise_filter_{obs.name}_{dets[0]}-{dets[-1]}"
+                )
             convolve(
                 signal,
                 rate,
                 kernel_freq=kern_freq,
                 kernels=kernels,
                 algorithm="numpy",
-                debug=self.debug_root,
+                debug=debug_root,
             )
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ install(FILES
     io_hdf5.py
     io_compression.py
     ops_noise_estim.py
+    ops_noise_filter.py
     ops_yield_cut.py
     ops_elevation_noise.py
     ops_signal_diff_noise.py

--- a/src/toast/tests/ops_noise_filter.py
+++ b/src/toast/tests/ops_noise_filter.py
@@ -42,15 +42,7 @@ class NoiseFilterTest(MPITestCase):
             self.make_plots = True
 
     def plot_noise_model(
-        self,
-        fname,
-        net,
-        true_freq,
-        true_psd,
-        est_freq,
-        est_psd,
-        fit_freq=None,
-        fit_psd=None,
+        self, fname, net, input_freq, input_psd, est_freq, est_psd, fit_freq, fit_psd
     ):
         set_matplotlib_backend()
         import matplotlib.pyplot as plt
@@ -58,8 +50,8 @@ class NoiseFilterTest(MPITestCase):
         fig = plt.figure(figsize=[12, 8])
         ax = fig.add_subplot(1, 1, 1)
         ax.loglog(
-            true_freq.to_value(u.Hz),
-            true_psd.to_value(u.K**2 * u.s),
+            input_freq.to_value(u.Hz),
+            input_psd.to_value(u.K**2 * u.s),
             color="black",
             label="Input",
         )
@@ -69,13 +61,12 @@ class NoiseFilterTest(MPITestCase):
             color="red",
             label="Estimated",
         )
-        if fit_freq is not None:
-            ax.loglog(
-                fit_freq.to_value(u.Hz),
-                fit_psd.to_value(u.K**2 * u.s),
-                color="green",
-                label="Fit to 1/f Model",
-            )
+        ax.loglog(
+            fit_freq.to_value(u.Hz),
+            fit_psd.to_value(u.K**2 * u.s),
+            color="green",
+            label="Fit to 1/f Model",
+        )
         net = net.to_value(u.K / u.Hz**0.5)
         ax.axhline(
             net**2,
@@ -84,43 +75,94 @@ class NoiseFilterTest(MPITestCase):
             color="blue",
         )
         ax.set_xlim(est_freq[0].to_value(u.Hz), est_freq[-1].to_value(u.Hz))
-        ax.set_ylim(
-            np.amin(est_psd.to_value(u.K**2 * u.s)),
-            1.1 * np.amax(est_psd.to_value(u.K**2 * u.s)),
-        )
         ax.set_xlabel("Frequency [Hz]")
         ax.set_ylabel("PSD [K$^2$ / Hz]")
         ax.legend(loc="best")
         fig.savefig(fname)
         plt.close()
 
-    def compare_timestreams(self, det, times, original, filtered, flags, plotroot=None):
-        good = flags == 0
-        if plotroot is not None:
-            import matplotlib.pyplot as plt
+    def check_timestreams(self, data, testdir, wmin, wmax):
+        # First estimate the noise on the filtered timestreams
+        estim = ops.NoiseEstim(
+            name="estimate_model",
+            output_dir=testdir,
+            out_model="noise_estimate",
+            lagmax=200,
+            nbin_psd=64,
+            nsum=10,
+        )
+        estim.apply(data)
 
-            for prange in [(0, 500), (0, len(times))]:
-                pslc = slice(prange[0], prange[1], 1)
-                plotfile = f"{plotroot}_{prange[0]}-{prange[1]}.pdf"
-                fig = plt.figure(figsize=(12, 12), dpi=72)
-                ax = fig.add_subplot(2, 1, 1, aspect="auto")
-                ax.plot(
-                    times[good][pslc],
-                    original[good][pslc],
-                    color="black",
-                    label=f"{det} Input",
-                )
-                ax.legend(loc="best")
-                ax = fig.add_subplot(2, 1, 2, aspect="auto")
-                ax.plot(
-                    times[good][pslc],
-                    filtered[good][pslc],
-                    color="red",
-                    label=f"{det} Filtered",
-                )
-                ax.legend(loc="best")
-                fig.savefig(plotfile)
-                plt.close(fig)
+        # Compute a 1/f fit to this
+        noise_fitter = ops.FitNoiseModel(
+            noise_model=estim.out_model,
+            out_model="fit_noise_model",
+            white_noise_min=wmin,
+            white_noise_max=wmax,
+        )
+        noise_fitter.apply(data)
+
+        # Check each detector, optionally with comparison plots
+        for obs in data.obs:
+            times = obs.shared[defaults.times].data
+            shflags = obs.shared[defaults.shared_flags].data
+            for det in obs.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                flags = np.array(shflags)
+                flags |= obs.detdata[defaults.det_flags][det]
+                good = flags == 0
+                original = obs.detdata["original"][det]
+                filtered = obs.detdata[defaults.det_data][det]
+
+                nse_in = obs["noise_model"]
+                net_in = nse_in.NET(det)
+                fknee_in = nse_in.fknee(det)
+                nse_out = obs["fit_noise_model"]
+                net_out = nse_out.NET(det)
+                fknee_out = nse_out.fknee(det)
+
+                if self.make_plots:
+                    import matplotlib.pyplot as plt
+
+                    pltroot = os.path.join(testdir, f"tod_{obs.name}-{det}")
+                    for prange in [(0, 500), (0, len(times))]:
+                        pslc = slice(prange[0], prange[1], 1)
+                        plotfile = f"{pltroot}_{prange[0]}-{prange[1]}.pdf"
+                        fig = plt.figure(figsize=(12, 12), dpi=72)
+                        ax = fig.add_subplot(2, 1, 1, aspect="auto")
+                        ax.plot(
+                            times[good][pslc],
+                            original[good][pslc],
+                            color="black",
+                            label=f"{det} Input",
+                        )
+                        ax.legend(loc="best")
+                        ax = fig.add_subplot(2, 1, 2, aspect="auto")
+                        ax.plot(
+                            times[good][pslc],
+                            filtered[good][pslc],
+                            color="red",
+                            label=f"{det} Filtered",
+                        )
+                        ax.legend(loc="best")
+                        fig.savefig(plotfile)
+                        plt.close(fig)
+                    self.plot_noise_model(
+                        os.path.join(testdir, f"psd_{obs.name}-{det}.pdf"),
+                        net_in,
+                        nse_in.freq(det),
+                        nse_in.psd(det),
+                        obs["noise_estimate"].freq(det),
+                        obs["noise_estimate"].psd(det),
+                        nse_out.freq(det),
+                        nse_out.psd(det),
+                    )
+
+                # Check that the f_knee of the fit model is small enough
+                if fknee_out > 0.1 * fknee_in:
+                    msg = f"{obs.name}:{det} resulting f_knee ({fknee_out}) too high"
+                    msg += f" compared to input ({fknee_in})"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
 
     def test_clean_filter(self):
         testdir = os.path.join(self.outdir, "clean")
@@ -129,7 +171,7 @@ class NoiseFilterTest(MPITestCase):
 
         # Create a fake ground data set for testing.  Use a high fknee.
         data = create_ground_data(
-            self.comm, sample_rate=100.0 * u.Hz, fknee=20.0 * u.Hz
+            self.comm, sample_rate=100.0 * u.Hz, fknee=10.0 * u.Hz
         )
 
         # Create an uncorrelated noise model from focalplane detector properties
@@ -145,113 +187,17 @@ class NoiseFilterTest(MPITestCase):
 
         # Since we are using an analytic noise model, it is already smooth
         # enough to use for the kernel.
-
-        nse_filter = ops.NoiseFilter(noise_model=sim_noise.noise_model, debug=None)
+        wmin = 40.0 * u.Hz
+        wmax = 50.0 * u.Hz
+        nse_filter = ops.NoiseFilter(
+            noise_model=sim_noise.noise_model,
+            white_noise_min=wmin,
+            white_noise_max=wmax,
+            debug=None,
+        )
         nse_filter.apply(data)
 
         # Compare filtered data.
-        for ob in data.obs:
-            times = ob.shared[defaults.times].data
-            shflags = ob.shared[defaults.shared_flags].data
-            for det in ob.select_local_detectors(flagmask=nse_filter.det_mask):
-                flags = np.array(shflags)
-                flags |= ob.detdata[defaults.det_flags][det]
-                pltroot = None
-                if self.make_plots:
-                    pltroot = os.path.join(testdir, f"tod_{ob.name}:{det}")
-                self.compare_timestreams(
-                    det,
-                    times,
-                    ob.detdata["original"][det],
-                    ob.detdata[defaults.det_data][det],
-                    flags,
-                    plotroot=pltroot,
-                )
+        self.check_timestreams(data, testdir, wmin, wmax)
 
         close_data(data)
-
-    # def test_bandpassed(self):
-    #     # Test the challenging case where the timestreams have been bandpassed.
-
-    #     # Create a fake ground data set for testing
-    #     data = create_ground_data(self.comm, sample_rate=100.0 * u.Hz, fknee=5.0 * u.Hz)
-
-    #     # Create some detector pointing matrices
-    #     detpointing = ops.PointingDetectorSimple()
-    #     pixels = ops.PixelsHealpix(
-    #         nside=64,
-    #         create_dist="pixel_dist",
-    #         detector_pointing=detpointing,
-    #     )
-    #     pixels.apply(data)
-    #     weights = ops.StokesWeights(
-    #         mode="IQU",
-    #         hwp_angle="hwp_angle",
-    #         detector_pointing=detpointing,
-    #     )
-    #     weights.apply(data)
-
-    #     # Create an uncorrelated noise model from focalplane detector properties
-    #     default_model = ops.DefaultNoiseModel(noise_model="noise_model")
-    #     default_model.apply(data)
-
-    #     # Simulate noise from this model
-    #     sim_noise = ops.SimNoise(noise_model="noise_model")
-    #     sim_noise.apply(data)
-
-    #     # Estimate noise
-    #     estim = ops.NoiseEstim(
-    #         name="estimate_model",
-    #         output_dir=self.outdir,
-    #         out_model="noise_estimate",
-    #         lagmax=200,
-    #         nbin_psd=128,
-    #         nsum=4,
-    #     )
-    #     estim.apply(data)
-
-    #     # Compute a 1/f fit to this
-    #     noise_fitter = ops.FitNoiseModel(
-    #         noise_model=estim.out_model,
-    #         out_model="fit_noise_model",
-    #     )
-    #     noise_fitter.apply(data)
-
-    #     for ob in data.obs:
-    #         if ob.comm.group_rank == 0:
-    #             input_model = ob["noise_model"]
-    #             estim_model = ob["noise_estimate"]
-    #             fit_model = ob[noise_fitter.out_model]
-    #             for det in ob.select_local_detectors(flagmask=estim.det_flag_mask):
-    #                 fname = os.path.join(
-    #                     self.outdir, f"estimate_model_{ob.name}_{det}.pdf"
-    #                 )
-    #                 plot_noise_estim_compare(
-    #                     fname,
-    #                     input_model.NET(det),
-    #                     input_model.freq(det),
-    #                     input_model.psd(det),
-    #                     estim_model.freq(det),
-    #                     estim_model.psd(det),
-    #                     fit_freq=fit_model.freq(det),
-    #                     fit_psd=fit_model.psd(det),
-    #                 )
-    #         if ob.comm.comm_group is not None:
-    #             ob.comm.comm_group.barrier()
-
-    #     if data.comm.comm_world is not None:
-    #         data.comm.comm_world.barrier()
-
-    #     # Verify that the fit NET is close to the input.
-    #     for ob in data.obs:
-    #         input_model = ob["noise_model"]
-    #         estim_model = ob["noise_estimate"]
-    #         fit_model = ob[noise_fitter.out_model]
-    #         for det in ob.select_local_detectors(flagmask=estim.det_flag_mask):
-    #             np.testing.assert_almost_equal(
-    #                 np.mean(input_model.psd(det)[-5:]).value,
-    #                 np.mean(fit_model.psd(det)[-5:]).value,
-    #                 decimal=3,
-    #             )
-
-    #     close_data(data)

--- a/src/toast/tests/ops_noise_filter.py
+++ b/src/toast/tests/ops_noise_filter.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+import numpy.testing as nt
+from astropy import units as u
+from astropy.table import Column
+from scipy import interpolate
+
+from .. import ops as ops
+from .. import qarray as qa
+from ..noise import Noise
+from ..observation import default_values as defaults
+from ..vis import set_matplotlib_backend
+from .helpers import (
+    close_data,
+    create_fake_healpix_scanned_tod,
+    create_ground_data,
+    create_outdir,
+    fake_flags,
+)
+from .mpi import MPITestCase
+
+XAXIS, YAXIS, ZAXIS = np.eye(3)
+
+
+class NoiseFilterTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+        np.random.seed(123456)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
+
+    def plot_noise_model(
+        self,
+        fname,
+        net,
+        true_freq,
+        true_psd,
+        est_freq,
+        est_psd,
+        fit_freq=None,
+        fit_psd=None,
+    ):
+        set_matplotlib_backend()
+        import matplotlib.pyplot as plt
+
+        fig = plt.figure(figsize=[12, 8])
+        ax = fig.add_subplot(1, 1, 1)
+        ax.loglog(
+            true_freq.to_value(u.Hz),
+            true_psd.to_value(u.K**2 * u.s),
+            color="black",
+            label="Input",
+        )
+        ax.loglog(
+            est_freq.to_value(u.Hz),
+            est_psd.to_value(u.K**2 * u.s),
+            color="red",
+            label="Estimated",
+        )
+        if fit_freq is not None:
+            ax.loglog(
+                fit_freq.to_value(u.Hz),
+                fit_psd.to_value(u.K**2 * u.s),
+                color="green",
+                label="Fit to 1/f Model",
+            )
+        net = net.to_value(u.K / u.Hz**0.5)
+        ax.axhline(
+            net**2,
+            label=f"NET = {net:.3f} K" + r" / $\sqrt{\mathrm{Hz}}$",
+            linestyle="--",
+            color="blue",
+        )
+        ax.set_xlim(est_freq[0].to_value(u.Hz), est_freq[-1].to_value(u.Hz))
+        ax.set_ylim(
+            np.amin(est_psd.to_value(u.K**2 * u.s)),
+            1.1 * np.amax(est_psd.to_value(u.K**2 * u.s)),
+        )
+        ax.set_xlabel("Frequency [Hz]")
+        ax.set_ylabel("PSD [K$^2$ / Hz]")
+        ax.legend(loc="best")
+        fig.savefig(fname)
+        plt.close()
+
+    def compare_timestreams(self, det, times, original, filtered, flags, plotroot=None):
+        good = flags == 0
+        if plotroot is not None:
+            import matplotlib.pyplot as plt
+
+            for prange in [(0, 500), (0, len(times))]:
+                pslc = slice(prange[0], prange[1], 1)
+                plotfile = f"{plotroot}_{prange[0]}-{prange[1]}.pdf"
+                fig = plt.figure(figsize=(12, 12), dpi=72)
+                ax = fig.add_subplot(2, 1, 1, aspect="auto")
+                ax.plot(
+                    times[good][pslc],
+                    original[good][pslc],
+                    color="black",
+                    label=f"{det} Input",
+                )
+                ax.legend(loc="best")
+                ax = fig.add_subplot(2, 1, 2, aspect="auto")
+                ax.plot(
+                    times[good][pslc],
+                    filtered[good][pslc],
+                    color="red",
+                    label=f"{det} Filtered",
+                )
+                ax.legend(loc="best")
+                fig.savefig(plotfile)
+                plt.close(fig)
+
+    def test_clean_filter(self):
+        testdir = os.path.join(self.outdir, "clean")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create a fake ground data set for testing.  Use a high fknee.
+        data = create_ground_data(
+            self.comm, sample_rate=100.0 * u.Hz, fknee=20.0 * u.Hz
+        )
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise from this model
+        sim_noise = ops.SimNoise(noise_model="noise_model")
+        sim_noise.apply(data)
+
+        # Make a copy of the original data
+        ops.Copy(detdata=[(sim_noise.det_data, "original")]).apply(data)
+
+        # Since we are using an analytic noise model, it is already smooth
+        # enough to use for the kernel.
+
+        nse_filter = ops.NoiseFilter(noise_model=sim_noise.noise_model, debug=None)
+        nse_filter.apply(data)
+
+        # Compare filtered data.
+        for ob in data.obs:
+            times = ob.shared[defaults.times].data
+            shflags = ob.shared[defaults.shared_flags].data
+            for det in ob.select_local_detectors(flagmask=nse_filter.det_mask):
+                flags = np.array(shflags)
+                flags |= ob.detdata[defaults.det_flags][det]
+                pltroot = None
+                if self.make_plots:
+                    pltroot = os.path.join(testdir, f"tod_{ob.name}:{det}")
+                self.compare_timestreams(
+                    det,
+                    times,
+                    ob.detdata["original"][det],
+                    ob.detdata[defaults.det_data][det],
+                    flags,
+                    plotroot=pltroot,
+                )
+
+        close_data(data)
+
+    # def test_bandpassed(self):
+    #     # Test the challenging case where the timestreams have been bandpassed.
+
+    #     # Create a fake ground data set for testing
+    #     data = create_ground_data(self.comm, sample_rate=100.0 * u.Hz, fknee=5.0 * u.Hz)
+
+    #     # Create some detector pointing matrices
+    #     detpointing = ops.PointingDetectorSimple()
+    #     pixels = ops.PixelsHealpix(
+    #         nside=64,
+    #         create_dist="pixel_dist",
+    #         detector_pointing=detpointing,
+    #     )
+    #     pixels.apply(data)
+    #     weights = ops.StokesWeights(
+    #         mode="IQU",
+    #         hwp_angle="hwp_angle",
+    #         detector_pointing=detpointing,
+    #     )
+    #     weights.apply(data)
+
+    #     # Create an uncorrelated noise model from focalplane detector properties
+    #     default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+    #     default_model.apply(data)
+
+    #     # Simulate noise from this model
+    #     sim_noise = ops.SimNoise(noise_model="noise_model")
+    #     sim_noise.apply(data)
+
+    #     # Estimate noise
+    #     estim = ops.NoiseEstim(
+    #         name="estimate_model",
+    #         output_dir=self.outdir,
+    #         out_model="noise_estimate",
+    #         lagmax=200,
+    #         nbin_psd=128,
+    #         nsum=4,
+    #     )
+    #     estim.apply(data)
+
+    #     # Compute a 1/f fit to this
+    #     noise_fitter = ops.FitNoiseModel(
+    #         noise_model=estim.out_model,
+    #         out_model="fit_noise_model",
+    #     )
+    #     noise_fitter.apply(data)
+
+    #     for ob in data.obs:
+    #         if ob.comm.group_rank == 0:
+    #             input_model = ob["noise_model"]
+    #             estim_model = ob["noise_estimate"]
+    #             fit_model = ob[noise_fitter.out_model]
+    #             for det in ob.select_local_detectors(flagmask=estim.det_flag_mask):
+    #                 fname = os.path.join(
+    #                     self.outdir, f"estimate_model_{ob.name}_{det}.pdf"
+    #                 )
+    #                 plot_noise_estim_compare(
+    #                     fname,
+    #                     input_model.NET(det),
+    #                     input_model.freq(det),
+    #                     input_model.psd(det),
+    #                     estim_model.freq(det),
+    #                     estim_model.psd(det),
+    #                     fit_freq=fit_model.freq(det),
+    #                     fit_psd=fit_model.psd(det),
+    #                 )
+    #         if ob.comm.comm_group is not None:
+    #             ob.comm.comm_group.barrier()
+
+    #     if data.comm.comm_world is not None:
+    #         data.comm.comm_world.barrier()
+
+    #     # Verify that the fit NET is close to the input.
+    #     for ob in data.obs:
+    #         input_model = ob["noise_model"]
+    #         estim_model = ob["noise_estimate"]
+    #         fit_model = ob[noise_fitter.out_model]
+    #         for det in ob.select_local_detectors(flagmask=estim.det_flag_mask):
+    #             np.testing.assert_almost_equal(
+    #                 np.mean(input_model.psd(det)[-5:]).value,
+    #                 np.mean(fit_model.psd(det)[-5:]).value,
+    #                 decimal=3,
+    #             )
+
+    #     close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -51,6 +51,7 @@ from . import ops_mapmaker_solve as test_ops_mapmaker_solve
 from . import ops_mapmaker_utils as test_ops_mapmaker_utils
 from . import ops_memory_counter as test_ops_memory_counter
 from . import ops_noise_estim as test_ops_noise_estim
+from . import ops_noise_filter as test_ops_noise_filter
 from . import ops_perturbhwp as test_ops_perturbhwp
 from . import ops_pixels_healpix as test_ops_pixels_healpix
 from . import ops_pointing_detector as test_ops_pointing_detector
@@ -242,6 +243,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_ops_perturbhwp))
         suite.addTest(loader.loadTestsFromModule(test_ops_filterbin))
         suite.addTest(loader.loadTestsFromModule(test_ops_noise_estim))
+        suite.addTest(loader.loadTestsFromModule(test_ops_noise_filter))
         suite.addTest(loader.loadTestsFromModule(test_ops_yield_cut))
         suite.addTest(loader.loadTestsFromModule(test_ops_elevation_noise))
         suite.addTest(loader.loadTestsFromModule(test_ops_signal_diff_noise))


### PR DESCRIPTION
For (at least) 25 years, the inverse time domain noise covariance has been used as a "change of basis" when solving a generalized least squares problem for the maximum likelihood map in pixel space.

For simpler "filter and bin" mapmaking techniques, application of this N_tt'^-1 filter may be useful.  This work adds an operator which uses a given noise model for detector PSDs to compute the inverse noise covariance fourier domain kernels for each detector and convolve the timestreams by those.