### PR TITLE
Implement ops.Detrend

### DIFF
--- a/src/toast/ops/__init__.py
+++ b/src/toast/ops/__init__.py
@@ -15,6 +15,7 @@ from .crosslinking import CrossLinking
 from .delete import Delete
 from .demodulation import Demodulate, StokesWeightsDemod
 from .demod_common_mode import DemodCommonModeFilter
+from .detrend import Detrend
 from .elevation_noise import ElevationNoise
 from .fill_gaps import FillGaps
 from .filterbin import FilterBin, combine_observation_matrix

--- a/src/toast/ops/detrend.py
+++ b/src/toast/ops/detrend.py
@@ -1,0 +1,200 @@
+# Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+import os
+
+import numpy as np
+import traitlets
+
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Int, Unicode, trait_docs
+from ..utils import Logger
+from .operator import Operator
+
+@trait_docs
+class Detrend(Operator):
+    """Remove mean/median/slope of detector data.
+
+    method='mean'   will subtract mean of each detector data.
+
+    method='median' will subtract median of each detector data.
+
+    method='linear' will subtract mean and slope of each detector data,
+    matching `match_nsample` samples at the beginning and end of detector data.
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    det_data = Unicode(
+        defaults.det_data,
+        help="Observation detdata key apply detrend to",
+    )
+
+    det_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask value for per-detector flagging",
+    )
+
+    shared_flags = Unicode(
+        defaults.shared_flags,
+        allow_none=True,
+        help="Observation shared key for telescope flags to use",
+    )
+
+    shared_flag_mask = Int(
+        defaults.shared_mask_invalid,
+        help="Bit mask value for optional shared flagging",
+    )
+
+    det_flags = Unicode(
+        defaults.det_flags,
+        allow_none=True,
+        help="Observation detdata key for flags to use",
+    )
+
+    det_flag_mask = Int(
+        defaults.det_mask_nonscience,
+        help="Bit mask value for detector sample flagging",
+    )
+
+    detrend_flag_mask = Int(
+        defaults.det_mask_invalid,
+        help="Bit mask to use when det_data cannot be detrended.",
+    )
+
+    method = Unicode(
+        "linear",
+        help="Method to detrend. Valid methods are 'linear', 'mean', 'median'",
+    )
+
+    edge_nsample = Int(
+        100,
+        help="When using 'linear' method, number of samples to calculate mean level at the edge",
+    )
+
+    edge_nsample_method = Unicode(
+        'mean',
+        help="When using 'linear' method, method to calculate mean level at the edge. "
+        "Valid methods are 'mean' and 'median'",
+    )
+
+    @traitlets.validate("shared_flag_mask")
+    def _check_shared_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Shared flag mask should be a positive integer")
+        return check
+
+    @traitlets.validate("det_flag_mask")
+    def _check_det_flag_mask(self, proposal):
+        check = proposal["value"]
+        if check < 0:
+            raise traitlets.TraitError("Det flag mask should be a positive integer")
+        return check
+
+    @traitlets.validate("method")
+    def _check_method(self, proposal):
+        check = proposal["value"]
+        allowed = ["mean", "linear", "median"]
+        if check not in allowed:
+            msg = f"method must be one of {allowed}, not {check}"
+            raise traitlets.TraitError(msg)
+        return check
+
+    @traitlets.validate("edge_nsample")
+    def _check_edge_nsample(self, proposal):
+        check = proposal["value"]
+        if check < 1:
+            raise traitlets.TraitError("edge_nsample should be an integer >= 1")
+        return check
+
+    @traitlets.validate("edge_nsample_method")
+    def _check_edge_nsample(self, proposal):
+        check = proposal["value"]
+        allowed = ["mean", "median"]
+        if check not in allowed:
+            msg = f"method must be one of {allowed}, not {check}"
+            raise traitlets.TraitError(msg)
+        return check
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, **kwargs):
+        log = Logger.get()
+
+        for ob in data.obs:
+            local_dets = ob.select_local_detectors(selection=detectors, flagmask=self.det_mask)
+            shared_flags = ob.shared[self.shared_flags].data & self.shared_flag_mask
+            if len(local_dets) == 0:
+                # Nothing to do for this observation
+                continue
+            for det in local_dets:
+                sig = ob.detdata[self.det_data][det]
+                det_flags = ob.detdata[self.det_flags][det]
+                good_samples_flag = np.logical_and(
+                    shared_flags == 0,
+                    (det_flags & self.det_flag_mask) == 0,
+                )
+                good_samples_i = np.flatnonzero(good_samples_flag)
+                if self.method == "mean":
+                    sig -= np.mean(sig[good_samples_flag])
+                elif self.method == "median":
+                    sig -= np.median(sig[good_samples_flag])
+                elif self.method == "linear":
+                    start_match_slc = slice(
+                            good_samples_i[0],
+                            good_samples_i[0]+self.edge_nsample,
+                            1)
+                    end_match_slc = slice(
+                            good_samples_i[-1]+1-self.edge_nsample,
+                            good_samples_i[-1]+1,
+                            1)
+                    if start_match_slc.stop >= end_match_slc.start:
+                        ob.local_detector_flags[det] |= self.detrend_flag_mask
+                        log.info_rank(f"Not enough good samples, flagged observation {ob.name}")
+                        continue
+                    if self.edge_nsample_method == 'mean':
+                        start_level = np.mean(
+                                sig[start_match_slc][good_samples_flag[start_match_slc]]
+                                )
+                        end_level = np.mean(
+                                sig[end_match_slc][good_samples_flag[end_match_slc]]
+                                )
+                    elif self.edge_nsample_method == 'median':
+                        start_level = np.median(
+                                sig[start_match_slc][good_samples_flag[start_match_slc]]
+                                )
+                        end_level = np.median(
+                                sig[end_match_slc][good_samples_flag[end_match_slc]]
+                                )
+                    slope = (end_level - start_level)/(good_samples_i[-1] - good_samples_i[0] + 1.0 - self.edge_nsample)
+                    # Remove slope, the slope at the middle point of edge_nsample shoule be zero
+                    sig -= (np.arange(sig.size) - good_samples_i[0] - (self.edge_nsample-1.0)/2.0) * slope
+                    # This assertion should be True if all the black magic indices counting above are correct
+                    #assert np.mean(sig[start_match_slc][good_samples_flag[start_match_slc]]) == start_level
+                    sig -= start_level
+                else:
+                    raise RuntimeError(f"Unknow method={self.method}.")
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = {
+            "meta": list(),
+            "shared": list(),
+            "detdata": [self.det_data],
+        }
+        if self.shared_flags is not None:
+            req["shared"].append(self.shared_flags)
+        if self.det_flags is not None:
+            req["detdata"].append(self.det_flags)
+        return req
+
+    def _provides(self):
+        return dict()

--- a/src/toast/tests/CMakeLists.txt
+++ b/src/toast/tests/CMakeLists.txt
@@ -75,6 +75,7 @@ install(FILES
     ops_sss.py
     ops_demodulate.py
     ops_demod_common_mode.py
+    ops_detrend.py
     ops_perturbhwp.py
     ops_filterbin.py
     io_hdf5.py

--- a/src/toast/tests/ops_detrend.py
+++ b/src/toast/tests/ops_detrend.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+
+from .. import ops as ops
+from ..observation import default_values as defaults
+from .helpers import close_data, create_ground_data, create_outdir
+from .mpi import MPITestCase
+
+
+class DetrendTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+
+    def _test_detrend(self, method):
+
+        data = create_ground_data(self.comm)
+
+        # Flag some samples
+        for ob in data.obs:
+            nsample = ob.shared[defaults.times].data.shape[0]
+            for i, det in enumerate(ob.local_detectors):
+                detflags = ob.detdata[defaults.det_flags][det]
+                detflags[:] = 0
+                # Flag some samples at the edge
+                edge_nsample = i
+                if i > 0:
+                    detflags[:edge_nsample] = defaults.det_mask_invalid
+                    detflags[-edge_nsample:] = defaults.det_mask_invalid
+                # Flag some samples at the middle
+                for j in range(
+                        edge_nsample+len(ob.local_detectors)+100,
+                        nsample-len(ob.local_detectors)-edge_nsample-100,
+                        200):
+                    detflags[j+j%10:j+10*(j%10)] = defaults.det_mask_invalid
+                # Flag a large chunk of data
+                if nsample//4 > edge_nsample+len(ob.local_detectors)+100:
+                    detflags[nsample//4:nsample//2] = defaults.det_mask_invalid
+
+        if method == 'linear':
+            nsample0 = max(*[ob.shared[defaults.times].data.shape[0] for ob in data.obs])
+            # Test edge samples cases:
+            # - 1 edge samples
+            # - odd/even edge samples
+            # - edge samples is half of total samples
+            # - edge samples is total samples
+            # - edge samples is larger than total samples
+            for edge_nsample in [1,2,3,4,5, nsample0//2, nsample0, nsample0+100]:
+                abnormal_number = edge_nsample%10 * (-1)**(edge_nsample%2) * 1e5
+                for ob in data.obs:
+                    nsample = ob.shared[defaults.times].data.shape[0]
+                    for i, det in enumerate(ob.local_detectors):
+                        detflags = ob.detdata[defaults.det_flags][det]
+                        detdata = ob.detdata[defaults.det_data][det]
+                        detdata[:] = (-1)**(i//2) * np.arange(float(nsample))
+                        # For all flagged samples add some value to detect if they are ignored
+                        detdata[detflags != 0] += abnormal_number
+
+                linear_detrend = ops.Detrend(
+                        method='linear',
+                        edge_nsample=edge_nsample,
+                        edge_nsample_method=['mean', 'median'][edge_nsample%2],
+                        )
+                linear_detrend.apply(data)
+
+                for ob in data.obs:
+                    nsample = ob.shared[defaults.times].data.shape[0]
+                    if edge_nsample in [nsample0//2, nsample0, nsample0+100]:
+                        assert len(ob.select_local_detectors(flagmask=defaults.det_mask_invalid)) == 0
+                    for i, det in enumerate(ob.select_local_detectors(flagmask=defaults.det_mask_invalid)):
+                        detdata = ob.detdata[defaults.det_data][det]
+                        detflags = ob.detdata[defaults.det_flags][det]
+                        detdata[detflags != 0] -= abnormal_number
+                        if edge_nsample < nsample0//2:
+                            assert np.all(detdata == 0.0)
+                        else:
+                            assert np.allclose(np.abs(detdata), np.arange(float(nsample)))
+
+        else:
+            for ob in data.obs:
+                nsample = ob.shared[defaults.times].data.shape[0]
+                for i, det in enumerate(ob.local_detectors):
+                    detflags = ob.detdata[defaults.det_flags][det]
+                    detdata = ob.detdata[defaults.det_data][det]
+                    detdata[:] = (-1)**(i//2) * np.arange(float(nsample))
+                    # multiply number of unflagged samples reduce rounding error when calculating mean
+                    detdata *= np.sum(detflags == 0)
+                    # For all flagged samples add some value to detect if they are ignored
+                    detdata[detflags != 0] += 1e10
+
+            detrend = ops.Detrend(method=method)
+            detrend.apply(data)
+
+            for ob in data.obs:
+                for i, det in enumerate(ob.select_local_detectors(flagmask=defaults.det_mask_invalid)):
+                    detdata = ob.detdata[defaults.det_data][det]
+                    detflags = ob.detdata[defaults.det_flags][det]
+                    if method == 'mean':
+                        assert np.mean(detdata[detflags==0]) == 0.0
+                    elif method == 'median':
+                        assert np.median(detdata[detflags==0]) == 0.0
+                    else:
+                        raise RuntimeError(f"Unknown method={method}")
+
+        close_data(data)
+
+    def test_detrend_median(self):
+        self._test_detrend(method='median')
+
+    def test_detrend_mean(self):
+        self._test_detrend(method='mean')
+
+    def test_detrend_linear(self):
+        self._test_detrend(method='linear')
+

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -34,6 +34,7 @@ from . import ops_common_mode_noise as test_ops_common_mode_noise
 from . import ops_crosslinking as test_ops_crosslinking
 from . import ops_demodulate as test_ops_demodulate
 from . import ops_demod_common_mode as test_ops_demod_common_mode
+from . import ops_detrend as test_ops_detrend
 from . import ops_elevation_noise as test_ops_elevation_noise
 from . import ops_example_ground as test_ops_example_ground
 from . import ops_fill_gaps as test_ops_fill_gaps
@@ -244,6 +245,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_ops_stokes_weights))
         suite.addTest(loader.loadTestsFromModule(test_ops_demodulate))
         suite.addTest(loader.loadTestsFromModule(test_ops_demod_common_mode))
+        suite.addTest(loader.loadTestsFromModule(test_ops_detrend))
         suite.addTest(loader.loadTestsFromModule(test_ops_perturbhwp))
         suite.addTest(loader.loadTestsFromModule(test_ops_filterbin))
         suite.addTest(loader.loadTestsFromModule(test_ops_noise_estim))


### PR DESCRIPTION
Simple detrend operator, removing mean/median/slope

Based on `sotodlib.tod_ops.detrend_tod` and `pixell.utils.deslope`. But ignoring flagged samples when calculate mean, median, slope.