### PR TITLE
Add a generic "toast_run" workflow for arbitrary nested Pipelines.

### DIFF
--- a/packaging/conda/deps.txt
+++ b/packaging/conda/deps.txt
@@ -4,6 +4,7 @@ libtool
 automake
 psutil
 cython
+ruamel.yaml
 pytest
 tomlkit
 traitlets

--- a/setup.py
+++ b/setup.py
@@ -325,6 +325,7 @@ conf["scripts"] = scripts
 conf["entry_points"] = {
     "console_scripts": [
         "toast_env = toast.scripts.toast_env:main",
+        "toast_run = toast.scripts.toast_run:main",
         "toast_fake_focalplane = toast.scripts.toast_fake_focalplane:main",
         "toast_ground_schedule = toast.scripts.toast_ground_schedule:main",
         "toast_project_schedule = toast.scripts.toast_project_schedule:main",

--- a/src/toast/config/__init__.py
+++ b/src/toast/config/__init__.py
@@ -9,6 +9,7 @@ from .cli import (
     dump_config,
     load_config,
     parse_config,
+    run_config,
 )
 from .json import dump_json
 from .toml import dump_toml

--- a/src/toast/config/cli.py
+++ b/src/toast/config/cli.py
@@ -20,7 +20,7 @@ from tomlkit.exceptions import TOMLKitError
 from ..trait_utils import scalar_to_string as trait_scalar_to_string
 from ..trait_utils import string_to_scalar as trait_string_to_scalar
 from ..trait_utils import string_to_trait, trait_to_string
-from ..utils import Environment, Logger
+from ..utils import Environment, Logger, import_from_name
 from .json import dump_json, load_json
 from .toml import dump_toml, load_toml
 from .yaml import dump_yaml, load_yaml
@@ -81,10 +81,11 @@ def load_config(file, input=None, comm=None):
         return ret
 
 
-def dump_config(file, conf, format="toml", comm=None):
+def dump_config(file, conf, format=None, comm=None):
     """Dump a config file to a supported format.
 
-    Writes the configuration to a file in the specified format.
+    Writes the configuration to a file in the specified format.  If `format` is
+    None, the format with be determined from the file name.
 
     Args:
         file (str):  The file to write.
@@ -96,6 +97,19 @@ def dump_config(file, conf, format="toml", comm=None):
         None
 
     """
+    if format is None:
+        # Guess from the file name
+        base, ext = os.path.splitext(file)
+        if ext == ".toml":
+            format = "toml"
+        elif ext == ".json" or ext == ".jsn":
+            format = "json"
+        elif ext == ".yaml" or ext == ".yml":
+            format = "yaml"
+        else:
+            msg = "Cannot determine format (yaml, toml, json) from"
+            msg += f" path '{file}'"
+            raise RuntimeError(msg)
     if format == "toml":
         dump_toml(file, conf, comm=comm)
     elif format == "json":
@@ -361,6 +375,133 @@ def args_update_config(args, conf, useropts, section, prefix="", separator=r"\."
     return remain
 
 
+def add_job_parser_options(parser):
+    # Add an option to load one or more config files.  These should have compatible
+    # names for the operators used in defaults.
+    parser.add_argument(
+        "--config",
+        type=str,
+        required=False,
+        nargs="+",
+        help="One or more input config files.",
+    )
+
+    parser.add_argument(
+        "--job_group_size",
+        required=False,
+        type=int,
+        default=None,
+        help="(Advanced) Size of the process groups",
+    )
+
+    parser.add_argument(
+        "--job_node_mem",
+        required=False,
+        type=int,
+        default=None,
+        help="(Advanced) Override the detected memory per node in bytes",
+    )
+
+
+def add_default_parser_options(parser, prefix, operators, templates):
+     # Add options to dump default values
+    parser.add_argument(
+        "--defaults_toml",
+        type=str,
+        required=False,
+        default=None,
+        help="Dump default config values to a TOML file",
+    )
+    parser.add_argument(
+        "--defaults_json",
+        type=str,
+        required=False,
+        default=None,
+        help="Dump default config values to a JSON file",
+    )
+    parser.add_argument(
+        "--defaults_yaml",
+        type=str,
+        required=False,
+        default=None,
+        help="Dump default config values to a YAML file",
+    )
+
+    # The default configuration
+    defaults_op = build_config(operators)
+    defaults_tmpl = build_config(templates)
+
+    # Add commandline overrides
+    if len(operators) > 0:
+        add_config_args(
+            parser,
+            defaults_op,
+            "operators",
+            ignore=["API"],
+            prefix=prefix,
+        )
+    if len(templates) > 0:
+        add_config_args(
+            parser,
+            defaults_tmpl,
+            "templates",
+            ignore=["API"],
+            prefix=prefix,
+        )
+
+    # Combine all the defaults
+    defaults = OrderedDict()
+    defaults["operators"] = OrderedDict()
+    defaults["templates"] = OrderedDict()
+    if "operators" in defaults_op:
+        defaults["operators"].update(defaults_op["operators"])
+    if "templates" in defaults_tmpl:
+        defaults["templates"].update(defaults_tmpl["templates"])
+    return defaults
+
+
+def process_job_args(args):
+    # Parse job args
+    jobargs = types.SimpleNamespace(
+        node_mem=args.job_node_mem,
+        group_size=args.job_group_size,
+    )
+    del args.job_node_mem
+    del args.job_group_size
+    return jobargs
+
+
+def process_default_args(args, defaults):
+    # Dump default config values.
+    if args.defaults_toml is not None:
+        dump_toml(args.defaults_toml, defaults)
+        del args.default_toml
+    if args.defaults_json is not None:
+        dump_json(args.defaults_json, defaults)
+        del args.default_json
+    if args.defaults_yaml is not None:
+        dump_yaml(args.defaults_yaml, defaults)
+        del args.default_yaml
+
+
+def process_object_args(args, prefix, config, opts, operators, templates):
+    # Parse operator and template commandline options.  These override any config
+    # file or default values.
+    if len(operators) > 0:
+        op_remaining = args_update_config(
+            args, config, opts, "operators", prefix=prefix
+        )
+    else:
+        op_remaining = args
+    if len(templates) > 0:
+        remaining = args_update_config(
+            op_remaining, config, opts, "templates", prefix=prefix
+        )
+    else:
+        remaining = op_remaining
+    return remaining
+
+
 def parse_config(
     parser,
     operators=list(),
@@ -404,138 +545,123 @@ def parse_config(
         opts (list):  If not None, parse arguments from this list instead of sys.argv.
 
     Returns:
-        (tuple):  The (config dictionary, args).  The args namespace contains all the
-            remaining parameters after extracting the operator and template options.
+        (tuple):  The (config dictionary, other args, run args).  The other args
+            namespace contains all the remaining parameters after extracting the
+            operator and template options.
 
     """
+    add_job_parser_options(parser)
 
-    # The default configuration
-    defaults_op = build_config(operators)
-    defaults_tmpl = build_config(templates)
-
-    # Add commandline overrides
-    if len(operators) > 0:
-        add_config_args(
-            parser,
-            defaults_op,
-            "operators",
-            ignore=["API"],
-            prefix=prefix,
-        )
-    if len(templates) > 0:
-        add_config_args(
-            parser,
-            defaults_tmpl,
-            "templates",
-            ignore=["API"],
-            prefix=prefix,
-        )
-
-    # Combine all the defaults
-    defaults = OrderedDict()
-    defaults["operators"] = OrderedDict()
-    defaults["templates"] = OrderedDict()
-    if "operators" in defaults_op:
-        defaults["operators"].update(defaults_op["operators"])
-    if "templates" in defaults_tmpl:
-        defaults["templates"].update(defaults_tmpl["templates"])
-
-    # Add an option to load one or more config files.  These should have compatible
-    # names for the operators used in defaults.
-    parser.add_argument(
-        "--config",
-        type=str,
-        required=False,
-        nargs="+",
-        help="One or more input config files.",
-    )
-
-    # Add options to dump default values
-    parser.add_argument(
-        "--defaults_toml",
-        type=str,
-        required=False,
-        default=None,
-        help="Dump default config values to a TOML file",
-    )
-    parser.add_argument(
-        "--defaults_json",
-        type=str,
-        required=False,
-        default=None,
-        help="Dump default config values to a JSON file",
-    )
-    parser.add_argument(
-        "--defaults_yaml",
-        type=str,
-        required=False,
-        default=None,
-        help="Dump default config values to a YAML file",
-    )
-
-    parser.add_argument(
-        "--job_group_size",
-        required=False,
-        type=int,
-        default=None,
-        help="(Advanced) Size of the process groups",
-    )
-
-    parser.add_argument(
-        "--job_node_mem",
-        required=False,
-        type=int,
-        default=None,
-        help="(Advanced) Override the detected memory per node in bytes",
-    )
-
-    # Parse commandline or list of options.
+    # Select commandline or list of options.
     if opts is None:
         opts = sys.argv[1:]
+
+    # Add options for user-provided objects
+    defaults = add_default_parser_options(parser, prefix, operators, templates)
+
+    # Parse everything
     args = parser.parse_args(args=opts)
 
-    # Dump default config values.
-    if args.defaults_toml is not None:
-        dump_toml(args.defaults_toml, defaults)
-    if args.defaults_json is not None:
-        dump_json(args.defaults_json, defaults)
-    if args.defaults_yaml is not None:
-        dump_yaml(args.defaults_yaml, defaults)
+    # Process the default logging options
+    process_default_args(args, defaults)
 
-    # Parse job args
-    jobargs = types.SimpleNamespace(
-        node_mem=args.job_node_mem,
-        group_size=args.job_group_size,
-    )
-    del args.job_node_mem
-    del args.job_group_size
+    # Extract the job args
+    jobargs = process_job_args(args)
 
     # Load any config files.  This overrides default values with config file contents.
     config = copy.deepcopy(defaults)
-
     if args.config is not None:
         for conf in args.config:
             config = load_config(conf, input=config)
+    del args.config
 
-    # Parse operator and template commandline options.  These override any config
-    # file or default values.
-    if len(operators) > 0:
-        op_remaining = args_update_config(
-            args, config, opts, "operators", prefix=prefix
-        )
-    else:
-        op_remaining = args
-    if len(templates) > 0:
-        remaining = args_update_config(
-            op_remaining, config, opts, "templates", prefix=prefix
-        )
-    else:
-        remaining = op_remaining
-
-    # Remove the options we created in this function
-    del remaining.config
-    del remaining.defaults_toml
-    del remaining.defaults_json
-    del remaining.defaults_yaml
+    # Now override defaults and config options with command line options
+    remaining = process_object_args(args, prefix, config, opts, operators, templates)
 
     return config, remaining, jobargs
+
+
+def run_config(
+    parser,
+    prefix="",
+    opts=None,
+):
+    """Use config files to instantiate operators and templates.
+
+    This function is similar to `parse_config()`, but the lists of operators and
+    templates is read from the config files rather than being provided by the calling
+    code.
+
+    Args:
+        parser (ArgumentParser):  The argparse parser.
+        prefix (str):  Optional string to prefix all options by.
+        opts (list):  If not None, parse arguments from this list instead of sys.argv.
+
+    Returns:
+        (tuple):  The (job namespace, config dictionary, other args, runtime args)
+            from the result of parsing opts + config_files or command line and then
+            configuring all operators and templates.
+
+    """
+    add_job_parser_options(parser)
+
+    # Select commandline or list of options.
+    if opts is None:
+        opts = sys.argv[1:]
+
+    # Parse the initial args, including the config file names
+    initial_args, remaining_opts = parser.parse_known_args(args=opts)
+
+    # Parse the job args
+    jobargs = process_job_args(initial_args)
+
+    # Get the config files
+    if initial_args.config is None:
+        raise RuntimeError("run_config() requires at least one config file.")
+    config_files = list(initial_args.config)
+    del initial_args.config
+
+    # Make a pass through the config files, just to get the object names and types
+    raw_config = dict()
+    for conf in config_files:
+        raw_config = load_config(conf, input=raw_config)
+    operators = list()
+    templates = list()
+    for section, lst in [("operators", operators), ("templates", templates)]:
+        if section not in raw_config:
+            continue
+        for objname, obj in raw_config[section].items():
+            if "name" not in obj:
+                msg = "config files used with run_config() must have a name for "
+                msg += "each object"
+                raise RuntimeError(msg)
+            if "class" not in obj:
+                msg = "config files used with run_config() must have a class for "
+                msg += "each object"
+                raise RuntimeError(msg)
+            cls_path = obj["class"]
+            cls = import_from_name(cls_path)
+            lst.append(cls(name=obj["name"]["value"]))
+
+    # Now we can build the config of default values for all objects.
+    defaults = add_default_parser_options(parser, prefix, operators, templates)
+
+    # Parse the remaining options now that we have our object options in the parser
+    args = parser.parse_args(args=remaining_opts)
+
+    # Parse the default logging options
+    process_default_args(args, defaults)
+
+    # Make a second pass through the config files.  This overrides default values with
+    # config file contents.
+    config = copy.deepcopy(defaults)
+    for conf in config_files:
+        config = load_config(conf, input=config)
+
+    # Now override defaults and config options with command line options
+    remaining = process_object_args(args, prefix, config, opts, operators, templates)
+
+    other_dict = {**vars(remaining), **vars(initial_args)}
+    otherargs = types.SimpleNamespace(**other_dict)
+
+    return config, otherargs, jobargs

--- a/src/toast/config/cli.py
+++ b/src/toast/config/cli.py
@@ -47,6 +47,56 @@ def build_config(objects):
     return conf
 
 
+def check_config_format(path, format=None):
+    """Given a path name, return the config file format.
+
+    Args:
+        path (str):  The file name.
+        format (str):  If specified, check that the file extension matches.
+
+    Returns:
+        (str):  The format ("toml", "json", "yaml")
+
+    """
+    log = Logger.get()
+
+    # Determine the format from the file name
+    _, rawext = os.path.splitext(path)
+    ext = rawext.lower()
+    if ext == ".toml" or ext == ".tml":
+        file_format = "toml"
+    elif ext == ".json" or ext == ".jsn":
+        file_format = "json"
+    elif ext == ".yaml" or ext == ".yml":
+        file_format = "yaml"
+    else:
+        file_format = None
+
+    if format is None:
+        # No information from the calling code
+        if file_format is None:
+            # ... and we couldn't determine it.
+            msg = "Cannot determine format (yaml, toml, json) from"
+            msg += f" path '{path}'"
+            raise RuntimeError(msg)
+        else:
+            # Return our guess
+            return file_format
+    else:
+        # Calling code claims it is a particular format
+        if file_format is None:
+            # We could not determine format from path, trust the caller
+            return format
+        else:
+            # Warn if they disagree, but still trust caller
+            if file_format != format:
+                msg = (
+                    f"Config format '{format}' does not match filename '{file_format}'"
+                )
+                log.warning(msg)
+            return format
+
+
 def load_config(file, input=None, comm=None):
     """Load a config file in a supported format.
 
@@ -61,24 +111,13 @@ def load_config(file, input=None, comm=None):
         (dict):  The result.
 
     """
-    ret = None
-    # If the file has a recognized extension, just use that instead of guessing.
-    ext = os.path.splitext(file)[1]
-    if ext in [".yml", ".yaml"]:
+    format = check_config_format(file)
+    if format == "yaml":
         return load_yaml(file, input=input, comm=comm)
-    elif ext in [".json", ".jsn"]:
+    elif format == "json":
         return load_json(file, input=input, comm=comm)
-    elif ext in [".toml", ".tml"]:
-        return load_toml(file, input=input, comm=comm)
     else:
-        try:
-            ret = load_toml(file, input=input, comm=comm)
-        except TOMLKitError:
-            try:
-                ret = load_json(file, input=input, comm=comm)
-            except (ValueError, JSONDecodeError):
-                ret = load_yaml(file, input=input, comm=comm)
-        return ret
+        return load_toml(file, input=input, comm=comm)
 
 
 def dump_config(file, conf, format=None, comm=None):
@@ -97,28 +136,13 @@ def dump_config(file, conf, format=None, comm=None):
         None
 
     """
-    if format is None:
-        # Guess from the file name
-        base, ext = os.path.splitext(file)
-        if ext == ".toml":
-            format = "toml"
-        elif ext == ".json" or ext == ".jsn":
-            format = "json"
-        elif ext == ".yaml" or ext == ".yml":
-            format = "yaml"
-        else:
-            msg = "Cannot determine format (yaml, toml, json) from"
-            msg += f" path '{file}'"
-            raise RuntimeError(msg)
-    if format == "toml":
-        dump_toml(file, conf, comm=comm)
-    elif format == "json":
-        dump_json(file, conf, comm=comm)
-    elif format == "yaml":
+    real_format = check_config_format(file, format=format)
+    if real_format == "yaml":
         dump_yaml(file, conf, comm=comm)
+    elif real_format == "json":
+        dump_json(file, conf, comm=comm)
     else:
-        msg = "Unknown config format '{format}'"
-        raise ValueError(msg)
+        dump_toml(file, conf, comm=comm)
 
 
 class TraitAction(argparse.Action):
@@ -404,27 +428,13 @@ def add_job_parser_options(parser):
 
 
 def add_default_parser_options(parser, prefix, operators, templates):
-     # Add options to dump default values
+    # Add options to dump default values
     parser.add_argument(
-        "--defaults_toml",
+        "--defaults",
         type=str,
         required=False,
         default=None,
-        help="Dump default config values to a TOML file",
-    )
-    parser.add_argument(
-        "--defaults_json",
-        type=str,
-        required=False,
-        default=None,
-        help="Dump default config values to a JSON file",
-    )
-    parser.add_argument(
-        "--defaults_yaml",
-        type=str,
-        required=False,
-        default=None,
-        help="Dump default config values to a YAML file",
+        help="Dump default config values to a file",
     )
 
     # The default configuration
@@ -473,15 +483,9 @@ def process_job_args(args):
 
 def process_default_args(args, defaults):
     # Dump default config values.
-    if args.defaults_toml is not None:
-        dump_toml(args.defaults_toml, defaults)
-        del args.default_toml
-    if args.defaults_json is not None:
-        dump_json(args.defaults_json, defaults)
-        del args.default_json
-    if args.defaults_yaml is not None:
-        dump_yaml(args.defaults_yaml, defaults)
-        del args.default_yaml
+    if args.defaults is not None:
+        dump_config(args.defaults, defaults)
+    del args.defaults
 
 
 def process_object_args(args, prefix, config, opts, operators, templates):

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -6,5 +6,10 @@
 
 from .compression import compress_detdata, decompress_detdata
 from .hdf_utils import H5File, have_hdf5_parallel, hdf5_config, hdf5_open
-from .observation_hdf_load import load_hdf5, load_hdf5_obs_meta
-from .observation_hdf_save import save_hdf5
+from .observation_hdf_load import (
+    load_hdf5,
+    load_hdf5_obs_meta,
+    load_hdf5_detdata,
+    load_instrument_file,
+)
+from .observation_hdf_save import save_hdf5, save_hdf5_detdata, save_instrument_file

--- a/src/toast/ops/signal_diff_noise_model.py
+++ b/src/toast/ops/signal_diff_noise_model.py
@@ -33,7 +33,7 @@ class SignalDiffNoiseModel(Operator):
     det_data = Unicode(defaults.det_data, help="Observation detdata key to analyze")
 
     det_mask = Int(
-        defaults.det_mask_nonscience,
+        defaults.det_mask_invalid,
         help="Bit mask value for per-detector flagging",
     )
 

--- a/src/toast/scripts/CMakeLists.txt
+++ b/src/toast/scripts/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 set(ENTRY_POINTS
     toast_env.py
+    toast_run.py
     toast_fake_focalplane.py
     toast_ground_schedule.py
     toast_satellite_schedule.py

--- a/src/toast/scripts/toast_run.py
+++ b/src/toast/scripts/toast_run.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""
+This script runs a TOAST simulation and / or processing pipeline
+that is specified primarily with config files.  This parses all
+config and command line options and runs an operator (usually
+a Pipeline) named "main".
+
+You can see the automatically generated command line options with:
+
+    toast_run --help
+
+This script contains just comments about what is going on.  For details about all the
+options for a specific Operator, see the documentation or use the help() function from
+an interactive python session.
+
+"""
+
+import argparse
+import datetime
+import os
+import types
+
+import toast
+import toast.config
+import toast.ops
+import toast.traits
+
+
+def print_job(job):
+    def dump(node, indent):
+        spacer = " " * indent
+        for k, v in vars(node).items():
+            if isinstance(v, types.SimpleNamespace):
+                # Descend
+                new_indent = indent + 2
+                print(f"{spacer}{k}:")
+                dump(v, new_indent)
+            elif isinstance(v, toast.traits.TraitConfig):
+                print(f"{spacer}{k}:")
+                for trait_name, trait in v.traits().items():
+                    print(f"{spacer}  {trait_name} = {trait.get(v)}")
+            else:
+                print(f"{spacer}{k} = {v}")
+    dump(job, 0)
+
+
+def main(opts=None):
+    log = toast.utils.Logger.get()
+    gt = toast.timing.GlobalTimers.get()
+    gt.start("toast_run (total)")
+    timer = toast.timing.Timer()
+    timer.start()
+
+    # Get optional MPI parameters
+    comm, procs, rank = toast.get_world()
+
+    # If the user has not told us to use multiple threads,
+    # then just use one.
+
+    if "OMP_NUM_THREADS" in os.environ:
+        nthread = os.environ["OMP_NUM_THREADS"]
+    else:
+        nthread = "???"
+        msg = "OMP_NUM_THREADS not set in the environment. "
+        msg += "Job may try to use all cores for threads."
+        log.warning_rank(msg, comm=comm)
+
+    msg = f"Executing workflow with {procs} MPI tasks, each with "
+    msg += f"{nthread} OpenMP threads at {datetime.datetime.now()}"
+    log.info_rank(msg, comm=comm)
+
+    mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)
+    log.info_rank(f"Start of the workflow:  {mem}", comm=comm)
+
+    # Argument parsing
+    parser = argparse.ArgumentParser(description="Toast Pipeline Runner")
+
+    parser.add_argument(
+        "--out_dir",
+        required=False,
+        type=str,
+        default="toast_out",
+        help="The output directory",
+    )
+    parser.add_argument(
+        "--log_config",
+        required=False,
+        default=None,
+        help="Dump out config log to this file",
+    )
+    parser.add_argument(
+        "--main",
+        required=False,
+        type=str,
+        default="main",
+        help="The operator to run as the 'main'",
+    )
+    parser.add_argument(
+        "--dry_run",
+        required=False,
+        default=False,
+        action="store_true",
+        help="If True, log the job config and exit",
+    )
+
+    # The operators and templates we want to configure from the command line
+    # or a parameter file.
+    config, otherargs, runargs = toast.config.run_config(parser, opts=opts)
+
+    # Instantiate operators and templates
+    job = toast.traits.create_from_config(config)
+
+    # Log the config that was actually used at runtime.
+    if otherargs.log_config is not None:
+        toast.config.dump_config(otherargs.log_config, config, comm=comm)
+
+    # Check that the required operator exists
+    if not hasattr(job.operators, otherargs.main):
+        msg = "The input config files do not specify an operator named "
+        msg += f"'{otherargs.main}'"
+        log.error_rank(msg, comm=comm)
+        raise RuntimeError(msg)
+
+    # Create communicators and empty data container.
+    log = toast.utils.Logger.get()
+    if runargs.group_size is not None:
+        msg = "Using user-specifed process group size of {runargs.group_size}"
+        log.info_rank(msg, comm=comm)
+        group_size = runargs.group_size
+    else:
+        msg = "Using default process group size"
+        log.info_rank(msg, comm=comm)
+        if comm is None:
+            group_size = 1
+        else:
+            group_size = comm.size
+
+    if otherargs.dry_run:
+        print_job(job)
+        return
+
+    toast_comm = toast.Comm(world=comm, groupsize=group_size)
+    data = toast.Data(comm=toast_comm)
+
+    # Run the main pipeline
+    main = getattr(job.operators, otherargs.main)
+    main.apply(data)
+
+    # Collect optional timing information
+    alltimers = toast.timing.gather_timers(comm=comm)
+    if data.comm.world_rank == 0:
+        out = os.path.join(otherargs.out_dir, "timing")
+        toast.timing.dump(alltimers, out)
+
+    mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)
+    log.info_rank(f"End of the workflow:  {mem}", comm=comm)
+    log.info_rank("Workflow completed in", comm=comm, timer=timer)
+
+    # Cleanup
+    data.clear()
+    del data
+    toast_comm.close()
+    del toast_comm
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -692,14 +692,14 @@ class ConfigTest(MPITestCase):
         # Create the telescope and schedule files
         tele_file = os.path.join(self.outdir, "toast_run_telescope.h5:/leve1/level2")
         tele = create_space_telescope(self.toastcomm.group_size)
-        if self.comm.rank == 0:
+        if self.toastcomm.world_rank == 0:
             save_instrument_file(tele_file, tele, None)
 
         sch_file = os.path.join(self.outdir, "toast_run_schedule.ecsv")
         sch = create_satellite_schedule(
             mission_start=datetime(2023, 2, 23), num_observations=self.toastcomm.ngroups
         )
-        if self.comm.rank == 0:
+        if self.toastcomm.world_rank == 0:
             sch.write(sch_file)
 
         # Create the config file on disk

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -23,9 +23,11 @@ from ..config import (
     dump_yaml,
     load_config,
     parse_config,
+    run_config,
 )
 from ..data import Data
 from ..instrument import Focalplane, Telescope
+from ..io import save_instrument_file
 from ..schedule_sim_satellite import create_satellite_schedule
 from ..templates import Offset, SubHarmonic
 from ..trait_utils import string_to_trait, trait_to_string
@@ -449,6 +451,19 @@ class ConfigTest(MPITestCase):
             if self.toastcomm.comm_world is not None:
                 self.toastcomm.comm_world.barrier()
 
+            conf_defaults_auto_file = os.path.join(
+                self.outdir, f"multi_defaults_auto.{case}"
+            )
+            if self.toastcomm.world_rank == 0:
+                dump_config(
+                    conf_defaults_auto_file,
+                    defaults,
+                    format=None,
+                    comm=self.toastcomm.comm_world,
+                )
+            if self.toastcomm.comm_world is not None:
+                self.toastcomm.comm_world.barrier()
+
             # Now change some values
             testops["mem_count"].prefix = "newpref"
             testops["mem_count"].enabled = False
@@ -540,9 +555,9 @@ class ConfigTest(MPITestCase):
 
                 # Check
                 self.assertTrue(runops.mem_count.prefix == "altpref")
-                self.assertTrue(runops.mem_count.enabled == True)
-                self.assertTrue(runops.sim_noise.serial == True)
-                self.assertTrue(runops.sim_satellite.distribute_time == False)
+                self.assertTrue(runops.mem_count.enabled)
+                self.assertTrue(runops.sim_noise.serial)
+                self.assertFalse(runops.sim_satellite.distribute_time)
                 self.assertTrue(runops.sim_satellite.hwp_rpm == 3.0)
                 self.assertTrue(runops.sim_satellite.shared_flags is None)
                 self.assertTrue(runops.fake.unicode_none is None)
@@ -621,3 +636,104 @@ class ConfigTest(MPITestCase):
         run.operators.sim_pipe.apply(data)
 
         close_data(data)
+
+    def test_config_bootstrap(self):
+        # This tests instantiating operators directly from a config file.
+
+        testops = self.create_operators()
+        testtmpl = self.create_templates()
+        conf_pipe = dict()
+        for op_name, op in testops.items():
+            conf_pipe = op.get_config(input=conf_pipe)
+        pipe = ops.Pipeline(name="sim_pipe")
+        pipe.operators = [y for x, y in testops.items() if x != "det_pointing"]
+        conf_pipe = pipe.get_config(input=conf_pipe)
+        for tmpl_name, tmpl in testtmpl.items():
+            conf_pipe = tmpl.get_config(input=conf_pipe)
+
+        conf_file = os.path.join(self.outdir, "run_bootstrap.yml")
+        if self.toastcomm.world_rank == 0:
+            dump_yaml(conf_file, conf_pipe)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
+
+        parser = argparse.ArgumentParser(description="Bootstrap test")
+        config, otherargs, runargs = run_config(
+            parser,
+            prefix="",
+            opts=["--config", conf_file],
+        )
+
+        run = create_from_config(config)
+
+        data = Data(self.toastcomm)
+
+        tele = create_space_telescope(self.toastcomm.group_size)
+        sch = create_satellite_schedule(
+            mission_start=datetime(2023, 2, 23), num_observations=self.toastcomm.ngroups
+        )
+
+        # Add our fake telescope and schedule
+        run.operators.sim_satellite.telescope = tele
+        run.operators.sim_satellite.schedule = sch
+
+        # Set up detector pointing
+        run.operators.pixels.detector_pointing = run.operators.det_pointing
+
+        # Run it
+        run.operators.sim_pipe.apply(data)
+
+        close_data(data)
+
+    def test_script_run_config(self):
+        # This tests the toast_run:main entry point
+        from ..scripts.toast_run import main as run_main
+
+        # Create the telescope and schedule files
+        tele_file = os.path.join(self.outdir, "toast_run_telescope.h5:/leve1/level2")
+        tele = create_space_telescope(self.toastcomm.group_size)
+        if self.comm.rank == 0:
+            save_instrument_file(tele_file, tele, None)
+
+        sch_file = os.path.join(self.outdir, "toast_run_schedule.ecsv")
+        sch = create_satellite_schedule(
+            mission_start=datetime(2023, 2, 23), num_observations=self.toastcomm.ngroups
+        )
+        if self.comm.rank == 0:
+            sch.write(sch_file)
+
+        # Create the config file on disk
+        testops = self.create_operators()
+
+        # Set the telescope / schedule file traits, and cross references to other
+        # operators
+        testops["sim_satellite"].telescope_file = tele_file
+        testops["sim_satellite"].schedule_file = sch_file
+        testops["pixels"].detector_pointing = testops["det_pointing"]
+
+        testtmpl = self.create_templates()
+        conf_pipe = dict()
+        for op_name, op in testops.items():
+            conf_pipe = op.get_config(input=conf_pipe)
+        pipe = ops.Pipeline(name="sim_pipe")
+        pipe.operators = [y for x, y in testops.items() if x != "det_pointing"]
+        conf_pipe = pipe.get_config(input=conf_pipe)
+        for tmpl_name, tmpl in testtmpl.items():
+            conf_pipe = tmpl.get_config(input=conf_pipe)
+
+        conf_file = os.path.join(self.outdir, "toast_run_input.yml")
+        if self.toastcomm.world_rank == 0:
+            dump_yaml(conf_file, conf_pipe)
+        if self.toastcomm.comm_world is not None:
+            self.toastcomm.comm_world.barrier()
+
+        opts = [
+            "--config",
+            conf_file,
+            "--main",
+            "sim_pipe",
+            "--out_dir",
+            self.outdir,
+        ]
+
+        run_main(opts=opts)

--- a/src/toast/traits.py
+++ b/src/toast/traits.py
@@ -526,26 +526,34 @@ class TraitConfig(HasTraits):
         avail_traits = set(cls.class_trait_names())
         for k, v in props.items():
             if k == "class":
+                # print(f"CONF {name}: skipping class", flush=True)
                 continue
             if k not in avail_traits:
                 msg = f"Class {cls_path} currently has no configuration"
                 msg += f" trait '{k}'.  This will be ignored, and your config "
-                msg += f"file is likely out of date."
+                msg += "file is likely out of date."
                 log.warning(msg)
                 continue
-            # print(f"from_config: parsing {v}", flush=True)
-            if v["value"] == "None":
-                # Regardless of type, we set this to None
-                kw[k] = None
-            elif v["type"] == "unknown":
-                # This was a None value in the TOML or similar unknown object
-                pass
-            elif v["type"] in parsable:
-                kw[k] = string_to_trait(v["value"])
+            # print(f"CONF {name}: parsing {v}", flush=True)
+            if isinstance(v["value"], str):
+                if v["value"] == "None":
+                    # Regardless of type, we set this to None
+                    kw[k] = None
+                    # print(f"CONF {name}:   (str -> None) {k} = None", flush=True)
+                elif v["type"] == "unknown":
+                    # This was a None value or similar unknown object
+                    # print(f"CONF {name}:   (str, type unknown) {k} = pass", flush=True)
+                    pass
+                elif v["type"] in parsable:
+                    kw[k] = string_to_trait(v["value"])
+                    # print(f"CONF {name}:   (str -> parsable) {k} = {kw[k]}", flush=True)
+                else:
+                    # print(f"CONF {name}:   (str, nonparsable) {k} != {v['value']}", flush=True)
+                    pass
             else:
-                # This is either a class instance of some arbitrary type,
-                # or a callable.
-                pass
+                kw[k] = v["value"]
+                # print(f"CONF {name}:   ({type(kw[k])}) {k} = {kw[k]}", flush=True)
+
         # Instantiate class and return
         # print(f"Instantiate class with {kw}", flush=True)
         return cls(**kw)


### PR DESCRIPTION
In practice, many workflows can be expressed as nested sequences (toast.ops.Pipeline) instances.  Internal references between objects in config files have been supported for years, but using these in complex situations required a couple of small fixes.

- Add toast_run script, which looks for a single "main" operator and runs it.

- Add HDF5 helper functions for saving / loading just the instrument models in the same format as used in HDF5 Volumes.

- In SimGround and SimSatellite, add support for loading instrument models and schedule files as traits.

- Expand unit tests for nested pipelines in config files.