### PR TITLE
Fix focalplane loading in workflows

### DIFF
--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -985,7 +985,13 @@ class Focalplane(object):
 
     @classmethod
     def _load_hdf5(
-        cls, handle, comm=None, detectors=None, file_det_sets=None, **kwargs
+            cls,
+            handle,
+            comm=None,
+            detectors=None,
+            file_det_sets=None,
+            sample_rate=None,
+            **kwargs,
     ):
         """Load a base class Focalplane"""
         log = Logger.get()
@@ -995,11 +1001,11 @@ class Focalplane(object):
         need_bcast = hdf5_use_serial(handle, comm) and comm is not None
 
         detector_data = None
-        sample_rate = None
         field_of_view = None
         if handle is not None:
             detector_data = read_table_hdf5(handle, path="focalplane")
-            sample_rate = detector_data.meta["sample_rate"]
+            if sample_rate is None:
+                sample_rate = detector_data.meta["sample_rate"]
             field_of_view = detector_data.meta["field_of_view"]
 
         if need_bcast:

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -829,7 +829,7 @@ class Calibrate(Operator):
 
     mc_index = Int(None, allow_none=True, help="The Monte-Carlo index")
 
-    mc_root = Unicode(None, allow_node=True, help="Root name for Monte Carlo products")
+    mc_root = Unicode(None, allow_none=True, help="Root name for Monte Carlo products")
 
     reset_pix_dist = Bool(
         False,

--- a/workflows/toast_sim_ground.py
+++ b/workflows/toast_sim_ground.py
@@ -182,12 +182,10 @@ def load_instrument_and_schedule(args, comm):
         if comm is not None:
             focalplane = comm.bcast(focalplane, root=0)
     else:
-        focalplane = toast.instrument.Focalplane(
-            sample_rate=sample_rate,
-            thinfp=args.thinfp,
-        )
         with toast.io.H5File(args.focalplane, "r", comm=comm, force_serial=True) as f:
-            focalplane.load_hdf5(f.handle, comm=comm)
+            focalplane = toast.instrument.Focalplane.load_hdf5(
+                f.handle, comm=comm, sample_rate=sample_rate, thinfp=args.thinfp
+            )
         log.info_rank(f"Saving focalplane to {fname_pickle}", comm=comm)
         if comm is None or comm.rank == 0:
             with open(fname_pickle, "wb") as handle:

--- a/workflows/toast_sim_ground_simple.py
+++ b/workflows/toast_sim_ground_simple.py
@@ -70,9 +70,10 @@ def main():
             os.makedirs(out_dir)
 
     # Load a generic focalplane file.
-    focalplane = toast.instrument.Focalplane(thinfp=args.thinfp)
     with toast.io.H5File(args.focalplane, "r", comm=comm, force_serial=True) as f:
-        focalplane.load_hdf5(f.handle, comm=comm)
+        focalplane = toast.instrument.Focalplane.load_hdf5(
+            f.handle, comm=comm, thinfp=args.thinfp
+        )
 
     # Load the schedule file
     schedule = toast.schedule.GroundSchedule()

--- a/workflows/toast_sim_satellite.py
+++ b/workflows/toast_sim_satellite.py
@@ -114,13 +114,11 @@ def load_instrument_and_schedule(args, comm):
         sample_rate = args.sample_rate * u.Hz
     else:
         sample_rate = None
-    focalplane = toast.instrument.Focalplane(
-        sample_rate=sample_rate,
-        thinfp=args.thinfp,
-    )
 
     with toast.io.H5File(args.focalplane, "r", comm=comm, force_serial=True) as f:
-        focalplane.load_hdf5(f.handle, comm=comm)
+        focalplane = toast.instrument.Focalplane.load_hdf5(
+            f.handle, comm=comm, sample_rate=sample_rate, thinfp=args.thinfp
+        )
     log.info_rank("Loaded focalplane in", comm=comm, timer=timer)
     log.info_rank(f"Focalplane: {str(focalplane)}", comm=comm)
     mem = toast.utils.memreport(msg="(whole node)", comm=comm, silent=True)


### PR DESCRIPTION
`Focalplane.load_hdf5()` recently began returning new instances instead of updating in place. This PR upgrades the three TOAST example workflows to use the new API. It also adds support for `thinfp` and `sample_rate` in the load method.