### PR TITLE
Add infrastructure to store additional metadata to HEALPix and WCS he…

### DIFF
--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -684,9 +684,9 @@ class FilterBin(Operator):
                 # memreport.apply(data)
 
                 if (
-                        template_covariance is None or
-                        template_covariance.shape[0] != det_templates.ntemplate or
-                        np.any(last_good_fit != good_fit)
+                    template_covariance is None
+                    or template_covariance.shape[0] != det_templates.ntemplate
+                    or np.any(last_good_fit != good_fit)
                 ):
                     template_covariance = self._build_template_covariance(
                         det_templates, good_fit
@@ -1343,7 +1343,9 @@ class FilterBin(Operator):
             else:
                 stop = max(stop, times[-1])
             all_dets.update(ob.select_local_detectors(detectors))
-            good_dets.update(ob.select_local_detectors(detectors, flagmask=self.det_mask))
+            good_dets.update(
+                ob.select_local_detectors(detectors, flagmask=self.det_mask)
+            )
         if self.comm is not None:
             start = self.comm.allreduce(start, op=MPI.MIN)
             stop = self.comm.allreduce(stop, op=MPI.MAX)
@@ -1355,6 +1357,7 @@ class FilterBin(Operator):
         extra_header["STOP"] = (stop, "Dataset stop time")
         extra_header["NDET"] = (len(all_dets), "Total number of detectors")
         extra_header["NGOOD"] = (len(good_dets), "Total number of usable detectors")
+        extra_header["OPERATOR"] = ("TOAST FilterBin", "Generating code")
 
         return extra_header
 

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -206,7 +206,7 @@ def combine_observation_matrix(rootname):
 
 @trait_docs
 class FilterBin(Operator):
-    """FilterBin buids a template matrix and projects out
+    """FilterBin builds a template matrix and projects out
     compromised modes.  It then bins the signal and optionally
     writes out the sparse observation matrix that matches the
     filtering operations.
@@ -220,6 +220,8 @@ class FilterBin(Operator):
     # Class traits
 
     API = Int(0, help="Internal interface version for this operator")
+
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
 
     det_data = Unicode(
         defaults.det_data, help="Observation detdata key for the timestream data"
@@ -542,6 +544,8 @@ class FilterBin(Operator):
 
         self._initialize_comm(data)
 
+        extra_header = self._get_extra_header(data, detectors)
+
         # Filter data
 
         self._initialize_obs_matrix()
@@ -556,7 +560,7 @@ class FilterBin(Operator):
             "FilterBin: Loaded deprojection map in", comm=self.comm, timer=timer
         )
 
-        self._bin_map(data, detectors, filtered=False)
+        self._bin_map(data, detectors, filtered=False, extra_header=extra_header)
         log.debug_rank(
             "FilterBin: Binned unfiltered map in", comm=self.comm, timer=timer
         )
@@ -746,7 +750,7 @@ class FilterBin(Operator):
 
         # Bin filtered signal
 
-        self._bin_map(data, detectors, filtered=True)
+        self._bin_map(data, detectors, filtered=True, extra_header=extra_header)
         log.debug_rank("FilterBin: Binned filtered map in", comm=self.comm, timer=timer)
 
         log.info_rank(
@@ -1320,6 +1324,41 @@ class FilterBin(Operator):
         return
 
     @function_timer
+    def _get_extra_header(self, data, detectors):
+        """Extract useful information from the data object to record in
+        map headers"""
+        extra_header = {}
+        start = None
+        stop = None
+        all_dets = set()
+        good_dets = set()
+        for ob in data.obs:
+            times = ob.shared[self.times].data
+            if start is None:
+                start = times[0]
+            else:
+                start = min(start, times[0])
+            if stop is None:
+                stop = times[-1]
+            else:
+                stop = max(stop, times[-1])
+            all_dets.update(ob.select_local_detectors(detectors))
+            good_dets.update(ob.select_local_detectors(detectors, flagmask=self.det_mask))
+        if self.comm is not None:
+            start = self.comm.allreduce(start, op=MPI.MIN)
+            stop = self.comm.allreduce(stop, op=MPI.MAX)
+            all_dets_list = self.comm.allgather(all_dets)
+            good_dets_list = self.comm.allgather(good_dets)
+            all_dets.update(*all_dets_list)
+            good_dets.update(*good_dets_list)
+        extra_header["START"] = (start, "Dataset start time")
+        extra_header["STOP"] = (stop, "Dataset stop time")
+        extra_header["NDET"] = (len(all_dets), "Total number of detectors")
+        extra_header["NGOOD"] = (len(good_dets), "Total number of usable detectors")
+
+        return extra_header
+
+    @function_timer
     def _initialize_obs_matrix(self):
         if self.write_obs_matrix:
             self.obs_matrix = scipy.sparse.csr_matrix(
@@ -1489,7 +1528,7 @@ class FilterBin(Operator):
         return
 
     @function_timer
-    def _bin_map(self, data, detectors, filtered):
+    def _bin_map(self, data, detectors, filtered, extra_header=None):
         """Bin the signal onto a map.  Optionally write out hits and
         white noise covariance matrices.
         """
@@ -1586,7 +1625,11 @@ class FilterBin(Operator):
                             f"Skipping existing file: {fname}", comm=self.comm
                         )
                         continue
-                data[key].write(fname, force_serial=self.write_hdf5_serial)
+                data[key].write(
+                    fname,
+                    force_serial=self.write_hdf5_serial,
+                    extra_header=extra_header,
+                )
                 log.info_rank(f"Wrote {fname} in", comm=self.comm, timer=timer)
             if not keep and not self.mc_mode:
                 if key in data:

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -603,11 +603,7 @@ class MapMaker(Operator):
             extra_header=extra_header,
         )
         self._write_del(
-            self.cov_name,
-            self.write_cov,
-            False,
-            self.name,
-            extra_header=extra_header
+            self.cov_name, self.write_cov, False, self.name, extra_header=extra_header
         )
 
         self._log.info_rank(
@@ -655,8 +651,13 @@ class MapMaker(Operator):
             else:
                 stop = max(stop, times[-1])
             all_dets.update(ob.select_local_detectors(detectors))
-            good_dets.update(ob.select_local_detectors(detectors, flagmask=self.det_mask))
-        if self.comm is not None:
+            good_dets.update(
+                ob.select_local_detectors(
+                    detectors,
+                    flagmask=self.binning.det_mask,
+                )
+            )
+        if self._comm is not None:
             start = self._comm.allreduce(start, op=MPI.MIN)
             stop = self._comm.allreduce(stop, op=MPI.MAX)
             all_dets_list = self._comm.allgather(all_dets)
@@ -667,6 +668,7 @@ class MapMaker(Operator):
         extra_header["STOP"] = (stop, "Dataset stop time")
         extra_header["NDET"] = (len(all_dets), "Total number of detectors")
         extra_header["NGOOD"] = (len(good_dets), "Total number of usable detectors")
+        extra_header["OPERATOR"] = ("TOAST MapMaker", "Generating code")
 
         return extra_header
 

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -25,7 +25,7 @@ from .scan_map import ScanMap, ScanMask
 
 @trait_docs
 class MapMaker(Operator):
-    """Operator for making maps.
+    r"""Operator for making maps.
 
     This operator first solves for a maximum likelihood set of template amplitudes
     that model the timestream contributions from noise, systematics, etc:
@@ -212,7 +212,7 @@ class MapMaker(Operator):
         super().__init__(**kwargs)
 
     @function_timer
-    def _write_del(self, prod_key, prod_write, force, rootname):
+    def _write_del(self, prod_key, prod_write, force, rootname, extra_header=None):
         """Write data object to file and delete it from cache"""
         log = Logger.get()
 
@@ -245,6 +245,7 @@ class MapMaker(Operator):
                     force_serial=self.write_hdf5_serial,
                     single_precision=True,
                     report_memory=self.report_memory,
+                    extra_header=extra_header,
                 )
             log.info_rank(f"Wrote {fname} in", comm=self._comm, timer=wtimer)
 
@@ -454,7 +455,7 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _bin_and_write_raw_signal(self, map_binning):
+    def _bin_and_write_raw_signal(self, map_binning, extra_header=None):
         """Optionally bin and save an undestriped map"""
 
         if not self.write_binmap:
@@ -475,7 +476,13 @@ class MapMaker(Operator):
             comm=self._comm,
             timer=self._timer,
         )
-        self._write_del(self.binmap_name, self.write_binmap, True, self._mc_root)
+        self._write_del(
+            self.binmap_name,
+            self.write_binmap,
+            True,
+            self._mc_root,
+            extra_header=extra_header,
+        )
 
         self._memreport.prefix = "After binning final map"
         self._memreport.apply(self._data, use_accel=self._use_accel)
@@ -577,7 +584,7 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _write_maps(self):
+    def _write_maps(self, extra_header=None):
         """Write and delete the outputs"""
 
         self._write_del(
@@ -586,8 +593,20 @@ class MapMaker(Operator):
             True,
             self._mc_root,
         )
-        self._write_del(self.map_name, self.write_map, True, self._mc_root)
-        self._write_del(self.cov_name, self.write_cov, False, self.name)
+        self._write_del(
+            self.map_name,
+            self.write_map,
+            True,
+            self._mc_root,
+            extra_header=extra_header,
+        )
+        self._write_del(
+            self.cov_name,
+            self.write_cov,
+            False,
+            self.name,
+            extra_header=extra_header
+        )
 
         self._log.info_rank(
             f"{self._log_prefix}  finished output write in",
@@ -615,6 +634,41 @@ class MapMaker(Operator):
         return
 
     @function_timer
+    def _get_extra_header(self, data, detectors):
+        """Extract useful information from the data object to record in
+        map headers"""
+        extra_header = {}
+        start = None
+        stop = None
+        all_dets = set()
+        good_dets = set()
+        for ob in data.obs:
+            times = ob.shared[self.times].data
+            if start is None:
+                start = times[0]
+            else:
+                start = min(start, times[0])
+            if stop is None:
+                stop = times[-1]
+            else:
+                stop = max(stop, times[-1])
+            all_dets.update(ob.select_local_detectors(detectors))
+            good_dets.update(ob.select_local_detectors(detectors, flagmask=self.det_mask))
+        if self.comm is not None:
+            start = self._comm.allreduce(start, op=MPI.MIN)
+            stop = self._comm.allreduce(stop, op=MPI.MAX)
+            all_dets_list = self._comm.allgather(all_dets)
+            good_dets_list = self._comm.allgather(good_dets)
+            all_dets.update(*all_dets_list)
+            good_dets.update(*good_dets_list)
+        extra_header["START"] = (start, "Dataset start time")
+        extra_header["STOP"] = (stop, "Dataset stop time")
+        extra_header["NDET"] = (len(all_dets), "Total number of detectors")
+        extra_header["NGOOD"] = (len(good_dets), "Total number of usable detectors")
+
+        return extra_header
+
+    @function_timer
     def _exec(self, data, detectors=None, use_accel=None, **kwargs):
         # First confirm that there is at least one valid detector
 
@@ -637,6 +691,8 @@ class MapMaker(Operator):
 
         self._setup(data, detectors, use_accel)
 
+        extra_header = self._get_extra_header(data, detectors)
+
         self._memreport.prefix = "Start of mapmaking"
         self._memreport.apply(self._data, use_accel=self._use_accel)
 
@@ -646,7 +702,7 @@ class MapMaker(Operator):
 
         self._build_pixel_covariance(map_binning)
 
-        self._bin_and_write_raw_signal(map_binning)
+        self._bin_and_write_raw_signal(map_binning, extra_header=extra_header)
 
         out_cleaned = self._clean_signal(template_amplitudes)
 
@@ -655,7 +711,7 @@ class MapMaker(Operator):
 
         self._purge_cleaned_tod()  # Potentially frees memory for writing maps
 
-        self._write_maps()
+        self._write_maps(extra_header=extra_header)
 
         self._memreport.prefix = "End of mapmaking"
         self._memreport.apply(self._data, use_accel=self._use_accel)
@@ -688,7 +744,7 @@ class MapMaker(Operator):
 
 @trait_docs
 class Calibrate(Operator):
-    """Operator for calibrating timestreams using solved templates.
+    r"""Operator for calibrating timestreams using solved templates.
 
     This operator first solves for a maximum likelihood set of template amplitudes
     that model the timestream contributions from noise, systematics, etc:

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -69,6 +69,8 @@ class MapMaker(Operator):
 
     API = Int(0, help="Internal interface version for this operator")
 
+    times = Unicode(defaults.times, help="Observation shared key for timestamps")
+
     det_data = Unicode(
         defaults.det_data, help="Observation detdata key for the timestream data"
     )

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -1175,6 +1175,7 @@ class PixelData(AcceleratorObject):
         comm_bytes=10000000,
         report_memory=False,
         single_precision=False,
+        extra_header=None,
     ):
         """Write distributed PixelData to a WCS file.
 
@@ -1192,6 +1193,7 @@ class PixelData(AcceleratorObject):
                 the root node just before writing out the map.
             single_precision (bool): If True, write floats and integers in single
                 precision.
+            extra_header (dict): Additional metadata to include with the map
 
         Returns:
             None
@@ -1219,7 +1221,14 @@ class PixelData(AcceleratorObject):
             if report_memory:
                 mem = memreport(msg="(root node)", silent=True)
                 log.info(f"About to write {path}:  {mem}")
-            write_wcs(path, image, dist.wcs, self.units, dtype=dtype)
+            write_wcs(
+                path,
+                image,
+                dist.wcs,
+                self.units,
+                dtype=dtype,
+                extra_header=extra_header,
+            )
         del image
 
     def _write_healpix_fits(
@@ -1228,6 +1237,7 @@ class PixelData(AcceleratorObject):
         comm_bytes=10000000,
         report_memory=False,
         single_precision=False,
+        extra_header=None,
     ):
         """Write distributed PixelData to a healpix FITS file.
 
@@ -1238,6 +1248,7 @@ class PixelData(AcceleratorObject):
                 the root node just before writing out the map.
             single_precision (bool): If True, write floats and integers in single
                 precision.
+            extra_header (dict): Additional metadata to include with the map
 
         Returns:
             None
@@ -1280,6 +1291,15 @@ class PixelData(AcceleratorObject):
                 mem = memreport(msg="(root node)", silent=True)
                 log.info(f"About to write {path}:  {mem}")
             extra = [(f"TUNIT{x}", f"{funits}") for x in range(self.n_value)]
+            if extra_header is not None:
+                for key, value in extra_header.items():
+                    try:
+                        value, comment = value
+                        # key, value, comment format
+                        extra.append((key, value, comment))
+                    except:
+                        # key, value format
+                        extra.append((key, value))
             hp.write_map(
                 path,
                 fview,
@@ -1300,6 +1320,7 @@ class PixelData(AcceleratorObject):
         report_memory=False,
         single_precision=False,
         force_serial=True,
+        extra_header=None,
     ):
         """Write distributed PixelData to a healpix HDF5 file.
 
@@ -1312,6 +1333,7 @@ class PixelData(AcceleratorObject):
                 precision.
             force_serial (bool): If True, use serial I/O, even if the HDF5
                 implementation is built with MPI.
+            extra_header (dict): Additional metadata to include with the map
 
         Returns:
             None
@@ -1351,7 +1373,10 @@ class PixelData(AcceleratorObject):
             allowners = np.zeros_like(owners)
             dist.comm.Allreduce(owners, allowners, op=MPI.MIN)
 
-        header = {}
+        if extra_header is None:
+            header = {}
+        else:
+            header = extra_header
         if nest:
             header["ORDERING"] = "NESTED"
         else:
@@ -1449,7 +1474,11 @@ class PixelData(AcceleratorObject):
                             dset[:, first:last] = recvbuffer[i, :, 0 : last - first]
 
                     for key, value in header.items():
-                        dset.attrs[key] = value
+                        try:
+                            value, comment = value
+                            dset.attrs[key] = value
+                        except:
+                            dset.attrs[key] = value
             else:
                 # All others wait for their turn to send
                 if sendbuffer is not None:
@@ -1462,6 +1491,7 @@ class PixelData(AcceleratorObject):
         report_memory=False,
         single_precision=False,
         force_serial=True,
+        extra_header=None,
     ):
         """Write distributed PixelData to a healpix file.
 
@@ -1480,6 +1510,7 @@ class PixelData(AcceleratorObject):
                 precision.
             force_serial (bool): If True, use serial I/O, even if the HDF5
                 implementation is built with MPI.
+            extra_header (dict): Additional metadata to include with the map
 
         Returns:
             None
@@ -1491,6 +1522,7 @@ class PixelData(AcceleratorObject):
                 comm_bytes=comm_bytes,
                 report_memory=report_memory,
                 single_precision=single_precision,
+                extra_header=extra_header,
             )
         elif filename_is_hdf5(path):
             self._write_healpix_hdf5(
@@ -1499,6 +1531,7 @@ class PixelData(AcceleratorObject):
                 report_memory=report_memory,
                 single_precision=single_precision,
                 force_serial=force_serial,
+                extra_header=extra_header,
             )
         else:
             msg = f"Could not determine file type for '{path}'"
@@ -1512,6 +1545,7 @@ class PixelData(AcceleratorObject):
         report_memory=False,
         single_precision=False,
         force_serial=True,
+        extra_header=None,
     ):
         """Write distributed PixelData to a file.
 
@@ -1534,6 +1568,7 @@ class PixelData(AcceleratorObject):
                 precision.
             force_serial (bool): If True, use serial I/O, even if the HDF5
                 implementation is built with MPI.
+            extra_header (dict): Additional metadata to include with the map
 
         Returns:
             None
@@ -1548,6 +1583,7 @@ class PixelData(AcceleratorObject):
                 comm_bytes=comm_bytes,
                 report_memory=report_memory,
                 single_precision=single_precision,
+                extra_header=extra_header,
             )
         elif hasattr(dist, "nest"):
             self._write_healpix(
@@ -1556,6 +1592,7 @@ class PixelData(AcceleratorObject):
                 report_memory=report_memory,
                 single_precision=single_precision,
                 force_serial=force_serial,
+                extra_header=extra_header,
             )
         else:
             msg = "Could not determine pixelization type.  PixelDistribution"

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -1477,7 +1477,7 @@ class PixelData(AcceleratorObject):
                         try:
                             value, comment = value
                             dset.attrs[key] = value
-                        except:
+                        except (TypeError, ValueError):
                             dset.attrs[key] = value
             else:
                 # All others wait for their turn to send

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -1,15 +1,17 @@
-# Copyright (c) 2015-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
+from datetime import UTC, datetime
 
-import numpy as np
-import healpy as hp
 import h5py
+import healpy as hp
+import numpy as np
 from astropy import units as u
 from pshmem.utils import mpi_data_type
 
+from . import __version__
 from ._libtoast import global_to_local as libtoast_global_to_local
 from .accelerator import (
     AcceleratorObject,
@@ -26,6 +28,9 @@ from .accelerator import (
 from .dist import distribute_uniform
 from .io import have_hdf5_parallel
 from .mpi import MPI, use_mpi
+from .pixels_io_healpix import collect_healpix_submaps
+from .pixels_io_utils import filename_is_fits, filename_is_hdf5
+from .pixels_io_wcs import broadcast_image, collect_wcs_submaps, read_wcs, write_wcs
 from .timing import GlobalTimers, function_timer
 from .utils import (
     AlignedF32,
@@ -42,9 +47,6 @@ from .utils import (
     memreport,
     unit_conversion,
 )
-from .pixels_io_healpix import collect_healpix_submaps
-from .pixels_io_utils import filename_is_fits, filename_is_hdf5
-from .pixels_io_wcs import collect_wcs_submaps, broadcast_image, write_wcs, read_wcs
 
 
 class PixelDistribution(AcceleratorObject):
@@ -1575,6 +1577,15 @@ class PixelData(AcceleratorObject):
 
         """
         dist = self.distribution
+
+        # Set up basic header information
+        if extra_header is None:
+            extra_header = {}
+        extra_header["CREATED"] = (
+            datetime.now(tz=UTC).timestamp(),
+            "Creation time [UTC]",
+        )
+        extra_header["VERSION"] = (__version__, "TOAST version")
 
         # Check if we have WCS information
         if hasattr(dist, "wcs"):

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -3,7 +3,7 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-from datetime import UTC, datetime
+from datetime import datetime
 
 import h5py
 import healpy as hp
@@ -1582,7 +1582,7 @@ class PixelData(AcceleratorObject):
         if extra_header is None:
             extra_header = {}
         extra_header["CREATED"] = (
-            datetime.now(tz=UTC).timestamp(),
+            datetime.utcnow().timestamp(),
             "Creation time [UTC]",
         )
         extra_header["VERSION"] = (__version__, "TOAST version")

--- a/src/toast/pixels.py
+++ b/src/toast/pixels.py
@@ -1297,7 +1297,7 @@ class PixelData(AcceleratorObject):
                         value, comment = value
                         # key, value, comment format
                         extra.append((key, value, comment))
-                    except:
+                    except (TypeError, ValueError):
                         # key, value format
                         extra.append((key, value))
             hp.write_map(

--- a/src/toast/pixels_io_wcs.py
+++ b/src/toast/pixels_io_wcs.py
@@ -248,7 +248,7 @@ def broadcast_image(image, fscale, pix, comm_bytes):
 
 
 @function_timer
-def write_wcs(filename, image, wcs, units=None, dtype=None):
+def write_wcs(filename, image, wcs, units=None, dtype=None, extra_header=None):
     """Write a FITS or HDF5 WCS map on the calling process
 
     Args:
@@ -256,6 +256,7 @@ def write_wcs(filename, image, wcs, units=None, dtype=None):
         image (ndarray): 2 or 3-dimensional image
         wcs (astropy.WCS):  The World Coordinate System
         units (str):  Image units
+        extra_header (dict):  Additional metadata to include with the map
 
     Returns:
         None
@@ -267,6 +268,9 @@ def write_wcs(filename, image, wcs, units=None, dtype=None):
 
     # Basic wcs header
     header = wcs.to_header(relax=True)
+
+    if extra_header is not None:
+        header.update(extra_header)
 
     # Output units
     if dtype is None:

--- a/src/toast/tests/pixels_healpix.py
+++ b/src/toast/tests/pixels_healpix.py
@@ -38,6 +38,13 @@ class PixelTest(MPITestCase):
         # self.nsides = [2]
         # self.nsub = [8]
         # self.types = [np.int32]
+        self.extra_header = {
+            "key1" : "value1",
+            "key2" : 0,
+            "key3" : True,
+            "key4" : ("value4", "comment4"),
+            "key5" : (0.0, "comment5"),
+        }
 
     def tearDown(self):
         pass
@@ -158,7 +165,7 @@ class PixelTest(MPITestCase):
                             nside, nsb, np.dtype(tp).char
                         ),
                     )
-                    pdata.write(fitsfile)
+                    pdata.write(fitsfile, extra_header=self.extra_header)
                     check = self._make_pixdata(dist, tp, n_value, zero=True)
                     check.read(fitsfile)
                     nt.assert_equal(pdata.data, check.data)
@@ -234,7 +241,7 @@ class PixelTest(MPITestCase):
                             nside, nsb, np.dtype(tp).char
                         ),
                     )
-                    pdata.write(hdf5file)
+                    pdata.write(hdf5file, extra_header=self.extra_header)
                     check = self._make_pixdata(dist, tp, n_value, zero=True)
                     check.read(hdf5file)
                     nt.assert_equal(pdata.data, check.data)

--- a/src/toast/tests/pixels_wcs.py
+++ b/src/toast/tests/pixels_wcs.py
@@ -49,6 +49,13 @@ class PixelTest(MPITestCase):
             np.uint8,
         ]
         self.datatypes = [np.float64, np.float32, np.int64, np.int32]
+        self.extra_header = {
+            "key1" : "value1",
+            "key2" : 0,
+            "key3" : True,
+            "key4" : ("value4", "comment4"),
+            "key5" : (0.0, "comment5"),
+        }
 
     def tearDown(self):
         pass
@@ -104,7 +111,7 @@ class PixelTest(MPITestCase):
                     self.outdir,
                     "data_sub{}_type-{}.{}".format(nsb, np.dtype(tp).char, suffix),
                 )
-                pdata.write(wcsfile)
+                pdata.write(wcsfile, extra_header=self.extra_header)
                 check = self._make_pixdata(dist, tp, n_value, zero=True)
                 check.read(wcsfile)
                 nt.assert_equal(pdata.data, check.data)


### PR DESCRIPTION
Add support for appending metadata to HEALPix and WCS headers.

The `extra_header` keyword argument defaults to `None` but expects dictionaries of
```
key : value
```
or
```
key : (value, comment)
```

Currently, only the total number of detectors and the start and stop times are recorded but it will be trivial to add
- TOAST version
- TOAST operator
- execution time
- details about the compute system and software environment