### PR TITLE
Fix a typo that has been causing excessive memory use

### DIFF
--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -674,7 +674,7 @@ class Demodulate(Operator):
         for det in dets:
             # Get weights
             obs_data = data.select(obs_uid=obs.uid)
-            self.stokes_weights.apply(obs_data, dets=[det])
+            self.stokes_weights.apply(obs_data, detectors=[det])
             weights = obs.detdata[self.stokes_weights.weights][det]
             # iweights = 1
             # qweights = eta * cos(2 * psi_det + 4 * psi_hwp)


### PR DESCRIPTION
The function kwarg to apply an operator to a subset of detectors is `detectors=`.  Unknown arguments are intentionally passed on to derived operators so that they can handle those as needed.  So this argument was simply ignored by the `apply()` method, causing the generation of the stokes weights and detector quaternions for all detectors in memory.