### PR TITLE
Fix loading of HDF5 volumes

### DIFF
--- a/src/toast/io/hdf_utils.py
+++ b/src/toast/io/hdf_utils.py
@@ -227,25 +227,27 @@ def save_meta_object(parent, objname, obj):
         # Not participating
         return
 
-    if "type" not in parent.attrs:
+    if "python_data_type" not in parent.attrs:
         # This must be the root
-        parent.attrs["type"] = "dict"
+        parent.attrs["python_data_type"] = "dict"
 
     if isinstance(obj, dict):
         child = parent.create_group(objname)
-        child.attrs["type"] = _type_to_str(obj)
+        child.attrs["python_data_type"] = _type_to_str(obj)
         for k, v in obj.items():
             save_meta_object(child, k, v)
     elif isinstance(obj, (list, tuple)):
         child = parent.create_group(objname)
-        child.attrs["type"] = _type_to_str(obj)
+        child.attrs["python_data_type"] = _type_to_str(obj)
         for indx, item in enumerate(obj):
             k = f"item_{indx:04d}"
             save_meta_object(child, k, item)
     elif isinstance(obj, u.Quantity):
         if isinstance(obj.value, np.ndarray):
             # Array quantity
-            odata = parent.create_dataset(objname, data=replace_unicode_arrays(obj.value))
+            odata = parent.create_dataset(
+                objname, data=replace_unicode_arrays(obj.value)
+            )
             odata.attrs["units"] = obj.unit.to_string()
             del odata
         else:
@@ -281,11 +283,13 @@ def load_meta_object(parent):
         (object):  The populated python container
 
     """
-    if "type" not in parent.attrs:
-        raise RuntimeError("metadata group does not contain 'type' attribute")
+    if "python_data_type" not in parent.attrs:
+        raise RuntimeError(
+            "metadata group does not contain 'python_data_type' attribute"
+        )
 
     parsed = dict()
-    parsed["type"] = parent.attrs["type"]
+    parsed["python_data_type"] = parent.attrs["python_data_type"]
 
     # First process child groups / datasets
     for child_name in list(sorted(parent.keys())):
@@ -309,7 +313,7 @@ def load_meta_object(parent):
     units_pat = re.compile(r"(.*)_units")
     value_pat = re.compile(r"(.*)_value")
     for k, v in parent.attrs.items():
-        if k == "type":
+        if k == "python_data_type":
             continue
         if value_pat.match(k) is not None:
             # We will process this when matching units
@@ -328,22 +332,22 @@ def load_meta_object(parent):
     # If the parent container is a list or tuple, construct that now and sort the
     # children into the original order.
     ret = None
-    ctype = parsed["type"]
+    ctype = parsed["python_data_type"]
     if ctype == "dict":
-        del parsed["type"]
+        del parsed["python_data_type"]
         return parsed
     elif ctype == "list":
         keys = list(sorted(parsed.keys()))
         ret = list()
         for k in keys:
-            if k == "type":
+            if k == "python_data_type":
                 continue
             ret.append(parsed[k])
     elif ctype == "tuple":
         keys = list(sorted(parsed.keys()))
         ret = tuple()
         for k in keys:
-            if k == "type":
+            if k == "python_data_type":
                 continue
             ret = ret + (parsed[k],)
     else:

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -166,10 +166,23 @@ class LoadHDF5(Operator):
         if self.volume_index is None or len(self.files) > 0:
             # Either we are loading a list of files or disabling use of the index
             vindx = None
-        elif self.volume_index == "DEFAULT":
-            vindx = VolumeIndex(os.path.join(self.volume, VolumeIndex.default_name))
         else:
-            vindx = VolumeIndex(self.volume_index)
+            if self.volume_index == "DEFAULT":
+                index_path = os.path.join(self.volume, VolumeIndex.default_name)
+            else:
+                index_path = self.volume_index
+            index_exists = False
+            if rank == 0:
+                if os.path.isfile(index_path):
+                    index_exists = True
+            if comm is not None:
+                index_exists = comm.bcast(index_exists, root=0)
+            if index_exists:
+                vindx = VolumeIndex(index_path)
+            else:
+                msg = f"Volume index '{index_path}' does not exist, scanning filesystem for observations."
+                log.warning_rank(msg, comm=comm)
+                vindx = None
 
         # If using the index, the fields we are querying
         select_prefix = "select name, path, samples, valid_dets from "

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -269,8 +269,13 @@ class IoHdf5Test(MPITestCase):
         for ob in data.obs:
             original[ob.name] = ob.duplicate(times="times")
 
+        # Disable index for this test, to check that the loader works in this case
         saver = ops.SaveHDF5(
-            volume=datadir, detdata=det_data_fields, config=config, verify=True
+            volume=datadir,
+            volume_index=None,
+            detdata=det_data_fields,
+            config=config,
+            verify=True,
         )
         saver.apply(data)
 


### PR DESCRIPTION
Older HDF5 volumes will not have an index.  If the user does not explicitly disable use of the index, simply print a warning and proceed to scan the filesystem as if the index was disabled.

Also fix a corner case where metadata objects containing the keyword "type" would break the technique we use to instantiate classes based on the contents of the HDF5 attributes before calling the class loading function.