### PR TITLE
Add stdout / stderr redirection to toast_run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -305,12 +305,12 @@ conf["install_requires"] = [
     "astropy",
     "healpy",
     "ephem",
+    "wurlitzer",
 ]
 conf["extras_require"] = {
     "mpi": ["mpi4py>=3.0"],
     "totalconvolve": ["ducc0"],
     "interactive": [
-        "wurlitzer",
         "ipywidgets",
         "plotly",
         "plotly-resampler",

--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ conf["install_requires"] = [
     "matplotlib",
     "psutil",
     "h5py",
-    "pshmem>=1.1.0",
+    "pshmem>=1.3.0",
     "ruamel.yaml",
     "astropy",
     "healpy",

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -689,13 +689,17 @@ class ConfigTest(MPITestCase):
         # This tests the toast_run:main entry point
         from ..scripts.toast_run import main as run_main
 
+        testdir = os.path.join(self.outdir, "script_run_config")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
         # Create the telescope and schedule files
-        tele_file = os.path.join(self.outdir, "toast_run_telescope.h5:/leve1/level2")
+        tele_file = os.path.join(testdir, "toast_run_telescope.h5:/leve1/level2")
         tele = create_space_telescope(self.toastcomm.group_size)
         if self.toastcomm.world_rank == 0:
             save_instrument_file(tele_file, tele, None)
 
-        sch_file = os.path.join(self.outdir, "toast_run_schedule.ecsv")
+        sch_file = os.path.join(testdir, "toast_run_schedule.ecsv")
         sch = create_satellite_schedule(
             mission_start=datetime(2023, 2, 23), num_observations=self.toastcomm.ngroups
         )
@@ -721,7 +725,7 @@ class ConfigTest(MPITestCase):
         for tmpl_name, tmpl in testtmpl.items():
             conf_pipe = tmpl.get_config(input=conf_pipe)
 
-        conf_file = os.path.join(self.outdir, "toast_run_input.yml")
+        conf_file = os.path.join(testdir, "toast_run_input.yml")
         if self.toastcomm.world_rank == 0:
             dump_yaml(conf_file, conf_pipe)
         if self.toastcomm.comm_world is not None:
@@ -733,7 +737,7 @@ class ConfigTest(MPITestCase):
             "--main",
             "sim_pipe",
             "--out_dir",
-            self.outdir,
+            testdir,
         ]
 
-        run_main(opts=opts)
+        run_main(opts=opts, comm=self.comm)


### PR DESCRIPTION
- Add a new context manager that uses wurlitzer to redirect both python and libc output to a file. Per-process output is written to separate files and then collated at the end.

- Use redirection in toast_run so that all output is logged to the top level out_dir.

- Several small fixes.