### PR TITLE
Add support for indexing an HDF5 volume

### DIFF
--- a/src/toast/io/CMakeLists.txt
+++ b/src/toast/io/CMakeLists.txt
@@ -9,6 +9,7 @@ install(FILES
     observation_hdf_load_v0.py
     observation_hdf_load_v1.py
     hdf_utils.py
+    hdf_volume.py
     deprecated_compression.py
     DESTINATION ${PYTHON_SITE}/toast/io
 )

--- a/src/toast/io/__init__.py
+++ b/src/toast/io/__init__.py
@@ -5,6 +5,7 @@
 # Namespace imports
 
 from .hdf_utils import H5File, have_hdf5_parallel, hdf5_config, hdf5_open
+from .hdf_volume import VolumeIndex
 from .observation_hdf_load import (
     load_hdf5,
     load_hdf5_obs_meta,

--- a/src/toast/io/hdf_utils.py
+++ b/src/toast/io/hdf_utils.py
@@ -1,28 +1,17 @@
-# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# Copyright (c) 2021-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
-import datetime
-import json
-import os
 import re
 
 import h5py
 import numpy as np
 from astropy import units as u
 
-from ..instrument import Focalplane, GroundSite, SpaceSite, Telescope
-from ..mpi import MPI, use_mpi
-from ..observation import Observation
-from ..timing import GlobalTimers, Timer, function_timer
 from ..utils import (
-    Environment,
     Logger,
-    dtype_to_aligned,
     have_hdf5_parallel,
-    import_from_name,
 )
-from ..weather import SimWeather
 
 
 def check_dataset_buffer_size(msg, slices, dtype, parallel):

--- a/src/toast/io/hdf_volume.py
+++ b/src/toast/io/hdf_volume.py
@@ -10,8 +10,11 @@ from collections.abc import MutableMapping
 import numpy as np
 from astropy import units as u
 
+from ..coordinates import azel_to_radec
 from ..mpi import MPI
+from ..instrument import GroundSite
 from ..observation import default_values as defaults
+from .. import qarray as qa
 from ..timing import function_timer
 from ..utils import Logger, sqlite_connect, sqlite_scalar
 from .observation_hdf_load import load_hdf5
@@ -182,6 +185,7 @@ class VolumeIndex(object):
         return col_types
 
     def _db_create(self, schema):
+        """Create a new observation table."""
         create_str = f"CREATE TABLE {self.obs_table} ("
         fcreate = list()
         for k, v in schema.items():
@@ -200,6 +204,36 @@ class VolumeIndex(object):
         del cur
         conn.close()
         del conn
+
+    def _ground_scan_center(self, obs):
+        """If the observation is from a GroundSite, compute the scan center."""
+        if isinstance(obs.telescope.site, GroundSite):
+            # FIXME: Eventually handle arbitrary data distributions here
+            result = None
+            if obs.comm.group_rank == 0:
+                bad = (
+                    obs.shared[defaults.shared_flags].data
+                    & defaults.shared_mask_invalid
+                )
+                good = np.logical_not(bad)
+                mean_az = np.mean(np.unwrap(obs.shared[defaults.azimuth].data[good]))
+                mean_el = np.mean(obs.shared[defaults.elevation].data[good])
+                mean_time = np.mean(obs.shared[defaults.times].data[good])
+                bore_azel = qa.from_lonlat_angles(
+                    -np.array([mean_az]), np.array([mean_el]), np.zeros(1)
+                )
+                bore_radec = azel_to_radec(
+                    obs.telescope.site,
+                    np.array([mean_time]),
+                    bore_azel,
+                )
+                ra, dec, _ = qa.to_lonlat_angles(bore_radec)
+                result = (mean_az, mean_el, ra[0], dec[0])
+            if obs.comm.comm_group is not None:
+                result = obs.comm.comm_group.bcast(result, root=0)
+            return result
+        else:
+            return None
 
     @function_timer
     def append(self, obs, rel_path, indexfields=None):
@@ -260,6 +294,7 @@ class VolumeIndex(object):
 
         """
         log = Logger.get()
+
         # Gather the total number of valid detectors
         n_valid_local = np.count_nonzero(
             [y & defaults.det_mask_invalid for x, y in obs.local_detector_flags.items()]
@@ -269,6 +304,9 @@ class VolumeIndex(object):
         else:
             n_valid = n_valid_local
         n_valid = int(n_valid)
+
+        # Get ground scan center, if available
+        ground_props = self._ground_scan_center(obs)
 
         if obs.comm.group_rank == 0:
             # Get the user-specified properties
@@ -283,6 +321,13 @@ class VolumeIndex(object):
             fields["valid_dets"] = n_valid
             fields["start"] = obs.session.start.timestamp()
             fields["end"] = obs.session.end.timestamp()
+
+            if ground_props is not None:
+                az_center, el_center, ra_center, dec_center = ground_props
+                fields["az"] = np.degrees(az_center)
+                fields["el"] = np.degrees(el_center)
+                fields["ra"] = np.degrees(ra_center)
+                fields["dec"] = np.degrees(dec_center)
 
             field_types = self._field_schema(fields)
 
@@ -346,8 +391,8 @@ class VolumeIndex(object):
 
         """
         log = Logger.get()
-        # Load the observation with only metadata and no detector or
-        # shared data.
+        # Load the observation with only metadata and shared fields
+        # (no detector data).
         obs_path = os.path.join(volume_path, rel_path)
         try:
             obs = load_hdf5(
@@ -356,7 +401,7 @@ class VolumeIndex(object):
                 process_rows=None,
                 meta=None,
                 detdata=list(),
-                shared=list(),
+                shared=None,
                 intervals=list(),
                 detectors=None,
                 force_serial=False,

--- a/src/toast/io/hdf_volume.py
+++ b/src/toast/io/hdf_volume.py
@@ -6,6 +6,7 @@ import os
 import re
 import numbers
 from collections.abc import MutableMapping
+import tempfile
 
 import numpy as np
 from astropy import units as u
@@ -196,14 +197,18 @@ class VolumeIndex(object):
                 fcreate.append(f"{k} {v}")
         create_str += ", ".join(fcreate)
         create_str += ")"
-        conn = sqlite_connect(self._path, mode="w")
-        cur = conn.cursor()
-        cur.execute(create_str)
-        conn.commit()
-        cur.close()
-        del cur
-        conn.close()
-        del conn
+        with tempfile.TemporaryDirectory() as tdir:
+            temp_path = os.path.join(tdir, "index.sqlite")
+            conn = sqlite_connect(temp_path, mode="w")
+            cur = conn.cursor()
+            cur.execute(create_str)
+            conn.commit()
+            cur.close()
+            del cur
+            conn.close()
+            del conn
+            if not os.path.isfile(self._path):
+                os.rename(temp_path, self._path)
 
     def _ground_scan_center(self, obs):
         """If the observation is from a GroundSite, compute the scan center."""

--- a/src/toast/io/hdf_volume.py
+++ b/src/toast/io/hdf_volume.py
@@ -1,0 +1,425 @@
+# Copyright (c) 2026-2026 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+import re
+import numbers
+from collections.abc import MutableMapping
+
+import numpy as np
+from astropy import units as u
+
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..utils import Logger, sqlite_connect, sqlite_scalar
+from .observation_hdf_load import load_hdf5
+
+
+class VolumeIndex(object):
+    """Class representing per-observation metadata in a volume.
+
+    Args:
+        path (str):  The path to the volume sqlite DB.
+
+    """
+
+    default_name = "index.sqlite"
+
+    obs_table = "observations"
+
+    def __init__(self, path):
+        self._path = path
+
+    @function_timer
+    def select(self, query, comm=None):
+        """Run a query on the index DB and return the native SQL results.
+
+        This executes the query and fetches all results (a list of tuples).  If comm
+        is not None, the query is run on the rank 0 process and the results broadcast
+        across the communicator.
+
+        Args:
+            query (str):  The SQL query.
+            comm (MPI.Comm):  The optional MPI communicator
+
+        Returns:
+            (list):  The list of result tuples.
+
+        """
+        result = None
+        if comm is None or comm.rank == 0:
+            conn = sqlite_connect(self._path, mode="r")
+            cur = conn.cursor()
+            cur.execute(query)
+            result = cur.fetchall()
+            cur.close()
+            del cur
+            conn.close()
+            del conn
+        if comm is not None:
+            result = comm.bcast(result, root=0)
+        return result
+
+    def _parse_index_fields(self, obs, indexfields):
+        """Parse strings into actual object references in the observation."""
+        attr_pat = re.compile(r"\.(\w*)(.*)")
+        dict_pat = re.compile(r"\[(\w*)\](.*)")
+
+        def _op_reduce(input, op):
+            if op == "mean":
+                return np.mean(input)
+            elif op == "median":
+                return np.median(input)
+            elif op == "first":
+                return input[0]
+            elif op == "last":
+                return input[-1]
+            else:
+                msg = f"Invalid reduction operation '{op}'"
+                raise RuntimeError(msg)
+
+        def _get_obj(parent, key):
+            if key == "":
+                return parent
+            attr_mat = attr_pat.match(key)
+            if attr_mat is None:
+                # Not an attribute, maybe a dictionary key?
+                dict_mat = dict_pat.match(key)
+                if dict_mat is None:
+                    msg = f"VolumeIndex invalid key {key} for object {parent}"
+                    raise RuntimeError(msg)
+                else:
+                    sub_key = dict_mat.group(1)
+                    remainder = dict_mat.group(2)
+                    # The key might be string, or it might be an integer
+                    # position into a list or tuple.
+                    if isinstance(parent, MutableMapping):
+                        # This is dictionary-like.  Try a string key.
+                        try:
+                            child = parent[sub_key]
+                        except KeyError:
+                            # Try converting key to int.
+                            try:
+                                elem = int(sub_key)
+                                child = parent[elem]
+                            except (ValueError, KeyError):
+                                # Not an int...
+                                msg = f"key {sub_key} not valid for object {parent}"
+                                raise RuntimeError(msg)
+                    else:
+                        # Try converting key to integer index
+                        try:
+                            elem = int(sub_key)
+                            child = parent[elem]
+                        except (ValueError, KeyError):
+                            # Not an int...
+                            msg = f"key {sub_key} not valid for object {parent}"
+                            raise RuntimeError(msg)
+                    return _get_obj(child, remainder)
+            else:
+                # Parse the attribute
+                sub_key = attr_mat.group(1)
+                remainder = attr_mat.group(2)
+                child = getattr(parent, sub_key)
+                return _get_obj(child, remainder)
+
+        props = dict()
+        if indexfields is None:
+            return props
+        for fld, raw in indexfields.items():
+            key_op = raw.split(":")
+            obj = _get_obj(obs, key_op[0])
+            if len(key_op) > 1:
+                # We are doing a reduction, does that make sense?
+                if not isinstance(obj, (np.ndarray, list, tuple)):
+                    msg = f"Cannot apply reduction '{key_op[1]}' to object {obj}"
+                    raise RuntimeError(msg)
+                val = _op_reduce(obj, key_op[1])
+            else:
+                if isinstance(obj, (np.ndarray, list, tuple)):
+                    # This is array-like, but no reduction was specified.
+                    # Use the mean.
+                    val = np.mean(obj)
+                else:
+                    # A scalar
+                    val = obj
+            props[fld] = val
+        return props
+
+    def _field_schema(self, fields):
+        """Determine the sqlite type for each field."""
+
+        ftypes = dict()
+        for fname, fval in fields.items():
+            if isinstance(fval, numbers.Integral):
+                ftypes[fname] = "INTEGER"
+            elif isinstance(fval, u.Quantity):
+                # We store the floating point value
+                ftypes[fname] = "REAL"
+            elif isinstance(fval, numbers.Number):
+                # We already checked integers above, so this must be float
+                ftypes[fname] = "REAL"
+            else:
+                # Must be a string
+                ftypes[fname] = "TEXT"
+        return ftypes
+
+    def _db_schema(self):
+        """Query the current DB schema"""
+        conn = sqlite_connect(self._path, mode="r")
+        cur = conn.cursor()
+        cur.execute(f"PRAGMA table_info({self.obs_table})")
+        col_info = cur.fetchall()
+        cur.close()
+        del cur
+        conn.close()
+        del conn
+        col_types = dict()
+        for col in col_info:
+            col_types[col[1]] = col[2]
+        return col_types
+
+    def _db_create(self, schema):
+        create_str = f"CREATE TABLE {self.obs_table} ("
+        fcreate = list()
+        for k, v in schema.items():
+            if k == "name":
+                # Primary key
+                fcreate.append(f"{k} {v} PRIMARY KEY")
+            else:
+                fcreate.append(f"{k} {v}")
+        create_str += ", ".join(fcreate)
+        create_str += ")"
+        conn = sqlite_connect(self._path, mode="w")
+        cur = conn.cursor()
+        cur.execute(create_str)
+        conn.commit()
+        cur.close()
+        del cur
+        conn.close()
+        del conn
+
+    @function_timer
+    def append(self, obs, rel_path, indexfields=None):
+        """Append observation to the index while extracting metadata.
+
+        This appends the specified observation to the index while extracting
+        metadata fields.  Basic properties of the observation (number of samples,
+        time range, etc) are always indexed.  Additional index fields can be
+        specified as a dictionary with `indexfields`.
+
+        Each entry in indexfields is a mapping from an observation key / attribute
+        to a field in the index.  The observation meta data to be indexed can be a
+        scalar or a list / array.  In the case of multiple values in the specified
+        metadata, this can be reduced to a scalar for the index using an operation
+        specified by "mean", "median", "first" or "last" strings.  The syntax for each
+        entry in the indexfields dictionary for an observation metadata key and for
+        arbitrary attributes is:
+
+            [obs_key_name]:OP   or
+            .attr_name:OP
+
+        This attribute access (".") and dictionary key access ("[...]") can be nested.
+        For example:
+
+            .attr_name.sub_attr_name[some_key][other_key]:OP
+
+        For example, to index an observation key representing the nominal elevation
+        of a ground simulation and store it in the index under "elevation", you could
+        do:
+
+            indexfields={"elevation": "scan_el"}
+
+        Similarly, to index the simulated PWV from a weather object in a ground
+        simulation you could do:
+
+            indexfields={
+                "elevation": "scan_el",
+                "PWV": ".telescope.site.weather.pwv",
+            }
+
+        As a further example, imagine you have an attribute of the observation called
+        "hk" that acts as a dictionary of housekeeping data.  You want to index the
+        mean focalplane temperature, which is an array stored in `hk["temperature"]`:
+
+            indexfields={
+                "fp_temp": ".hk[temperature]:mean",
+            }
+
+        Note that we leave off the string quotes in this syntax.
+
+        Args:
+            obs (Observation):  The observation to add to the index.
+            rel_path (str):  The relative path of the observation within the volume.
+            indexfields (dict):  Additional fields to index.
+
+        Returns:
+            (None)
+
+        """
+        log = Logger.get()
+        # Gather the total number of valid detectors
+        n_valid_local = np.count_nonzero(
+            [y & defaults.det_mask_invalid for x, y in obs.local_detector_flags.items()]
+        )
+        if obs.comm_col is not None:
+            n_valid = obs.comm_col.allreduce(n_valid_local, op=MPI.SUM)
+        else:
+            n_valid = n_valid_local
+        n_valid = int(n_valid)
+
+        if obs.comm.group_rank == 0:
+            # Get the user-specified properties
+            fields = self._parse_index_fields(obs, indexfields)
+
+            # Add in fields that we always index
+            fields["name"] = obs.name
+            fields["path"] = rel_path
+            fields["uid"] = obs.uid
+            fields["session"] = obs.session.name
+            fields["samples"] = obs.n_all_samples
+            fields["valid_dets"] = n_valid
+            fields["start"] = obs.session.start.timestamp()
+            fields["end"] = obs.session.end.timestamp()
+
+            field_types = self._field_schema(fields)
+
+            if os.path.isfile(self._path):
+                # DB already exists, verify schema
+                msg = f"VolumeIndex.append(): {self._path} exists, checking schema"
+                log.verbose(msg)
+                db_types = self._db_schema()
+                if field_types != db_types:
+                    msg = f"Index {self._path}: "
+                    msg += f"Observation {obs.name} meta schema ({field_types}) does "
+                    msg += f"not match existing database schema ({db_types})"
+                    raise RuntimeError(msg)
+            else:
+                # Create DB
+                msg = f"VolumeIndex.append(): creating {self._path} with schema"
+                msg += f" {field_types}"
+                log.verbose(msg)
+                self._db_create(field_types)
+
+            # Write entry
+            names = list()
+            wilds = list()
+            vals = list()
+            for k, v in fields.items():
+                names.append(f"{k}")
+                wilds.append("?")
+                vals.append(sqlite_scalar(v))
+            vals = tuple(vals)
+            insert_str = f"INSERT INTO {self.obs_table} ("
+            insert_str += ", ".join(names)
+            insert_str += ")"
+            insert_str += " VALUES ("
+            insert_str += ", ".join(wilds)
+            insert_str += ")"
+            conn = sqlite_connect(self._path, mode="w")
+            cur = conn.cursor()
+            cur.execute(insert_str, vals)
+            conn.commit()
+            cur.close()
+            del cur
+            conn.close()
+            del conn
+        if obs.comm.comm_group is not None:
+            obs.comm.comm_group.barrier()
+
+    @function_timer
+    def append_file(self, volume_path, rel_path, indexfields=None, toastcomm=None):
+        """Load observation metadata from a file and append.
+
+        See the docstring of `append()` for details about the indexfields syntax.
+
+        Args:
+            volume_path (str):  The path to the top-level volume.
+            rel_path (str):  The relative path within the volume of the observation
+                file to append.
+            indexfields (dict):  Additional fields to index.
+
+        Returns:
+            (None)
+
+        """
+        log = Logger.get()
+        # Load the observation with only metadata and no detector or
+        # shared data.
+        obs_path = os.path.join(volume_path, rel_path)
+        try:
+            obs = load_hdf5(
+                obs_path,
+                toastcomm,
+                process_rows=None,
+                meta=None,
+                detdata=list(),
+                shared=list(),
+                intervals=list(),
+                detectors=None,
+                force_serial=False,
+            )
+            msg = f"Loaded metadata for '{obs_path}'"
+            log.debug(msg)
+            # Append it
+            self.append(obs, rel_path, indexfields=indexfields)
+            msg = f"Appended metadata for '{obs_path}'"
+            log.debug(msg)
+        except Exception as e:
+            msg = f"File '{obs_path}' was not loadable as an Observation, skipping."
+            log.warning(msg)
+            raise e
+
+    @staticmethod
+    def find_observations(volume_path, pattern_str=r".*\.h5"):
+        """Recursively search volume for files matching a pattern.
+
+        The basename of each file is matched against pattern_str.  A list of relative
+        paths to each observation file is returned.
+
+        Args:
+            volume_path (str):  The path to the top-level volume.
+            pattern_str (str):  The pattern compiled into a regex for matching against
+                each observation file basename.
+
+        Returns:
+            (list):  The list of observation relative paths.
+
+        """
+        pattern = re.compile(pattern_str)
+        obs_files = list()
+        for root, dirs, files in os.walk(volume_path):
+            for fname in files:
+                if pattern.search(fname) is not None:
+                    full_path = os.path.join(root, fname)
+                    rel_path = os.path.relpath(full_path, start=volume_path)
+                    obs_files.append(rel_path)
+        return obs_files
+
+    def reindex(self, volume_path, indexfields=None, toastcomm=None):
+        log = Logger.get()
+        if toastcomm.ngroups > 1:
+            msg = "Toast communicator has multiple process groups- "
+            msg += f"refusing to re-index volume '{volume_path}'"
+            log.error(msg)
+            raise RuntimeError(msg)
+
+        msg = f"Re-building index for Volume '{volume_path}'"
+        log.info_rank(msg, toastcomm.comm_world)
+
+        # One process builds the list of files to try
+        obs_files = None
+        if toastcomm.world_rank == 0:
+            obs_files = self.find_observations(volume_path)
+        if toastcomm.comm_world is not None:
+            obs_files = toastcomm.comm_world.bcast(obs_files, root=0)
+        for fname in obs_files:
+            self.append_file(
+                volume_path, fname, indexfields=indexfields, toastcomm=toastcomm
+            )
+
+    def __repr__(self):
+        val = f"<VolumeIndex file = '{self._path}'>"
+        return val

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -1,12 +1,10 @@
-# Copyright (c) 2021-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2021-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import ast
 import json
 import os
-import re
-from datetime import datetime, timezone
 
 import h5py
 import numpy as np
@@ -16,9 +14,9 @@ import flacarray
 
 from ..instrument import Telescope, Session, Focalplane
 from ..observation import Observation
+from ..observation import default_values as defaults
 from ..timing import Timer, function_timer
 from ..utils import Environment, Logger, import_from_name
-from ..weather import SimWeather, Weather
 from .hdf_utils import (
     check_dataset_buffer_size,
     hdf5_config,
@@ -683,6 +681,13 @@ def load_hdf5(
     log = Logger.get()
     env = Environment.get()
 
+    if intervals is not None and len(intervals) > 0:
+        # Make sure we are also loading timestamps
+        if shared is not None and defaults.times not in shared:
+            msg = "When loading intervals, you must also load timestamps"
+            log.error(msg)
+            raise RuntimeError(msg)
+
     rank = comm.group_rank
     nproc = comm.group_size
     if nproc == 1:
@@ -694,9 +699,6 @@ def load_hdf5(
     log_prefix = f"HDF5 load {os.path.basename(path)}: "
 
     # Open the file and get the root group.
-    hf = None
-    hfgroup = None
-
     parallel, _, _ = hdf5_config(comm=comm.comm_group, force_serial=force_serial)
     if (
         (not parallel)
@@ -776,22 +778,23 @@ def load_hdf5(
 
     # Load intervals
 
-    intervals_group = None
-    intervals_times = None
-    if hgroup is not None:
-        intervals_group = hgroup["intervals"]
-        intervals_times = intervals_group.attrs["times"]
-    if not parallel and nproc > 1:
-        intervals_times = comm.comm_group.bcast(intervals_times, root=0)
-    load_hdf5_intervals(
-        obs,
-        intervals_group,
-        obs.shared[intervals_times],
-        intervals,
-        log_prefix,
-        parallel,
-    )
-    del intervals_group
+    if intervals is None or len(intervals) > 0:
+        intervals_group = None
+        intervals_times = None
+        if hgroup is not None:
+            intervals_group = hgroup["intervals"]
+            intervals_times = intervals_group.attrs["times"]
+        if not parallel and nproc > 1:
+            intervals_times = comm.comm_group.bcast(intervals_times, root=0)
+        load_hdf5_intervals(
+            obs,
+            intervals_group,
+            obs.shared[intervals_times],
+            intervals,
+            log_prefix,
+            parallel,
+        )
+        del intervals_group
     log.debug_rank(
         f"{log_prefix} Finished intervals in",
         comm=comm.comm_group,

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -1,18 +1,15 @@
-# Copyright (c) 2021-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2021-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import json
 import os
-from datetime import timezone
 
 import h5py
 import numpy as np
-from astropy import units as u
 
 import flacarray
 
-from ..instrument import GroundSite
 from ..observation import default_values as defaults
 from ..observation_dist import global_interval_times
 from ..timing import Timer, function_timer

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -8,7 +8,7 @@ import re
 import h5py
 
 from ..dist import distribute_discrete
-from ..io import load_hdf5
+from ..io import load_hdf5, VolumeIndex
 from ..observation import default_values as defaults
 from ..timing import function_timer
 from ..traits import Bool, Int, List, Unicode, trait_docs
@@ -20,7 +20,22 @@ from .operator import Operator
 class LoadHDF5(Operator):
     """Operator which loads HDF5 data files into observations.
 
-    This operator expects a top-level volume directory.
+    Selected observation files are distributed across process groups in a load-balanced
+    way, using the number of samples and (if using an index), the number of valid
+    detectors in each observation.
+
+    The list of observation files can be built in multiple ways:
+
+    - If `files` is specified, that is used and `volume` is ignored.
+
+    - If `volume_select` is specified, it should contain the conditional portion of the
+      SQL select command (e.g. "where X < Y").  This will be used to extract the
+      observation metadata needed to load files.
+
+    - If `volume_select` is not specified then all observations are chosen (either
+      from the volume index if specified, or using the filesystem).  This full list
+      of observations then has the regex `pattern` applied to the basename of each
+      observation file.
 
     """
 
@@ -32,12 +47,30 @@ class LoadHDF5(Operator):
         None, allow_none=True, help="Top-level directory containing the data volume"
     )
 
-    pattern = Unicode(r"obs_.*_.*\.h5", help="Regexp pattern to match files against")
+    volume_index = Unicode(
+        "DEFAULT",
+        allow_none=True,
+        help=(
+            "Path to index file.  None disables use of index.  "
+            "'DEFAULT' uses the default VolumeIndex name at the top of the volume."
+        ),
+    )
 
-    files = List([], help="Override `volume` and load a list of files")
+    volume_select = Unicode(
+        None,
+        allow_none=True,
+        help="SQL selection string applied to the observation table of the index.",
+    )
 
-    # FIXME:  We should add a filtering mechanism here to load a subset of
-    # observations and / or detectors, as well as figure out subdirectory organization.
+    pattern = Unicode(
+        r"obs_.*_.*\.h5",
+        help="Regexp pattern to match files against (if not using index).",
+    )
+
+    files = List(
+        [],
+        help="Override `volume` and load a list of files",
+    )
 
     meta = List([], help="Only load this list of meta objects")
 
@@ -69,19 +102,6 @@ class LoadHDF5(Operator):
 
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
-        log = Logger.get()
-
-        pattern = re.compile(self.pattern)
-
-        filenames = None
-        if len(self.files) > 0:
-            if self.volume is not None:
-                log.warning(
-                    f'LoadHDF5: volume="{self.volume}" trait overridden by '
-                    f"files={self.files}"
-                )
-            filenames = list(self.files)
-
         meta_fields = None
         if len(self.meta) > 0:
             meta_fields = list(self.meta)
@@ -99,53 +119,10 @@ class LoadHDF5(Operator):
         if len(self.intervals) > 0:
             intervals_fields = list(self.intervals)
 
-        # FIXME:  Eventually we will use the volume index / DB to select observations
-        # and their sizes for a load-balanced assignment.  For now, we read this from
-        # the file.
-
-        # One global process computes the list of observations and their approximate
-        # relative size.
-
-        def _get_obs_samples(path):
-            n_samp = 0
-            with h5py.File(path, "r") as hf:
-                n_samp = int(hf.attrs["observation_samples"])
-            return n_samp
-
-        obs_props = list()
-        if data.comm.world_rank == 0:
-            if filenames is None:
-                filenames = []
-                for root, dirs, files in os.walk(self.volume):
-                    # Process top-level files
-                    filenames += [
-                        os.path.join(root, fname)
-                        for fname in files
-                        if pattern.search(fname) is not None
-                    ]
-                    # Also process sub-directories one level deep
-                    for d in dirs:
-                        for root2, dirs2, files2 in os.walk(os.path.join(root, d)):
-                            filenames += [
-                                os.path.join(root2, fname)
-                                for fname in files2
-                                if pattern.search(fname) is not None
-                            ]
-                    break
-
-            for ofile in sorted(filenames):
-                fsize = _get_obs_samples(ofile)
-                obs_props.append((fsize, ofile))
-
-        if self.sort_by_size:
-            obs_props.sort(key=lambda x: x[0])
-        else:
-            obs_props.sort(key=lambda x: x[1])
-        if data.comm.comm_world is not None:
-            obs_props = data.comm.comm_world.bcast(obs_props, root=0)
+        # Get our list of observation files and relative sizes for load-balancing
+        obs_props = self._get_obs_props(data.comm.comm_world)
 
         # Distribute observations among groups
-
         obs_sizes = [x[0] for x in obs_props]
         groupdist = distribute_discrete(obs_sizes, data.comm.ngroups)
         group_firstobs = groupdist[data.comm.group].offset
@@ -169,6 +146,98 @@ class LoadHDF5(Operator):
             data.obs.append(ob)
 
         return
+
+    def _get_obs_samples(self, path):
+        """Helper function to extract the number of samples in each observation."""
+        n_samp = 0
+        with h5py.File(path, "r") as hf:
+            n_samp = int(hf.attrs["observation_samples"])
+        return n_samp
+
+    def _get_obs_props(self, comm):
+        """Query the index or filesystem for observations and their properties."""
+        log = Logger.get()
+        if comm is None:
+            rank = 0
+        else:
+            rank = comm.rank
+
+        # Index for the volume, if we are using it.
+        if self.volume_index is None or len(self.files) > 0:
+            # Either we are loading a list of files or disabling use of the index
+            vindx = None
+        elif self.volume_index == "DEFAULT":
+            vindx = VolumeIndex(os.path.join(self.volume, VolumeIndex.default_name))
+        else:
+            vindx = VolumeIndex(self.volume_index)
+
+        # If using the index, the fields we are querying
+        select_prefix = "select name, path, samples, valid_dets from "
+        select_prefix += VolumeIndex.obs_table
+        select_prefix += " "
+
+        obs_props = None
+        if rank == 0:
+            # Perform all filesystem and index queries on one process.
+            obs_props = list()
+            if len(self.files) > 0:
+                # The user gave an explicit list of files.  We use the number of
+                # samples for load-balancing.
+                if self.volume is not None:
+                    log.warning(
+                        f'LoadHDF5: volume="{self.volume}" trait overridden by '
+                        f"files={self.files}"
+                    )
+                for ofile in self.files:
+                    fsize = self._get_obs_samples(ofile)
+                    obs_props.append((fsize, ofile))
+            else:
+                # We are using the volume trait.  Get the list of relative file paths
+                # for each observation.
+                if self.volume is None:
+                    msg = "Either the volume or a list of files must be specified"
+                    log.error(msg)
+                    raise RuntimeError(msg)
+                if self.volume_select is None:
+                    # We are selecting all observations, and matching a regex.
+                    if vindx is None:
+                        # We have no index, just check the filesystem.  This is slow
+                        # for many observations.  Use the number of samples for load
+                        # balancing.
+                        rel_files = VolumeIndex.find_observations(
+                            self.volume, pattern_str=self.pattern
+                        )
+                        for rfile in rel_files:
+                            full_path = os.path.join(self.volume, rfile)
+                            fsize = self._get_obs_samples(full_path)
+                            obs_props.append((fsize, full_path))
+                    else:
+                        # We are using the index.  Get the full list of obs and then
+                        # apply the regex.  We use the number of valid detector-samples
+                        # for load balancing.
+                        pattern = re.compile(self.pattern)
+                        all_obs = vindx.select(select_prefix)
+                        for oname, opath, osamples, odets in all_obs:
+                            if pattern.search(opath) is not None:
+                                sz = osamples * odets
+                                full_path = os.path.join(self.volume, opath)
+                                obs_props.append((sz, full_path))
+                else:
+                    # Using a custom selection with the index.  Use the number of
+                    # valid detector-samples for load balancing.
+                    sel_str = f"{select_prefix}{self.volume_select}"
+                    sel_obs = vindx.select(sel_str)
+                    for oname, opath, osamples, odets in sel_obs:
+                        sz = osamples * odets
+                        full_path = os.path.join(self.volume, opath)
+                        obs_props.append((sz, full_path))
+            if self.sort_by_size:
+                obs_props.sort(key=lambda x: x[0])
+            else:
+                obs_props.sort(key=lambda x: x[1])
+        if comm is not None:
+            obs_props = comm.bcast(obs_props, root=0)
+        return obs_props
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 import warnings
 
-from ..io import load_hdf5, save_hdf5
+from ..io import load_hdf5, save_hdf5, VolumeIndex
 from ..mpi import MPI
 from ..observation import default_values as defaults
 from ..timing import function_timer
@@ -177,6 +177,27 @@ class SaveHDF5(Operator):
         help="Top-level directory for the data volume",
     )
 
+    volume_index = Unicode(
+        "DEFAULT",
+        allow_none=True,
+        help=(
+            "Path to index file.  None disables use of index.  "
+            "'DEFAULT' uses the default VolumeIndex name at the top of the volume."
+        ),
+    )
+
+    volume_index_fields = Dict(
+        {}, help="Extra observation metadata to index.  See `VolumeIndex.append()`."
+    )
+
+    session_dirs = Bool(
+        False, help="Organize observation files in session sub-directories"
+    )
+
+    unix_time_dirs = Bool(
+        False, help="If True, organize files in 5 digit, time-prefix sub-directories"
+    )
+
     # FIXME:  We should add a filtering mechanism here to dump a subset of
     # observations and / or detectors, as well as figure out subdirectory organization.
 
@@ -259,6 +280,14 @@ class SaveHDF5(Operator):
         if data.comm.comm_world is not None:
             data.comm.comm_world.barrier()
 
+        # Index for the volume, if we are using it.
+        if self.volume_index is None:
+            vindx = None
+        elif self.volume_index == "DEFAULT":
+            vindx = VolumeIndex(os.path.join(self.volume, VolumeIndex.default_name))
+        else:
+            vindx = VolumeIndex(self.volume_index)
+
         meta_fields = None
         if len(self.meta) > 0:
             meta_fields = list(self.meta)
@@ -316,9 +345,29 @@ class SaveHDF5(Operator):
                 if ob.detdata[dd].detectors != ob.local_detectors:
                     del ob.detdata[dd]
 
+            time_prefix = None
+            if self.unix_time_dirs:
+                time_prefix = f"{ob.session.start.timestamp()}"[:5]
+
+            if self.session_dirs:
+                if time_prefix is None:
+                    outdir = os.path.join(self.volume, ob.session.name)
+                else:
+                    outdir = os.path.join(self.volume, time_prefix, ob.session.name)
+                # One process creates the top directory
+                if data.comm.group_rank == 0:
+                    os.makedirs(outdir, exist_ok=True)
+                if data.comm.comm_group is not None:
+                    data.comm.comm_group.barrier()
+            else:
+                if time_prefix is None:
+                    outdir = self.volume
+                else:
+                    outdir = os.path.join(self.volume, time_prefix)
+
             outpath = save_hdf5(
                 ob,
-                self.volume,
+                outdir,
                 meta=meta_fields,
                 detdata=detdata_fields,
                 shared=shared_fields,
@@ -330,6 +379,17 @@ class SaveHDF5(Operator):
             )
 
             log.info_rank(f"Wrote {outpath}", comm=data.comm.comm_group)
+
+            # Add this observation to the volume index
+            if vindx is not None:
+                rel_path = os.path.relpath(outpath, start=self.volume)
+                if len(self.volume_index_fields) == 0:
+                    index_fields = None
+                else:
+                    index_fields = self.volume_index_fields
+                msg = f"Add {ob.name} to index with extra fields {index_fields}"
+                log.verbose_rank(msg, comm=data.comm.comm_group)
+                vindx.append(ob, rel_path, indexfields=index_fields)
 
             if self.verify:
                 # We are going to load the data back in, but first we need to make

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -682,7 +682,7 @@ class IoHdf5Test(MPITestCase):
                             all_props.extend(pprops)
                     all_props = dt.comm.comm_group_rank.bcast(all_props, root=0)
                 else:
-                    all_props = [local_props]
+                    all_props = local_props
             if dt.comm.comm_group is not None:
                 all_props = dt.comm.comm_group.bcast(all_props)
             # Build the lookup tables

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -11,10 +11,10 @@ from astropy import units as u
 from .. import ops as ops
 from ..config import build_config
 from ..data import Data
-from ..io import load_hdf5, save_hdf5
+from ..io import load_hdf5, save_hdf5, VolumeIndex
 from ..ops.save_hdf5 import obs_approx_equal
 from ..weather import Weather
-from .helpers import close_data, create_ground_data, create_outdir
+from .helpers import close_data, create_ground_data, create_outdir, create_comm
 from .mpi import MPITestCase
 
 
@@ -23,6 +23,11 @@ class ExtraMeta(object):
 
     def __init__(self):
         self._data = np.random.normal(size=100)
+        self.meta = {"key": self._data}
+
+    @property
+    def data(self):
+        return self._data
 
     def save_hdf5(self, group, obs):
         if group is not None:
@@ -116,7 +121,7 @@ class IoHdf5Test(MPITestCase):
         fixture_name = os.path.splitext(os.path.basename(__file__))[0]
         self.outdir = create_outdir(self.comm, subdir=fixture_name)
 
-    def create_data(self, split=False, base_weather=False, no_meta=False):
+    def create_data(self, split=False, base_weather=False, no_meta=False, **kwargs):
         # Create fake observing of a small patch.  Use a multifrequency
         # focalplane so we can test split sessions.
 
@@ -127,6 +132,7 @@ class IoHdf5Test(MPITestCase):
             freqs=freq_list,
             pixel_per_process=ppp,
             split=split,
+            **kwargs,
         )
 
         # Add extra metadata attribute
@@ -312,6 +318,52 @@ class IoHdf5Test(MPITestCase):
 
         close_data(data)
 
+    def test_save_load_session_dirs(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "save_load_session")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        data, config = self.create_data(split=True)
+        det_data_fields = ["signal", "flags", "alt_signal"]
+
+        # Make a copy for later comparison.
+        original = dict()
+        for ob in data.obs:
+            original[ob.name] = ob.duplicate(times="times")
+
+        saver = ops.SaveHDF5(
+            volume=datadir,
+            session_dirs=True,
+            unix_time_dirs=True,
+            detdata=det_data_fields,
+            config=config,
+            verify=True,
+        )
+        saver.apply(data)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        check_data = Data(data.comm)
+        loader = ops.LoadHDF5(volume=datadir, detdata=det_data_fields)
+        loader.apply(check_data)
+
+        # Verify
+        for ob in check_data.obs:
+            orig = original[ob.name]
+            if not obs_approx_equal(ob, orig):
+                print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
+                self.assertTrue(False)
+        del check_data
+
+        close_data(data)
+
     def test_save_load_empty_detdata(self):
         rank = 0
         if self.comm is not None:
@@ -456,5 +508,301 @@ class IoHdf5Test(MPITestCase):
             if not obs_approx_equal(ob, orig):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
+
+        close_data(data)
+
+    def test_index(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "index")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        # Generate the data and create the index using a single group
+
+        data, config = self.create_data(split=True, single_group=True)
+        det_data_fields = [
+            ("signal", {"quanta": 1.0e-7}),
+            ("flags", {}),
+            ("alt_signal", {"quanta": 1.0e-12}),
+        ]
+
+        # Write data with NO index
+        saver = ops.SaveHDF5(
+            volume=datadir,
+            volume_index=None,
+            session_dirs=True,
+            unix_time_dirs=True,
+            detdata=det_data_fields,
+            config=config,
+            verify=True,
+        )
+        saver.apply(data)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        # Reference different types of metadata for testing the index
+        index_fields = {
+            "extra_data": ".extra.data:mean",
+            "extra_key": ".extra.meta[key]:median",
+            "leaf_scalar": "[top_tuple][0][qarr]:mean",
+        }
+        check_leaf = data.obs[0]["top_tuple"][0]["qarr"]
+        all_obs_names = list()
+        all_sessions = set()
+        obs_sessions = dict()
+        check_times = dict()
+        for ob in data.obs:
+            all_sessions.add(ob.session.name)
+            all_obs_names.append(ob.name)
+            if ob.session.name not in obs_sessions:
+                obs_sessions[ob.session.name] = set()
+            if ob.session.name not in check_times:
+                check_times[ob.session.name] = np.mean(ob.shared["times"].data)
+            obs_sessions[ob.session.name].add(ob.name)
+        all_obs_names = set(all_obs_names)
+
+        # Create an index and close our data.
+        iname = os.path.join(datadir, VolumeIndex.default_name)
+        vindx = VolumeIndex(iname)
+        vindx.reindex(datadir, toastcomm=data.comm, indexfields=index_fields)
+        del vindx
+        close_data(data)
+
+        # Now test that we can use the index independently and that queries
+        # make sense.
+        vindx = VolumeIndex(iname)
+
+        # Verify that we can load the index with multiple groups and with
+        # the world communicator
+        toastcomm = create_comm(self.comm, single_group=False)
+
+        # Select everything.  Should return all obs names.
+        for test_comm in [toastcomm.comm_world, toastcomm.comm_group]:
+            sel_all = vindx.select("select name from observations", comm=test_comm)
+            sel_all = set([x[0] for x in sel_all])
+            if sel_all != all_obs_names:
+                msg = f"select all returned {sel_all} not {all_obs_names}"
+                print(msg, flush=True)
+                self.assertTrue(False)
+            if toastcomm.comm_world is not None:
+                toastcomm.comm_world.barrier()
+
+        # Select by session.  There are 3 observations (at different frequencies)
+        # per session.
+        for test_comm in [toastcomm.comm_world, toastcomm.comm_group]:
+            for ses in sorted(all_sessions):
+                sel_str = f"select name from observations where session = '{ses}'"
+                sel_session = vindx.select(
+                    sel_str,
+                    comm=test_comm,
+                )
+                sel_session = set([x[0] for x in sel_session])
+                if sel_session != obs_sessions[ses]:
+                    msg = f"select session {ses} returned {sel_session} "
+                    msg += f"not {obs_sessions[ses]}"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+            if toastcomm.comm_world is not None:
+                toastcomm.comm_world.barrier()
+
+        # Select by arbitrary metadata (constant in all obs in this case)
+        check_val = np.mean(check_leaf.value)
+        check_low = 0.9 * check_val
+        check_high = 1.1 * check_val
+        sel_str = "select name from observations where "
+        sel_str += f"leaf_scalar > {check_low} and "
+        sel_str += f"leaf_scalar < {check_high}"
+        for test_comm in [toastcomm.comm_world, toastcomm.comm_group]:
+            sel_leaf = vindx.select(sel_str, comm=test_comm)
+            sel_leaf = set([x[0] for x in sel_leaf])
+            if sel_all != all_obs_names:
+                msg = f"select leaf_scalar returned {sel_leaf} not {all_obs_names}"
+                print(msg, flush=True)
+                self.assertTrue(False)
+            if toastcomm.comm_world is not None:
+                toastcomm.comm_world.barrier()
+
+        # Select by a timestamp in the center of each session.
+        for test_comm in [toastcomm.comm_world, toastcomm.comm_group]:
+            for ses in sorted(check_times.keys()):
+                timestamp = check_times[ses]
+                sel_str = "select name from observations where "
+                sel_str += f"start < {timestamp} and "
+                sel_str += f"end > {timestamp}"
+                sel_time = vindx.select(sel_str, comm=test_comm)
+                sel_time = set([x[0] for x in sel_time])
+                if sel_time != obs_sessions[ses]:
+                    msg = f"select time {ses} returned {sel_time} "
+                    msg += f"not {obs_sessions[ses]}"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+            if toastcomm.comm_world is not None:
+                toastcomm.comm_world.barrier()
+
+    def test_save_load_index(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "save_load_index")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        # Generate the data
+
+        data, config = self.create_data(split=True)
+        det_data_fields = [
+            ("signal", {"quanta": 1.0e-7}),
+            ("flags", {}),
+            ("alt_signal", {"quanta": 1.0e-12}),
+        ]
+
+        def _allreduce_obs_props(dt):
+            """Helper function to get observation and session mapping.
+            This is needed to find the information across all process groups and
+            communicate it to all processes for checks below.
+            """
+            local_time = {x.name: np.mean(x.shared["times"].data) for x in dt.obs}
+            local_props = [(x.name, x.session.name, local_time[x.name]) for x in dt.obs]
+            all_props = None
+            if dt.comm.group_rank == 0:
+                if dt.comm.comm_group_rank is not None:
+                    proc_props = dt.comm.comm_group_rank.gather(local_props, root=0)
+                    if dt.comm.comm_group_rank.rank == 0:
+                        all_props = list()
+                        for pprops in proc_props:
+                            all_props.extend(pprops)
+                    all_props = dt.comm.comm_group_rank.bcast(all_props, root=0)
+                else:
+                    all_props = [local_props]
+            if dt.comm.comm_group is not None:
+                all_props = dt.comm.comm_group.bcast(all_props)
+            # Build the lookup tables
+            a_obs = set([x[0] for x in all_props])
+            a_sessions = set([x[1] for x in all_props])
+            s_obs = dict()
+            s_times = dict()
+            for oname, sname, stime in all_props:
+                if sname not in s_obs:
+                    s_obs[sname] = set()
+                if sname not in s_times:
+                    s_times[sname] = stime
+                s_obs[sname].add(oname)
+            return a_obs, a_sessions, s_obs, s_times
+
+        orig_obs, orig_sessions, orig_ses_obs, orig_ses_times = _allreduce_obs_props(
+            data
+        )
+
+        # The fields we will index
+
+        index_fields = {
+            "extra_data": ".extra.data:mean",
+            "extra_key": ".extra.meta[key]:median",
+            "leaf_scalar": "[top_tuple][0][qarr]:mean",
+        }
+        check_leaf = data.obs[0]["top_tuple"][0]["qarr"]
+
+        # Save data and create the index
+
+        saver = ops.SaveHDF5(
+            volume=datadir,
+            volume_index_fields=index_fields,
+            session_dirs=True,
+            unix_time_dirs=True,
+            detdata=det_data_fields,
+            config=config,
+            verify=True,
+        )
+        saver.apply(data)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        # Now load the data with various selections and confirm the expected
+        # set of observations are loaded.
+
+        # Select everything (using the index).  Should load all obs.
+
+        check_data = Data(data.comm)
+        loader = ops.LoadHDF5(
+            volume=datadir,
+            volume_select=None,
+        )
+        loader.apply(check_data)
+
+        (loaded_obs, loaded_sessions, loaded_ses_obs, loaded_ses_times) = (
+            _allreduce_obs_props(check_data)
+        )
+        if loaded_obs != orig_obs:
+            msg = f"select all returned {loaded_obs} not {orig_obs}"
+            print(msg, flush=True)
+            self.assertTrue(False)
+        del check_data
+
+        # Check that we can load individual sessions
+
+        for ses in sorted(orig_sessions):
+            check_data = Data(data.comm)
+            loader.volume_select = f"where session = '{ses}'"
+            loader.apply(check_data)
+            (loaded_obs, loaded_sessions, loaded_ses_obs, loaded_ses_times) = (
+                _allreduce_obs_props(check_data)
+            )
+
+            if loaded_obs != orig_ses_obs[ses]:
+                msg = f"select {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
+                print(msg, flush=True)
+                self.assertTrue(False)
+            del check_data
+
+        # Check that we can load observations based on some metadata.
+        check_val = np.mean(check_leaf.value)
+        check_low = 0.9 * check_val
+        check_high = 1.1 * check_val
+        sel_str = "where "
+        sel_str += f"leaf_scalar > {check_low} and "
+        sel_str += f"leaf_scalar < {check_high}"
+
+        check_data = Data(data.comm)
+        loader.volume_select = sel_str
+        loader.apply(check_data)
+        (loaded_obs, loaded_sessions, loaded_ses_obs, loaded_ses_times) = (
+            _allreduce_obs_props(check_data)
+        )
+
+        if loaded_obs != orig_obs:
+            msg = f"select on common meta returned {loaded_obs} not {orig_obs}"
+            print(msg, flush=True)
+            self.assertTrue(False)
+        del check_data
+
+        # Check we can load observations based on session times
+        for ses in sorted(orig_ses_times.keys()):
+            timestamp = orig_ses_times[ses]
+            sel_str = "where "
+            sel_str += f"start < {timestamp} and "
+            sel_str += f"end > {timestamp}"
+
+            check_data = Data(data.comm)
+            loader.volume_select = sel_str
+            loader.apply(check_data)
+            (loaded_obs, loaded_sessions, loaded_ses_obs, loaded_ses_times) = (
+                _allreduce_obs_props(check_data)
+            )
+
+            if loaded_obs != orig_ses_obs[ses]:
+                msg = f"select time {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
+                print(msg, flush=True)
+                self.assertTrue(False)
+            del check_data
 
         close_data(data)

--- a/src/toast/tests/ops_sim_tod_atm.py
+++ b/src/toast/tests/ops_sim_tod_atm.py
@@ -644,7 +644,7 @@ class SimAtmTest(MPITestCase):
         )
 
         # HDF5 saving
-        saver = ops.SaveHDF5(detdata_float32=True, verify=True)
+        saver = ops.SaveHDF5(verify=True)
 
         # Simulate and process all detectors simultaneously
 

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -7,13 +7,16 @@ import gc
 import glob
 import hashlib
 import importlib
+import numbers
 import os
+import sqlite3
 import time
 from collections import UserDict
 from tempfile import TemporaryDirectory
 from contextlib import contextmanager
 
 import astropy.io.misc.hdf5 as aspy5
+from astropy import units as u
 import h5py
 import numpy as np
 from astropy.table import meta as aspymeta
@@ -1037,3 +1040,116 @@ def flagged_noise_fill(data, flags, buffer, poly_order=1):
         data[full_first:full_last][fit_bad] = full_fit[fit_bad] + np.random.normal(
             scale=rms, size=n_bad
         )
+
+
+def sqlite_connect(filename=None, mode="w"):
+    """Utility function for connecting to an sqlite3 DB.
+
+    This provides a single function for opening an sqlite connection
+    consistently across the code base.  When connecting to a file on
+    disk we try to use options which will be more performant in the
+    situation where the DB is on a networked / shared filesystem and
+    being accessed from multiple processes.
+
+    Args:
+        filename (str):  The path on disk or None if using an in-memory DB.
+        mode (str):  Either "r" or "w".
+
+    Returns:
+        (sqlite3.Connection):  The database connection.
+
+    """
+    if filename is None or filename == ":memory:":
+        # Memory-backed DB
+        if mode == "r":
+            raise ValueError("Cannot open memory DB in read-only mode")
+        return sqlite3.connect(":memory:")
+
+    # This timeout is in seconds.  If multiple processes are writing, they
+    # might be blocked for a while until they get their turn.  This prevents
+    # them from giving up too soon if other processes have a write lock.
+    # https://www.sqlite.org/pragma.html#pragma_busy_timeout
+    busy_time = 100
+
+    # Journaling options
+
+    # Persistent journaling mode.  File creation / deletion can be expensive
+    # on some filesystems.  This just writes some zeros to the header and
+    # leaves the file.  This journal is a "side car" file next to the original
+    # DB file and is safe to delete manually if one is sure that no processes
+    # are accessing the DB.
+    # https://www.sqlite.org/pragma.html#pragma_journal_mode
+    if mode == "r":
+        journal_mode = "off"
+    else:
+        journal_mode = "persist"
+
+    # Max size of the journal.  Although it is being overwritten repeatedly,
+    # if it gets too large we purge it and recreate.  This should not happen
+    # for most normal operations.
+    # https://www.sqlite.org/pragma.html#pragma_journal_size_limit
+    journal_size = f"{10 * 1024 * 1024}"
+
+    # Disk synchronization options
+
+    # Using "normal" instead of the default "full" can avoid potentially expensive
+    # (on network filesystems) sync operations.
+    # https://www.sqlite.org/pragma.html#pragma_synchronous
+    if mode == "r":
+        sync_mode = "off"
+    else:
+        sync_mode = "normal"
+
+    # Memory caching
+
+    # The default page size in modern sqlite is 4096 bytes, and should be fine.
+    # We set this explicitly to allow easy changing in the future or keeping it
+    # fixed if the default changes.
+    # https://www.sqlite.org/pragma.html#pragma_page_size
+    page_size = 4096
+
+    # The number of pages to cache in memory.  Setting this to a few MB of RAM
+    # can have substantial performance benefits.  Total will be number of pages
+    # times page size.
+    # https://www.sqlite.org/pragma.html#pragma_cache_size
+    n_cache_pages = 4000
+
+    # Open connection
+    if mode == "r":
+        connstr = f"file:{filename}?mode=ro"
+    else:
+        connstr = f"file:{filename}?mode=rwc"
+    conn = sqlite3.connect(connstr, uri=True, timeout=busy_time)
+
+    # Set cache sizes
+    conn.execute(f"pragma page_size={page_size}")
+    conn.execute(f"pragma cache_size={n_cache_pages}")
+
+    # Set journaling / sync options
+    conn.execute(f"pragma journal_mode={journal_mode}")
+    conn.execute(f"pragma journal_size_limit={journal_size}")
+    conn.execute(f"pragma synchronous={sync_mode}")
+
+    # Other tuning options
+
+    # Hold temporary tables in memory.
+    # https://www.sqlite.org/pragma.html#pragma_temp_store
+    conn.execute("pragma temp_store=memory")
+
+    if mode == "r":
+        conn.execute("pragma query_only=true")
+    return conn
+
+
+def sqlite_scalar(input):
+    """Ensure that any scalars are one of the sqlite types."""
+    if isinstance(input, numbers.Integral):
+        return int(input)
+    elif isinstance(input, u.Quantity):
+        return float(input.value)
+    elif isinstance(input, numbers.Number):
+        # We already checked integers above, so this must be float
+        return float(input)
+    else:
+        # Must be a string
+        return input


### PR DESCRIPTION
- Add a new VolumeIndex class, which interfaces to an sqlite DB that can be located anywhere (e.g. a different filesystem with better sqlite performance).  Support indexing arbitrary Observation metadata and nested attributes.  Support selection of observations with standard SQL across an arbitrary MPI communicator.

- Add util function for connections to an sqlite DB with options tuned for parallel / networked filesystems.

- In SaveHDF5, support creating a hierarchy of sub-directories in the volume, arranged by the first 5 digits of UNIX time and / or session name.

- In LoadHDF5, add support for arbitrary SQL select commands when choosing observations to load.

- Expand unit tests to include various uses of the index.

- Remove un-needed imports.