### PR TITLE
sim_tod_atm_observe.py: Avoid repeatly access det_flags and det_data

### DIFF
--- a/src/toast/ops/sim_tod_atm_observe.py
+++ b/src/toast/ops/sim_tod_atm_observe.py
@@ -200,6 +200,12 @@ class ObserveAtmosphere(Operator):
 
             # Loop over views
             views = ob.view[self.view]
+            # Avoid repeatly access det_flags and det_data in loops.
+            det_flags = views.detdata[self.det_flags]
+            det_data = views.detdata[self.det_data]
+            det_quats_azel = views.detdata[self.quats_azel]
+            if self.weights is not None:
+                det_weights = views.detdata[self.weights]
 
             ngood_tot = 0
             nbad_tot = 0
@@ -234,7 +240,7 @@ class ObserveAtmosphere(Operator):
                     flags = None
                     if self.det_flags is not None:
                         flags = (
-                            np.array(views.detdata[self.det_flags][vw][det])
+                            np.array(det_flags[vw][det])
                             & self.det_flag_mask
                         )
                         if sh_flags is not None:
@@ -243,7 +249,7 @@ class ObserveAtmosphere(Operator):
                         flags = sh_flags
 
                     good = slice(None, None, None)
-                    ngood = len(views.detdata[self.det_data][vw][det])
+                    ngood = len(det_data[vw][det])
                     if flags is not None:
                         good = flags == 0
                         ngood = np.sum(good)
@@ -253,7 +259,7 @@ class ObserveAtmosphere(Operator):
                     ngood_tot += ngood
 
                     # Detector Az / El quaternions for good samples
-                    azel_quat = views.detdata[self.quats_azel][vw][det][good]
+                    azel_quat = det_quats_azel[vw][det][good]
 
                     # Convert Az/El quaternion of the detector back into
                     # angles from the simulation.
@@ -264,7 +270,7 @@ class ObserveAtmosphere(Operator):
                         weights_I = 1
                         weights_Q = 0
                     else:
-                        weights = views.detdata[self.weights][vw][det][good]
+                        weights = det_weights[vw][det][good]
                         if "I" in self.weights_mode:
                             ind = self.weights_mode.index("I")
                             weights_I = weights[:, ind].copy()
@@ -387,7 +393,7 @@ class ObserveAtmosphere(Operator):
                                         "Cannot flag samples"
                                     )
                                 else:
-                                    views.detdata[self.det_flags][vw][det][good][
+                                    det_flags[vw][det][good][
                                         bad
                                     ] |= self.det_flag_mask
                                     nbad_tot += nbad
@@ -474,7 +480,7 @@ class ObserveAtmosphere(Operator):
                         )
 
                     # Add contribution to output
-                    views.detdata[self.det_data][vw][det, good] += scale * atmdata
+                    det_data[vw][det, good] += scale * atmdata
                     gt.stop("ObserveAtmosphere:  detector accumulate")
 
                     # Dump timestream snapshot


### PR DESCRIPTION
This seemly trivial change actually has a large performance improvement for observations that have more detectors and atm slabs.

#### Test setup
```bash
#!/bin/bash

schedule="schedule.txt"

export TOAST_LOGLEVEL='DEBUG'
export OMP_NUM_THREADS=16
export OMP_PLACES=cores
export OMP_PROC_BIND=spread

toast_so_sim \
        --job_group_size 1 \
        --sim_ground.use_qpoint \
        --sim_ground.no_use_ephem \
        --schedule schedule.txt \
        --thinfp 2 \
        --band 'LAT_f090' \
        --wafer_slots 'w18' \
        --sample_rate 100 \
        --sim_noise.enable \
        --sim_atmosphere.enable \
            --sim_atmosphere.cache_dir "atm" \
        --common_mode_noise.disable \
        --sim_sss.disable \
        --mapmaker.disable \
        --out "log"
```
with single schedule in `schedule.txt`
```
#Site           Telescope        Latitude [deg] Longitude [deg]   Elevation [m]
ATACAMA         LAT                     -22.958         -67.786          5200.0
#     Start time UTC        Stop time UTC Rotation Patch name                            Az min   Az max       El  Pass Sub
2026-08-01 14:43 | 2026-08-01 15:43 | 180.0 | SETTING_SCAN_50 | 210.0 | 330.0 | 50.0 | 46 | 2
```

#### Baseline results using 6658e3f5265daa3d43afc527cea09645002f85f2
It takes 270s to observe the atmosphere
```
TOAST DEBUG: 0 : SETTING_SCAN_50-46-2 : SimAtmosphere: Loaded atmosphere 0.00 s
TOAST DEBUG: 0 : SETTING_SCAN_50-46-2_w18 : Simulate and observe atmosphere:  277.34444635 seconds
```
and `timing.csv`
```
Timer,Processes,Minimum Calls,Maximum Calls,Minimum Time,Maximum Time,Mean Time,Median Time
ObserveAtmosphere:  detector AtmSim.observe,1,19260,19260,9.603323133999984,9.603323133999984,9.603323133999984,9.603323133999984
ObserveAtmosphere:  detector accumulate,1,19260,19260,87.07112114200028,87.07112114200028,87.07112114200028,87.07112114200028
ObserveAtmosphere:  detector setup,1,19260,19260,179.32976912100057,179.32976912100057,179.32976912100057,179.32976912100057
ObserveAtmosphere:  per-observation setup,1,428,428,0.10389771100000002,0.10389771100000002,0.10389771100000002,0.10389771100000002
ObserveAtmosphere:  total,1,428,428,276.9455577930001,276.9455577930001,276.9455577930001,276.9455577930001
toast_so_sim (total),1,1,1,290.833025102,290.833025102,290.833025102,290.833025102
```
So it takes 80s in `detector accumulate` and 180s in `detector setup`

#### Profiling
Adding some timers
```diff
@@ -200,6 +200,9 @@ class ObserveAtmosphere(Operator):
 
             # Loop over views
             views = ob.view[self.view]
+            # Avoid repeatly access det_flags and det_data in loops.
+            det_flags = views.detdata[self.det_flags]
+            det_data = views.detdata[self.det_data]
 
             ngood_tot = 0
             nbad_tot = 0
@@ -230,6 +233,36 @@ class ObserveAtmosphere(Operator):
                 sim_list = data[self.sim][session_name][cur_wind]
 
                 for det in dets:
+                    gt.start("ObserveAtmosphere:  views.detdata")
+                    _a = views.detdata
+                    gt.stop("ObserveAtmosphere:  views.detdata")
+
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_flags]")
+                    _b = _a[self.det_flags]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_flags]")
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_flags][vw]")
+                    _c = _b[vw]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_flags][vw]")
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_flags][vw][det]")
+                    _d = _c[det]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_flags][vw][det]")
+                    gt.start("ObserveAtmosphere:  det_flags[vw][det]")
+                    _e = det_flags[vw][det]
+                    gt.stop("ObserveAtmosphere:  det_flags[vw][det]")
+
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_data]")
+                    _b = _a[self.det_data]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_data]")
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_data][vw]")
+                    _c = _b[vw]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_data][vw]")
+                    gt.start("ObserveAtmosphere:  views.detdata[self.det_data][vw][det]")
+                    _d = _c[det]
+                    gt.stop("ObserveAtmosphere:  views.detdata[self.det_data][vw][det]")
+                    gt.start("ObserveAtmosphere:  det_data[vw][det]")
+                    _e = det_data[vw][det]
+                    gt.stop("ObserveAtmosphere:  det_data[vw][det]")
+
                     gt.start("ObserveAtmosphere:  detector setup")
                     flags = None
                     if self.det_flags is not None:
```
We get
```
Timer,Processes,Minimum Calls,Maximum Calls,Minimum Time,Maximum Time,Mean Time,Median Time
ObserveAtmosphere:  det_data[vw][det],1,19260,19260,0.021680832999999487,0.021680832999999487,0.021680832999999487,0.021680832999999487
ObserveAtmosphere:  det_flags[vw][det],1,19260,19260,0.023027569999999675,0.023027569999999675,0.023027569999999675,0.023027569999999675
ObserveAtmosphere:  detector AtmSim.observe,1,19260,19260,9.793126393999987,9.793126393999987,9.793126393999987,9.793126393999987
ObserveAtmosphere:  detector accumulate,1,19260,19260,86.76825504900002,86.76825504900002,86.76825504900002,86.76825504900002
ObserveAtmosphere:  detector setup,1,19260,19260,179.9651198199999,179.9651198199999,179.9651198199999,179.9651198199999
ObserveAtmosphere:  per-observation setup,1,428,428,3.644027991,3.644027991,3.644027991,3.644027991
ObserveAtmosphere:  total,1,428,428,449.169926974,449.169926974,449.169926974,449.169926974
ObserveAtmosphere:  views.detdata,1,19260,19260,0.005124857000000371,0.005124857000000371,0.005124857000000371,0.005124857000000371
ObserveAtmosphere:  views.detdata[self.det_data],1,19260,19260,84.66491736699999,84.66491736699999,84.66491736699999,84.66491736699999
ObserveAtmosphere:  views.detdata[self.det_data][vw],1,19260,19260,0.12162259800000161,0.12162259800000161,0.12162259800000161,0.12162259800000161
ObserveAtmosphere:  views.detdata[self.det_data][vw][det],1,19260,19260,0.037072933000000065,0.037072933000000065,0.037072933000000065,0.037072933000000065
ObserveAtmosphere:  views.detdata[self.det_flags],1,19260,19260,83.08136147699962,83.08136147699962,83.08136147699962,83.08136147699962
ObserveAtmosphere:  views.detdata[self.det_flags][vw],1,19260,19260,0.1168412950000013,0.1168412950000013,0.1168412950000013,0.1168412950000013
ObserveAtmosphere:  views.detdata[self.det_flags][vw][det],1,19260,19260,0.04413828099999949,0.04413828099999949,0.04413828099999949,0.04413828099999949
toast_so_sim (total),1,1,1,463.597922349,463.597922349,463.597922349,463.597922349
```
So simply access `views.detdata[self.det_flags]` and `views.detdata[self.det_data]` cost 80s each, accumulating all loops. That's alot! It spends much more time access these objects than doing `qa.to_iso_angles` or line of sight integral. And storing the view outside the loops does reduce access time a lot.

#### Improved results
Now it takes 22s to observe the atmosphere
```
TOAST DEBUG: 0 : SETTING_SCAN_50-46-2 : SimAtmosphere: Loaded atmosphere 0.00 s
TOAST DEBUG: 0 : SETTING_SCAN_50-46-2_w18 : Simulate and observe atmosphere:  21.987692749 seconds
```
and only spend 6s on `detector setup` and 2s on `detector accumulate`
```
Timer,Processes,Minimum Calls,Maximum Calls,Minimum Time,Maximum Time,Mean Time,Median Time
ObserveAtmosphere:  detector AtmSim.observe,1,19260,19260,9.259320321000061,9.259320321000061,9.259320321000061,9.259320321000061
ObserveAtmosphere:  detector accumulate,1,19260,19260,1.7318890799999893,1.7318890799999893,1.7318890799999893,1.7318890799999893
ObserveAtmosphere:  detector setup,1,19260,19260,5.892024163999998,5.892024163999998,5.892024163999998,5.892024163999998
ObserveAtmosphere:  per-observation setup,1,428,428,3.677438364000001,3.677438364000001,3.677438364000001,3.677438364000001
ObserveAtmosphere:  total,1,428,428,21.295407181000016,21.295407181000016,21.295407181000016,21.295407181000016
toast_so_sim (total),1,1,1,35.687428893,35.687428893,35.687428893,35.687428893
```