### PR TITLE
Update timing plot

### DIFF
--- a/src/toast/scripts/toast_timing_plot.py
+++ b/src/toast/scripts/toast_timing_plot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2021-2021 by the parties listed in the AUTHORS file.
+# Copyright (c) 2021-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 

--- a/src/toast/scripts/toast_timing_plot.py
+++ b/src/toast/scripts/toast_timing_plot.py
@@ -147,10 +147,10 @@ def main():
     df = pd.DataFrame(data=data, columns=cnames)
 
     img_px = 800
-    pio.kaleido.scope.default_format = "pdf"
-    pio.kaleido.scope.default_width = img_px
-    pio.kaleido.scope.default_height = img_px
-    pio.kaleido.scope.mathjax = None
+    pio.defaults.default_format = "pdf"
+    pio.defaults.default_width = img_px
+    pio.defaults.default_height = img_px
+    pio.defaults.mathjax = None
 
     fig = px.sunburst(
         data_frame=df,


### PR DESCRIPTION
Trivial fix to resolve these warnings:

```
/home/reijo/software/soconda/envs/soconda_0.2.2.dev322/bin/toast_timing_plot:150: DeprecationWarning:


Use of plotly.io.kaleido.scope.default_format is deprecated and support will be removed after September 2025.
Please use plotly.io.defaults.default_format instead.


/home/reijo/software/soconda/envs/soconda_0.2.2.dev322/bin/toast_timing_plot:151: DeprecationWarning:


Use of plotly.io.kaleido.scope.default_width is deprecated and support will be removed after September 2025.
Please use plotly.io.defaults.default_width instead.


/home/reijo/software/soconda/envs/soconda_0.2.2.dev322/bin/toast_timing_plot:152: DeprecationWarning:


Use of plotly.io.kaleido.scope.default_height is deprecated and support will be removed after September 2025.
Please use plotly.io.defaults.default_height instead.


/home/reijo/software/soconda/envs/soconda_0.2.2.dev322/bin/toast_timing_plot:153: DeprecationWarning:


Use of plotly.io.kaleido.scope.mathjax is deprecated and support will be removed after September 2025.
Please use plotly.io.defaults.mathjax instead.
```