### PR TITLE
Fix issues loading version-1 HDF5 files

### DIFF
--- a/etc/hdf5_formats/save_load.py
+++ b/etc/hdf5_formats/save_load.py
@@ -4,7 +4,7 @@
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-"""Test saving and loading different HDF5 formats"""
+"""Test saving and loading HDF5 formats"""
 
 import argparse
 

--- a/etc/hdf5_formats/save_load.py
+++ b/etc/hdf5_formats/save_load.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2025-2025 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+"""Test saving and loading different HDF5 formats"""
+
+import argparse
+
+import numpy as np
+from astropy import units as u
+
+import toast
+import toast.ops
+from toast.utils import Logger
+
+from toast.tests.helpers import create_ground_data
+
+
+def main(opts=None):
+    log = Logger.get()
+
+    parser = argparse.ArgumentParser(description="Save or Load HDF5 Volumes.")
+
+    parser.add_argument(
+        "--out_volume",
+        required=False,
+        default=None,
+        help="Output volume",
+    )
+
+    parser.add_argument(
+        "--in_volume",
+        required=False,
+        default=None,
+        help="Output volume",
+    )
+
+    parser.add_argument(
+        "--no_meta",
+        required=False,
+        default=False,
+        action="store_true",
+        help="If True, disable metadata generation",
+    )
+
+    args = parser.parse_args(args=opts)
+
+    if args.in_volume is None and args.out_volume is None:
+        log.error("Nothing to do!")
+        return
+
+    world, procs, rank = toast.mpi.get_world()
+
+    # Create data, either for writing or for comparison.
+
+    ppp = 2
+    freq_list = [(100 + 10 * x) * u.GHz for x in range(3)]
+    data = create_ground_data(
+        world,
+        freqs=freq_list,
+        pixel_per_process=ppp,
+        split=True,
+    )
+
+    # Add extra metadata attribute
+    if not args.no_meta:
+        from toast.tests.io_hdf5 import ExtraMeta, create_other_meta
+
+        for ob in data.obs:
+            ob.extra = ExtraMeta()
+        other = create_other_meta()
+        ob.update(other)
+
+    # Replace the simulated weather with the base class for testing
+    for ob in data.obs:
+        old_weather = ob.telescope.site.weather
+        new_weather = toast.weather.Weather(
+            time=old_weather.time,
+            ice_water=old_weather.ice_water,
+            liquid_water=old_weather.liquid_water,
+            pwv=old_weather.pwv,
+            humidity=old_weather.humidity,
+            surface_pressure=old_weather.surface_pressure,
+            surface_temperature=old_weather.surface_temperature,
+            air_temperature=old_weather.air_temperature,
+            west_wind=old_weather.west_wind,
+            south_wind=old_weather.south_wind,
+        )
+        ob.telescope.site.weather = new_weather
+        del old_weather
+
+    # Simple detector pointing for el weighted noise
+    detpointing_azel = toast.ops.PointingDetectorSimple(
+        boresight="boresight_azel", quats="quats_azel"
+    )
+
+    # Create a noise model from focalplane detector properties
+    default_model = toast.ops.DefaultNoiseModel()
+    default_model.apply(data)
+
+    # Make an elevation-dependent noise model
+    el_model = toast.ops.ElevationNoise(
+        noise_model="noise_model",
+        out_model="el_weighted",
+        detector_pointing=detpointing_azel,
+    )
+    el_model.apply(data)
+
+    # Simulate noise and accumulate to signal
+    sim_noise = toast.ops.SimNoise(noise_model=el_model.out_model)
+    sim_noise.apply(data)
+
+    config = toast.config.build_config(
+        [
+            detpointing_azel,
+            default_model,
+            el_model,
+            sim_noise,
+        ]
+    )
+
+    det_data_fields = [
+        ("signal", None),
+        ("flags", None),
+    ]
+
+    # det_data_fields = [
+    #     ("signal", {"type": "flac", "quanta": 1.0e-14}),
+    #     ("flags", None),
+    # ]
+
+    if args.in_volume is None:
+        # We are saving the simulated data
+        toast.ops.SaveHDF5(
+            volume=args.out_volume,
+            detdata=det_data_fields,
+            config=config,
+        ).apply(data)
+    else:
+        # We are loading data and comparing
+        in_data = toast.Data(comm=data.comm)
+        toast.ops.LoadHDF5(volume=args.in_volume).apply(in_data)
+        obs_lookup = {x.name: x for x in data.obs}
+        for ob in in_data.obs:
+            orig = obs_lookup[ob.name]
+            if not toast.ops.save_hdf5.obs_approx_equal(ob, orig):
+                msg = f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n"
+                msg += f"NOT EQUAL TO {ob}"
+                print(msg, flush=True)
+            log.info_rank(
+                f"Finished comparison of {ob.name}", comm=data.comm.comm_group
+            )
+
+
+if __name__ == "__main__":
+    world, procs, rank = toast.mpi.get_world()
+    with toast.mpi.exception_guard(comm=world):
+        main()

--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -1039,7 +1039,11 @@ class Focalplane(object):
 
         focalplane_class_name = None
         if handle is not None:
-            focalplane_class_name = handle.attrs["focalplane_class"]
+            if "focalplane_class" in handle.attrs:
+                focalplane_class_name = handle.attrs["focalplane_class"]
+            else:
+                # Assume the base class
+                focalplane_class_name = object_fullname(cls)
         if need_bcast:
             focalplane_class_name = comm.bcast(focalplane_class_name, root=0)
 

--- a/src/toast/io/observation_hdf_load_v1.py
+++ b/src/toast/io/observation_hdf_load_v1.py
@@ -449,7 +449,11 @@ def load_instrument(parent_group, detectors=None, file_det_sets=None, comm=None)
     new_detsets = file_det_sets
     if parent_group is not None:
         inst_group = parent_group["instrument"]
-        toast_version = int(inst_group.attrs["toast_format_version"])
+        if "toast_format_version" in inst_group.attrs:
+            toast_version = int(inst_group.attrs["toast_format_version"])
+        else:
+            # V1 code did not write this
+            toast_version = 1
         if toast_version != 1:
             msg = "Version 1 of load_instrument() called on file format "
             msg += f"version {toast_version}"

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -753,6 +753,9 @@ def save_hdf5(
     if rank == 0:
         os.rename(hfpath_temp, hfpath)
 
+    if comm is not None:
+        comm.barrier()
+
     return hfpath
 
 

--- a/src/toast/io/observation_hdf_save_v1.py
+++ b/src/toast/io/observation_hdf_save_v1.py
@@ -952,6 +952,9 @@ def save_hdf5(
     if rank == 0:
         os.rename(hfpath_temp, hfpath)
 
+    if comm is not None:
+        comm.barrier()
+
     return hfpath
 
 

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -131,10 +131,10 @@ class IoHdf5Test(MPITestCase):
 
         # Add extra metadata attribute
         if not no_meta:
+            other = create_other_meta()
             for ob in data.obs:
                 ob.extra = ExtraMeta()
-            other = create_other_meta()
-            ob.update(other)
+                ob.update(other)
 
         if base_weather:
             # Replace the simulated weather with the base class for testing

--- a/src/toast/tests/ops_mapmaker_utils.py
+++ b/src/toast/tests/ops_mapmaker_utils.py
@@ -333,12 +333,12 @@ class MapmakerUtilsTest(MPITestCase):
                     for j in range(3):
                         check_zmap.data[local_sm[i], local_pix[i], j] += (
                             noise.detector_weight(det).to_value(invnpp_units)
-                            * ob.detdata["noise"][det, i]
+                            * ob.detdata["noise"][det][i]
                             * wt[i, j]
                         )
                         check_zmap_corr.data[local_sm[i], local_pix[i], j] += (
                             noise_corr.detector_weight(det).to_value(invnpp_units)
-                            * ob.detdata["noise_corr"][det, i]
+                            * ob.detdata["noise_corr"][det][i]
                             * wt[i, j]
                         )
 


### PR DESCRIPTION
- Handle case where version format string was missing

- Add standalone script for generating / comparing HDF5 files.  This was used to generate v1 files with an older toast code version and verify loading with latest code version.

- Add an MPI barrier when writing HDF5 files to a temp location and moving them into place.