### PR TITLE
Clarify per-map noise weights in coaddition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           source ~/conda/etc/profile.d/conda.sh \
             && conda activate base \
             && ./platforms/conda_dev_setup.sh toast ${{ matrix.python }} yes \
-            && python3 -m pip install spt3g
+            && python3 -m pip install 'spt3g==1.0.0'
 
       - name: Install
         run: |

--- a/src/toast/scripts/toast_healpix_coadd.py
+++ b/src/toast/scripts/toast_healpix_coadd.py
@@ -286,12 +286,13 @@ def main(opts=None, comm=None):
                 inmap *= args.scale
             invcov /= args.scale**2
 
-        # Apply per-map weights
+        # Apply per-map weights.  The weights loaded from the file
+        # are assumed to be inverse noise weights for each map.
         if noiseweighted:
-            inmap /= weights[infile_map]
-        else:
             inmap *= weights[infile_map]
-        invcov /= weights[infile_map] ** 2
+        else:
+            inmap /= weights[infile_map]
+        invcov *= weights[infile_map]
 
         if not noiseweighted:
             # Must reverse the multiplication with the

--- a/src/toast/scripts/toast_healpix_coadd.py
+++ b/src/toast/scripts/toast_healpix_coadd.py
@@ -286,14 +286,6 @@ def main(opts=None, comm=None):
                 inmap *= args.scale
             invcov /= args.scale**2
 
-        # Apply per-map weights.  The weights loaded from the file
-        # are assumed to be inverse noise weights for each map.
-        if noiseweighted:
-            inmap *= weights[infile_map]
-        else:
-            inmap /= weights[infile_map]
-        invcov *= weights[infile_map]
-
         if not noiseweighted:
             # Must reverse the multiplication with the
             # white noise covariance matrix
@@ -304,6 +296,11 @@ def main(opts=None, comm=None):
             inmap = inmap.reshape(ngood, -1).T.copy()
             invcov = invcov.reshape(ngood, -1).T.copy()
             log.info_rank(f"{prefix}Applied inverse matrix in", timer=timer1, comm=None)
+
+        # Apply per-map weights.  The weights loaded from the file
+        # are assumed to be inverse noise weights for each map.
+        inmap *= weights[infile_map]
+        invcov *= weights[infile_map]
 
         if noiseweighted_sum is None:
             noiseweighted_sum = np.zeros([nnz, npix], dtype=float)


### PR DESCRIPTION
When specifying weights in a file with the list of maps, these weights are inverse noise weights, and each one is applied directly to the corresponding noise weighted map and the inverse covariance.