### PR TITLE
Cleanup use of MPIShared objects

### DIFF
--- a/src/toast/ops/pixels_wcs.py
+++ b/src/toast/ops/pixels_wcs.py
@@ -573,7 +573,7 @@ class PixelsWCS(Operator):
             # detector pointing.
             flags = None
             if self.detector_pointing.shared_flags is not None:
-                flags = ob.shared[self.detector_pointing.shared_flags].data
+                flags = np.copy(ob.shared[self.detector_pointing.shared_flags].data)
                 flags &= self.detector_pointing.shared_flag_mask
 
             center_lonlat = None

--- a/src/toast/tests/ops_hwpss_model.py
+++ b/src/toast/tests/ops_hwpss_model.py
@@ -60,7 +60,7 @@ class HWPModelTest(MPITestCase):
         for ob in data.obs:
             end_rampup = int(0.1 * ob.n_local_samples)
             begin_rampup = end_rampup - n_ramp
-            hwp_data = ob.shared[defaults.hwp_angle].data
+            hwp_data = ob.shared[defaults.hwp_angle]
             ang_end = hwp_data[end_rampup - 1]
             half_ramp = n_ramp // 2
             max_accel = ang_per_sample * 2 / n_ramp
@@ -77,8 +77,11 @@ class HWPModelTest(MPITestCase):
             ramp = ang_pos - off
 
             if ob.comm.group_rank == 0:
-                hwp_data[:end_rampup] = ramp[0]
+                hwp_data[:end_rampup] = ramp[0] * np.ones(end_rampup)
                 hwp_data[begin_rampup:end_rampup] = ramp
+            else:
+                hwp_data[:end_rampup] = None
+                hwp_data[begin_rampup:end_rampup] = None
 
         # Create an uncorrelated noise model from focalplane detector properties
         default_model = ops.DefaultNoiseModel(noise_model="noise_model")

--- a/src/toast/tests/ops_pointing_wcs.py
+++ b/src/toast/tests/ops_pointing_wcs.py
@@ -201,9 +201,7 @@ class PointingWCSTest(MPITestCase):
 
                 self.assertFalse(pixels.auto_bounds)
                 self.assertTrue(pixels.center == center)
-                self.assertTrue(
-                    pixels.resolution == (0.02 * u.degree, 0.02 * u.degree)
-                )
+                self.assertTrue(pixels.resolution == (0.02 * u.degree, 0.02 * u.degree))
                 self.assertTrue(pixels.dimensions == self.proj_dims)
                 self.assertTrue(pixels.dimensions[0] == pixels.wcs_shape[1])
                 self.assertTrue(pixels.dimensions[1] == pixels.wcs_shape[0])
@@ -693,9 +691,9 @@ class PointingWCSTest(MPITestCase):
             # be realistic, but at least should cover the source
             for obs in data.obs:
                 if obs.comm_col_rank == 0:
-                    obs.shared["boresight_azel"].data[:, :] = obs.shared[
-                        "boresight_radec"
-                    ].data[:, :]
+                    obs.shared["boresight_azel"].set(obs.shared["boresight_radec"].data)
+                else:
+                    obs.shared["boresight_azel"].set(None)
 
             # Create source motion and simulated detector data.
             dbgdir = None


### PR DESCRIPTION
MPIShared objects should be considered read-only, except when collectively updating them with `set()` or `__setitem__`.  Future versions of `pshmem` will enforce this behavior.  This PR cleans up some places where we were being sloppy with this behavior.