### PR TITLE
Small changes for dealing with numpy arrays of unicode strings

### DIFF
--- a/src/toast/io/hdf_utils.py
+++ b/src/toast/io/hdf_utils.py
@@ -131,6 +131,62 @@ class H5File(object):
         self.close()
 
 
+def unicode_array_to_fixed(input):
+    """Convert numpy arrays with Unicode strings to fixed-length bytes.
+
+    Args:
+        input (str):  The input array.
+
+    Returns:
+        (array):  The input converted to 'S' bytes, or the original if not
+            an array of strings.
+
+    """
+    utype_pat = re.compile(r"[><]U(\d+).*")
+    if np.issubdtype(input.dtype, np.str_):
+        # Unicode string
+        mat = utype_pat.match(str(input.dtype))
+        if mat is not None:
+            maxlen = mat.group(1)
+            stype = f"S{maxlen}"
+            return input.astype(stype)
+    else:
+        return input
+
+
+def replace_unicode_arrays(obj):
+    """Recursively replace unicode numpy arrays.
+
+    Descend the object container recursively and replace numpy unicode arrays with
+    fixed-length byte arrays.
+
+    Args:
+        obj (object):  A container or array
+
+    Returns:
+        (object):  The same style container as the input, with unicode arrays replaced
+
+    """
+    if isinstance(obj, dict):
+        new_obj = dict()
+        for k, v in obj.items():
+            new_obj[k] = replace_unicode_arrays(v)
+    elif isinstance(obj, tuple):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_unicode_arrays(val))
+        new_obj = tuple(new_obj)
+    elif isinstance(obj, list):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_unicode_arrays(val))
+    elif isinstance(obj, np.ndarray):
+        new_obj = unicode_array_to_fixed(obj)
+    else:
+        new_obj = obj
+    return new_obj
+
+
 def save_meta_object(parent, objname, obj):
     """Recursive function to save python metadata objects.
 
@@ -189,7 +245,7 @@ def save_meta_object(parent, objname, obj):
     elif isinstance(obj, u.Quantity):
         if isinstance(obj.value, np.ndarray):
             # Array quantity
-            odata = parent.create_dataset(objname, data=obj.value)
+            odata = parent.create_dataset(objname, data=replace_unicode_arrays(obj.value))
             odata.attrs["units"] = obj.unit.to_string()
             del odata
         else:
@@ -198,7 +254,7 @@ def save_meta_object(parent, objname, obj):
             parent.attrs[f"{objname}_units"] = obj.unit.to_string()
     elif isinstance(obj, np.ndarray):
         # Array
-        arr = parent.create_dataset(objname, data=obj)
+        arr = parent.create_dataset(objname, data=replace_unicode_arrays(obj))
         del arr
     else:
         # This is a scalar or some kind of unknown object.  Try

--- a/src/toast/io/hdf_volume.py
+++ b/src/toast/io/hdf_volume.py
@@ -197,7 +197,9 @@ class VolumeIndex(object):
                 fcreate.append(f"{k} {v}")
         create_str += ", ".join(fcreate)
         create_str += ")"
-        with tempfile.TemporaryDirectory() as tdir:
+        # We create the temp directory in the same filesystem as the final index, so
+        # that os.rename() will always work as expected.
+        with tempfile.TemporaryDirectory(dir=os.path.dirname(self._path)) as tdir:
             temp_path = os.path.join(tdir, "index.sqlite")
             conn = sqlite_connect(temp_path, mode="w")
             cur = conn.cursor()

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -538,8 +538,7 @@ def save_hdf5(
     comm = obs.comm.comm_group
     rank = obs.comm.group_rank
 
-    namestr = f"{obs.name}_{obs.uid}"
-    hfpath = os.path.join(dir, f"obs_{namestr}.h5")
+    hfpath = os.path.join(dir, f"{obs.name}.h5")
     hfpath_temp = f"{hfpath}.tmp"
 
     # Create the file and get the root group

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -215,7 +215,8 @@ class Observation(MutableMapping):
         # In order to ensure that observations always have a unique name, assign a
         # random name if the user does not specify one.
         if self._name is None:
-            int_name = np.random.Generator.integers(2147483647, dtype=np.int32)
+            rng = np.random.default_rng()
+            int_name = rng.integers(0, high=2147483647, size=None, dtype=np.int32)
             self._name = f"{int_name:010d}"
             if self._uid is None:
                 # Set the UID to the same random integer

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -1,30 +1,25 @@
-# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import copy
-import numbers
-import sys
 import types
-from collections.abc import Mapping, MutableMapping, Sequence
+from collections.abc import MutableMapping
 
 import numpy as np
 from astropy import units as u
-from pshmem.utils import mpi_data_type
 
 from .accelerator import AcceleratorObject
-from .dist import distribute_samples
-from .instrument import Session, Telescope
+from .instrument import Session
 from .intervals import IntervalList, interval_dtype
-from .mpi import MPI, comm_equal
+from .mpi import MPI
 from .observation_data import (
     DetDataManager,
-    DetectorData,
     IntervalsManager,
     SharedDataManager,
 )
 from .observation_dist import DistDetSamp, redistribute_data
-from .observation_view import DetDataView, SharedView, View, ViewInterface, ViewManager
+from .observation_view import ViewInterface
 from .timing import function_timer
 from .utils import Logger, name_UID
 
@@ -212,14 +207,22 @@ class Observation(MutableMapping):
         sample_sets=None,
         process_rows=None,
     ):
-        log = Logger.get()
         self._telescope = telescope
         self._name = name
         self._uid = uid
         self._session = session
 
-        if self._uid is None and self._name is not None:
-            self._uid = name_UID(self._name)
+        # In order to ensure that observations always have a unique name, assign a
+        # random name if the user does not specify one.
+        if self._name is None:
+            int_name = np.random.Generator.integers(2147483647, dtype=np.int32)
+            self._name = f"{int_name:010d}"
+            if self._uid is None:
+                # Set the UID to the same random integer
+                self._uid = int_name
+        else:
+            if self._uid is None:
+                self._uid = name_UID(self._name)
 
         if self._session is None:
             if self._name is not None:

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -63,8 +63,8 @@ class LoadHDF5(Operator):
     )
 
     pattern = Unicode(
-        r"obs_.*_.*\.h5",
-        help="Regexp pattern to match files against (if not using index).",
+        r".*\.h5",
+        help="Regexp pattern to match files against (if not using volume_select).",
     )
 
     files = List(

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -14,15 +14,17 @@ from pshmem import MPIShared
 from .. import ops
 from ..data import Data
 from ..mpi import MPI, Comm
-from ..observation import DetectorData, Observation
+from ..observation import Observation
 from ..observation import default_values as defaults
 from ..observation import set_default_values
+from ..observation_data import DetectorData
 from .helpers import (
     close_data,
     create_ground_data,
     create_outdir,
     create_satellite_empty,
     create_overdistributed_data,
+    create_space_telescope,
 )
 from .mpi import MPITestCase
 
@@ -76,6 +78,12 @@ class ObservationTest(MPITestCase):
                 np.testing.assert_equal(view[1], tdata[1, 0:2])
 
                 tdata.clear()
+
+    def test_empty_name(self):
+        comm = Comm(world=self.comm)
+        tele = create_space_telescope(comm.group_size)
+        obs = Observation(comm, tele, 10)
+        self.assertTrue(obs.uid == int(obs.name))
 
     def test_observation(self):
         # Populate the observations


### PR DESCRIPTION
Numpy-2 introduced arrays of variable-length unicode strings.  These are incompatible with h5py datasets.  This PR:

- Adds helper functions for replacing numpy unicode arrays with fixed width byte strings.

- Process all observation metadata through these conversion functions when saving to HDF5.