### PR TITLE
Cleanup of observation metadata handling in HDF5

### DIFF
--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -21,8 +21,8 @@ import astropy.time as astime
 import h5py
 import numpy as np
 from astropy import units as u
-from astropy.io.misc.hdf5 import read_table_hdf5, write_table_hdf5
-from astropy.table import Column, QTable
+from astropy.io.misc.hdf5 import read_table_hdf5
+from astropy.table import Column, QTable, Table
 from scipy.constants import c, h, k
 
 try:
@@ -45,6 +45,8 @@ from .utils import (
     object_fullname,
     table_write_parallel_hdf5,
     import_from_name,
+    table_equal,
+    replace_byte_arrays,
 )
 
 # CMB temperature
@@ -974,9 +976,13 @@ class Focalplane(object):
             return False
         if self.detectors != other.detectors:
             return False
-        if self.detector_data.colnames != other.detector_data.colnames:
-            return False
-        if not self.detector_data.values_equal(other.detector_data):
+        if not isinstance(self.detector_data, Table):
+            msg = f"self.detector_data is not a Table ({self.detector_data})"
+            raise RuntimeError(msg)
+        if not isinstance(self.detector_data, Table):
+            msg = f"other.detector_data is not a Table ({other.detector_data})"
+            raise RuntimeError(msg)
+        if not table_equal(self.detector_data, other.detector_data):
             return False
         return True
 
@@ -985,13 +991,13 @@ class Focalplane(object):
 
     @classmethod
     def _load_hdf5(
-            cls,
-            handle,
-            comm=None,
-            detectors=None,
-            file_det_sets=None,
-            sample_rate=None,
-            **kwargs,
+        cls,
+        handle,
+        comm=None,
+        detectors=None,
+        file_det_sets=None,
+        sample_rate=None,
+        **kwargs,
     ):
         """Load a base class Focalplane"""
         log = Logger.get()
@@ -1003,7 +1009,9 @@ class Focalplane(object):
         detector_data = None
         field_of_view = None
         if handle is not None:
-            detector_data = read_table_hdf5(handle, path="focalplane")
+            detector_data = replace_byte_arrays(
+                read_table_hdf5(handle, path="focalplane")
+            )
             if sample_rate is None:
                 sample_rate = detector_data.meta["sample_rate"]
             field_of_view = detector_data.meta["field_of_view"]
@@ -1036,7 +1044,7 @@ class Focalplane(object):
             comm (MPI.Comm):  If loading from a file, optional communicator.
 
         Returns:
-            None
+            (Focalplane):  The constructed Focalplane.
 
         """
         # Determine if we need to broadcast results.  This occurs if only one process

--- a/src/toast/io/hdf_utils.py
+++ b/src/toast/io/hdf_utils.py
@@ -11,6 +11,8 @@ from astropy import units as u
 from ..utils import (
     Logger,
     have_hdf5_parallel,
+    replace_unicode_arrays,
+    replace_byte_arrays,
 )
 
 
@@ -131,62 +133,6 @@ class H5File(object):
         self.close()
 
 
-def unicode_array_to_fixed(input):
-    """Convert numpy arrays with Unicode strings to fixed-length bytes.
-
-    Args:
-        input (str):  The input array.
-
-    Returns:
-        (array):  The input converted to 'S' bytes, or the original if not
-            an array of strings.
-
-    """
-    utype_pat = re.compile(r"[><]U(\d+).*")
-    if np.issubdtype(input.dtype, np.str_):
-        # Unicode string
-        mat = utype_pat.match(str(input.dtype))
-        if mat is not None:
-            maxlen = mat.group(1)
-            stype = f"S{maxlen}"
-            return input.astype(stype)
-    else:
-        return input
-
-
-def replace_unicode_arrays(obj):
-    """Recursively replace unicode numpy arrays.
-
-    Descend the object container recursively and replace numpy unicode arrays with
-    fixed-length byte arrays.
-
-    Args:
-        obj (object):  A container or array
-
-    Returns:
-        (object):  The same style container as the input, with unicode arrays replaced
-
-    """
-    if isinstance(obj, dict):
-        new_obj = dict()
-        for k, v in obj.items():
-            new_obj[k] = replace_unicode_arrays(v)
-    elif isinstance(obj, tuple):
-        new_obj = list()
-        for val in obj:
-            new_obj.append(replace_unicode_arrays(val))
-        new_obj = tuple(new_obj)
-    elif isinstance(obj, list):
-        new_obj = list()
-        for val in obj:
-            new_obj.append(replace_unicode_arrays(val))
-    elif isinstance(obj, np.ndarray):
-        new_obj = unicode_array_to_fixed(obj)
-    else:
-        new_obj = obj
-    return new_obj
-
-
 def save_meta_object(parent, objname, obj):
     """Recursive function to save python metadata objects.
 
@@ -252,8 +198,8 @@ def save_meta_object(parent, objname, obj):
             del odata
         else:
             # Must be a scalar quantity
-            parent.attrs[f"{objname}_value"] = obj.value
-            parent.attrs[f"{objname}_units"] = obj.unit.to_string()
+            parent.attrs[f"{objname}:value"] = obj.value
+            parent.attrs[f"{objname}:units"] = obj.unit.to_string()
     elif isinstance(obj, np.ndarray):
         # Array
         arr = parent.create_dataset(objname, data=replace_unicode_arrays(obj))
@@ -302,16 +248,19 @@ def load_meta_object(parent):
             child = parent[child_name]
             if "units" in child.attrs:
                 # This is an array Quantity
-                arr = u.Quantity(child, u.Unit(child.attrs["units"]), copy=True)
+                arr = u.Quantity(
+                    replace_byte_arrays(child[...]), u.Unit(child.attrs["units"]), 
+                    copy=True
+                )
             else:
                 # Plain numpy array
-                arr = np.array(child, copy=True)
+                arr = np.array(replace_byte_arrays(child[...]), copy=True)
             parsed[child_name] = arr
             del child
 
     # Now process parent attributes
-    units_pat = re.compile(r"(.*)_units")
-    value_pat = re.compile(r"(.*)_value")
+    units_pat = re.compile(r"(.*):units$")
+    value_pat = re.compile(r"(.*):value$")
     for k, v in parent.attrs.items():
         if k == "python_data_type":
             continue
@@ -323,11 +272,11 @@ def load_meta_object(parent):
             # We have a quantity
             kname = units_mat.group(1)
             unit_str = v
-            kval = parent.attrs[f"{kname}_value"]
+            kval = replace_byte_arrays(np.array(parent.attrs[f"{kname}:value"]))
             parsed[kname] = u.Quantity(kval, u.Unit(unit_str))
         else:
-            # Simple scalar
-            parsed[k] = v
+            # Simple datatype
+            parsed[k] = replace_byte_arrays(v)
 
     # If the parent container is a list or tuple, construct that now and sort the
     # children into the original order.

--- a/src/toast/io/hdf_volume.py
+++ b/src/toast/io/hdf_volume.py
@@ -303,9 +303,10 @@ class VolumeIndex(object):
         log = Logger.get()
 
         # Gather the total number of valid detectors
-        n_valid_local = np.count_nonzero(
+        n_invalid = np.count_nonzero(
             [y & defaults.det_mask_invalid for x, y in obs.local_detector_flags.items()]
         )
+        n_valid_local = len(obs.local_detectors) - n_invalid
         if obs.comm_col is not None:
             n_valid = obs.comm_col.allreduce(n_valid_local, op=MPI.SUM)
         else:

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -5,6 +5,7 @@
 import ast
 import json
 import os
+import re
 
 import h5py
 import numpy as np
@@ -148,7 +149,7 @@ def load_hdf5_shared(obs, hgrp, fields, log_prefix, parallel):
 
 
 @function_timer
-def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
+def load_hdf5_detdata(obs, file_dets, hgrp, fields, log_prefix, parallel):
     log = Logger.get()
 
     timer = Timer()
@@ -176,6 +177,19 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
     if serial_load and obs.comm.comm_group is not None:
         # Broadcast the field list
         field_list = obs.comm.comm_group.bcast(field_list, root=0)
+
+    if len(obs.all_detectors) != len(file_dets):
+        # We are only loading a subset of detectors in the file.  We need to build
+        # the mapping from observation detectors to indices in the file.
+        det_subset = True
+        file_det_indx = {y: x for x, y in enumerate(file_dets)}
+        det_obs_to_file = np.zeros(len(obs.all_detectors), dtype=np.int32)
+        for idet, det in enumerate(obs.all_detectors):
+            det_obs_to_file[idet] = file_det_indx[det]
+    else:
+        # We are loading all detectors
+        det_subset = False
+        det_obs_to_file = np.arange(len(obs.all_detectors), dtype=np.int32)
 
     for field in field_list:
         if fields is not None and field not in fields:
@@ -231,6 +245,11 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
         if len(full_shape) > 2:
             sample_shape = full_shape[2:]
 
+        post_slice = ()
+        if sample_shape is not None:
+            for dim in sample_shape:
+                post_slice += slice(0, dim, 1)
+
         # All processes create their local detector data
         obs.detdata.create(
             field,
@@ -247,11 +266,30 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
 
         if compressed:
             # Load with flacarray
-            mpi_dist = [(x.offset, x.offset + x.n_elem) for x in dist_dets]
+            if det_subset:
+                keep_dets = np.zeros(len(file_dets), dtype=bool)
+                for iglobal in det_obs_to_file:
+                    keep_dets[iglobal] = True
+            else:
+                keep_dets = None
+            # The MPI distribution passed to flacarray is given in terms of
+            # the detectors in the file, not the ones we are loading.
+            if len(dist_dets) == 1:
+                mpi_dist = [(0, len(file_dets))]
+            else:
+                mpi_dist = [
+                    (
+                        det_obs_to_file[x.offset],
+                        det_obs_to_file[x.offset + x.n_elem],
+                    )
+                    for x in dist_dets[:-1]
+                ]
+                last_end = mpi_dist[-1][1]
+                mpi_dist.append((last_end, len(file_dets)))
             flcdata = (
                 flacarray.hdf5.read_array(
                     cgrp,
-                    keep=None,
+                    keep=keep_dets,
                     stream_slice=None,
                     keep_indices=False,
                     mpi_comm=obs.comm.comm_group,
@@ -270,14 +308,37 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
                 first_det = detrange.offset
                 end_det = detrange.offset + detrange.n_elem
                 n_local_det = detrange.n_elem
-                pslice = (slice(0, n_local_det, 1), slice(0, obs.n_all_samples, 1))
-                hslice = (
-                    slice(first_det, end_det, 1),
-                    slice(0, obs.n_all_samples, 1),
-                )
                 if obs.comm.group_rank == 0:
                     buffer = np.zeros((n_local_det, obs.n_all_samples), dtype=dtype)
-                    ds.read_direct(buffer, hslice, pslice)
+                    if det_subset:
+                        # We are reading multiple non-contiguous detectors.  Loop over
+                        # those to fill the buffer.
+                        for ilocal in range(n_local_det):
+                            det_file = det_obs_to_file[first_det + ilocal]
+                            pslice = (
+                                slice(ilocal, ilocal + 1, 1),
+                                slice(0, obs.n_all_samples, 1),
+                            )
+                            pslice += post_slice
+                            hslice = (
+                                slice(det_file, det_file + 1, 1),
+                                slice(0, obs.n_all_samples, 1),
+                            )
+                            hslice += post_slice
+                            ds.read_direct(buffer, hslice, pslice)
+                    else:
+                        # We are reading all dets in one shot.
+                        pslice = (
+                            slice(0, n_local_det, 1),
+                            slice(0, obs.n_all_samples, 1),
+                        )
+                        pslice += post_slice
+                        hslice = (
+                            slice(first_det, end_det, 1),
+                            slice(0, obs.n_all_samples, 1),
+                        )
+                        hslice += post_slice
+                        ds.read_direct(buffer, hslice, pslice)
                     if proc == 0:
                         # Copy data into place
                         obs.detdata[field][:] = buffer
@@ -295,17 +356,13 @@ def load_hdf5_detdata(obs, hgrp, fields, log_prefix, parallel):
                     del buffer
         else:
             # Uncompressed read in parallel
-            detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
-            hf_slice = [
+            detdata_slice = (slice(0, det_nelem, 1), slice(0, samp_nelem, 1))
+            detdata_slice += post_slice
+            hf_slice = (
                 slice(det_off, det_off + det_nelem, 1),
                 slice(samp_off, samp_off + samp_nelem, 1),
-            ]
-            if len(full_shape) > 2:
-                for dim in full_shape[2:]:
-                    detdata_slice.append(slice(0, dim))
-                    hf_slice.append(slice(0, dim))
-            detdata_slice = tuple(detdata_slice)
-            hf_slice = tuple(hf_slice)
+            )
+            hf_slice += post_slice
             msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
             check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
             ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
@@ -366,8 +423,15 @@ def load_hdf5_intervals(obs, hgrp, times, fields, log_prefix, parallel):
         )
 
 
-def load_instrument(parent_group, detectors=None, file_det_sets=None, comm=None):
+def load_instrument(
+    parent_group, detectors=None, det_select=None, file_det_sets=None, comm=None
+):
     """Load instrument information from an HDF5 group."""
+    log = Logger.get()
+    rank = 0
+    if comm is not None:
+        rank = comm.rank
+
     new_detsets = file_det_sets
     toast_version = None
     has_session = False
@@ -398,14 +462,51 @@ def load_instrument(parent_group, detectors=None, file_det_sets=None, comm=None)
     # If we are selecting only a subset of detectors, make a restricted
     # focalplane now and also modify detsets.
 
-    if detectors is not None:
+    if detectors is not None or det_select is not None:
         raw_focalplane = tele.focalplane
+
+        if detectors is not None:
+            keep = set(detectors)
+            msg = f"Proc {rank}:  Selecting detectors from {len(keep)} names"
+        else:
+            msg = f"Proc {rank}:  Selecting detectors from zero names"
+            keep = None
+        if det_select is not None:
+            col_pat = {x: re.compile(y) for x, y in det_select.items()}
+            msg += f" and {len(col_pat)} column matches"
+        else:
+            col_pat = None
+            msg += " and zero column matches"
+        log.verbose(msg)
 
         # Slice focalplane to include only these detectors.  Also modify
         # detector sets to include only these detectors.
-        keep = set(detectors)
-        fp_rows = [x["name"] in keep for x in raw_focalplane.detector_data]
+        fp_rows = list()
+        for row in raw_focalplane.detector_data:
+            use_row = False
+            if keep is not None and row["name"] in keep:
+                # We are using explicit list of dets, and this matches.
+                msg = f"Proc {rank}:    det {row['name']} in list, keeping"
+                log.verbose(msg)
+                use_row = True
+            elif col_pat is None:
+                # No matching on column values, keep the det.
+                msg = f"Proc {rank}:    det {row['name']} no column patterns, keeping"
+                log.verbose(msg)
+                use_row = True
+            else:
+                # Check if all column values match
+                ccheck = True
+                for cname, cpat in col_pat.items():
+                    if cpat.search(row[cname]) is None:
+                        ccheck = False
+                if ccheck:
+                    msg = f"Proc {rank}:    det {row['name']} matches columns, keeping"
+                    log.verbose(msg)
+                    use_row = True
+            fp_rows.append(use_row)
         fp_data = QTable(raw_focalplane.detector_data[fp_rows])
+        fp_dets = set(fp_data["name"])
 
         focalplane = Focalplane(
             detector_data=fp_data,
@@ -418,7 +519,7 @@ def load_instrument(parent_group, detectors=None, file_det_sets=None, comm=None)
             for ds in file_det_sets:
                 new_ds = list()
                 for d in ds:
-                    if d in keep:
+                    if d in fp_dets:
                         new_ds.append(d)
                 if len(new_ds) > 0:
                     new_detsets.append(new_ds)
@@ -427,7 +528,7 @@ def load_instrument(parent_group, detectors=None, file_det_sets=None, comm=None)
             for dskey, ds in file_det_sets.items():
                 new_ds = list()
                 for d in ds:
-                    if d in keep:
+                    if d in fp_dets:
                         new_ds.append(d)
                 if len(new_ds) > 0:
                     new_detsets.append(new_ds)
@@ -447,6 +548,7 @@ def load_hdf5_obs_meta(
     meta=None,
     detectors=None,
     process_rows=None,
+    det_select=None,
 ):
     log = Logger.get()
     rank = comm.group_rank
@@ -459,6 +561,7 @@ def load_hdf5_obs_meta(
     obs_samples = None
     obs_name = None
     obs_uid = None
+    obs_dets = None
     session = None
     obs_det_sets = None
     obs_sample_sets = None
@@ -481,8 +584,18 @@ def load_hdf5_obs_meta(
             ]
 
         # Instrument properties
+        dlist = None
+        if detectors is not None and len(detectors) > 0:
+            dlist = detectors
+        dselect = None
+        if det_select is not None and len(det_select) > 0:
+            dselect = det_select
         telescope, session, obs_det_sets = load_instrument(
-            hgroup, detectors=detectors, file_det_sets=file_det_sets, comm=None
+            hgroup,
+            detectors=dlist,
+            det_select=dselect,
+            file_det_sets=file_det_sets,
+            comm=None,
         )
 
         # Per detector flags.
@@ -500,6 +613,7 @@ def load_hdf5_obs_meta(
         obs_samples = comm.comm_group.bcast(obs_samples, root=0)
         obs_name = comm.comm_group.bcast(obs_name, root=0)
         obs_uid = comm.comm_group.bcast(obs_uid, root=0)
+        obs_dets = comm.comm_group.bcast(obs_dets, root=0)
         session = comm.comm_group.bcast(session, root=0)
         obs_det_sets = comm.comm_group.bcast(obs_det_sets, root=0)
         obs_sample_sets = comm.comm_group.bcast(obs_sample_sets, root=0)
@@ -638,7 +752,7 @@ def load_hdf5_obs_meta(
         comm=comm.comm_group,
         timer=timer,
     )
-    return obs
+    return obs, obs_dets
 
 
 @function_timer
@@ -652,6 +766,7 @@ def load_hdf5(
     intervals=None,
     detectors=None,
     force_serial=False,
+    det_select=None,
 ):
     """Load an HDF5 observation.
 
@@ -673,6 +788,8 @@ def load_hdf5(
             objects.
         force_serial (bool):  If True, do not use HDF5 parallel support,
             even if it is available.
+        det_select (dict):  A dictionary of column names and regex matches to apply
+            to the focalplane table to select detectors to load.
 
     Returns:
         (Observation):  The constructed observation.
@@ -753,7 +870,7 @@ def load_hdf5(
         raise RuntimeError(msg)
 
     # Load all metadata into an empty Observation
-    obs = load_hdf5_obs_meta(
+    obs, file_dets = load_hdf5_obs_meta(
         comm,
         hgroup,
         parallel=parallel,
@@ -761,6 +878,7 @@ def load_hdf5(
         meta=meta,
         detectors=detectors,
         process_rows=process_rows,
+        det_select=det_select,
     )
 
     # Load shared data
@@ -806,7 +924,7 @@ def load_hdf5(
     detdata_group = None
     if hgroup is not None:
         detdata_group = hgroup["detdata"]
-    load_hdf5_detdata(obs, detdata_group, detdata, log_prefix, parallel)
+    load_hdf5_detdata(obs, file_dets, detdata_group, detdata, log_prefix, parallel)
     del detdata_group
     log.debug_rank(
         f"{log_prefix} Finished detector data in",
@@ -849,5 +967,5 @@ def load_instrument_file(path, detectors=None, obs_det_sets=None, comm=None):
             if grp == "":
                 continue
             parent = parent[grp]
-        telescope, session, _ = load_instrument(parent)
+        telescope, session, _ = load_instrument(parent, detectors=detectors)
     return telescope, session

--- a/src/toast/observation.py
+++ b/src/toast/observation.py
@@ -8,6 +8,7 @@ from collections.abc import MutableMapping
 
 import numpy as np
 from astropy import units as u
+from astropy.table import Table
 
 from .accelerator import AcceleratorObject
 from .instrument import Session
@@ -21,7 +22,7 @@ from .observation_data import (
 from .observation_dist import DistDetSamp, redistribute_data
 from .observation_view import ViewInterface
 from .timing import function_timer
-from .utils import Logger, name_UID
+from .utils import Logger, name_UID, table_equal, array_equal
 
 default_values = None
 
@@ -607,49 +608,54 @@ class Observation(MutableMapping):
                     msg += f"{type(other_obj)}"
                     log.verbose(msg)
                     return False
+            if isinstance(self_obj, Table):
+                return table_equal(self_obj, other_obj)
             if isinstance(self_obj, dict):
-                if set(self_obj.keys()) != set(other_obj.keys()):
-                    msg = f"{prefix} meta_equal dict keys mismatch"
+                self_keys = set(self_obj.keys())
+                other_keys = set(other_obj.keys())
+                if self_keys != other_keys:
+                    msg = f"{prefix} meta_equal dict keys mismatch "
+                    msg += f"{self_keys} != {other_keys}"
                     log.verbose(msg)
                     return False
                 result = True
                 for k, v in self_obj.items():
                     v_other = other_obj[k]
-                    child_prefix = f"{prefix}_{k}"
+                    child_prefix = f"{prefix}:{k}"
                     check = _compare_nodes(v, v_other, child_prefix)
                     if not check:
                         result = False
                 return result
             if isinstance(self_obj, (list, tuple)):
                 if len(self_obj) != len(other_obj):
-                    msg = f"{prefix} meta_equal container length mismatch"
+                    msg = f"{prefix} meta_equal container length mismatch "
+                    msg += f"{len(self_obj)} != {len(other_obj)}"
                     log.verbose(msg)
                     return False
                 result = True
                 for index, val in enumerate(self_obj):
                     other_val = other_obj[index]
-                    child_prefix = f"{prefix}_{index:04d}"
+                    child_prefix = f"{prefix}:{index:04d}"
                     check = _compare_nodes(val, other_val, child_prefix)
                     if not check:
                         result = False
                 return result
-            try:
-                is_eq = np.allclose(self_obj, other_obj)
-                if not is_eq:
-                    msg = f"{prefix} meta_equal arrays are not close"
-                    log.verbose(msg)
-                result = is_eq
-            except Exception:
-                # Not arrays
-                result = self_obj == other_obj
-                if not result:
-                    msg = f"{prefix} meta_equal scalars are not equal"
-                    log.verbose(msg)
+            if isinstance(self_obj, np.ndarray):
+                result = array_equal(
+                    self_obj, other_obj, log_prefix=f"Observation eq {prefix}"
+                )
+                return result
+
+            # Not arrays
+            result = self_obj == other_obj
+            if not result:
+                msg = f"{prefix} meta_equal scalars {self_obj} != {other_obj}"
+                log.verbose(msg)
             return result
 
         return _compare_nodes(self._internal, other._internal, prefix)
 
-    def __eq__(self, other):
+    def __eq__(self, other, approx=False):
         # Note that testing for equality is quite expensive, since it means testing all
         # metadata and also all detector, shared, and interval data.  This is mainly
         # used for unit tests.
@@ -676,16 +682,20 @@ class Observation(MutableMapping):
             log.verbose(f"Proc {self.comm.world_rank}:  Obs distributions not equal")
         if self.local_detector_flags != other.local_detector_flags:
             fail = 1
-            log.verbose(
-                f"Proc {self.comm.world_rank}:  Obs local_detector_flags not equal"
-            )
+            msg = f"Proc {self.comm.world_rank}:  Obs local_detector_flags not equal: "
+            msg += f"LFLAGS = {self.local_detector_flags}, "
+            msg += f"RFLAGS = {other.local_detector_flags}"
+            log.verbose(msg)
 
-        self.meta_equal(other, f"Proc {self.comm.world_rank}:  Obs _internal")
+        rmeta = self.meta_equal(other, f"Proc {self.comm.world_rank}:  Obs _internal")
+        if not rmeta:
+            fail = 1
+            log.verbose(f"Proc {self.comm.world_rank}:  Obs meta data not equal")
 
         if self.shared != other.shared:
             fail = 1
             log.verbose(f"Proc {self.comm.world_rank}:  Obs shared data not equal")
-        if self.detdata != other.detdata:
+        if not self.detdata.__eq__(other.detdata, approx=approx):
             fail = 1
             log.verbose(f"Proc {self.comm.world_rank}:  Obs detdata not equal")
         if self.intervals != other.intervals:

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -24,7 +24,7 @@ from .accelerator import (
 )
 from .intervals import IntervalList
 from .mpi import MPI, comm_equivalent
-from .utils import Logger, dtype_to_aligned
+from .utils import Logger, dtype_to_aligned, array_equal
 
 if use_accel_jax:
     import jax
@@ -220,6 +220,13 @@ class DetectorData(AcceleratorObject):
     @property
     def detector_shape(self):
         return tuple(self._shape[1:])
+
+    @property
+    def sample_shape(self):
+        if len(self._shape) < 3:
+            return None
+        else:
+            return tuple(self._shape[2:])
 
     def memory_use(self):
         return self._memsize
@@ -531,7 +538,7 @@ class DetectorData(AcceleratorObject):
         val += "\n>"
         return val
 
-    def __eq__(self, other):
+    def __eq__(self, other, approx=False):
         # Please leave the commented-out lines for ease of future
         # debugging.
         if self.detectors != other.detectors:
@@ -551,47 +558,11 @@ class DetectorData(AcceleratorObject):
             # msg = f"DetectorData dets not equal {self.units} != {other.units}"
             # print(msg)
             return False
-        if self.dtype == np.dtype(np.float64):
-            drange = np.amax(self.data) - np.amin(self.data)
-            rtol = 1.0e-12
-            atol = 10.0 * drange * 1.0e-15
-            if not np.allclose(self.data, other.data, rtol=rtol, atol=atol):
-                # indx = np.logical_not(
-                #     np.isclose(self.data, other.data, rtol=rtol, atol=atol)
-                # )
-                # msg = f"DetectorData array not close rtol={rtol}, atol={atol}:"
-                # for d in np.arange(self.data.shape[0]):
-                #     dname = self.detectors[d]
-                #     for s in np.arange(self.data.shape[1])[indx[d]]:
-                #         msg += f"\n {dname}, {s}:  {self.data[d, s]}"
-                #         msg += f" != {other.data[d, s]}"
-                # print(msg)
-                return False
-        elif self.dtype == np.dtype(np.float32):
-            drange = np.amax(self.data) - np.amin(self.data)
-            rtol = 1.0e-6
-            atol = 10.0 * drange * 1.0e-6
-            if not np.allclose(self.data, other.data, rtol=rtol, atol=atol):
-                # indx = np.logical_not(
-                #     np.isclose(self.data, other.data, rtol=rtol, atol=atol)
-                # )
-                # msg = f"DetectorData array not close rtol={rtol}, atol={atol}:"
-                # for d in np.arange(self.data.shape[0]):
-                #     dname = self.detectors[d]
-                #     for s in np.arange(self.data.shape[1])[indx[d]]:
-                #         msg += f"\n {dname}, {s}:  {self.data[d, s]}"
-                #         msg += f" != {other.data[d, s]}"
-                # print(msg)
-                return False
-        elif not np.array_equal(self.data, other.data):
-            # indx = np.where(self.data != other.data)[0]
-            # msg = "DetectorData array not equal:"
-            # for d in np.arange(self.data.shape[0]):
-            #     dname = self.detectors[d]
-            #     for s in np.arange(self.data.shape[1])[indx[d]]:
-            #         msg += f"\n {dname}, {s}:  {self.data[d, s]}"
-            #         msg += f" != {other.data[d, s]}"
-            # print(msg)
+        # Compare array values
+        check = array_equal(
+            self.data, other.data, f32=approx, log_prefix="DetectorData"
+        )
+        if not check:
             return False
         return True
 
@@ -899,6 +870,26 @@ class DetDataManager(MutableMapping):
                         msg += "using neither openmp nor jax"
                         raise RuntimeError(msg)
         return existing
+
+    def rename(self, original, new_name):
+        """Rename a DetectorData object within the internal dictionary.
+
+        Args:
+            original (str):  The original name of the DetectorData
+            new_name (str):  The new name.
+
+        Returns:
+            (None)
+
+        """
+        if original not in self._internal:
+            msg = f"DetectorData '{original}' does not exist"
+            raise KeyError(original)
+        if new_name in self._internal:
+            msg = f"DetectorData '{new_name}' already exists.  Delete it "
+            msg += f"before renaming '{original}'"
+            raise RuntimeError(msg)
+        self._internal[new_name] = self._internal.pop(original)
 
     def accel_exists(self, key):
         """Check if the named detector data exists on the accelerator.
@@ -1252,7 +1243,7 @@ class DetDataManager(MutableMapping):
         val += ">"
         return val
 
-    def __eq__(self, other):
+    def __eq__(self, other, approx=False):
         log = Logger.get()
         if self.detectors != other.detectors:
             log.verbose(f"  detectors {self.detectors} != {other.detectors}")
@@ -1264,7 +1255,7 @@ class DetDataManager(MutableMapping):
             log.verbose(f"  keys {self._internal.keys()} != {other._internal.keys()}")
             return False
         for k in self._internal.keys():
-            if self._internal[k] != other._internal[k]:
+            if not self._internal[k].__eq__(other._internal[k], approx=approx):
                 msg = f"  detector data {k} not equal:  "
                 msg += f"{self._internal[k]} != {other._internal[k]}"
                 log.verbose(msg)

--- a/src/toast/ops/calibrate.py
+++ b/src/toast/ops/calibrate.py
@@ -7,17 +7,26 @@ import traitlets
 
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Int, Unicode, trait_docs
+from ..traits import Float, Int, Unicode, Unit, trait_docs
 from ..utils import Logger
 from .operator import Operator
 
 
 @trait_docs
 class CalibrateDetectors(Operator):
-    """Multiply detector data by factors in the observation dictionary.
+    """Multiply detector data by calibration factors.
 
-    Given a dictionary in each observation, apply the per-detector scaling factors
-    to the timestreams.  Detectors that do not exist in the dictionary are flagged.
+    The calibration factor can be specified as a fixed value for all detectors (for
+    example when converting from raw ADC values) or per-detector values can be
+    supplied as a dictionary within the observation metadata or a column of the
+    focalplane data table.  Detectors which are missing in the calibration dictionary
+    are flagged.
+
+    This operator is frequently the first one applied to "raw" data loaded from disk.
+    If the dtype of the input DetectorData is an integer type, it will be promoted
+    to float64 before applying the calibration.
+
+    The units of the DetectorData can be updated with the `cal_units` trait.
 
     """
 
@@ -27,6 +36,18 @@ class CalibrateDetectors(Operator):
 
     cal_name = Unicode(
         "calibration", help="The observation or focalplane key containing the gains"
+    )
+
+    cal_value = Float(
+        None,
+        allow_none=True,
+        help="Apply this constant value to all detectors.  Overrides `cal_name`",
+    )
+
+    cal_units = Unit(
+        None,
+        allow_none=True,
+        help="Update the detector data units",
     )
 
     det_data = Unicode(
@@ -74,18 +95,49 @@ class CalibrateDetectors(Operator):
                 continue
 
             fp = ob.telescope.focalplane
-            if self.cal_name in ob:
-                # Observation has a separate calibration table
-                cal = ob[self.cal_name]
-            elif self.cal_name in fp.properties:
-                # Gains are in the focalplane database
-                cal = {}
-                for det in dets:
-                    cal[det] = fp[det][self.cal_name]
+            if self.cal_value is not None:
+                cal = {x: self.cal_value for x in dets}
             else:
-                msg = f"{ob.name}: Gains '{self.cal_name}' do not exist "
-                msg += f"as a dictionary nor in the focalplane database"
-                raise RuntimeError(msg)
+                if self.cal_name in ob:
+                    # Observation has a separate calibration table
+                    cal = ob[self.cal_name]
+                elif self.cal_name in fp.properties:
+                    # Gains are in the focalplane database
+                    cal = {}
+                    for det in dets:
+                        cal[det] = fp[det][self.cal_name]
+                else:
+                    msg = f"{ob.name}: Gains '{self.cal_name}' do not exist "
+                    msg += "as a dictionary nor in the focalplane database"
+                    raise RuntimeError(msg)
+
+            # Check dtype of detector data
+            input_dtype = ob.detdata[self.det_data].dtype
+            if input_dtype == np.dtype(np.int32) or input_dtype == np.dtype(np.int64):
+                # Create a new DetectorData object and copy the original.  Then delete
+                # the original and move the new one into place.
+                temp_name = f"{self.name}_{self.det_data}_TEMPORARY"
+                if self.cal_units is None:
+                    temp_units = ob.detdata[self.det_data].units
+                else:
+                    temp_units = self.cal_units
+                ob.detdata.create(
+                    temp_name,
+                    sample_shape=ob.detdata[self.det_data].sample_shape,
+                    dtype=np.float64,
+                    detectors=ob.detdata[self.det_data].detectors,
+                    units=temp_units,
+                )
+                for det in ob.detdata[self.det_data].detectors:
+                    ob.detdata[temp_name][det] = ob.detdata[self.det_data][det].astype(
+                        np.float64
+                    )
+                del ob.detdata[self.det_data]
+                ob.detdata.rename(temp_name, self.det_data)
+            else:
+                # Just update units if needed
+                if self.cal_units is not None:
+                    ob.detdata[self.det_data].update_units(self.cal_units)
 
             # Process all detectors
             det_flags = dict(ob.local_detector_flags)

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -11,7 +11,7 @@ from ..dist import distribute_discrete
 from ..io import load_hdf5, VolumeIndex
 from ..observation import default_values as defaults
 from ..timing import function_timer
-from ..traits import Bool, Int, List, Unicode, trait_docs
+from ..traits import Bool, Dict, Int, List, Unicode, trait_docs
 from ..utils import Logger
 from .operator import Operator
 
@@ -79,6 +79,10 @@ class LoadHDF5(Operator):
         help="Only load this list of detdata objects",
     )
 
+    det_select = Dict(
+        {}, help="Keep a subset of detectors whose focalplane columns match."
+    )
+
     shared = List([], help="Only load this list of shared objects")
 
     intervals = List([], help="Only load this list of intervals objects")
@@ -141,6 +145,7 @@ class LoadHDF5(Operator):
                 shared=shared_fields,
                 intervals=intervals_fields,
                 force_serial=self.force_serial,
+                det_select=self.det_select,
             )
 
             data.obs.append(ob)

--- a/src/toast/ops/load_hdf5.py
+++ b/src/toast/ops/load_hdf5.py
@@ -204,6 +204,9 @@ class LoadHDF5(Operator):
                 for ofile in self.files:
                     fsize = self._get_obs_samples(ofile)
                     obs_props.append((fsize, ofile))
+                msg = "LoadHDF5 using specified file list with sizes: "
+                msg += f"{obs_props}"
+                log.verbose(msg)
             else:
                 # We are using the volume trait.  Get the list of relative file paths
                 # for each observation.
@@ -224,6 +227,10 @@ class LoadHDF5(Operator):
                             full_path = os.path.join(self.volume, rfile)
                             fsize = self._get_obs_samples(full_path)
                             obs_props.append((fsize, full_path))
+                        msg = "LoadHDF5 using volume with NO index and matching"
+                        msg += f" filename pattern '{self.pattern}' found sizes: "
+                        msg += f"{obs_props}"
+                        log.verbose(msg)
                     else:
                         # We are using the index.  Get the full list of obs and then
                         # apply the regex.  We use the number of valid detector-samples
@@ -235,6 +242,10 @@ class LoadHDF5(Operator):
                                 sz = osamples * odets
                                 full_path = os.path.join(self.volume, opath)
                                 obs_props.append((sz, full_path))
+                        msg = "LoadHDF5 using volume WITH index and matching"
+                        msg += f" filename pattern '{self.pattern}' found sizes: "
+                        msg += f"{obs_props}"
+                        log.verbose(msg)
                 else:
                     # Using a custom selection with the index.  Use the number of
                     # valid detector-samples for load balancing.
@@ -244,6 +255,9 @@ class LoadHDF5(Operator):
                         sz = osamples * odets
                         full_path = os.path.join(self.volume, opath)
                         obs_props.append((sz, full_path))
+                    msg = f"LoadHDF5 using volume with query '{self.volume_select}'"
+                    msg += f" found sizes: {obs_props}"
+                    log.verbose(msg)
             if self.sort_by_size:
                 obs_props.sort(key=lambda x: x[0])
             else:

--- a/src/toast/ops/save_hdf5.py
+++ b/src/toast/ops/save_hdf5.py
@@ -16,138 +16,6 @@ from ..utils import Logger
 from .operator import Operator
 
 
-def obs_approx_equal(obs1, obs2):
-    """Compare observations with relaxed floating point data comparisons.
-
-    Normal equality tests for detector data may be too stringent in the case where
-    float64 data is compressed to 32bit integer FLAC data.  Here we do a normal equality
-    test except for detector data that has floating point values, where we instead
-    use an increased tolerance.
-
-    Args:
-        obs1 (Observation):  The first observation to compare.
-        obs2 (Observation):  The second observation to compare.
-
-    Returns:
-        (bool):  True if observations are approximately equal.
-
-    """
-    log = Logger.get()
-    fail = 0
-    if obs1.name != obs2.name:
-        fail = 1
-        log.verbose(
-            f"Proc {obs1.comm.world_rank}:  Obs names {obs1.name} != {obs2.name}"
-        )
-    if obs1.uid != obs2.uid:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs uid {obs1.uid} != {obs2.uid}")
-    if obs1.telescope != obs2.telescope:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs telescopes not equal")
-    if obs1.session != obs2.session:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs sessions not equal")
-    if obs1.dist != obs2.dist:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs distributions not equal")
-
-    if not obs1.meta_equal(obs2, f"Proc {obs1.comm.world_rank}:  Obs _internal"):
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs metadata not equal")
-
-    # Compare any extra metadata class instances
-    extra_objs1 = list()
-    for k, v in vars(obs1).items():
-        if k.startswith("_"):
-            continue
-        if hasattr(v, "save_hdf5"):
-            extra_objs1.append(k)
-    extra_objs2 = list()
-    for k, v in vars(obs2).items():
-        if k.startswith("_"):
-            continue
-        if hasattr(v, "save_hdf5"):
-            extra_objs2.append(k)
-
-    if extra_objs1 != extra_objs2:
-        fail = 1
-        log.verbose(
-            f"Proc {obs1.comm.world_rank}:  Obs extra metadata obj lists not equal"
-        )
-    else:
-        for exobj in extra_objs1:
-            obj1 = getattr(obs1, exobj)
-            obj2 = getattr(obs2, exobj)
-            if obj1 != obj2:
-                fail = 1
-                log.verbose(
-                    f"Proc {obs1.comm.world_rank}:  Obs extra {exobj} not equal"
-                )
-
-    if obs1.shared != obs2.shared:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs shared data not equal")
-    if obs1.intervals != obs2.intervals:
-        fail = 1
-        log.verbose(f"Proc {obs1.comm.world_rank}:  Obs intervals not equal")
-
-    # Walk through the detector data
-    o1d = obs1.detdata
-    o2d = obs2.detdata
-    if o1d.detectors != o2d.detectors:
-        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata detectors"
-        msg += f" {o1d.detectors} != {o2d.detectors}"
-        log.verbose(msg)
-        fail = 1
-    if o1d.samples != o2d.samples:
-        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata samples "
-        msg += f"{o1d.samples} != {o2d.samples}"
-        log.verbose(msg)
-        fail = 1
-    if set(o1d._internal.keys()) != set(o2d._internal.keys()):
-        msg = f"Proc {obs1.comm.world_rank}:  Obs detdata keys "
-        msg += f"{o1d._internal.keys()} != {o2d._internal.keys()}"
-        log.verbose(msg)
-        fail = 1
-    for k in o1d._internal.keys():
-        if o1d[k].detectors != o2d[k].detectors:
-            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} detectors "
-            msg += f"{o1d[k].detectors} != {o2d[k].detectors}"
-            log.verbose(msg)
-            fail = 1
-        if o1d[k].dtype.char != o2d[k].dtype.char:
-            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} dtype "
-            msg += f"{o1d[k].dtype} != {o2d[k].dtype}"
-            log.verbose(msg)
-            fail = 1
-        if o1d[k].shape != o2d[k].shape:
-            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} shape "
-            msg += f"{o1d[k].shape} != {o2d[k].shape}"
-            log.verbose(msg)
-            fail = 1
-        if o1d[k].units != o2d[k].units:
-            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} units "
-            msg += f"{o1d[k].units} != {o2d[k].units}"
-            log.verbose(msg)
-            fail = 1
-        if o1d[k].dtype == np.dtype(np.float64) or o1d[k].dtype == np.dtype(np.float32):
-            # Only compare to 32bit precision
-            if not np.allclose(o1d[k].data, o2d[k].data, rtol=1.0e-3, atol=1.0e-5):
-                msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} array "
-                msg += f"{o1d[k].data} != {o2d[k].data}"
-                log.verbose(msg)
-                fail = 1
-        elif not np.array_equal(o1d[k].data, o2d[k].data):
-            msg = f"Proc {obs1.comm.world_rank}:  Obs detdata {k} array "
-            msg += f"{o1d[k].data} != {o2d[k].data}"
-            log.verbose(msg)
-            fail = 1
-    if obs1.comm.comm_group is not None:
-        fail = obs1.comm.comm_group.allreduce(fail, op=MPI.SUM)
-    return fail == 0
-
-
 @trait_docs
 class SaveHDF5(Operator):
     """Operator which saves observations to HDF5.
@@ -428,14 +296,20 @@ class SaveHDF5(Operator):
                     force_serial=self.force_serial,
                 )
 
-                if not obs_approx_equal(compare, original):
-                    msg = "Observation HDF5 verify failed:\n"
-                    msg += f"Input = {original}\n"
-                    msg += f"Loaded = {compare}\n"
-                    msg += f"Input signal[0] = {original.detdata['signal'][0]}\n"
-                    msg += f"Loaded signal[0] = {compare.detdata['signal'][0]}"
-                    log.error(msg)
-                    raise RuntimeError(msg)
+                failed = 0
+                fail_msg = None
+                if not original.__eq__(compare, approx=True):
+                    fail_msg = "Observation HDF5 verify failed:\n"
+                    fail_msg += f"Input = {original}\n"
+                    fail_msg += f"Loaded = {compare}\n"
+                    fail_msg += f"Input signal[0] = {original.detdata['signal'][0]}\n"
+                    fail_msg += f"Loaded signal[0] = {compare.detdata['signal'][0]}"
+                    log.error(fail_msg)
+                    failed = 1
+                if data.comm.comm_group is not None:
+                    failed = data.comm.comm_group.allreduce(failed, op=MPI.SUM)
+                if failed:
+                    raise RuntimeError(fail_msg)
 
         return
 

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -4,6 +4,7 @@
 
 import io
 import os
+import json
 
 import h5py
 import numpy as np
@@ -97,7 +98,7 @@ def export_detdata(
         raise KeyError(f"DetectorData object '{name}' does not exist in observation")
     if g3t == c3g.G3TimestreamMap and times is None:
         raise RuntimeError(
-            f"If exporting a G3TimestreamMap, the times name must be specified"
+            "If exporting a G3TimestreamMap, the times name must be specified"
         )
     gunit, scale = to_g3_unit(obs.detdata[name].units)
 
@@ -171,12 +172,14 @@ def export_intervals(obs, name, iframe):
     frame = iframe.data[0]
     for ival in obs.intervals[name]:
         if frame.start <= ival.stop and frame.stop >= ival.start:
-            overlap.append((
-                ival.start,
-                ival.stop,
-                max(frame.first, ival.first),
-                min(frame.last, ival.last),
-            ))
+            overlap.append(
+                (
+                    ival.start,
+                    ival.stop,
+                    max(frame.first, ival.first),
+                    min(frame.last, ival.last),
+                )
+            )
     overlap = IntervalList(
         iframe.timestamps,
         intervals=np.array(overlap, dtype=interval_dtype).view(np.recarray),
@@ -243,6 +246,7 @@ class export_obs_meta(object):
         ob["observation_detector_sets"] = c3g.G3VectorVectorString(
             obs.all_detector_sets
         )
+        ob["observation_detector_flags"] = json.dumps(obs.local_detector_flags)
         ob["telescope_name"] = c3g.G3String(obs.telescope.name)
         ob["telescope_class"] = c3g.G3String(object_fullname(obs.telescope.__class__))
         ob["telescope_uid"] = c3g.G3Int(obs.telescope.uid)

--- a/src/toast/spt3g/spt3g_import.py
+++ b/src/toast/spt3g/spt3g_import.py
@@ -4,6 +4,7 @@
 
 import datetime
 import io
+import json
 import os
 import re
 
@@ -207,6 +208,7 @@ class import_obs_meta(object):
                 "observation_name",
                 "observation_uid",
                 "observation_detector_sets",
+                "observation_detector_flags",
                 "telescope_name",
                 "telescope_class",
                 "telescope_uid",
@@ -239,7 +241,8 @@ class import_obs_meta(object):
 
         Returns:
             (tuple):  The (observation name, observation UID, observation meta
-                dictionary, observation det sets, Telescope, list of noise models)
+                dictionary, observation det sets, Telescope, list of noise models,
+                detector flags)
 
         """
         name = None
@@ -253,6 +256,7 @@ class import_obs_meta(object):
         telescope = None
         noise = list()
         detsets = None
+        detflags = None
         for frm in frames:
             if frm.type == c3g.G3FrameType.Observation:
                 name = from_g3_scalar_type(frm["observation_name"])
@@ -260,6 +264,10 @@ class import_obs_meta(object):
                 detsets = list()
                 for dset in frm["observation_detector_sets"]:
                     detsets.append(list(dset))
+                if "observation_detector_flags" in frm:
+                    detflags = json.loads(frm["observation_detector_flags"])
+                else:
+                    detflags = dict()
                 site_class = import_from_name(from_g3_scalar_type(frm["site_class"]))
                 if "site_lat_deg" in frm:
                     # This is a GroundSite
@@ -388,8 +396,7 @@ class import_obs_meta(object):
                 # Extract the focalplane and noise models
                 byte_reader = io.BytesIO(np.array(frm["focalplane"], dtype=np.uint8))
                 with h5py.File(byte_reader, "r") as f:
-                    focalplane = Focalplane()
-                    focalplane.load_hdf5(f)
+                    focalplane = Focalplane.load_hdf5(f)
                 del byte_reader
 
                 telescope = telescope_class(
@@ -424,7 +431,7 @@ class import_obs_meta(object):
 
                 del fake_obs
 
-        return name, uid, meta, detsets, telescope, session, noise
+        return name, uid, meta, detsets, telescope, session, noise, detflags
 
 
 class import_obs_data(object):
@@ -673,6 +680,7 @@ class import_obs(object):
         obs_session = None
         obs_detsets = None
         obs_noise = None
+        obs_detflags = None
         if self._rank == lead_rank:
             (
                 obs_name,
@@ -682,6 +690,7 @@ class import_obs(object):
                 obs_telescope,
                 obs_session,
                 obs_noise,
+                obs_detflags,
             ) = self._meta_import(frames)
         if self._comm.comm_group is not None:
             obs_telescope = self._comm.comm_group.bcast(obs_telescope, root=lead_rank)
@@ -691,6 +700,7 @@ class import_obs(object):
             obs_session = self._comm.comm_group.bcast(obs_session, root=lead_rank)
             obs_detsets = self._comm.comm_group.bcast(obs_detsets, root=lead_rank)
             obs_noise = self._comm.comm_group.bcast(obs_noise, root=lead_rank)
+            obs_detflags = self._comm.comm_group.bcast(obs_detflags, root=lead_rank)
 
         # Every process with data builds some information about their
         # scan frames, which can then be used to sort and redistribute them
@@ -738,6 +748,9 @@ class import_obs(object):
 
         # Add the metadata
         ob.update(obs_meta)
+
+        # Update det flags
+        ob.update_local_detector_flags(obs_detflags)
 
         # Add the noise models
         for model_name, model in obs_noise.items():

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -12,7 +12,7 @@ from .. import ops as ops
 from ..config import build_config
 from ..data import Data
 from ..io import load_hdf5, save_hdf5, VolumeIndex
-from ..ops.save_hdf5 import obs_approx_equal
+from ..utils import replace_byte_arrays
 from ..weather import Weather
 from .helpers import close_data, create_ground_data, create_outdir, create_comm
 from .mpi import MPITestCase
@@ -61,6 +61,8 @@ def create_other_meta():
     qscalar = 1.234 * u.second
     arr = np.arange(10, dtype=np.float64)
     qarr = arr * u.meter
+    uarr = np.array(["abc", "defg", "hijklm", "no"], dtype=np.dtype("U6"))
+    sarr = np.array([b"abc", b"defg", b"hijklm", b"no"], dtype=np.dtype("|S6"))
 
     def _leaf_dict():
         return {
@@ -68,6 +70,8 @@ def create_other_meta():
             "qscalar": qscalar,
             "arr": arr,
             "qarr": qarr,
+            "uarr": uarr,
+            "sarr": sarr,
         }
 
     def _leaf_list():
@@ -76,6 +80,8 @@ def create_other_meta():
             qscalar,
             arr,
             qarr,
+            uarr,
+            sarr,
         ]
 
     def _leaf_tuple():
@@ -84,6 +90,8 @@ def create_other_meta():
             qscalar,
             arr,
             qarr,
+            uarr,
+            sarr,
         )
 
     def _node_dict():
@@ -135,9 +143,12 @@ class IoHdf5Test(MPITestCase):
             **kwargs,
         )
 
-        # Add extra metadata attribute
+        # Add extra metadata attribute.  Since we are going to test equality on the
+        # observation metadata when saving to HDF5 and loading back in, we convert
+        # any bytestrings to unicode first.
         if not no_meta:
-            other = create_other_meta()
+            raw_other = create_other_meta()
+            other = replace_byte_arrays(raw_other)
             for ob in data.obs:
                 ob.extra = ExtraMeta()
                 ob.update(other)
@@ -242,7 +253,7 @@ class IoHdf5Test(MPITestCase):
 
             # Verify
             for ob, orig in zip(check_data.obs, original):
-                if not obs_approx_equal(ob, orig):
+                if not orig.__eq__(ob, approx=True):
                     print(
                         f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}"
                     )
@@ -289,7 +300,7 @@ class IoHdf5Test(MPITestCase):
         # Verify
         for ob in check_data.obs:
             orig = original[ob.name]
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -302,7 +313,7 @@ class IoHdf5Test(MPITestCase):
 
         for ob in check_data.obs:
             orig = original[ob.name]
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -316,7 +327,7 @@ class IoHdf5Test(MPITestCase):
 
         for ob in check_data.obs:
             orig = original[ob.name]
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -362,7 +373,7 @@ class IoHdf5Test(MPITestCase):
         # Verify
         for ob in check_data.obs:
             orig = original[ob.name]
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -406,7 +417,7 @@ class IoHdf5Test(MPITestCase):
         for ob in check_data.obs:
             orig = original[ob.name]
             orig.detdata.clear()
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -452,7 +463,7 @@ class IoHdf5Test(MPITestCase):
         # Verify
         for ob in check_data.obs:
             orig = original[ob.name]
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
         del check_data
@@ -474,7 +485,9 @@ class IoHdf5Test(MPITestCase):
         if self.comm is not None:
             self.comm.barrier()
 
-        data, config = self.create_data(split=True, no_meta=True)
+        # Version 1 did not save per-detector flags in the observation to HDF5,
+        # so we disable them for this test.
+        data, config = self.create_data(split=True, no_meta=True, flagged_pixels=False)
         det_data_names = ["signal", "flags", "alt_signal"]
         det_data_fields = [
             ("signal", {"type": "flac", "quanta": 1.0e-7}),
@@ -510,7 +523,7 @@ class IoHdf5Test(MPITestCase):
 
         # Verify
         for ob, orig in zip(check_data.obs, original):
-            if not obs_approx_equal(ob, orig):
+            if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
 

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -4,6 +4,7 @@
 
 import glob
 import os
+import re
 
 import numpy as np
 from astropy import units as u
@@ -12,7 +13,7 @@ from .. import ops as ops
 from ..config import build_config
 from ..data import Data
 from ..io import load_hdf5, save_hdf5, VolumeIndex
-from ..utils import replace_byte_arrays
+from ..utils import replace_byte_arrays, array_equal
 from ..weather import Weather
 from .helpers import close_data, create_ground_data, create_outdir, create_comm
 from .mpi import MPITestCase
@@ -663,6 +664,39 @@ class IoHdf5Test(MPITestCase):
             if toastcomm.comm_world is not None:
                 toastcomm.comm_world.barrier()
 
+    def _allreduce_obs_props(self, dt):
+        """Helper function to get observation and session mapping.
+        This is needed to find the information across all process groups and
+        communicate it to all processes for checks below.
+        """
+        local_time = {x.name: np.mean(x.shared["times"].data) for x in dt.obs}
+        local_props = [(x.name, x.session.name, local_time[x.name]) for x in dt.obs]
+        all_props = None
+        if dt.comm.group_rank == 0:
+            if dt.comm.comm_group_rank is not None:
+                proc_props = dt.comm.comm_group_rank.gather(local_props, root=0)
+                if dt.comm.comm_group_rank.rank == 0:
+                    all_props = list()
+                    for pprops in proc_props:
+                        all_props.extend(pprops)
+                all_props = dt.comm.comm_group_rank.bcast(all_props, root=0)
+            else:
+                all_props = local_props
+        if dt.comm.comm_group is not None:
+            all_props = dt.comm.comm_group.bcast(all_props)
+        # Build the lookup tables
+        a_obs = set([x[0] for x in all_props])
+        a_sessions = set([x[1] for x in all_props])
+        s_obs = dict()
+        s_times = dict()
+        for oname, sname, stime in all_props:
+            if sname not in s_obs:
+                s_obs[sname] = set()
+            if sname not in s_times:
+                s_times[sname] = stime
+            s_obs[sname].add(oname)
+        return a_obs, a_sessions, s_obs, s_times
+
     def test_save_load_index(self):
         rank = 0
         if self.comm is not None:
@@ -716,9 +750,12 @@ class IoHdf5Test(MPITestCase):
                 s_obs[sname].add(oname)
             return a_obs, a_sessions, s_obs, s_times
 
-        orig_obs, orig_sessions, orig_ses_obs, orig_ses_times = _allreduce_obs_props(
-            data
-        )
+        (
+            orig_obs,
+            orig_sessions,
+            orig_ses_obs,
+            orig_ses_times,
+        ) = self._allreduce_obs_props(data)
 
         # The fields we will index
 
@@ -813,9 +850,12 @@ class IoHdf5Test(MPITestCase):
             check_data = Data(data.comm)
             loader.volume_select = sel_str
             loader.apply(check_data)
-            (loaded_obs, loaded_sessions, loaded_ses_obs, loaded_ses_times) = (
-                _allreduce_obs_props(check_data)
-            )
+            (
+                loaded_obs,
+                loaded_sessions,
+                loaded_ses_obs,
+                loaded_ses_times,
+            ) = _allreduce_obs_props(check_data)
 
             if loaded_obs != orig_ses_obs[ses]:
                 msg = f"select time {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
@@ -823,4 +863,79 @@ class IoHdf5Test(MPITestCase):
                 self.assertTrue(False)
             del check_data
 
+        close_data(data)
+
+    def test_det_select(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        datadir = os.path.join(self.outdir, "det_select")
+        if rank == 0:
+            os.makedirs(datadir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        # Generate the data
+
+        data, config = self.create_data(split=False)
+        det_data_fields = [
+            ("signal", {"quanta": 1.0e-7}),
+            ("flags", {}),
+            ("alt_signal", {"quanta": 1.0e-12}),
+        ]
+
+        # The fields we will index
+
+        index_fields = {
+            "extra_data": ".extra.data:mean",
+            "extra_key": ".extra.meta[key]:median",
+            "leaf_scalar": "[top_tuple][0][qarr]:mean",
+        }
+
+        # Save data and create the index
+
+        saver = ops.SaveHDF5(
+            volume=datadir,
+            volume_index_fields=index_fields,
+            session_dirs=True,
+            unix_time_dirs=True,
+            detdata=det_data_fields,
+            config=config,
+            verify=True,
+        )
+        saver.apply(data)
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
+
+        # Now load the data with a detector selection.
+
+        check_data = Data(data.comm)
+        loader = ops.LoadHDF5(
+            volume=datadir,
+            volume_select=None,
+            det_select={"pixel": r"D.*[02468]"},
+        )
+        loader.apply(check_data)
+
+        # Verify that loaded observations have the expected set of detectors.
+        pat = re.compile(r"D.*[13579]")
+        for obs, orig in zip(check_data.obs, data.obs):
+            upixels = np.unique(obs.telescope.focalplane.detector_data["pixel"])
+            for pix in upixels:
+                if pat.match(pix) is not None:
+                    msg = f"Loaded incorrect pixel '{pix}' from {obs.name}"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+            for det in obs.local_detectors:
+                self.assertTrue(
+                    array_equal(
+                        obs.detdata["signal"][det],
+                        orig.detdata["signal"][det],
+                        f32=True,
+                    )
+                )
+
+        del check_data
         close_data(data)

--- a/src/toast/tests/ops_scan_healpix_detector.py
+++ b/src/toast/tests/ops_scan_healpix_detector.py
@@ -10,6 +10,7 @@ from astropy import units as u
 
 from .. import ops as ops
 from ..observation import default_values as defaults
+from ..mpi import flatten
 from ..pixels import PixelData
 from .helpers import (
     close_data,
@@ -46,7 +47,16 @@ class ScanHealpixDetectorTest(MPITestCase):
         )
         weights.apply(data)
 
-        pixel_names = np.unique(data.obs[0].telescope.focalplane.detector_data["pixel"])
+        local_pixel_names = np.unique(
+            data.obs[0].telescope.focalplane.detector_data["pixel"]
+        )
+        if data.comm.comm_group is not None:
+            pixel_names = list(
+                flatten(data.comm.comm_group.allgather(local_pixel_names))
+            )
+            pixel_names = np.unique(pixel_names)
+        else:
+            pixel_names = local_pixel_names
 
         hpix_file = os.path.join(self.outdir, "fake_fits_{pixel}.fits")
         # Create fake polarized sky signal independently for each pixel
@@ -66,6 +76,9 @@ class ScanHealpixDetectorTest(MPITestCase):
                 U_scale=0,
                 det_data=f"det_data_{pixel}",
             )
+
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.barrier()
 
         # Run the scanning from the file. Each pixel will scan a different file
         scan_hpix = ops.ScanHealpixDetectorMap(

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -9,6 +9,7 @@ import hashlib
 import importlib
 import numbers
 import os
+import re
 import sqlite3
 import time
 from collections import UserDict
@@ -20,6 +21,7 @@ from astropy import units as u
 import h5py
 import numpy as np
 from astropy.table import meta as aspymeta
+from astropy.table import Table
 from wurlitzer import pipes, STDOUT
 
 from ._libtoast import (
@@ -856,12 +858,10 @@ def table_write_parallel_hdf5(table, root, name, comm=None):
     # Table with numpy unicode strings can't be written in HDF5 so
     # to write such a table a copy of table is made containing columns as
     # bytestrings.  Now this copy of the table can be written in HDF5.
-    if any(col.info.dtype.kind == "U" for col in table.itercols()):
-        table = table.copy(copy_data=False)
-        table.convert_unicode_to_bytestring()
+    safe_table = replace_unicode_arrays(table)
 
     # Write the table to the root group
-    tarray = table.as_array()
+    tarray = safe_table.as_array()
     dset_shape = tarray.shape
     dset_type = tarray.dtype
     dset = None
@@ -874,7 +874,7 @@ def table_write_parallel_hdf5(table, root, name, comm=None):
     del dset
 
     # Serialize metadata
-    header_yaml = aspymeta.get_yaml_from_table(table)
+    header_yaml = aspymeta.get_yaml_from_table(safe_table)
     header_encoded = np.array([h.encode("utf-8") for h in header_yaml])
     mdset_shape = header_encoded.shape
     mdset_type = header_encoded.dtype
@@ -1153,3 +1153,303 @@ def sqlite_scalar(input):
     else:
         # Must be a string
         return input
+
+
+def array_equal(left, right, f32=False, log_prefix=""):
+    log = Logger.get()
+    if isinstance(left, u.Quantity):
+        # Floating point values with units
+        if not isinstance(right, u.Quantity):
+            msg = f"{log_prefix}: Lefthand array is a Quantity, Righthand is not"
+            log.verbose(msg)
+            return False
+        if left.unit != right.unit:
+            msg = f"{log_prefix}: Lefthand unit ({left.unit}) != "
+            msg += f"Righthand unit ({right.unit})"
+            log.verbose(msg)
+            return False
+        lval = left.value
+        rval = right.value
+    else:
+        lval = left
+        rval = right
+    if lval.dtype != rval.dtype:
+        msg = f"{log_prefix}: Lefthand dtype ({lval.dtype}) != "
+        msg += f"Righthand dtype ({rval.dtype})"
+        log.verbose(msg)
+        return False
+    if lval.dtype == np.dtype(np.float64) or lval.dtype == np.dtype(np.float32):
+        # Float data
+        drange = np.nanmax(lval) - np.nanmin(lval)
+        if lval.dtype == np.dtype(np.float32) or f32:
+            rtol = 1.0e-6
+            atol = 10.0 * drange * 1.0e-6
+        else:
+            rtol = 1.0e-12
+            atol = 10.0 * drange * 1.0e-15
+        if not np.allclose(lval, rval, rtol=rtol, atol=atol, equal_nan=True):
+            msg = f"{log_prefix}: (atol={atol}, rtol={rtol}) "
+            msg += f"Lefthand data {lval} != "
+            msg += f"Righthand data {rval}"
+            log.verbose(msg)
+            return False
+    else:
+        # Some other type of data
+        if not np.array_equal(lval, rval):
+            msg = f"{log_prefix}: "
+            msg += f"Lefthand data {lval} != "
+            msg += f"Righthand data {rval}"
+            log.verbose(msg)
+            return False
+    return True
+
+
+def table_equal(left, right):
+    """Improved table comparison beyond astropy.Table.values_equal()
+
+    Do an elementwise comparison with extra care for boolean columns.
+
+    Args:
+        left (Table):  The first table to compare.
+        right (Table):  The second table to compare.
+
+    Returns:
+        (bool):  True if all elements are equal.
+
+    """
+    log = Logger.get()
+    left_names = set(left.colnames)
+    right_names = set(right.colnames)
+    if left_names != right_names:
+        msg = f"Table colnames {left_names} != {right_names}"
+        log.verbose(msg)
+        return False
+
+    for nm in left_names:
+        left_col = left[nm]
+        right_col = right[nm]
+        if isinstance(left_col, u.Quantity):
+            # floating point values with units
+            if not isinstance(right_col, u.Quantity):
+                msg = f"Column {nm} is a Quantity on left, but not right"
+                log.verbose(msg)
+                return False
+            if left_col.unit != right_col.unit:
+                msg = f"Column {nm} unit mismatch {left_col.unit} != {right_col.unit}"
+                log.verbose(msg)
+                return False
+            check = array_equal(
+                left_col.value, right_col.value, log_prefix=f"Column {nm} Quantities"
+            )
+            if not check:
+                return False
+        else:
+            # Normal arrays
+            check = array_equal(left_col, right_col, log_prefix=f"Column {nm}")
+            if not check:
+                return False
+    return True
+
+
+def unicode_array_to_bytes(input):
+    """Convert numpy arrays with Unicode strings to fixed-length bytes.
+
+    Args:
+        input (str):  The input array.
+
+    Returns:
+        (array):  The input converted to 'S' bytes, or the original if not
+            an array of strings.
+
+    """
+    utype_pat = re.compile(r"[><|]*U(\d+)$")
+    if np.issubdtype(input.dtype, np.str_):
+        # Unicode string
+        mat = utype_pat.match(str(input.dtype))
+        if mat is not None:
+            maxlen = mat.group(1)
+            stype = f"S{maxlen}"
+            return input.astype(np.dtype(stype))
+        else:
+            msg = f"unicode to bytes string type has dtype {str(input.dtype)}"
+            raise RuntimeError(msg)
+    else:
+        return input
+
+
+def byte_array_to_unicode(input):
+    """Convert fixed length byte arrays to unicode dtype.
+
+    Args:
+        input (str):  The input array.
+
+    Returns:
+        (array):  The input converted to 'U' dtype, or the original if not
+            an array of type 'S'.
+
+    """
+    stype_pat = re.compile(r".*S(\d+)$")
+    if np.issubdtype(input.dtype, np.bytes_):
+        # Unicode string
+        mat = stype_pat.match(str(input.dtype))
+        if mat is not None:
+            maxlen = mat.group(1)
+            utype = f"U{maxlen}"
+            return input.astype(np.dtype(utype))
+        else:
+            msg = f"bytes to unicode bytes type has dtype {str(input.dtype)}"
+            raise RuntimeError(msg)
+    else:
+        return input
+
+
+def replace_unicode_arrays(obj):
+    """Recursively replace unicode numpy arrays.
+
+    Descend the object container recursively and replace numpy unicode arrays with
+    fixed-length byte arrays.
+
+    Args:
+        obj (object):  A container or array
+
+    Returns:
+        (object):  The same style container as the input, with unicode arrays replaced
+
+    """
+    if isinstance(obj, Table):
+        # Modify table columns as needed.
+        new_obj = obj.copy()
+        tnames = new_obj.colnames
+        for nm in tnames:
+            old_col = new_obj[nm]
+            if np.issubdtype(old_col.dtype, np.str_):
+                # Replace it
+                new_col = replace_unicode_arrays(old_col)
+                new_obj.replace_column(nm, new_col)
+    elif isinstance(obj, dict):
+        new_obj = dict()
+        for k, v in obj.items():
+            new_obj[k] = replace_unicode_arrays(v)
+    elif isinstance(obj, tuple):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_unicode_arrays(val))
+        new_obj = tuple(new_obj)
+    elif isinstance(obj, list):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_unicode_arrays(val))
+    elif isinstance(obj, np.ndarray):
+        new_obj = unicode_array_to_bytes(obj)
+    else:
+        new_obj = obj
+    return new_obj
+
+
+def replace_byte_arrays(obj):
+    """Recursively replace fixed-length numpy byte arrays.
+
+    Descend the object container recursively and replace numpy byte arrays with
+    Unicode arrays.
+
+    Args:
+        obj (object):  A container or array
+
+    Returns:
+        (object):  The same style container as the input, with byte arrays replaced
+
+    """
+    if isinstance(obj, Table):
+        # Modify table columns as needed.
+        new_obj = obj.copy()
+        tnames = new_obj.colnames
+        for nm in tnames:
+            old_col = new_obj[nm]
+            if np.issubdtype(old_col.dtype, np.bytes_):
+                # Replace it
+                new_col = replace_byte_arrays(old_col)
+                new_obj.replace_column(nm, new_col)
+    elif isinstance(obj, dict):
+        new_obj = dict()
+        for k, v in obj.items():
+            new_obj[k] = replace_byte_arrays(v)
+    elif isinstance(obj, tuple):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_byte_arrays(val))
+        new_obj = tuple(new_obj)
+    elif isinstance(obj, list):
+        new_obj = list()
+        for val in obj:
+            new_obj.append(replace_byte_arrays(val))
+    elif isinstance(obj, np.ndarray):
+        new_obj = byte_array_to_unicode(obj)
+    else:
+        new_obj = obj
+    return new_obj
+
+
+def count_string_arrays(obj, prefix="", verbose=False):
+    """Recursively count the number of unicode and byte arrays.
+
+    This is intended for debugging, and prints to stdout.
+
+    Args:
+        obj (object):  A container or array
+        prefix (str):  Prefix to prepend to print statements
+        verbose (bool):  If True, print info for every object
+
+    Returns:
+        (tuple):  The number of (unicode, byte) arrays (dtype 'U' and 'S') found.
+
+    """
+    ufound = 0
+    sfound = 0
+    stype_pat = re.compile(r".*S(\d+)$")
+    utype_pat = re.compile(r"[><|]*U(\d+)$")
+    if isinstance(obj, Table):
+        # Modify table columns as needed.
+        tnames = obj.colnames
+        for nm in tnames:
+            col = obj[nm]
+            if np.issubdtype(col.dtype, np.bytes_):
+                # Count it
+                if verbose:
+                    print(f"{prefix}found byte array in table column {nm}", flush=True)
+                sfound += 1
+            if np.issubdtype(col.dtype, np.str_):
+                # Count it
+                if verbose:
+                    print(
+                        f"{prefix}found unicode array in table column {nm}", flush=True
+                    )
+                ufound += 1
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            dufound, dsfound = count_string_arrays(v)
+            ufound += dufound
+            sfound += dsfound
+    elif isinstance(obj, tuple):
+        for val in obj:
+            dufound, dsfound = count_string_arrays(val)
+            ufound += dufound
+            sfound += dsfound
+    elif isinstance(obj, list):
+        for val in obj:
+            dufound, dsfound = count_string_arrays(val)
+            ufound += dufound
+            sfound += dsfound
+    elif isinstance(obj, np.ndarray):
+        smat = stype_pat.match(str(obj.dtype))
+        umat = utype_pat.match(str(obj.dtype))
+        if smat is not None:
+            if verbose:
+                print(f"{prefix}found S array {obj}", flush=True)
+            sfound += 1
+        elif umat is not None:
+            if verbose:
+                print(f"{prefix}found U array {obj}", flush=True)
+            ufound += 1
+    else:
+        pass
+    return (ufound, sfound)


### PR DESCRIPTION
- Remove the `obs_approx_equal()` function and simply add optional `approx=` keywords to the `__eq__()` methods of Observation and DetectorData classes.

- Add new helper functions for comparison of arrays in the case where one of the arrays might contain truncated float32 values.

- Add new helper function to compare astropy tables for equality.

- Move unicode array conversion functions from `toast.io.hdf_utils` to `toast.utils`.

- Change naming convention for observation metadata Quantities that are serialized to HDF5.  Fix regex match that was missing some metadata to load.