### PR TITLE
Highpass before demod

### DIFF
--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2019-2025 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -760,6 +760,10 @@ class Focalplane(object):
         return list(self._det_to_row.keys())
 
     @property
+    def properties(self):
+        return list(self.detector_data.colnames)
+
+    @property
     def n_detectors(self):
         return len(self._det_to_row.keys())
 

--- a/src/toast/ops/CMakeLists.txt
+++ b/src/toast/ops/CMakeLists.txt
@@ -13,6 +13,7 @@ install(FILES
     memory_counter.py
     simple_deglitch.py
     simple_jumpcorrect.py
+    simple_statcut.py
     sim_catalog.py
     sim_hwp.py
     sim_tod_noise.py

--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -73,6 +73,7 @@ from .sim_tod_dipole import SimDipole
 from .sim_tod_noise import SimNoise
 from .simple_deglitch import SimpleDeglitch
 from .simple_jumpcorrect import SimpleJumpCorrect
+from .simple_statcut import SimpleStatCut
 from .sss import SimScanSynchronousSignal
 from .statistics import Statistics
 from .stokes_weights import StokesWeights

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -891,6 +891,11 @@ class StokesWeightsDemod(Operator):
         "Requires `detector_pointing_in` to be set.",
     )
 
+    det_mask = Int(
+        defaults.det_mask_nonscience,
+        help="Bit mask value for per-detector flagging",
+    )
+
     @traitlets.validate("mode")
     def _check_mode(self, proposal):
         mode = proposal["value"]
@@ -1004,7 +1009,7 @@ class StokesWeightsDemod(Operator):
             dtype = np.float64
 
         for obs in data.obs:
-            dets = obs.select_local_detectors(detectors)
+            dets = obs.select_local_detectors(detectors, flagmask=self.det_mask)
             if len(dets) == 0:
                 continue
 

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -290,7 +290,8 @@ class Demodulate(Operator):
             n_obs = data.comm.comm_world.allreduce(n_obs)
         if n_obs == 0:
             raise RuntimeError(
-                "None of the observations have a spinning HWP.  Nothing to demodulate."
+                "None of the observations have a spinning HWP and/or enough detectors. "
+                "Nothing to demodulate."
             )
 
         # Each modulated detector demodulates into one or more pseudo detectors
@@ -677,35 +678,6 @@ class Demodulate(Operator):
                     bandpassed = bandpass4f(signal)
                     det_data[f"demod4r_{det}"] = lowpass(bandpassed * 2 * qweights)
                     det_data[f"demod4i_{det}"] = lowpass(bandpassed * 2 * uweights)
-                # DEBUG begin
-                """
-                import matplotlib.pyplot as plt
-                import pdb
-                print(f"Making debug plot", flush=True)
-                hwp_angle = obs.shared["hwp_angle"].data
-                times = obs.shared["times"].data
-                dt = np.median(np.diff(times))
-                lowpassed_times = times[::lowpass._nskip]
-                lowpassed_dt = np.median(np.diff(lowpassed_times))
-                psd_in = np.sqrt(np.abs(np.fft.rfft(signal)))
-                psd_in_lowpass = np.sqrt(np.abs(np.fft.rfft(lowpass(signal))))
-                psd_in_bandpass = np.sqrt(np.abs(np.fft.rfft(bandpass4f(signal))))
-                psd_q = np.sqrt(np.abs(np.fft.rfft(det_data[f"demod4r_{det}"])))
-                psd_u = np.sqrt(np.abs(np.fft.rfft(det_data[f"demod4i_{det}"])))
-                freq_in = np.fft.rfftfreq(times.size, dt)
-                freq_out = np.fft.rfftfreq(lowpassed_times.size, lowpassed_dt)
-                fig = plt.figure()
-                ax = fig.add_subplot(1, 1, 1)
-                ax.loglog(freq_in, psd_in, label="input")
-                ax.loglog(freq_in, psd_in_bandpass, label="bandpassed input")
-                ax.loglog(freq_out, psd_in_lowpass, label="lowpassed input")
-                ax.loglog(freq_out, psd_q, label="demod Q")
-                ax.loglog(freq_out, psd_u, label="demod U")
-                ax.legend(loc="best")
-                fig.savefig("test.png")
-                pdb.set_trace()
-                """
-                # DEBUG end
                 if self.do_2f:
                     # Start by evaluating the 2f demodulation factors from the
                     # pointing matrix.  We use the half-angle formulas and some

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -234,6 +234,11 @@ class Demodulate(Operator):
             msg = "Cannot produce demodulated QU without QU Stokes weights"
             raise RuntimeError(msg)
 
+        if self.stokes_weights.hwp_angle is None:
+            msg = f"The Stokes weights operator (self.stokes_weights) "
+            msg += "does not have HWP angle"
+            raise RuntimeError(msg)
+
         if self.in_place:
             self.demod_data = None
         else:
@@ -333,12 +338,8 @@ class Demodulate(Operator):
             lowpass = Lowpass(
                 wkernel, 0.95 * fmod, fsample, offset, self.nskip, self.window
             )
-            bandpass2f = Bandpass(
-                wkernel, 2 * fmod, 0.95 * fmod, fsample, self.window
-            )
-            bandpass4f = Bandpass(
-                wkernel, 4 * fmod, 0.95 * fmod, fsample, self.window
-            )
+            bandpass2f = Bandpass(wkernel, 2 * fmod, 0.95 * fmod, fsample, self.window)
+            bandpass4f = Bandpass(wkernel, 4 * fmod, 0.95 * fmod, fsample, self.window)
 
             # Create a new observation to hold the demodulated and downsampled data
 
@@ -644,7 +645,7 @@ class Demodulate(Operator):
 
     @function_timer
     def _demodulate_signal(
-            self, data, obs, demod_obs, dets, lowpass, bandpass2f, bandpass4f
+        self, data, obs, demod_obs, dets, lowpass, bandpass2f, bandpass4f
     ):
         """demodulate signal TOD"""
 
@@ -676,6 +677,35 @@ class Demodulate(Operator):
                     bandpassed = bandpass4f(signal)
                     det_data[f"demod4r_{det}"] = lowpass(bandpassed * 2 * qweights)
                     det_data[f"demod4i_{det}"] = lowpass(bandpassed * 2 * uweights)
+                # DEBUG begin
+                """
+                import matplotlib.pyplot as plt
+                import pdb
+                print(f"Making debug plot", flush=True)
+                hwp_angle = obs.shared["hwp_angle"].data
+                times = obs.shared["times"].data
+                dt = np.median(np.diff(times))
+                lowpassed_times = times[::lowpass._nskip]
+                lowpassed_dt = np.median(np.diff(lowpassed_times))
+                psd_in = np.sqrt(np.abs(np.fft.rfft(signal)))
+                psd_in_lowpass = np.sqrt(np.abs(np.fft.rfft(lowpass(signal))))
+                psd_in_bandpass = np.sqrt(np.abs(np.fft.rfft(bandpass4f(signal))))
+                psd_q = np.sqrt(np.abs(np.fft.rfft(det_data[f"demod4r_{det}"])))
+                psd_u = np.sqrt(np.abs(np.fft.rfft(det_data[f"demod4i_{det}"])))
+                freq_in = np.fft.rfftfreq(times.size, dt)
+                freq_out = np.fft.rfftfreq(lowpassed_times.size, lowpassed_dt)
+                fig = plt.figure()
+                ax = fig.add_subplot(1, 1, 1)
+                ax.loglog(freq_in, psd_in, label="input")
+                ax.loglog(freq_in, psd_in_bandpass, label="bandpassed input")
+                ax.loglog(freq_out, psd_in_lowpass, label="lowpassed input")
+                ax.loglog(freq_out, psd_q, label="demod Q")
+                ax.loglog(freq_out, psd_u, label="demod U")
+                ax.legend(loc="best")
+                fig.savefig("test.png")
+                pdb.set_trace()
+                """
+                # DEBUG end
                 if self.do_2f:
                     # Start by evaluating the 2f demodulation factors from the
                     # pointing matrix.  We use the half-angle formulas and some

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -49,11 +49,34 @@ class Lowpass:
         self._offset = offset
         self._nskip = nskip
 
-    def __call__(self, signal, downsample=True):
+    def __call__(self, signal):
         lowpassed = fftconvolve(signal, self.lpf, mode="same").real
-        if downsample:
-            lowpassed = lowpassed[self._offset % self._nskip :: self._nskip]
-        return lowpassed
+        downsampled = lowpassed[self._offset % self._nskip :: self._nskip]
+        return downsampled
+
+
+class Bandpass:
+    """A callable class that applies the bandpass filter"""
+
+    def __init__(self, wkernel, fcenter, fradius, fsample, window="hamming"):
+        """
+        Args:
+            wkernel (int) : width of the filter kernel
+            fcenter (float) : center frequency of the passband
+            fradius (float) : radius of the passband
+            fsample (float) : signal sampling frequency
+        """
+        self.bpf = firwin(
+            wkernel,
+            [(fcenter - fradius).to_value(u.Hz), (fcenter + fradius).to_value(u.Hz)],
+            window=window,
+            pass_zero=False,
+            fs=fsample.to_value(u.Hz),
+        )
+
+    def __call__(self, signal, downsample=True):
+        bandpassed = fftconvolve(signal, self.bpf, mode="same").real
+        return bandpassed
 
 
 @trait_docs
@@ -304,10 +327,18 @@ class Demodulate(Operator):
             nsample = obs.n_local_samples
 
             fsample = obs.telescope.focalplane.sample_rate
-            fmax, hwp_rate = self._get_fmax(obs)
+            fmod = self._get_fmod(obs)
 
-            wkernel = self._get_wkernel(fmax, fsample)
-            lowpass = Lowpass(wkernel, fmax, fsample, offset, self.nskip, self.window)
+            wkernel = self._get_wkernel(fmod, fsample)
+            lowpass = Lowpass(
+                wkernel, 0.95 * fmod, fsample, offset, self.nskip, self.window
+            )
+            bandpass2f = Bandpass(
+                wkernel, 2 * fmod, 0.95 * fmod, fsample, self.window
+            )
+            bandpass4f = Bandpass(
+                wkernel, 4 * fmod, 0.95 * fmod, fsample, self.window
+            )
 
             # Create a new observation to hold the demodulated and downsampled data
 
@@ -356,9 +387,18 @@ class Demodulate(Operator):
             )
 
             self._demodulate_flags(obs, demod_obs, local_dets, wkernel, offset)
-            self._demodulate_signal(data, obs, demod_obs, local_dets, lowpass)
+            self._demodulate_signal(
+                data, obs, demod_obs, local_dets, lowpass, bandpass2f, bandpass4f
+            )
             self._demodulate_noise(
-                obs, demod_obs, local_dets, fsample, hwp_rate, lowpass
+                obs,
+                demod_obs,
+                local_dets,
+                fsample,
+                fmod,
+                lowpass,
+                bandpass2f,
+                bandpass4f,
             )
 
             self._demodulate_intervals(obs, demod_obs)
@@ -381,18 +421,14 @@ class Demodulate(Operator):
             self.demod_data.obs = demodulate_obs
 
     @function_timer
-    def _get_fmax(self, obs):
+    def _get_fmod(self, obs):
+        """Return the modulation frequency"""
         times = obs.shared[self.times].data
         hwp_angle = np.unwrap(obs.shared[self.hwp_angle].data)
         hwp_rate = np.absolute(
             np.mean(np.diff(hwp_angle) / np.diff(times)) / (2 * np.pi) * u.Hz
         )
-        if self.fmax is not None:
-            fmax = self.fmax
-        else:
-            # set low-pass filter cut-off frequency as same as HWP 1f
-            fmax = hwp_rate
-        return fmax, hwp_rate
+        return hwp_rate
 
     @function_timer
     def _get_wkernel(self, fmax, fsample):
@@ -607,7 +643,9 @@ class Demodulate(Operator):
         return new_flags
 
     @function_timer
-    def _demodulate_signal(self, data, obs, demod_obs, dets, lowpass):
+    def _demodulate_signal(
+            self, data, obs, demod_obs, dets, lowpass, bandpass2f, bandpass4f
+    ):
         """demodulate signal TOD"""
 
         for det in dets:
@@ -635,9 +673,9 @@ class Demodulate(Operator):
                 if "I" in self.mode:
                     det_data[f"demod0_{det}"] = lowpass(signal)
                 if "QU" in self.mode:
-                    highpassed = signal - lowpass(signal, downsample=False)
-                    det_data[f"demod4r_{det}"] = lowpass(highpassed * 2 * qweights)
-                    det_data[f"demod4i_{det}"] = lowpass(highpassed * 2 * uweights)
+                    bandpassed = bandpass4f(signal)
+                    det_data[f"demod4r_{det}"] = lowpass(bandpassed * 2 * qweights)
+                    det_data[f"demod4i_{det}"] = lowpass(bandpassed * 2 * uweights)
                 if self.do_2f:
                     # Start by evaluating the 2f demodulation factors from the
                     # pointing matrix.  We use the half-angle formulas and some
@@ -660,7 +698,7 @@ class Demodulate(Operator):
                         bad = np.hstack([bad, False])
                         sig[bad] *= -1
                     # Demodulate and lowpass for 2f
-                    highpassed = signal - lowpass(signal, downsample=False)
+                    highpassed = bandpass2f(signal)
                     det_data[f"demod2r_{det}"] = lowpass(highpassed * signal_demod2r)
                     det_data[f"demod2i_{det}"] = lowpass(highpassed * signal_demod2i)
 
@@ -699,6 +737,8 @@ class Demodulate(Operator):
         fsample,
         hwp_rate,
         lowpass,
+        bandpass2f,
+        bandpass4f,
     ):
         """Add Noise objects for the new detectors"""
         noise = obs[self.noise_model]

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -147,19 +147,19 @@ class Demodulate(Operator):
         0.95, help="Low pass cut-off frequency in units if HWP frequency"
     )
 
-    fmin2f = Float(
+    fmin_2f = Float(
         1.05, help="Low frequency end of the 2f-bandpass filter in units of HWP frequency"
     )
 
-    fmax2f = Float(
+    fmax_2f = Float(
         2.95, help="High frequency end of the 2f-bandpass filter in units of HWP frequency"
     )
 
-    fmin4f = Float(
+    fmin_4f = Float(
         3.05, help="Low frequency end of the 4f-bandpass filter in units of HWP frequency"
     )
 
-    fmax4f = Float(
+    fmax_4f = Float(
         4.95, help="High frequency end of the 4fbandpass filter in units of HWP frequency"
     )
 

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -58,17 +58,17 @@ class Lowpass:
 class Bandpass:
     """A callable class that applies the bandpass filter"""
 
-    def __init__(self, wkernel, fcenter, fradius, fsample, window="hamming"):
+    def __init__(self, wkernel, fmin, fmax, fsample, window="hamming"):
         """
         Args:
             wkernel (int) : width of the filter kernel
-            fcenter (float) : center frequency of the passband
-            fradius (float) : radius of the passband
+            fmin (float) : minimum frequency of the passband
+            fmax (float) : maximum frequency of the passband
             fsample (float) : signal sampling frequency
         """
         self.bpf = firwin(
             wkernel,
-            [(fcenter - fradius).to_value(u.Hz), (fcenter + fradius).to_value(u.Hz)],
+            [fmin.to_value(u.Hz), fmax.to_value(u.Hz)],
             window=window,
             pass_zero=False,
             fs=fsample.to_value(u.Hz),
@@ -143,8 +143,24 @@ class Demodulate(Operator):
 
     wkernel = Int(None, allow_none=True, help="Override automatic filter kernel size")
 
-    fmax = Quantity(
-        None, allow_none=True, help="Override automatic lowpass cut-off frequency"
+    fcut = Float(
+        0.95, help="Low pass cut-off frequency in units if HWP frequency"
+    )
+
+    fmin2f = Float(
+        1.05, help="Low frequency end of the 2f-bandpass filter in units of HWP frequency"
+    )
+
+    fmax2f = Float(
+        2.95, help="High frequency end of the 2f-bandpass filter in units of HWP frequency"
+    )
+
+    fmin4f = Float(
+        3.05, help="Low frequency end of the 4f-bandpass filter in units of HWP frequency"
+    )
+
+    fmax4f = Float(
+        4.95, help="High frequency end of the 4fbandpass filter in units of HWP frequency"
     )
 
     nskip = Int(3, help="Downsampling factor")
@@ -333,14 +349,19 @@ class Demodulate(Operator):
             nsample = obs.n_local_samples
 
             fsample = obs.telescope.focalplane.sample_rate
+            # fmod is the HWP spin frequency.  Polarization signal is at 4 x fmod
             fmod = self._get_fmod(obs)
 
             wkernel = self._get_wkernel(fmod, fsample)
             lowpass = Lowpass(
-                wkernel, 0.95 * fmod, fsample, offset, self.nskip, self.window
+                wkernel, self.fcut * fmod, fsample, offset, self.nskip, self.window
             )
-            bandpass2f = Bandpass(wkernel, 2 * fmod, 0.95 * fmod, fsample, self.window)
-            bandpass4f = Bandpass(wkernel, 4 * fmod, 0.95 * fmod, fsample, self.window)
+            bandpass2f = Bandpass(
+                wkernel, self.fmin_2f * fmod, self.fmax_2f * fmod, fsample, self.window
+            )
+            bandpass4f = Bandpass(
+                wkernel, self.fmin_4f * fmod, self.fmax_4f * fmod, fsample, self.window
+            )
 
             # Create a new observation to hold the demodulated and downsampled data
 

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -49,10 +49,11 @@ class Lowpass:
         self._offset = offset
         self._nskip = nskip
 
-    def __call__(self, signal):
+    def __call__(self, signal, downsample=True):
         lowpassed = fftconvolve(signal, self.lpf, mode="same").real
-        downsampled = lowpassed[self._offset % self._nskip :: self._nskip]
-        return downsampled
+        if downsample:
+            lowpassed = lowpassed[self._offset % self._nskip :: self._nskip]
+        return lowpassed
 
 
 @trait_docs
@@ -600,8 +601,8 @@ class Demodulate(Operator):
         # FIXME:    measuring the total flag within the filter window
         flags = flags.copy()
         # flag invalid samples in both ends
-        flags[: wkernel // 2] |= self.demod_flag_mask
-        flags[-(wkernel // 2) :] |= self.demod_flag_mask
+        flags[:wkernel] |= self.demod_flag_mask
+        flags[-wkernel:] |= self.demod_flag_mask
         new_flags = np.array(flags[offset % self.nskip :: self.nskip])
         return new_flags
 
@@ -634,8 +635,9 @@ class Demodulate(Operator):
                 if "I" in self.mode:
                     det_data[f"demod0_{det}"] = lowpass(signal)
                 if "QU" in self.mode:
-                    det_data[f"demod4r_{det}"] = lowpass(signal * 2 * qweights)
-                    det_data[f"demod4i_{det}"] = lowpass(signal * 2 * uweights)
+                    highpassed = signal - lowpass(signal, downsample=False)
+                    det_data[f"demod4r_{det}"] = lowpass(highpassed * 2 * qweights)
+                    det_data[f"demod4i_{det}"] = lowpass(highpassed * 2 * uweights)
                 if self.do_2f:
                     # Start by evaluating the 2f demodulation factors from the
                     # pointing matrix.  We use the half-angle formulas and some
@@ -658,8 +660,9 @@ class Demodulate(Operator):
                         bad = np.hstack([bad, False])
                         sig[bad] *= -1
                     # Demodulate and lowpass for 2f
-                    det_data[f"demod2r_{det}"] = lowpass(signal * signal_demod2r)
-                    det_data[f"demod2i_{det}"] = lowpass(signal * signal_demod2i)
+                    highpassed = signal - lowpass(signal, downsample=False)
+                    det_data[f"demod2r_{det}"] = lowpass(highpassed * signal_demod2r)
+                    det_data[f"demod2i_{det}"] = lowpass(highpassed * signal_demod2i)
 
         return
 

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -1258,6 +1258,11 @@ class CovarianceAndHits(Operator):
             rcond_min = data.comm.comm_world.reduce(rcond_min, root=0, op=MPI.MIN)
             rcond_max = data.comm.comm_world.reduce(rcond_max, root=0, op=MPI.MAX)
         if data.comm.world_rank == 0:
+            if rcond_max < 1e-10:
+                log.warning(
+                    f"There are no valid pixels. rcond_max = {rcond_max}. "
+                    "Check detector weights and pixel distribution."
+                )
             msg = f"  Pixel covariance condition number range = "
             msg += f"{rcond_min:1.3e} ... {rcond_max:1.3e}"
             log.debug(msg)

--- a/src/toast/ops/simple_deglitch.py
+++ b/src/toast/ops/simple_deglitch.py
@@ -84,6 +84,11 @@ class SimpleDeglitch(Operator):
         help="Glitch detection threshold in units of RMS",
     )
 
+    nglitch_limit = Int(
+        10,
+        help="Maximum number of glitches in a view",
+    )
+
     nsample_min = Int(
         100,
         help="Minimum number of good samples in an interval.",
@@ -200,7 +205,10 @@ class SimpleDeglitch(Operator):
                             # Not significant enough
                             break
                         nglitch += 1
-                        sig_view = sig_view_test
+                        if nglitch > self.nglitch_limit:
+                            sig_view[:] = np.nan
+                            break
+                        sig_view[:] = sig_view_test
                         rms = rms_test
                     if nglitch == 0:
                         continue

--- a/src/toast/ops/simple_deglitch.py
+++ b/src/toast/ops/simple_deglitch.py
@@ -144,10 +144,42 @@ class SimpleDeglitch(Operator):
         self.rates = []
 
     @function_timer
+    def _get_coupled_detectors(self, det, dets):
+        """See if other detectors should be flagged symmetrically"""
+        coupled = [det]
+        if det.startswith("demod0"):
+            qdet = det.replace("demod0", "demod4r")
+            udet = det.replace("demod0", "demod4i")
+            alt_dets = [qdet, udet]
+        elif det.startswith("demod4r"):
+            idet = det.replace("demod4r", "demod0")
+            udet = det.replace("demod4r", "demod4i")
+            alt_dets = [idet, udet]
+        elif det.startswith("demod4i"):
+            idet = det.replace("demod4i", "demod0")
+            qdet = det.replace("demod4i", "demod4r")
+            alt_dets = [idet, qdet]
+        else:
+            alt_dets = []
+        for alt_det in alt_dets:
+            if alt_det in dets:
+                coupled.append(alt_det)
+        return coupled
+
+    @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
+        timer = Timer()
+        timer.start()
 
+        nobs = 0
+        nbad = 0
+        ndet = 0
+        obstimer = Timer()
+        obstimer.start()
         for ob in data.obs:
+            if ob.comm.comm_group is None or ob.comm.comm_group.rank == 0:
+                nobs += 1
             if not ob.is_distributed_by_detector:
                 msg = "Observation data must be distributed by detector, not samples"
                 log.error(msg)
@@ -156,12 +188,19 @@ class SimpleDeglitch(Operator):
             focalplane = ob.telescope.focalplane
 
             local_dets = ob.select_local_detectors(flagmask=self.det_mask)
+            ndet += len(local_dets)
             shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
+            if self.reset_det_flags:
+                for det in local_dets:
+                    ob.detdata[self.det_flags][det][:] = 0
+            bad_detectors = set()
             for det in local_dets:
+                if det in bad_detectors:
+                    # This detector was coupled to a detector with too many glitches
+                    continue
+                coupled_detectors = self._get_coupled_detectors(det, local_dets)
                 sig = ob.detdata[self.det_data][det]
                 det_flags = ob.detdata[self.det_flags][det]
-                if self.reset_det_flags:
-                    det_flags[:] = 0
                 bad = np.logical_or(
                     shared_flags != 0,
                     (det_flags & self.det_flag_mask) != 0,
@@ -177,13 +216,11 @@ class SimpleDeglitch(Operator):
                         # Special treatment for the ends
                         sig_view[:w] -= np.median(sig_view[:w])
                         sig_view[-w:] -= np.median(sig_view[-w:])
-                    trend = sig[ind] - sig_view
                     sig_view[bad[ind]] = np.nan
                     if np.all(np.isnan(sig_view)):
                         continue
                     offset = np.nanmedian(sig_view)
                     sig_view -= offset
-                    trend += offset
                     rms = np.nanstd(sig_view)
                     nglitch = 0
                     while True:
@@ -213,20 +250,48 @@ class SimpleDeglitch(Operator):
                     if nglitch == 0:
                         continue
                     bad_view = np.isnan(sig_view)
-                    det_flags[ind][bad_view] |= self.glitch_mask
+                    for alt_det in coupled_detectors:
+                        # Raise the same flags in all coupled detectors
+                        alt_flags = ob.detdata[self.det_flags][alt_det]
+                        alt_flags[ind][bad_view] |= self.glitch_mask
 
-                if np.all(det_flags != 0):
+                if np.all((det_flags & self.det_flag_mask) != 0):
                     # This detector is a total loss. Raise the detector flag
-                    ob.local_detector_flags[det] |= defaults.det_mask_invalid
+                    for alt_det in coupled_detectors:
+                        ob.local_detector_flags[alt_det] |= defaults.det_mask_invalid
+                        bad_detectors.add(alt_det)
                 elif self.fill_gaps:
                     # 1 second buffer
                     buffer_ = int(focalplane.sample_rate.to_value(u.Hz))
-                    flagged_noise_fill(
-                        sig,
-                        det_flags,
-                        buffer_,
-                        poly_order=1,
-                    )
+                    for alt_det in coupled_detectors:
+                        flagged_noise_fill(
+                            ob.detdata[self.det_data][alt_det],
+                            ob.detdata[self.det_flags][alt_det],
+                            buffer_,
+                            poly_order=1,
+                        )
+            nbad_obs = len(bad_detectors)
+            ndet_obs = len(local_dets)
+            nbad += nbad_obs
+            if ob.comm.comm_group is not None:
+                nbad_obs = ob.comm.comm_group.reduce(nbad_obs)
+                ndet_obs = ob.comm.comm_group.reduce(ndet_obs)
+            log.debug_rank(
+                f"Flagged {nbad_obs} / {ndet_obs} badly glitched detectors "
+                f"in {ob.name} in",
+                comm=ob.comm.comm_group,
+                timer=obstimer,
+            )
+        if data.comm.comm_world is not None:
+            nobs = data.comm.comm_world.reduce(nobs)
+            nbad = data.comm.comm_world.reduce(nbad)
+            ndet = data.comm.comm_world.reduce(ndet)
+        log.info_rank(
+            f"Flagged {nbad} / {ndet} badly glitched detectors over {nobs} "
+            f"observations in",
+            comm=data.comm.comm_world,
+            timer=timer,
+        )
 
         return
 

--- a/src/toast/ops/simple_statcut.py
+++ b/src/toast/ops/simple_statcut.py
@@ -114,11 +114,6 @@ class SimpleStatCut(Operator):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.net_factors = []
-        self.total_factors = []
-        self.weights_in = []
-        self.weights_out = []
-        self.rates = []
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):

--- a/src/toast/ops/simple_statcut.py
+++ b/src/toast/ops/simple_statcut.py
@@ -124,6 +124,8 @@ class SimpleStatCut(Operator):
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
         comm = data.comm.comm_group
+        timer = Timer()
+        timer.start()
 
         for ob in data.obs:
             if not ob.is_distributed_by_detector:
@@ -136,15 +138,23 @@ class SimpleStatCut(Operator):
 
             all_local_dets = ob.select_local_detectors(flagmask=self.det_mask)
 
-            if all_local_dets[0].startswith("demod"):
+            if len(all_local_dets) > 0 and all_local_dets[0].startswith("demod"):
+                demod = True
+            else:
+                demod = False
+            if comm is not None:
+                demod = comm.allreduce(demod, op=MPI.LOR)
+            if demod:
                 # Demodulated case. Process I/Q/U detectors separately
                 prefixes = ["demod0", "demod4r", "demod4i"]
             else:
+                # Standad processing
                 prefixes = [""]
 
             shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
 
-            nbad = 0
+            cut_obs = set()
+            ndet_obs = len(all_local_dets)
             for prefix in prefixes:
                 local_dets = []
                 for det in all_local_dets:
@@ -159,7 +169,7 @@ class SimpleStatCut(Operator):
                 local_kurtosis = np.zeros(ndet)
                 for idet, det in enumerate(local_dets):
                     sig = ob.detdata[self.det_data][det].copy()
-                    det_flags = ob.detdata[self.det_flags][det] % self.det_flag_mask
+                    det_flags = ob.detdata[self.det_flags][det] & self.det_flag_mask
                     good = np.logical_and(shared_flags == 0, det_flags == 0)
                     nsample = sig.size
                     w = self.medfilt_kernel_size
@@ -186,7 +196,7 @@ class SimpleStatCut(Operator):
                     all_skew = local_skew
                     all_kurtosis = local_kurtosis
 
-                if len(all_dets) == 0:
+                if len(local_dets) == 0:
                     continue
 
                 stat_dict = {}
@@ -215,7 +225,7 @@ class SimpleStatCut(Operator):
                     local_bad = np.abs(local_stat - med) > rms * self.limit
                     for det in local_dets[local_bad]:
                         ob.local_detector_flags[det] |= defaults.det_mask_invalid
-                        nbad += 1
+                        cut_obs.add(det)
                         if prefix != "":
                             # Demodulated case, flag the associated pseudo detectors
                             for alt_prefix in ["demod0", "demod4r", "demod4i"]:
@@ -225,12 +235,17 @@ class SimpleStatCut(Operator):
                                 if alt_det in ob.local_detector_flags:
                                     ob.local_detector_flags[alt_det] \
                                         |= defaults.det_mask_invalid
-                                    nbad += 1
+                                    cut_obs.add(alt_det)
 
+            nbad_obs = len(cut_obs)
             if comm is not None:
-                nbad = comm.reduce(nbad)
-            log.debug(
-                f"Flagged {nbad} additional detectors in {ob.name} due to statistics"
+                ndet_obs = comm.reduce(ndet_obs)
+                nbad_obs = comm.reduce(nbad_obs)
+            log.debug_rank(
+                f"Flagged {nbad_obs} / {ndet_obs} additional detectors in "
+                f"{ob.name} due to statistics in",
+                comm=comm,
+                timer=timer,
             )
 
         return

--- a/src/toast/ops/simple_statcut.py
+++ b/src/toast/ops/simple_statcut.py
@@ -1,0 +1,286 @@
+# Copyright (c) 2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import copy
+from collections import namedtuple
+
+import numpy as np
+import traitlets
+from astropy import units as u
+from scipy.signal import medfilt
+import scipy.stats as ss
+
+from .. import qarray as qa
+from ..intervals import IntervalList
+from ..mpi import MPI
+from ..noise import Noise
+from ..noise_sim import AnalyticNoise
+from ..observation import default_values as defaults
+from ..timing import Timer, function_timer
+from ..traits import Bool, Float, Instance, Int, Quantity, Unicode, trait_docs
+from ..utils import Environment, Logger, flagged_noise_fill, name_UID
+from .operator import Operator
+
+
+@trait_docs
+class SimpleStatCut(Operator):
+    """An operator that flags extreme detector samples."""
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    det_data = Unicode(defaults.det_data, help="Observation detdata key to analyze")
+
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
+    det_flags = Unicode(
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
+    )
+
+    det_flag_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for detector sample flagging",
+    )
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_nonscience,
+        help="Bit mask value for optional shared flagging",
+    )
+
+    view = Unicode(
+        None,
+        allow_none=True,
+        help="Find glitches in this view",
+    )
+
+    medfilt_kernel_size = Int(
+        101,
+        help="Median filter kernel width.  Either 0 (full interval) "
+        "or a positive odd number",
+    )
+
+    limit = Float(
+        3.0,
+        help="Distance from median to be considered pathological",
+    )
+
+    out = Unicode(
+        "stats",
+        help="Observation key for statistics",
+    )
+
+    @traitlets.validate("det_mask")
+    def _check_det_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Det mask should be a positive integer")
+        return check
+
+    @traitlets.validate("shared_flag_mask")
+    def _check_shared_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Shared flag mask should be a positive integer")
+        return check
+
+    @traitlets.validate("det_flag_mask")
+    def _check_det_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Det flag mask should be a positive integer")
+        return check
+
+    @traitlets.validate("medfilt_kernel_size")
+    def _check_medfilt_kernel_size(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("medfilt_kernel_size cannot be negative")
+        if check > 0 and check % 2 == 0:
+            raise traitlets.TraitError("medfilt_kernel_size cannot be even")
+        return check
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.net_factors = []
+        self.total_factors = []
+        self.weights_in = []
+        self.weights_out = []
+        self.rates = []
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        log = Logger.get()
+        comm = data.comm.comm_group
+
+        for ob in data.obs:
+            if not ob.is_distributed_by_detector:
+                msg = "Observation data must be distributed by detector, not samples"
+                log.error(msg)
+                raise RuntimeError(msg)
+
+            views = ob.intervals[self.view]
+            focalplane = ob.telescope.focalplane
+
+            all_local_dets = ob.select_local_detectors(flagmask=self.det_mask)
+
+            if all_local_dets[0].startswith("demod"):
+                # Demodulated case. Process I/Q/U detectors separately
+                prefixes = ["demod0", "demod4r", "demod4i"]
+            else:
+                prefixes = [""]
+
+            shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
+
+            nbad = 0
+            for prefix in prefixes:
+                local_dets = []
+                for det in all_local_dets:
+                    if det.startswith(prefix):
+                        local_dets.append(det)
+                local_dets = np.array(local_dets)
+                ndet = len(local_dets)
+                bad_dets = np.zeros(ndet, dtype=bool)
+
+                local_rms = np.zeros(ndet)
+                local_skew = np.zeros(ndet)
+                local_kurtosis = np.zeros(ndet)
+                for idet, det in enumerate(local_dets):
+                    sig = ob.detdata[self.det_data][det].copy()
+                    det_flags = ob.detdata[self.det_flags][det] % self.det_flag_mask
+                    good = np.logical_and(shared_flags == 0, det_flags == 0)
+                    nsample = sig.size
+                    w = self.medfilt_kernel_size
+                    if w > 0 and nsample > 2 * w:
+                        # Remove the running median
+                        sig[w:-w] -= medfilt(sig, kernel_size=w)[w:-w]
+                        # Special treatment for the ends
+                        sig[:w] -= np.median(sig[:w])
+                        sig[-w:] -= np.median(sig[-w:])
+                    else:
+                        sig -= np.median(sig)
+                    local_rms[idet] = np.std(sig[good])
+                    local_skew[idet] = ss.skew(sig[good])
+                    local_kurtosis[idet] = ss.kurtosis(sig[good])
+
+                if comm is not None:
+                    all_dets = np.hstack(comm.allgather(local_dets))
+                    all_rms = np.hstack(comm.allgather(local_rms))
+                    all_skew = np.hstack(comm.allgather(local_skew))
+                    all_kurtosis = np.hstack(comm.allgather(local_kurtosis))
+                else:
+                    all_dets = local_dets
+                    all_rms = local_rms
+                    all_skew = local_skew
+                    all_kurtosis = local_kurtosis
+
+                if len(all_dets) == 0:
+                    continue
+
+                stat_dict = {}
+                Stats = namedtuple("Stats", ["rms", "skew", "kurtosis"])
+                for det, rms, skew, kurtosis in zip(
+                        all_dets, all_rms, all_skew, all_kurtosis
+                ):
+                    stat_dict[det] = Stats(rms, skew, kurtosis)
+                if self.out not in ob:
+                    ob[self.out] = {}
+                ob["stats"].update(stat_dict)
+
+                good = np.ones(len(all_dets), dtype=bool)
+                for all_stat, local_stat in zip(
+                        [all_rms, all_skew, all_kurtosis],
+                        [local_rms, local_skew, local_kurtosis],
+                ):
+                    while True:
+                        med = np.median(all_stat[good])
+                        rms = np.std(all_stat[good])
+                        bad = np.abs(all_stat - med) > rms * self.limit
+                        if np.any(bad[good]):
+                            good[bad] = False
+                        else:
+                            break
+                    # DEBUG begin
+                    # if prefix == "demod0":
+                    #     det0 = "demod0_sch_ufm_mv18_1712010980_5_296"
+                    #     idet = np.argwhere(all_dets == det0).ravel()
+                    #     sig0 = ob.detdata["signal"][det0].copy()
+                    #     sig1 = sig0.copy()
+                    #     sig1[w:-w] -= medfilt(sig1, kernel_size=w)[w:-w]
+                    #     import pdb
+                    #     import matplotlib.pyplot as plt
+                    #     pdb.set_trace()
+                    # DEBUG end
+                    local_bad = np.abs(local_stat - med) > rms * self.limit
+                    for det in local_dets[local_bad]:
+                        ob.local_detector_flags[det] |= defaults.det_mask_invalid
+                        nbad += 1
+                        if prefix != "":
+                            # Demodulated case, flag the associated pseudo detectors
+                            for alt_prefix in ["demod0", "demod4r", "demod4i"]:
+                                if prefix == alt_prefix:
+                                    continue
+                                alt_det = det.replace(prefix, alt_prefix)
+                                if alt_det in ob.local_detector_flags:
+                                    ob.local_detector_flags[alt_det] \
+                                        |= defaults.det_mask_invalid
+                                    nbad += 1
+
+                    # DEBUG begin
+                    #if det == "sch_ufm_mv18_1712010980_5_296":
+                    # if prefix == "demod0":
+                    #     import pdb
+                    #     import matplotlib.pyplot as plt
+                    #     pdb.set_trace()
+                    # DEBUG end
+
+                # DEBUG begin
+                # import pdb
+                # import matplotlib.pyplot as plt
+                # pdb.set_trace()
+                # DEBUG end
+
+            if comm is not None:
+                nbad = comm.reduce(nbad)
+            log.debug(
+                f"Flagged {nbad} additional detectors in {ob.name} due to statistics"
+            )
+
+        return
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "meta": list(),
+            "shared": list(),
+            "detdata": [self.det_data],
+            "intervals": list(),
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        if self.det_flags is not None:
+            req["detdata"].append(self.det_flags)
+        return req
+
+    def _provides(self):
+        prov = {
+            "meta": list(),
+            "shared": list(),
+            "detdata": list(),
+            "intervals": list(),
+        }
+        return prov

--- a/src/toast/ops/simple_statcut.py
+++ b/src/toast/ops/simple_statcut.py
@@ -212,17 +212,6 @@ class SimpleStatCut(Operator):
                             good[bad] = False
                         else:
                             break
-                    # DEBUG begin
-                    # if prefix == "demod0":
-                    #     det0 = "demod0_sch_ufm_mv18_1712010980_5_296"
-                    #     idet = np.argwhere(all_dets == det0).ravel()
-                    #     sig0 = ob.detdata["signal"][det0].copy()
-                    #     sig1 = sig0.copy()
-                    #     sig1[w:-w] -= medfilt(sig1, kernel_size=w)[w:-w]
-                    #     import pdb
-                    #     import matplotlib.pyplot as plt
-                    #     pdb.set_trace()
-                    # DEBUG end
                     local_bad = np.abs(local_stat - med) > rms * self.limit
                     for det in local_dets[local_bad]:
                         ob.local_detector_flags[det] |= defaults.det_mask_invalid
@@ -237,20 +226,6 @@ class SimpleStatCut(Operator):
                                     ob.local_detector_flags[alt_det] \
                                         |= defaults.det_mask_invalid
                                     nbad += 1
-
-                    # DEBUG begin
-                    #if det == "sch_ufm_mv18_1712010980_5_296":
-                    # if prefix == "demod0":
-                    #     import pdb
-                    #     import matplotlib.pyplot as plt
-                    #     pdb.set_trace()
-                    # DEBUG end
-
-                # DEBUG begin
-                # import pdb
-                # import matplotlib.pyplot as plt
-                # pdb.set_trace()
-                # DEBUG end
 
             if comm is not None:
                 nbad = comm.reduce(nbad)

--- a/src/toast/scripts/toast_obsmatrix_coadd.py
+++ b/src/toast/scripts/toast_obsmatrix_coadd.py
@@ -26,13 +26,16 @@ def main():
     parser.add_argument(
         "inmatrix",
         nargs="+",
-        help="One or more noise-weighted observation matrices",
+        help="One or more noise-weighted observation matrices.  "
+        "Each filename must contain 'noiseweighted'.  "
+        "Multiplicities can be indicated by appending +N to the filename.",
     )
 
     parser.add_argument(
         "--outmatrix",
         required=False,
-        help="Name of output file",
+        help="Name of output file.  If the filename contains 'noiseweighted' in it, "
+        "the output matrix will not be deweighted.",
     )
 
     parser.add_argument(

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ install(FILES
     ops_sim_tod_totalconvolve.py
     ops_flag_sso.py
     ops_statistics.py
+    ops_statcut.py
     ops_mapmaker_utils.py
     ops_mapmaker_binning.py
     ops_mapmaker_solve.py

--- a/src/toast/tests/ops_statcut.py
+++ b/src/toast/tests/ops_statcut.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import h5py
+import numpy as np
+import scipy.stats as stats
+from astropy import units as u
+
+from .. import ops as ops
+from ..observation import default_values as defaults
+from ..vis import set_matplotlib_backend
+from .helpers import close_data, create_outdir, create_satellite_data
+from .mpi import MPITestCase
+
+
+class StatisticsTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+
+    def test_statcut(self):
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(self.comm)
+
+        # This is a simulation with the same focalplane for every obs...
+        sample_rate = data.obs[0].telescope.focalplane.sample_rate
+
+        # Create a noise model from focalplane detector properties
+        noise_model = ops.DefaultNoiseModel()
+        noise_model.apply(data)
+
+        # Simulate noise using this model
+        sim_noise = ops.SimNoise()
+        sim_noise.apply(data)
+
+        # apply StatCut
+        statcut = ops.SimpleStatCut()
+        statcut.apply(data)
+
+        close_data(data)
+
+    def test_statcut_hwp(self):
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(self.comm)
+
+        # This is a simulation with the same focalplane for every obs...
+        sample_rate = data.obs[0].telescope.focalplane.sample_rate
+
+        # Create a noise model from focalplane detector properties
+        noise_model = ops.DefaultNoiseModel()
+        noise_model.apply(data)
+
+        # Simulate noise using this model
+        sim_noise = ops.SimNoise()
+        sim_noise.apply(data)
+
+        # Demodulation requires Stokes weights
+
+        detpointing = ops.PointingDetectorSimple()
+        
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+
+        # Demodulate
+        demod = ops.Demodulate(
+            stokes_weights=weights,
+            in_place=True,
+        )
+        demod.apply(data)
+
+        # apply StatCut
+        statcut = ops.SimpleStatCut()
+        statcut.apply(data)
+
+        close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -78,6 +78,7 @@ from . import ops_sim_tod_noise as test_ops_sim_tod_noise
 from . import ops_sim_tod_totalconvolve as test_ops_sim_tod_totalconvolve
 from . import ops_sss as test_ops_sss
 from . import ops_statistics as test_ops_statistics
+from . import ops_statcut as test_ops_statcut
 from . import ops_stokes_weights as test_ops_stokes_weights
 from . import ops_time_constant as test_ops_time_constant
 from . import ops_yield_cut as test_ops_yield_cut
@@ -211,6 +212,7 @@ def test(name=None, verbosity=2):
 
         suite.addTest(loader.loadTestsFromModule(test_ops_flag_sso))
         suite.addTest(loader.loadTestsFromModule(test_ops_statistics))
+        suite.addTest(loader.loadTestsFromModule(test_ops_statcut))
         suite.addTest(loader.loadTestsFromModule(test_ops_loader))
         suite.addTest(loader.loadTestsFromModule(test_ops_mapmaker_utils))
         suite.addTest(loader.loadTestsFromModule(test_ops_mapmaker_binning))


### PR DESCRIPTION
This PR extends TOAST capabilities to handle SO data.

- `Demodulate` now isolates the 2f and 4f signals with a user-configured bandpass filter
- there is a new operator, `SimpleStatCut`, that measures the median-filtered skew and kurtosis and uses them to reject outlier detectors
- `CalibrateDetectors` can retrieve the gains from the focalplane database
- 'SimpleDeglitch' works on demodulated data and will flag all affected streams