### PR TITLE
Verify Offset template noise prior consistency with MADAM

### DIFF
--- a/packaging/conda/install_deps_conda.sh
+++ b/packaging/conda/install_deps_conda.sh
@@ -51,6 +51,8 @@ export ENVNAME=${envname}
 . "${scriptdir}/create_env.sh"
 
 # Install conda packages
+echo "Installing python-${pyversion}..."
+conda install --yes --update-all python=${pyversion}
 
 echo "Installing conda packages for development..."
 conda install --yes --update-all --file "${scriptdir}/requirements.txt"

--- a/packaging/conda/requirements.txt
+++ b/packaging/conda/requirements.txt
@@ -3,7 +3,6 @@ compilers
 cmake
 make
 ninja
-python
 pip
 scikit-build-core>=0.11
 pybind11>=3.0

--- a/src/toast/_libtoast/template_offset.cpp
+++ b/src/toast/_libtoast/template_offset.cpp
@@ -55,10 +55,12 @@ void init_template_offset(py::module & m) {
                 n_amp_views, "n_amp_views", 1, temp_shape, {n_view}
             );
 
-            int64_t * amp_view_off = new int64_t(n_view);
+            int64_t * amp_view_off = new int64_t[n_view];
             amp_view_off[0] = 0;
+            int64_t aoff = raw_n_amp_views[0];
             for (int64_t iview = 1; iview < n_view; iview++) {
-                amp_view_off[iview] = raw_n_amp_views[iview - 1];
+                amp_view_off[iview] = aoff;
+                aoff += raw_n_amp_views[iview];
             }
 
             if (offload) {
@@ -138,7 +140,7 @@ void init_template_offset(py::module & m) {
                 }
             }
 
-            delete amp_view_off;
+            delete[] amp_view_off;
 
             return;
         });
@@ -189,10 +191,12 @@ void init_template_offset(py::module & m) {
                 n_amp_views, "n_amp_views", 1, temp_shape, {n_view}
             );
 
-            int64_t * amp_view_off = new int64_t(n_view);
+            int64_t * amp_view_off = new int64_t[n_view];
             amp_view_off[0] = 0;
+            int64_t aoff = raw_n_amp_views[0];
             for (int64_t iview = 1; iview < n_view; iview++) {
-                amp_view_off[iview] = raw_n_amp_views[iview - 1];
+                amp_view_off[iview] = aoff;
+                aoff += raw_n_amp_views[iview];
             }
 
             // Optionally use flags
@@ -322,7 +326,7 @@ void init_template_offset(py::module & m) {
                     }
                 }
             }
-            delete amp_view_off;
+            delete[] amp_view_off;
             return;
         });
 

--- a/src/toast/ops/mapmaker_binning.py
+++ b/src/toast/ops/mapmaker_binning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -290,7 +290,7 @@ class BinMap(Operator):
             log.verbose("  BinMap applying covariance")
         covariance_apply(cov, binned_map, use_alltoallv=(self.sync_type == "alltoallv"))
         # print("Binned final = ", data[self.binned].data)
-        
+
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/mapmaker_templates.py
+++ b/src/toast/ops/mapmaker_templates.py
@@ -204,6 +204,7 @@ class TemplateMatrix(Operator):
                     continue
                 if tmpl.view is None:
                     tmpl.view = self.view
+                tmpl.det_data = self.det_data
                 tmpl.det_data_units = self.det_data_units
                 tmpl.det_mask = self.det_mask
                 tmpl.det_flags = self.det_flags
@@ -766,7 +767,7 @@ class SolveAmplitudes(Operator):
         if self.mc_mode:
             # Shortcut, just verified that our flags exist
             self._log.info_rank(
-                f"{self._log_prefix} MC mode, reusing flags for solver", comm=comm
+                f"{self._log_prefix} MC mode, reusing flags for solver", comm=self._comm
             )
             return
 
@@ -834,7 +835,7 @@ class SolveAmplitudes(Operator):
         if self.mc_mode:
             # Shortcut, verify that our covariance and other products exist.
             if self.binning.pixel_dist not in self._data:
-                msg = f"MC mode, pixel distribution "
+                msg = "MC mode, pixel distribution "
                 msg += f"'{self.binning.pixel_dist}' does not exist"
                 self._log.error(msg)
                 raise RuntimeError(msg)
@@ -933,6 +934,7 @@ class SolveAmplitudes(Operator):
         )
 
         # Initialize the template matrix
+        self.template_matrix.reset()
         self.template_matrix.det_data = self.det_data
         self.template_matrix.det_data_units = self._det_data_units
         self.template_matrix.det_flags = self.solver_flags

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -463,7 +463,9 @@ class BuildInverseCovariance(Operator):
 
             for det in dets:
                 # Process every data view
-                for pview, wview, fview, shared_fview in zip(pix, wts, flgs, shared_flgs):
+                for pview, wview, fview, shared_fview in zip(
+                    pix, wts, flgs, shared_flgs
+                ):
                     # We require that the pointing matrix has the same number of
                     # non-zero elements for every detector and every observation.
                     # We check that here.
@@ -799,7 +801,7 @@ class BuildNoiseWeighted(Operator):
                     self.noise_model, ob.name
                 )
                 raise RuntimeError(msg)
-            
+
             if len(dets) == 0:
                 # Nothing to do for this observation
                 continue
@@ -909,7 +911,7 @@ class BuildNoiseWeighted(Operator):
                 data.comm.comm_world.Reduce(zmap_min, all_zmap_min, op=MPI.MIN, root=0)
                 data.comm.comm_world.Reduce(zmap_max, all_zmap_max, op=MPI.MAX, root=0)
             if data.comm.world_rank == 0:
-                msg = f"  Noise-weighted map pixel value range:\n"
+                msg = "  Noise-weighted map pixel value range:\n"
                 for m in range(data[self.zmap].n_value):
                     msg += f"    map {m} {zmap_min[m]:1.3e} ... {zmap_max[m]:1.3e}"
                 log.debug(msg)

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -42,7 +42,7 @@ class InjectCosmicRays(Operator):
     from simulations.   For each observation and each detector, we estimate the number of hits expected
     theroretically and draw a random integer, `N`,  with a Poissonian distribution given the expected number
     of events, `Nexp`.  We then  select randomly `N` timestamps where   the hits will be injected into the tod simulated in TOAST.
-    Evaluate the function :math:\gamma at a higher sampling rate (~150 Hz), decimate it to the TOD sample rate and coadd  it.
+    Evaluate the function :math:\\gamma at a higher sampling rate (~150 Hz), decimate it to the TOD sample rate and coadd  it.
 
     Args:
         crfile (string):  A `*.npz`  file encoding 4 attributes,
@@ -142,7 +142,7 @@ class InjectCosmicRays(Operator):
         for ob in data.obs:
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(detectors)
-            
+
             comm = ob.comm.comm_group
             rank = ob.comm.group_rank
             # Make sure detector data output exists

--- a/src/toast/templates/offset/kernels_numpy.py
+++ b/src/toast/templates/offset/kernels_numpy.py
@@ -38,14 +38,14 @@ def offset_add_to_signal_numpy(
         None (the result is put in det_data).
     """
     offset = amp_offset
-    for interval, view_offset in zip(intervals, n_amp_views):
+    for interval, view_n_amp in zip(intervals, n_amp_views):
         samples = slice(interval.first, interval.last, 1)
         sampidx = np.arange(0, interval.last - interval.first, dtype=np.int64)
-        amp_idx = sampidx // step_length
-        amp_vals = np.array([amplitudes[offset + x] for x in amp_idx])
-        amp_flags = np.array([amplitude_flags[offset + x] for x in amp_idx])
+        view_amp_idx = sampidx // step_length
+        amp_vals = np.array([amplitudes[offset + x] for x in view_amp_idx])
+        amp_flags = np.array([amplitude_flags[offset + x] for x in view_amp_idx])
         det_data[data_index, samples] += amp_vals[amp_flags == 0]
-        offset += view_offset
+        offset += view_n_amp
 
 
 @kernel(impl=ImplementationType.NUMPY, name="offset_project_signal")
@@ -85,13 +85,10 @@ def offset_project_signal_numpy(
         None (the result is put in amplitudes).
     """
     offset = amp_offset
-    for interval, view_offset in zip(intervals, n_amp_views):
+    for interval, view_n_amp in zip(intervals, n_amp_views):
         samples = slice(interval.first, interval.last, 1)
-        ampidx = (
-            offset
-            + np.arange(0, interval.last - interval.first, dtype=np.int64)
-            // step_length
-        )
+        sampidx = np.arange(0, interval.last - interval.first, dtype=np.int64)
+        ampidx = offset + sampidx // step_length
         ddata = det_data[data_index][samples]
         # skip sample if it is flagged
         if flag_index >= 0:
@@ -104,7 +101,7 @@ def offset_project_signal_numpy(
         # updates amplitude
         # using np.add to insure atomicity
         np.add.at(amplitudes, ampidx, ddata)
-        offset += view_offset
+        offset += view_n_amp
 
 
 @kernel(impl=ImplementationType.NUMPY, name="offset_apply_diag_precond")

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -17,7 +17,7 @@ from ...accelerator import ImplementationType
 from ...mpi import MPI
 from ...observation import default_values as defaults
 from ...timing import function_timer
-from ...traits import Bool, Float, Int, Quantity, Unicode, UseEnum, trait_docs
+from ...traits import Bool, Float, Int, Quantity, Unicode, trait_docs
 from ...utils import AlignedF64, Logger, rate_from_times
 from ...vis import set_matplotlib_backend
 from ..amplitudes import Amplitudes
@@ -37,6 +37,16 @@ class Offset(Template):
     amplitudes on other processes.  We project amplitudes one detector at a time, and
     so we arrange our template amplitudes in "detector major" order and store offsets
     into this for each observation.
+
+    If a noise model is used, the baseline covariance is computed from the detector
+    timestream noise model.  In this case, the baselines are assumed to be fixed in
+    length and contiguous across the observation.  As a result, the "view" (if
+    specified) will only be used to select good data samples.
+
+    If a noise model is not used and a "view" is specified, then the definition of
+    the offset sample ranges is changed.  A new offset will start at the beginning
+    of each interval.  If the step_time is longer than the interval, it will be
+    truncated at the interval end.
 
     """
 
@@ -121,6 +131,13 @@ class Offset(Template):
         if self.use_noise_prior and self.noise_model is None:
             raise RuntimeError("cannot use noise prior without specifying noise_model")
 
+        if self.use_noise_prior:
+            # We do not use the view to define the baseline boundaries
+            self._bounds_view = None
+        else:
+            # We allow the view to dictate the boundaries
+            self._bounds_view = self.view
+
         # Units for inverse variance weighting
         detnoise_units = 1.0 / self.det_data_units**2
 
@@ -130,6 +147,9 @@ class Offset(Template):
 
         # Amplitude lengths of all views for each obs
         self._obs_views = dict()
+
+        # The common flags for each observation based on the specified view
+        self._obs_view_flags = dict()
 
         # Sample rate for each obs.
         self._obs_rate = dict()
@@ -152,18 +172,19 @@ class Offset(Template):
 
             # Track number of offset amplitudes per view, per det.
             ob_views = list()
-            for view_slice in ob.view[self.view]:
-                view_len = None
-                if view_slice.start < 0:
-                    # This is a view of the whole obs
-                    view_len = ob.n_local_samples
-                else:
-                    view_len = view_slice.stop - view_slice.start
+            for vw in ob.intervals[self._bounds_view].data:
+                view_len = vw.last - vw.first
                 view_n_amp = view_len // step_length
                 if view_n_amp * step_length < view_len:
                     view_n_amp += 1
                 ob_views.append(view_n_amp)
             self._obs_views[iob] = np.array(ob_views, dtype=np.int64)
+
+            # Even if we are not using a noise prior, we still use the "view"
+            # to exclude samples.  Compute that common flag vector now.
+            self._obs_view_flags[iob] = np.ones(ob.n_local_samples, dtype=np.uint8)
+            for vw in ob.intervals[self.view]:
+                self._obs_view_flags[iob][vw.first : vw.last] = 0
 
             # The noise model.
             if self.noise_model is not None:
@@ -174,15 +195,28 @@ class Offset(Template):
                     log.error(msg)
                     raise RuntimeError(msg)
 
-                # Determine the binning for the noise prior
+                # Determine the frequency binning for the noise prior.  The noise
+                # prior (offset-offset noise covariance) is constructed at high
+                # resolution and then interpolated to the resolution needed for each
+                # observation interval later.
                 if self.use_noise_prior:
                     obstime = ob.shared[self.times][-1] - ob.shared[self.times][0]
                     tbase = self.step_time.to_value(u.second)
-                    powmin = np.floor(np.log10(1 / obstime)) - 1
-                    powmax = min(
-                        np.ceil(np.log10(1 / tbase)) + 2, np.log10(self._obs_rate[iob])
-                    )
-                    self._freq[iob] = np.logspace(powmin, powmax, 1000)
+                    fbase = 1.0 / tbase
+                    if (obstime * fbase) < 1.0:
+                        # Only one baseline in this observation, disable noise
+                        # prior use.
+                        msg = f"obs {ob.name} has only one offset amplitude,"
+                        msg += " disabling noise prior"
+                        log.warning(msg)
+                        self._freq[iob] = None
+                    else:
+                        # Choose equal spacing in log units
+                        powmin = np.floor(np.log10(1 / obstime)) - 1
+                        powmax = min(
+                            np.ceil(np.log10(1 / tbase)) + 2, np.log10(self._obs_rate[iob])
+                        )
+                        self._freq[iob] = np.logspace(powmin, powmax, 1000)
 
             # Build up detector list
             self._obs_dets[iob] = set()
@@ -256,15 +290,10 @@ class Offset(Template):
                     self.step_time.to_value(u.second), self._obs_rate[iob]
                 )
 
-                # Loop over views
-                views = ob.view[self.view]
-                for ivw, vw in enumerate(views):
-                    view_samples = None
-                    if vw.start < 0:
-                        # This is a view of the whole obs
-                        view_samples = ob.n_local_samples
-                    else:
-                        view_samples = vw.stop - vw.start
+                # Loop over boundary views
+                for ivw, vw in enumerate(ob.intervals[self._bounds_view].data):
+                    vw_slc = slice(vw.first, vw.last, 1)
+                    view_samples = vw.last - vw.first
                     n_amp_view = self._obs_views[iob][ivw]
 
                     # Move this loop to compiled code if it is slow...
@@ -276,37 +305,32 @@ class Offset(Template):
                             self._offsetvar[offset + amp] = 0.0
                             self._amp_flags[offset + amp] = True
                     else:
-                        if self.det_flags is None:
-                            voff = 0
-                            for amp in range(n_amp_view):
-                                amplen = step_length
-                                if amp == n_amp_view - 1:
-                                    amplen = view_samples - voff
+                        flags = np.array(
+                            self._obs_view_flags[iob][vw_slc], dtype=np.uint8
+                        )
+                        if self.det_flags is not None:
+                            flags[:] |= (
+                                ob.detdata[self.det_flags][det, vw_slc]
+                                & self.det_flag_mask
+                            )
+                        voff = 0
+                        for amp in range(n_amp_view):
+                            amplen = step_length
+                            if amp == n_amp_view - 1:
+                                amplen = view_samples - voff
+                            n_good = amplen - np.count_nonzero(
+                                flags[voff : voff + amplen]
+                            )
+                            if (n_good / amplen) <= self.good_fraction:
+                                # This detector is cut or too many samples flagged
+                                self._offsetvar[offset + amp] = 0.0
+                                self._amp_flags[offset + amp] = True
+                            else:
+                                # Keep this
                                 self._offsetvar[offset + amp] = 1.0 / (
-                                    detnoise * amplen
+                                    detnoise * n_good
                                 )
-                                voff += step_length
-                        else:
-                            flags = views.detdata[self.det_flags][ivw]
-                            voff = 0
-                            for amp in range(n_amp_view):
-                                amplen = step_length
-                                if amp == n_amp_view - 1:
-                                    amplen = view_samples - voff
-                                n_good = amplen - np.count_nonzero(
-                                    flags[det][voff : voff + amplen]
-                                    & self.det_flag_mask
-                                )
-                                if (n_good / amplen) <= self.good_fraction:
-                                    # This detector is cut or too many samples flagged
-                                    self._offsetvar[offset + amp] = 0.0
-                                    self._amp_flags[offset + amp] = True
-                                else:
-                                    # Keep this
-                                    self._offsetvar[offset + amp] = 1.0 / (
-                                        detnoise * n_good
-                                    )
-                                voff += step_length
+                            voff += step_length
                     offset += n_amp_view
 
         # Compute the amplitude noise filter and preconditioner for each detector
@@ -329,10 +353,11 @@ class Offset(Template):
                         self._filters[iob] = dict()
                         self._precond[iob] = dict()
 
+                    base_sec = self.step_time.to_value(u.second)
                     offset_psd = self._get_offset_psd(
                         ob[self.noise_model],
                         self._freq[iob],
-                        self.step_time.to_value(u.second),
+                        base_sec,
                         det,
                     )
 
@@ -373,7 +398,7 @@ class Offset(Template):
                         ax.loglog(
                             self._freq[iob],
                             offset_psd,
-                            label=f"Offset PSD",
+                            label="Offset PSD",
                         )
                         ax.set_xlabel("Frequency [Hz]")
                         ax.set_ylabel("PSD [K$^2$ / Hz]")
@@ -406,20 +431,16 @@ class Offset(Template):
                         fprec = os.path.join(
                             self.debug_plots, f"{self.name}_{det}_{ob.name}_prec.pdf"
                         )
-                        figfilter = plt.figure(figsize=[12, 8])
-                        axfilter = figfilter.add_subplot(1, 1, 1)
+                        figfilter = plt.figure(figsize=[12, 12])
+                        axfilter = figfilter.add_subplot(2, 1, 1)
+                        axffilter = figfilter.add_subplot(2, 1, 2)
                         figprec = plt.figure(figsize=[12, 8])
                         axprec = figprec.add_subplot(1, 1, 1)
 
                     # Loop over views
-                    views = ob.view[self.view]
-                    for ivw, vw in enumerate(views):
-                        view_samples = None
-                        if vw.start < 0:
-                            # This is a view of the whole obs
-                            view_samples = ob.n_local_samples
-                        else:
-                            view_samples = vw.stop - vw.start
+                    for ivw, vw in enumerate(ob.intervals[self._bounds_view].data):
+                        vw_slc = slice(vw.first, vw.last, 1)
+                        view_samples = vw.last - vw.first
                         n_amp_view = self._obs_views[iob][ivw]
                         offsetvar_slice = self._offsetvar[offset : offset + n_amp_view]
 
@@ -438,11 +459,11 @@ class Offset(Template):
                         # methods, we should instead keep this filter in the fourier
                         # domain.
 
-                        noisefilter = self._truncate(
-                            np.fft.irfft(
-                                self._interpolate_psd(filterfreq, logfreq, logfilter)
-                            )
+                        fourierfilter = self._interpolate_psd(
+                            filterfreq, logfreq, logfilter
                         )
+
+                        noisefilter = self._truncate(np.fft.irfft(fourierfilter))
 
                         self._filters[iob][det].append(noisefilter)
 
@@ -451,6 +472,11 @@ class Offset(Template):
                                 np.arange(len(noisefilter)),
                                 noisefilter,
                                 label=f"Noise filter {ivw}",
+                            )
+                            axffilter.plot(
+                                np.arange(len(fourierfilter)),
+                                fourierfilter,
+                                label=f"Fourier Noise filter {ivw}",
                             )
 
                         # Build the preconditioner
@@ -487,27 +513,46 @@ class Offset(Template):
                             # not invert "M" and solve M x = b using the Cholesky
                             # decomposition of M (*not* M^{-1}).
                             icenter = noisefilter.size // 2
-                            wband = min(self.precond_width, icenter)
-                            precond_width = max(
-                                wband, min(self.precond_width, n_amp_view)
-                            )
-                            preconditioner = np.zeros(
-                                [precond_width, n_amp_view], dtype=np.float64
-                            )
-                            if detnoise != 0:
-                                preconditioner[0, :] = 1.0 / offsetvar_slice
-                            preconditioner[:wband, :] += np.repeat(
-                                noisefilter[icenter : icenter + wband, np.newaxis],
-                                n_amp_view,
-                                1,
-                            )
-                            lower = True
-                            preconditioner = scipy.linalg.cholesky_banded(
-                                preconditioner,
-                                overwrite_ab=True,
-                                lower=lower,
-                                check_finite=True,
-                            )
+                            try_width = self.precond_width
+
+                            good_cholesky = False
+                            while not good_cholesky:
+                                wband = min(try_width, icenter)
+                                precond_width = max(wband, min(try_width, n_amp_view))
+                                preconditioner = np.zeros(
+                                    [precond_width, n_amp_view], dtype=np.float64
+                                )
+                                if detnoise != 0:
+                                    preconditioner[0, :] = 1.0 / offsetvar_slice
+                                preconditioner[:wband, :] += np.repeat(
+                                    noisefilter[icenter : icenter + wband, np.newaxis],
+                                    n_amp_view,
+                                    1,
+                                )
+                                lower = True
+                                try:
+                                    preconditioner = scipy.linalg.cholesky_banded(
+                                        preconditioner,
+                                        overwrite_ab=True,
+                                        lower=lower,
+                                        check_finite=True,
+                                    )
+                                    good_cholesky = True
+                                except scipy.linalg.LinAlgError:
+                                    if try_width < icenter and try_width < n_amp_view:
+                                        # Still room to increase the band width
+                                        try_width *= 2
+                                        msg = f"obs {ob.name}, det {det}, view {ivw} "
+                                        msg += " scipy cholesky_banded fail, increasing"
+                                        msg += f" width to {try_width}"
+                                        log.debug(msg)
+                                    else:
+                                        # Width is now the size of the data interval
+                                        msg = f"obs {ob.name}, det {det}, view {ivw} "
+                                        msg += " scipy cholesky_banded fail with max "
+                                        msg += "width of {try_width}"
+                                        log.error(msg)
+                                        raise RuntimeError(msg)
                             if self.debug_plots is not None:
                                 axprec.plot(
                                     np.arange(len(preconditioner)),
@@ -536,13 +581,16 @@ class Offset(Template):
 
     def _interpolate_psd(self, x, lfreq, lpsd):
         # Threshold for zero frequency
-        thresh = 1.0e-6
-        lowf = x < thresh
+        thresh = 1.0e-10
+        lowf = np.abs(x) < thresh
         good = np.logical_not(lowf)
 
+        # Note that for negative `m` values in the offset PSD calculation,
+        # we may be passed negative frequencies in `x`.  The PSD is symmetric
+        # about zero for this purpose.
         logx = np.empty_like(x)
         logx[lowf] = np.log(thresh)
-        logx[good] = np.log(x[good])
+        logx[good] = np.log(np.abs(x[good]))
         logresult = np.interp(logx, lfreq, lpsd)
         result = np.exp(logresult)
         return result
@@ -597,7 +645,6 @@ class Offset(Template):
         """Compute the PSD of the baseline offsets."""
         psdfreq = noise.freq(det).to_value(u.Hz)
         psd = noise.psd(det).to_value(self.det_data_units**2 * u.second)
-        rate = noise.rate(det).to_value(u.Hz)
 
         # Remove the white noise component from the PSD
         psd = self._remove_white_noise(psdfreq, psd)
@@ -608,7 +655,16 @@ class Offset(Template):
 
         # The calculation of `offset_psd` is based on Keihänen, E. et al:
         # "Making CMB temperature and polarization maps with Madam",
-        # A&A 510:A57, 2010, with a small algebra correction.
+        # A&A 510:A57, 2010, with a small algebra correction.  Specifically,
+        # the subsitution of equation 23 into equation 22 does not lead to
+        # equation 24.  Instead:
+        #
+        # P_a(f) = (1/T) SUM_m{
+        #              P(f + m/T) *
+        #              sin^2(Pi * T * (f + m/T)) / [Pi * T * (f + m/T)]^2
+        #          }
+        #
+        # and where we evaluate the sum over a small number of +/- m terms.
 
         m_max = 5
         tbase = step_time
@@ -617,13 +673,12 @@ class Offset(Template):
         def g(f, m):
             # The frequencies are constructed without the zero frequency,
             # so we do not need to handle it here.
-            # result = np.sin(np.pi * f * tbase) ** 2 / (np.pi * (f * tbase + m)) ** 2
-            x = np.pi * (f * tbase + m)
+            x = np.pi * tbase * (f + m * fbase)
             bad = np.abs(x) < 1.0e-30
             good = np.logical_not(bad)
             result = np.empty_like(x)
             result[bad] = 1.0
-            result[good] = np.sin(x[good]) ** 2 / x[good] ** 2
+            result[good] = (np.sin(x[good]) / x[good]) ** 2
             return result
 
         offset_psd = np.zeros_like(freq)
@@ -643,6 +698,7 @@ class Offset(Template):
             ) * g(freq, -m)
 
         offset_psd *= fbase
+
         return offset_psd
 
     def _detectors(self):
@@ -655,7 +711,7 @@ class Offset(Template):
         return z
 
     def _step_length(self, stime, rate):
-        return int(stime * rate + 0.5)
+        return int(np.rint(stime * rate))
 
     @function_timer
     def _add_to_signal(self, detector, amplitudes, use_accel=None, **kwargs):
@@ -721,7 +777,7 @@ class Offset(Template):
                 amplitudes.local_flags,
                 det_indx[0],
                 ob.detdata[self.det_data].data,
-                ob.intervals[self.view].data,
+                ob.intervals[self._bounds_view].data,
                 impl=implementation,
                 use_accel=use_accel,
             )
@@ -754,13 +810,15 @@ class Offset(Template):
         implementation, use_accel = self.select_kernels(use_accel=use_accel)
 
         amp_offset = self._det_start[detector]
+
         for iob, ob in enumerate(self.data.obs):
             if detector not in self._obs_dets[iob]:
                 continue
             det_indx = ob.detdata[self.det_data].indices([detector])
             if self.det_flags is not None:
                 flag_indx = ob.detdata[self.det_flags].indices([detector])
-                flag_data = ob.detdata[self.det_flags].data
+                flag_data = np.copy(ob.detdata[self.det_flags].data)
+                flag_data |= self.det_flag_mask * self._obs_view_flags[iob]
             else:
                 flag_indx = np.array([-1], dtype=np.int32)
                 flag_data = np.zeros(1, dtype=np.uint8)
@@ -794,7 +852,7 @@ class Offset(Template):
                 n_amp_views,
                 amplitudes.local,
                 amplitudes.local_flags,
-                ob.intervals[self.view].data,
+                ob.intervals[self._bounds_view].data,
                 impl=implementation,
                 use_accel=use_accel,
             )
@@ -829,7 +887,8 @@ class Offset(Template):
             for iob, ob in enumerate(self.data.obs):
                 if det not in self._obs_dets[iob]:
                     continue
-                for ivw, vw in enumerate(ob.view[self.view].detdata[self.det_data]):
+
+                for ivw, vw in enumerate(ob.intervals[self._bounds_view].data):
                     n_amp_view = self._obs_views[iob][ivw]
                     amp_slice = slice(offset, offset + n_amp_view, 1)
                     amps_in = amplitudes_in.local[amp_slice]
@@ -841,12 +900,13 @@ class Offset(Template):
                             amps_in,
                             self._filters[iob][det][ivw],
                             mode="same",
-                            method="direct",
+                            method="auto",
                         )
 
                         if self.debug_plots is not None:
                             # Find the first unused file name in the sequence
                             iter = -1
+                            fname = None
                             while iter < 0 or os.path.isfile(fname):
                                 iter += 1
                                 fname = os.path.join(
@@ -902,15 +962,7 @@ class Offset(Template):
                     if det not in self._obs_dets[iob]:
                         continue
                     # Loop over views
-                    views = ob.view[self.view]
-                    for ivw, vw in enumerate(views):
-                        view_samples = None
-                        if vw.start < 0:
-                            # This is a view of the whole obs
-                            view_samples = ob.n_local_samples
-                        else:
-                            view_samples = vw.stop - vw.start
-
+                    for ivw, vw in enumerate(ob.intervals[self._bounds_view].data):
                         n_amp_view = self._obs_views[iob][ivw]
                         amp_slice = slice(offset, offset + n_amp_view, 1)
 
@@ -927,6 +979,7 @@ class Offset(Template):
                                     amps_in,
                                     self._precond[iob][det][ivw][0],
                                     mode="same",
+                                    method="auto",
                                 )
                             else:
                                 # Use pre-computed Cholesky decomposition.  Note that this
@@ -1020,7 +1073,7 @@ class Offset(Template):
                     amp_last = list()
                     amp_start = list()
                     amp_stop = list()
-                    for ivw, vw in enumerate(ob.intervals[self.view]):
+                    for ivw, vw in enumerate(ob.intervals[self._bounds_view]):
                         n_amp_view = self._obs_views[iob][ivw]
                         for istep in range(n_amp_view):
                             istart = vw.first + istep * step_length
@@ -1041,8 +1094,7 @@ class Offset(Template):
                 # Loop over views and extract per-detector amplitudes and flags
                 det_amps = list()
                 det_flags = list()
-                views = ob.view[self.view]
-                for ivw, vw in enumerate(views):
+                for ivw, vw in enumerate(ob.intervals[self._bounds_view].data):
                     n_amp_view = self._obs_views[iob][ivw]
                     amp_slice = slice(amp_offset, amp_offset + n_amp_view, 1)
                     det_amps.append(amplitudes.local[amp_slice])
@@ -1063,6 +1115,9 @@ class Offset(Template):
         # to the datasets.
 
         for iob, ob in enumerate(self.data.obs):
+            if ob.name not in obs_det_amps:
+                # There were no good amplitudes in this observation
+                continue
             obs_local_amps = obs_det_amps[ob.name]
             if self.data.comm.group_size == 1:
                 all_obs_amps = [obs_local_amps]
@@ -1087,6 +1142,7 @@ class Offset(Template):
                 with h5py.File(out_file, "w") as hf:
                     hf.attrs["step_length"] = all_obs_amps[0]["bounds"]["step_length"]
                     hf.attrs["detectors"] = json.dumps(det_names)
+                    hf.attrs["samples"] = ob.n_all_samples
                     hamp_first = hf.create_dataset("amp_first", data=amp_first)
                     hamp_last = hf.create_dataset("amp_last", data=amp_last)
                     hamp_start = hf.create_dataset("amp_start", data=amp_start)
@@ -1138,6 +1194,7 @@ def plot(amp_file, compare=dict(), out=None, xlim=None):
 
     with h5py.File(amp_file, "r") as hf:
         step_length = hf.attrs["step_length"]
+        samples = hf.attrs["samples"]
         det_list = json.loads(hf.attrs["detectors"])
         n_det = len(det_list)
         amp_first = hf["amp_first"]
@@ -1152,7 +1209,7 @@ def plot(amp_file, compare=dict(), out=None, xlim=None):
         fig_height = 4
         fig_dpi = 100
 
-        x_samples = np.arange(amp_first[0], amp_last[-1], 1)
+        x_samples = np.arange(samples)
 
         for idet, det in enumerate(det_list):
             outfile = f"{out}_{det}.pdf"

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -322,7 +322,7 @@ class IoHdf5Test(MPITestCase):
                     )
                     self.assertTrue(False)
 
-            close_data(check_data)
+            del check_data
             close_data(data)
 
     def test_save_load_ops(self):
@@ -367,7 +367,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         # Also test loading explicit files
         check_data = Data(data.comm)
@@ -380,7 +380,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         # Also check loading by regex, in this case only one frequency
         check_data = Data(data.comm)
@@ -394,7 +394,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         close_data(data)
 
@@ -440,7 +440,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         close_data(data)
 
@@ -484,7 +484,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         close_data(data)
 
@@ -530,7 +530,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         close_data(data)
 
@@ -592,7 +592,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         close_data(data)
 
@@ -905,7 +905,7 @@ class IoHdf5Test(MPITestCase):
             msg = f"select all returned {loaded_obs} not {orig_obs}"
             print(msg, flush=True)
             self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         # Check that we can load individual sessions
 
@@ -921,7 +921,7 @@ class IoHdf5Test(MPITestCase):
                 msg = f"select {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
                 print(msg, flush=True)
                 self.assertTrue(False)
-            close_data(check_data)
+            del check_data
 
         # Check that we can load observations based on some metadata.
         check_val = np.mean(check_leaf.value)
@@ -942,7 +942,7 @@ class IoHdf5Test(MPITestCase):
             msg = f"select on common meta returned {loaded_obs} not {orig_obs}"
             print(msg, flush=True)
             self.assertTrue(False)
-        close_data(check_data)
+        del check_data
 
         # Check we can load observations based on session times
         for ses in sorted(orig_ses_times.keys()):
@@ -965,7 +965,7 @@ class IoHdf5Test(MPITestCase):
                 msg = f"select time {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
                 print(msg, flush=True)
                 self.assertTrue(False)
-            close_data(check_data)
+            del check_data
 
         close_data(data)
 
@@ -1052,6 +1052,6 @@ class IoHdf5Test(MPITestCase):
                     f32=True,
                 )
             )
-        close_data(check_data)
+        del check_data
 
         close_data(data)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -289,11 +289,14 @@ class IoHdf5Test(MPITestCase):
             data, config = self.create_data()
             det_data_fields = ["signal", "flags", "alt_signal"]
 
-            # Export the data, and make a copy for later comparison.
-            original = list()
+            # Index for later comparison
+            original = dict()
+            for iob, ob in enumerate(data.obs):
+                original[ob.name] = iob
+
+            # Export the data
             obfiles = list()
             for ob in data.obs:
-                original.append(ob.duplicate(times="times"))
                 obf = save_hdf5(
                     ob,
                     datadir,
@@ -315,7 +318,8 @@ class IoHdf5Test(MPITestCase):
                 )
 
             # Verify
-            for ob, orig in zip(check_data.obs, original):
+            for ob in check_data.obs:
+                orig = data.obs[original[ob.name]]
                 if not orig.__eq__(ob, approx=True):
                     print(
                         f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}"
@@ -339,10 +343,10 @@ class IoHdf5Test(MPITestCase):
         data, config = self.create_data(split=True)
         det_data_fields = ["signal", "flags", "alt_signal"]
 
-        # Make a copy for later comparison.
+        # Index for later comparison
         original = dict()
-        for ob in data.obs:
-            original[ob.name] = ob.duplicate(times="times")
+        for iob, ob in enumerate(data.obs):
+            original[ob.name] = iob
 
         # Disable index for this test, to check that the loader works in this case
         saver = ops.SaveHDF5(
@@ -363,7 +367,7 @@ class IoHdf5Test(MPITestCase):
 
         # Verify
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
@@ -376,7 +380,7 @@ class IoHdf5Test(MPITestCase):
         loader.apply(check_data)
 
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
@@ -390,7 +394,7 @@ class IoHdf5Test(MPITestCase):
         loader.apply(check_data)
 
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
@@ -412,10 +416,10 @@ class IoHdf5Test(MPITestCase):
         data, config = self.create_data(split=True)
         det_data_fields = ["signal", "flags", "alt_signal"]
 
-        # Make a copy for later comparison.
+        # Index for later comparison
         original = dict()
-        for ob in data.obs:
-            original[ob.name] = ob.duplicate(times="times")
+        for iob, ob in enumerate(data.obs):
+            original[ob.name] = iob
 
         saver = ops.SaveHDF5(
             volume=datadir,
@@ -436,7 +440,7 @@ class IoHdf5Test(MPITestCase):
 
         # Verify
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
@@ -460,10 +464,10 @@ class IoHdf5Test(MPITestCase):
         # Set detdata to an empty list so that no detector data is written or loaded.
         det_data_fields = []
 
-        # Make a copy for later comparison.
+        # Index for later comparison
         original = dict()
-        for ob in data.obs:
-            original[ob.name] = ob.duplicate(times="times")
+        for iob, ob in enumerate(data.obs):
+            original[ob.name] = iob
 
         saver = ops.SaveHDF5(
             volume=datadir, detdata=det_data_fields, config=config, verify=True
@@ -479,7 +483,7 @@ class IoHdf5Test(MPITestCase):
 
         # Verify.  Before checking equality, purge detdata from the original.
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             orig.detdata.clear()
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
@@ -507,10 +511,10 @@ class IoHdf5Test(MPITestCase):
         ]
         det_data_names = ["signal", "flags", "alt_signal"]
 
-        # Make a copy for later comparison.
+        # Index for later comparison
         original = dict()
-        for ob in data.obs:
-            original[ob.name] = ob.duplicate(times="times")
+        for iob, ob in enumerate(data.obs):
+            original[ob.name] = iob
 
         saver = ops.SaveHDF5(
             volume=datadir, detdata=det_data_fields, config=config, verify=True
@@ -526,7 +530,7 @@ class IoHdf5Test(MPITestCase):
 
         # Verify
         for ob in check_data.obs:
-            orig = original[ob.name]
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
@@ -561,11 +565,14 @@ class IoHdf5Test(MPITestCase):
             ("alt_signal", {"type": "flac", "quanta": 1.0e-7}),
         ]
 
-        # Export the data, and make a copy for later comparison.
-        original = list()
+        # Index for later comparison
+        original = dict()
+        for iob, ob in enumerate(data.obs):
+            original[ob.name] = iob
+
+        # Export the data
         obfiles = list()
         for ob in data.obs:
-            original.append(ob.duplicate(times="times"))
             obf = save_v1(
                 ob,
                 datadir,
@@ -588,7 +595,8 @@ class IoHdf5Test(MPITestCase):
             )
 
         # Verify
-        for ob, orig in zip(check_data.obs, original):
+        for ob in check_data.obs:
+            orig = data.obs[original[ob.name]]
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -322,6 +322,7 @@ class IoHdf5Test(MPITestCase):
                     )
                     self.assertTrue(False)
 
+            close_data(check_data)
             close_data(data)
 
     def test_save_load_ops(self):
@@ -366,7 +367,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         # Also test loading explicit files
         check_data = Data(data.comm)
@@ -379,7 +380,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         # Also check loading by regex, in this case only one frequency
         check_data = Data(data.comm)
@@ -393,7 +394,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         close_data(data)
 
@@ -439,7 +440,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         close_data(data)
 
@@ -483,7 +484,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         close_data(data)
 
@@ -529,7 +530,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         close_data(data)
 
@@ -591,6 +592,7 @@ class IoHdf5Test(MPITestCase):
             if not orig.__eq__(ob, approx=True):
                 print(f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}")
                 self.assertTrue(False)
+        close_data(check_data)
 
         close_data(data)
 
@@ -903,7 +905,7 @@ class IoHdf5Test(MPITestCase):
             msg = f"select all returned {loaded_obs} not {orig_obs}"
             print(msg, flush=True)
             self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         # Check that we can load individual sessions
 
@@ -919,7 +921,7 @@ class IoHdf5Test(MPITestCase):
                 msg = f"select {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
                 print(msg, flush=True)
                 self.assertTrue(False)
-            del check_data
+            close_data(check_data)
 
         # Check that we can load observations based on some metadata.
         check_val = np.mean(check_leaf.value)
@@ -940,7 +942,7 @@ class IoHdf5Test(MPITestCase):
             msg = f"select on common meta returned {loaded_obs} not {orig_obs}"
             print(msg, flush=True)
             self.assertTrue(False)
-        del check_data
+        close_data(check_data)
 
         # Check we can load observations based on session times
         for ses in sorted(orig_ses_times.keys()):
@@ -963,7 +965,7 @@ class IoHdf5Test(MPITestCase):
                 msg = f"select time {ses} returned {loaded_obs} not {orig_ses_obs[ses]}"
                 print(msg, flush=True)
                 self.assertTrue(False)
-            del check_data
+            close_data(check_data)
 
         close_data(data)
 
@@ -1050,6 +1052,6 @@ class IoHdf5Test(MPITestCase):
                     f32=True,
                 )
             )
+        close_data(check_data)
 
-        del check_data
         close_data(data)

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy import units as u
 
 from .. import ops as ops
-from .. import qarray as qa
+from .. import templates
 from ..observation import default_values as defaults
 from ..vis import set_matplotlib_backend
 from .helpers import (
@@ -68,7 +68,7 @@ class DemodulateTest(MPITestCase):
             weights="weights_radec",
         )
 
-        sky_file = os.path.join(self.outdir, f"fake_sky_coord_change.fits")
+        sky_file = os.path.join(self.outdir, "fake_sky_coord_change.fits")
         map_key = "fake_map"
         create_fake_healpix_scanned_tod(
             data,
@@ -570,3 +570,224 @@ class DemodulateTest(MPITestCase):
                     fname_plot = os.path.join(self.outdir, "i2p_leakage.pdf")
                     plt.savefig(fname_plot)
                     assert False
+
+    def _test_destripe(self, weight_mode, data, suffix=""):
+        nside = 256
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Pointing operators
+
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            shared_flag_mask=0,
+        )
+        detpointing_radec = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            shared_flag_mask=0,
+        )
+
+        pixels = ops.PixelsHealpix(
+            nside=nside,
+            detector_pointing=detpointing_radec,
+        )
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing_radec,
+        )
+
+        sky_file = os.path.join(self.outdir, f"fake_sky_{weight_mode}{suffix}.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            sky_file,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=1.0 * u.deg,
+            lmax=3 * nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
+        )
+
+        # Destripe signal without demodulation
+
+        step_seconds = 1.0
+        tmpl = templates.Offset(
+            times=defaults.times,
+            noise_model=default_model.noise_model,
+            step_time=step_seconds * u.second,
+        )
+
+        tmatrix = ops.TemplateMatrix(templates=[tmpl])
+
+        binner = ops.BinMap(
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        mapper = ops.MapMaker(
+            name=f"modulated_{weight_mode}{suffix}",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            write_hits=True,
+            write_map=True,
+            write_cov=True,
+            write_invcov=True,
+            write_rcond=True,
+            keep_final_products=False,
+            output_dir=self.outdir,
+            solve_rcond_threshold=1e-3,
+            map_rcond_threshold=1e-3,
+            reset_pix_dist=True,
+        )
+        mapper.apply(data)
+
+        # Demodulate
+
+        demod_weights_in = ops.StokesWeights(
+            weights="demod_weights_in",
+            mode=weight_mode,
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing_azel,
+        )
+
+        downsample = 3
+        demod = ops.Demodulate(
+            stokes_weights=demod_weights_in,
+            nskip=downsample,
+            purge=False,
+            mode=weight_mode,
+        )
+        demod_data = demod.apply(data)
+
+        # Map again
+
+        demod_weights = ops.StokesWeightsDemod(
+            detector_pointing_in=detpointing_azel,
+            detector_pointing_out=detpointing_radec,
+            mode=weight_mode,
+        )
+
+        mapper.name = f"demodulated_{weight_mode}{suffix}"
+        binner.stokes_weights = demod_weights
+        mapper.apply(demod_data)
+
+        if data.comm.world_rank == 0:
+            set_matplotlib_backend()
+            import matplotlib.pyplot as plt
+
+            fname_mod = os.path.join(
+                self.outdir, f"modulated_{weight_mode}{suffix}_map.fits"
+            )
+            fname_demod = os.path.join(
+                self.outdir, f"demodulated_{weight_mode}{suffix}_map.fits"
+            )
+            fname_hits = os.path.join(
+                self.outdir, f"demodulated_{weight_mode}{suffix}_hits.fits"
+            )
+
+            map_mod = hp.read_map(fname_mod, None)
+            map_demod = np.atleast_2d(hp.read_map(fname_demod, None))
+            hits = hp.read_map(fname_hits)
+            map_input = np.atleast_2d(hp.read_map(sky_file, None))
+
+            # Develop a comparison mask that excludes poorly observed pixels
+            sorted_hits = np.sort(hits[hits != 0])
+            nhit = len(sorted_hits)
+            hit_min = sorted_hits[int(0.1 * nhit)]  # worst 10% of hit pixels
+            rms_mask = hits > hit_min
+
+            fig = plt.figure(figsize=[18, 12])
+            nrow, ncol = 3, 3
+            rot = [42, -42]
+            reso = 1
+            xsize = 800
+
+            amp = 1e-5
+            for i, m in enumerate(map_mod):
+                # Modulated map is full IQU
+                value = map_input[i]
+                good = m != 0
+                rms = np.sqrt(np.mean((m - value)[rms_mask] ** 2))
+                m[m == 0] = hp.UNSEEN
+                stokes = "IQU"[i]
+                hp.gnomview(
+                    m,
+                    sub=[nrow, ncol, 1 + i],
+                    reso=reso,
+                    xsize=xsize,
+                    rot=rot,
+                    title=f"Modulated {stokes} : rms = {rms}",
+                    min=np.amin(value[good]) - amp,
+                    max=np.amax(value[good]) + amp,
+                    cmap="coolwarm",
+                )
+
+            all_good = True
+            for stokes, m in zip(weight_mode, map_demod):
+                # Demodulated map only has the prescribed components
+                i = "IQU".index(stokes)
+                value = map_input[i]
+                good = m != 0
+                rms0 = np.sqrt(np.mean(value[rms_mask] ** 2))
+                rms = np.sqrt(np.mean(m[rms_mask] ** 2))
+                rms1 = np.sqrt(np.mean((m - value)[rms_mask] ** 2))
+                m[m == 0] = hp.UNSEEN
+                hp.gnomview(
+                    m,
+                    sub=[nrow, ncol, ncol + i + 1],
+                    reso=reso,
+                    xsize=xsize,
+                    rot=rot,
+                    title=f"Demodulated {stokes} : rms = {rms / rms0:.3f} x rms(in)",
+                    min=np.amin(value[good]) - amp,
+                    max=np.amax(value[good]) + amp,
+                    cmap="coolwarm",
+                )
+                resid = m - value
+                resid[m == 0] = hp.UNSEEN
+                hp.gnomview(
+                    resid,
+                    sub=[nrow, ncol, 2 * ncol + i + 1],
+                    reso=reso,
+                    xsize=xsize,
+                    rot=rot,
+                    title=f"Residual {stokes} : resid rms = {rms1 / rms0:.3f} x rms(in)",
+                    min=np.amin(value[good]) - amp,
+                    max=np.amax(value[good]) + amp,
+                    cmap="coolwarm",
+                )
+                if rms1 / rms0 > 0.3:
+                    print(
+                        f"input - demodulated map RMS = {rms1}, (input RMS = {rms0})",
+                        flush=True,
+                    )
+                    all_good = False
+
+            outfile = os.path.join(
+                self.outdir, f"map_comparison.{weight_mode}{suffix}.png"
+            )
+            fig.savefig(outfile)
+            self.assertTrue(all_good)
+
+        if self.comm is not None:
+            self.comm.barrier()
+        close_data(demod_data)
+        close_data(data)
+
+    def test_destripe_IQU(self):
+        data = create_ground_data(self.comm)
+        self._test_destripe(weight_mode="IQU", data=data, suffix="_destripe")
+
+    def test_destripe_QU(self):
+        data = create_ground_data(self.comm)
+        self._test_destripe(weight_mode="QU", data=data, suffix="_destripe")

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -23,6 +23,7 @@ from .helpers import (
     create_fake_healpix_scanned_tod,
     create_outdir,
     create_satellite_data,
+    create_ground_data,
 )
 from .mpi import MPITestCase
 
@@ -39,12 +40,12 @@ class MapmakerTest(MPITestCase):
         if self.comm is not None and self.comm.size >= 2:
             self.obs_per_group = self.total_obs // 2
 
-    def test_offset(self):
+    def test_offset_satellite(self):
         if sys.platform.lower() == "darwin":
-            print(f"WARNING:  Skipping test_offset on MacOS")
+            print("WARNING:  Skipping test_offset on MacOS")
             return
 
-        testdir = os.path.join(self.outdir, "offset")
+        testdir = os.path.join(self.outdir, "offset_satellite")
         if self.comm is None or self.comm.rank == 0:
             os.makedirs(testdir)
 
@@ -121,6 +122,136 @@ class MapmakerTest(MPITestCase):
             - data.obs[0].shared[defaults.times][0]
         )
         step_seconds = float(int(ob_time / 10.0))
+        tmpl = templates.Offset(
+            times=defaults.times,
+            noise_model=default_model.noise_model,
+            step_time=step_seconds * u.second,
+        )
+
+        tmatrix = ops.TemplateMatrix(templates=[tmpl])
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="test1",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-1,
+            write_hits=False,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=False,
+            keep_final_products=False,
+            output_dir=testdir,
+        )
+
+        # Make the map
+        mapper.apply(data)
+
+        # Check that we can also run in full-memory mode
+        tmatrix.reset()
+        mapper.reset_pix_dist = True
+        pixels.apply(data)
+        weights.apply(data)
+
+        use_accel = None
+        if accel_enabled() and (
+            pixels.supports_accel()
+            and weights.supports_accel()
+            and mapper.supports_accel()
+        ):
+            use_accel = True
+            data.accel_create(pixels.requires())
+            data.accel_create(weights.requires())
+            data.accel_create(mapper.requires())
+            data.accel_update_device(pixels.requires())
+            data.accel_update_device(weights.requires())
+            data.accel_update_device(mapper.requires())
+
+        binner.full_pointing = True
+        mapper.name = "test2"
+        mapper.apply(data, use_accel=use_accel)
+
+        close_data(data)
+
+    def test_offset_ground(self):
+        if sys.platform.lower() == "darwin":
+            print("WARNING:  Skipping test_offset on MacOS")
+            return
+
+        testdir = os.path.join(self.outdir, "offset_ground")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create a fake ground data set for testing
+
+        data = create_ground_data(self.comm)
+
+        # Create some sky signal timestreams.
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=64,
+            create_dist="pixel_dist",
+            detector_pointing=detpointing,
+        )
+        pixels.apply(data)
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+        weights.apply(data)
+
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_map.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
+        )
+
+        # Now clear the pointing and reset things for use with the mapmaking test later
+        delete_pointing = ops.Delete(
+            detdata=[detpointing.quats, pixels.pixels, weights.weights]
+        )
+        delete_pointing.apply(data)
+        pixels.create_dist = None
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(
+            noise_model=default_model.noise_model, det_data=defaults.det_data
+        )
+        sim_noise.apply(data)
+
+        # Set up binning operator for solving
+        binner = ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        # Set up template matrix with just an offset template.
+
+        # Use a long baseline length, which we will truncate to the scanning
+        # interval.
+        step_seconds = 3600.0
         tmpl = templates.Offset(
             times=defaults.times,
             noise_model=default_model.noise_model,
@@ -593,7 +724,7 @@ class MapmakerTest(MPITestCase):
             step_time=step_seconds * u.second,
             use_noise_prior=True,
             precond_width=1,
-            # debug_plots=testdir,
+            debug_plots=testdir,
         )
 
         tmatrix = ops.TemplateMatrix(templates=[tmpl])
@@ -611,6 +742,7 @@ class MapmakerTest(MPITestCase):
             solve_rcond_threshold=1.0e-4,
             map_rcond_threshold=1.0e-4,
             iter_max=50,
+            output_dir=testdir,
             write_hits=False,
             write_map=False,
             write_cov=False,
@@ -865,8 +997,8 @@ class MapmakerTest(MPITestCase):
             noise_model=default_model.noise_model,
             step_time=step_seconds * u.second,
             use_noise_prior=True,
-            precond_width=10,
-            # debug_plots=testdir,
+            precond_width=2,
+            debug_plots=testdir,
         )
 
         tmatrix = ops.TemplateMatrix(templates=[tmpl])
@@ -884,6 +1016,7 @@ class MapmakerTest(MPITestCase):
             solve_rcond_threshold=1.0e-4,
             map_rcond_threshold=1.0e-4,
             iter_max=50,
+            output_dir=testdir,
             write_hits=False,
             write_map=False,
             write_cov=False,

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -17,12 +17,13 @@ from ..observation import default_values as defaults
 from ..timing import GlobalTimers
 from ..timing import dump as dump_timers
 from ..timing import gather_timers
-from ..vis import set_matplotlib_backend
+from ..vis import set_matplotlib_backend, plot_healpix_maps
 from .helpers import (
     close_data,
     create_fake_healpix_scanned_tod,
     create_outdir,
     create_satellite_data,
+    create_ground_data,
 )
 from .mpi import MPITestCase
 
@@ -38,13 +39,23 @@ class MapmakerTest(MPITestCase):
         self.obs_per_group = self.total_obs
         if self.comm is not None and self.comm.size >= 2:
             self.obs_per_group = self.total_obs // 2
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
+        # Additional debugging
+        self.extra_debug = False
 
-    def test_offset(self):
+    def test_offset_satellite(self):
         if sys.platform.lower() == "darwin":
-            print(f"WARNING:  Skipping test_offset on MacOS")
+            print("WARNING:  Skipping test_offset on MacOS")
             return
 
-        testdir = os.path.join(self.outdir, "offset")
+        testdir = os.path.join(self.outdir, "offset_satellite")
         if self.comm is None or self.comm.rank == 0:
             os.makedirs(testdir)
 
@@ -81,9 +92,9 @@ class MapmakerTest(MPITestCase):
             map_key=map_key,
             fwhm=30.0 * u.arcmin,
             lmax=3 * pixels.nside,
-            I_scale=0.001,
-            Q_scale=0.0001,
-            U_scale=0.0001,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
             det_data=defaults.det_data,
         )
 
@@ -175,6 +186,185 @@ class MapmakerTest(MPITestCase):
 
         close_data(data)
 
+    def test_offset_ground(self):
+        if sys.platform.lower() == "darwin":
+            print("WARNING:  Skipping test_offset on MacOS")
+            return
+
+        testdir = os.path.join(self.outdir, "offset_ground")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create a fake ground data set for testing
+
+        data = create_ground_data(self.comm)
+
+        # Create some sky signal timestreams.
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=64,
+            create_dist="pixel_dist",
+            detector_pointing=detpointing,
+            view="scanning",
+        )
+        pixels.apply(data)
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+        weights.apply(data)
+
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_map.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
+            det_data=defaults.det_data,
+        )
+
+        # Now clear the pointing and reset things for use with the mapmaking test later
+        delete_pointing = ops.Delete(
+            detdata=[detpointing.quats, pixels.pixels, weights.weights]
+        )
+        delete_pointing.apply(data)
+        pixels.create_dist = None
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(
+            noise_model=default_model.noise_model, det_data=defaults.det_data
+        )
+        sim_noise.apply(data)
+
+        # Copy the data for later use
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        # Set up binning operator for solving
+        binner = ops.BinMap(
+            pixel_dist="pixel_dist",
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        # Set up template matrix with just an offset template.
+
+        # Use a long baseline length, which we will truncate to the scanning
+        # interval.
+        step_seconds = 3600.0
+        tmpl = templates.Offset(
+            times=defaults.times,
+            noise_model=default_model.noise_model,
+            step_time=step_seconds * u.second,
+        )
+
+        tmatrix = ops.TemplateMatrix(templates=[tmpl])
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="test1",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-1,
+            write_hits=True,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=False,
+            keep_final_products=False,
+            output_dir=testdir,
+        )
+
+        # Make the map
+        mapper.apply(data)
+
+        # Check that we can also run in full-memory mode
+        tmatrix.reset()
+        mapper.reset_pix_dist = True
+        pixels.apply(data)
+        weights.apply(data)
+
+        use_accel = None
+        if accel_enabled() and (
+            pixels.supports_accel()
+            and weights.supports_accel()
+            and mapper.supports_accel()
+        ):
+            use_accel = True
+            data.accel_create(pixels.requires())
+            data.accel_create(weights.requires())
+            data.accel_create(mapper.requires())
+            data.accel_update_device(pixels.requires())
+            data.accel_update_device(weights.requires())
+            data.accel_update_device(mapper.requires())
+
+        binner.full_pointing = True
+        mapper = ops.MapMaker(
+            name="test2",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            solve_rcond_threshold=1.0e-1,
+            map_rcond_threshold=1.0e-1,
+            write_hits=True,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=True,
+            keep_final_products=False,
+            output_dir=testdir,
+        )
+        mapper.apply(data, use_accel=use_accel)
+
+        # Write offset amplitudes
+        oamps = data[f"{mapper.name}_solve_amplitudes"][tmpl.name]
+        oroot = os.path.join(testdir, f"{mapper.name}_offset")
+        tmpl.write(oamps, oroot)
+
+        # Plot some results
+        if data.comm.world_rank == 0 and self.make_plots:
+            for ob in data.obs:
+                oamp_file = f"{oroot}_{ob.name}.h5"
+                if os.path.isfile(oamp_file):
+                    templates.offset.plot(
+                        oamp_file,
+                        compare={
+                            x: ob.detdata["input"][x, :] for x in ob.local_detectors
+                        },
+                        out=f"{oroot}_{ob.name}",
+                    )
+            hit_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
+            map_file = os.path.join(testdir, f"{mapper.name}_map.fits")
+            plot_healpix_maps(
+                hitfile=hit_file,
+                mapfile=map_file,
+                truth=skyfile,
+                range_I=(-0.05, 0.05),
+                range_Q=(-0.005, 0.005),
+                range_U=(-0.005, 0.005),
+                gnomview=True,
+                gnomres=3.0,
+                image_format="png",
+            )
+
+        close_data(data)
+
     def test_compare_madam_noprior(self):
         if not ops.madam.available():
             print("libmadam not available, skipping destriping comparison")
@@ -217,9 +407,9 @@ class MapmakerTest(MPITestCase):
             map_key=map_key,
             fwhm=30.0 * u.arcmin,
             lmax=3 * pixels.nside,
-            I_scale=0.001,
-            Q_scale=0.0001,
-            U_scale=0.0001,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
             det_data=defaults.det_data,
         )
 
@@ -250,14 +440,7 @@ class MapmakerTest(MPITestCase):
 
         # Set up template matrix with just an offset template.
 
-        # Use 1/10 of an observation as the baseline length.  Make it not evenly
-        # divisible in order to test handling of the final amplitude.
-        ob_time = (
-            data.obs[0].shared[defaults.times][-1]
-            - data.obs[0].shared[defaults.times][0]
-        )
-        # step_seconds = float(int(ob_time / 10.0))
-        step_seconds = 5.0
+        step_seconds = 10.0
         tmpl = templates.Offset(
             times=defaults.times,
             noise_model=default_model.noise_model,
@@ -274,7 +457,7 @@ class MapmakerTest(MPITestCase):
 
         # Map maker
         mapper = ops.MapMaker(
-            name="toastmap",
+            name="toast",
             det_data=defaults.det_data,
             binning=binner,
             template_matrix=tmatrix,
@@ -308,7 +491,6 @@ class MapmakerTest(MPITestCase):
 
         toast_hit_path = os.path.join(testdir, f"{mapper.name}_hits.fits")
         toast_map_path = os.path.join(testdir, f"{mapper.name}_map.fits")
-        toast_mask_path = os.path.join(testdir, f"{mapper.name}_solve_rcond_mask.fits")
 
         # Now run Madam on the same data and compare
 
@@ -361,7 +543,6 @@ class MapmakerTest(MPITestCase):
 
         madam_hit_path = os.path.join(testdir, "madam_hmap.fits")
         madam_map_path = os.path.join(testdir, "madam_map.fits")
-        madam_mask_path = os.path.join(testdir, "madam_mask.fits")
 
         fail = False
 
@@ -371,7 +552,7 @@ class MapmakerTest(MPITestCase):
             for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
                 input_signal = ob.detdata["input_signal"][det]
                 madam_signal = ob.detdata["madam_cleaned"][det]
-                toast_signal = ob.detdata["toastmap_cleaned"][det]
+                toast_signal = ob.detdata["toast_cleaned"][det]
                 madam_base = input_signal - madam_signal
                 toast_base = input_signal - toast_signal
                 diff_base = madam_base - toast_base
@@ -432,71 +613,69 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
-            outfile = os.path.join(testdir, "madam_hits.png")
-            hp.mollview(madam_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "toast_hits.png")
-            hp.mollview(toast_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "diff_hits.png")
-            hp.mollview(diff_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-
-            # Compare masks
-
-            toast_mask = hp.read_map(toast_mask_path, field=None, nest=True)
-            madam_mask = hp.read_map(madam_mask_path, field=None, nest=True)
-
-            # Madam uses 1=good, 0=bad, Toast uses 0=good, non-zero=bad:
-            tgood = toast_mask == 0
-            toast_mask[:] = 0
-            toast_mask[tgood] = 1
-            diff_mask = toast_mask - madam_mask[0]
-
-            outfile = os.path.join(testdir, "madam_mask.png")
-            hp.mollview(madam_mask[0], xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "toast_mask.png")
-            hp.mollview(toast_mask, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "diff_mask.png")
-            hp.mollview(diff_mask, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
+            if self.make_plots:
+                outfile = os.path.join(testdir, "madam_hits.png")
+                hp.mollview(madam_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "toast_hits.png")
+                hp.mollview(toast_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "diff_hits.png")
+                hp.mollview(diff_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
             # Compare maps
 
+            if self.make_plots:
+                plot_healpix_maps(
+                    hitfile=toast_hit_path,
+                    mapfile=toast_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+                plot_healpix_maps(
+                    hitfile=madam_hit_path,
+                    mapfile=madam_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+
             toast_map = hp.read_map(toast_map_path, field=None, nest=True)
             madam_map = hp.read_map(madam_map_path, field=None, nest=True)
-            # Set madam unhit pixels to zero
-            for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
-                good = madam_map[stokes] != hp.UNSEEN
-                diff_map = toast_map[stokes] - madam_map[stokes]
 
-                outfile = os.path.join(testdir, "madam_map_{}.png".format(ststr))
-                hp.mollview(madam_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "toast_map_{}.png".format(ststr))
-                hp.mollview(toast_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
-                hp.mollview(diff_map, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
+            good = madam_hits > 0
+            bad = np.logical_not(good)
+            diff_map = toast_map - madam_map
+            diff_map[:, bad] = np.nan
+
+            for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
+                if self.make_plots:
+                    outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
+                    hp.gnomview(diff_map[stokes], xsize=1600, nest=True)
+                    plt.savefig(outfile)
+                    plt.close()
 
                 if not np.allclose(
-                    toast_map[stokes][good], madam_map[stokes][good], rtol=0.01
+                    toast_map[stokes][good],
+                    madam_map[stokes][good],
+                    rtol=0.01,
+                    atol=1.0e-5,
                 ):
-                    print(
-                        f"FAIL: max {ststr} diff = {np.max(np.absolute(diff_map[good]))}"
-                    )
+                    max_diff = np.max(np.absolute(diff_map[stokes][good]))
+                    print(f"FAIL: max {ststr} diff = {max_diff}", flush=True)
                     fail = True
 
         if data.comm.comm_world is not None:
@@ -548,9 +727,9 @@ class MapmakerTest(MPITestCase):
             map_key=map_key,
             fwhm=30.0 * u.arcmin,
             lmax=3 * pixels.nside,
-            I_scale=0.001,
-            Q_scale=0.0001,
-            U_scale=0.0001,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
             det_data=defaults.det_data,
         )
 
@@ -579,24 +758,22 @@ class MapmakerTest(MPITestCase):
 
         # Set up template matrix with just an offset template.
 
-        # Use 1/10 of an observation as the baseline length.  Make it not evenly
-        # divisible in order to test handling of the final amplitude.
-        ob_time = (
-            data.obs[0].shared[defaults.times][-1]
-            - data.obs[0].shared[defaults.times][0]
-        )
-        # step_seconds = float(int(ob_time / 10.0))
-        step_seconds = 5.0
+        step_seconds = 2.0
+        dbg_dir = None
+        if self.make_plots and self.extra_debug:
+            dbg_dir = testdir
         tmpl = templates.Offset(
             times=defaults.times,
             noise_model=default_model.noise_model,
             step_time=step_seconds * u.second,
             use_noise_prior=True,
             precond_width=1,
-            # debug_plots=testdir,
+            debug_plots=dbg_dir,
         )
 
         tmatrix = ops.TemplateMatrix(templates=[tmpl])
+
+        ops.Copy(detdata=[(defaults.det_data, "input_signal")]).apply(data)
 
         gt = GlobalTimers.get()
         gt.stop_all()
@@ -604,18 +781,25 @@ class MapmakerTest(MPITestCase):
 
         # Map maker
         mapper = ops.MapMaker(
-            name="toastmap",
+            name="toast",
             det_data=defaults.det_data,
             binning=binner,
             template_matrix=tmatrix,
             solve_rcond_threshold=1.0e-4,
             map_rcond_threshold=1.0e-4,
-            iter_max=50,
+            iter_max=100,
+            output_dir=testdir,
             write_hits=False,
             write_map=False,
             write_cov=False,
             write_rcond=False,
             keep_final_products=True,
+            write_solver_products=True,
+            save_cleaned=True,
+            overwrite_cleaned=False,
+            copy_groups=2,
+            purge_det_data=True,
+            restore_det_data=True,
         )
 
         # Make the map
@@ -627,8 +811,8 @@ class MapmakerTest(MPITestCase):
             dump_timers(alltimers, out)
 
         # Outputs
-        toast_hits = "toastmap_hits"
-        toast_map = "toastmap_map"
+        toast_hits = "toast_hits"
+        toast_map = "toast_map"
 
         # Write map to disk so we can load the whole thing on one process.
 
@@ -644,7 +828,7 @@ class MapmakerTest(MPITestCase):
         pars = {}
         pars["kfirst"] = "T"
         pars["basis_order"] = 0
-        pars["iter_max"] = 50
+        pars["iter_max"] = 100
         pars["base_first"] = step_seconds
         pars["fsample"] = sample_rate
         pars["nside_map"] = pixels.nside
@@ -675,6 +859,7 @@ class MapmakerTest(MPITestCase):
             pixel_pointing=pixels,
             stokes_weights=weights,
             noise_model="noise_model",
+            det_out="madam_cleaned",
         )
 
         # Generate persistent pointing
@@ -689,6 +874,82 @@ class MapmakerTest(MPITestCase):
 
         fail = False
 
+        # Compare local destriped TOD on every process
+
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                input_signal = ob.detdata["input_signal"][det]
+                madam_signal = ob.detdata["madam_cleaned"][det]
+                toast_signal = ob.detdata["toast_cleaned"][det]
+                madam_base = input_signal - madam_signal
+                toast_base = input_signal - toast_signal
+                diff_base = madam_base - toast_base
+                in_rms = np.std(input_signal)
+
+                if self.make_plots:
+                    set_matplotlib_backend()
+                    import matplotlib.pyplot as plt
+
+                    dbg_root = os.path.join(
+                        testdir, f"base_{ob.name}_{data.comm.world_rank}_{det}"
+                    )
+                    if self.extra_debug:
+                        np.savetxt(f"{dbg_root}_signal.txt", input_signal)
+                        np.savetxt(f"{dbg_root}_madam.txt", madam_base)
+                        np.savetxt(f"{dbg_root}_toast.txt", toast_base)
+                        np.savetxt(f"{dbg_root}_diff.txt", diff_base)
+
+                    fig = plt.figure(figsize=(12, 12), dpi=72)
+                    ax = fig.add_subplot(2, 1, 1, aspect="auto")
+                    ax.plot(
+                        np.arange(len(input_signal)),
+                        input_signal,
+                        c="black",
+                        label="Input",
+                    )
+                    ax.plot(
+                        np.arange(len(madam_base)),
+                        madam_base,
+                        c="green",
+                        label="Madam",
+                    )
+                    ax.plot(
+                        np.arange(len(toast_base)),
+                        toast_base,
+                        c="red",
+                        label="Toast",
+                    )
+                    ax.legend(loc=1)
+
+                    ax = fig.add_subplot(2, 1, 2, aspect="auto")
+                    ax.plot(
+                        np.arange(len(madam_base)),
+                        madam_base,
+                        c="green",
+                        label="Madam",
+                    )
+                    ax.plot(
+                        np.arange(len(toast_base)),
+                        toast_base,
+                        c="red",
+                        label="Toast",
+                    )
+                    ax.legend(loc=1)
+
+                    plt.title("Baseline Comparison")
+                    savefile = f"{dbg_root}.pdf"
+                    plt.savefig(savefile)
+                    plt.close()
+
+                if not np.allclose(
+                    toast_base, madam_base, rtol=0.2, atol=1.0e-2 * in_rms
+                ):
+                    msg = f"FAIL: {det} diff : in_rms = {in_rms}, "
+                    msg += f"PtP = {np.ptp(diff_base)}, "
+                    msg += f"mean = {np.mean(diff_base)}"
+                    print(msg, flush=True)
+                    fail = True
+
         if data.comm.world_rank == 0:
             set_matplotlib_backend()
             import matplotlib.pyplot as plt
@@ -699,72 +960,68 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
-            outfile = os.path.join(testdir, "madam_hits.png")
-            hp.mollview(madam_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "toast_hits.png")
-            hp.mollview(toast_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "diff_hits.png")
-            hp.mollview(diff_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
+            if self.make_plots:
+                outfile = os.path.join(testdir, "madam_hits.png")
+                hp.mollview(madam_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "toast_hits.png")
+                hp.mollview(toast_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "diff_hits.png")
+                hp.mollview(diff_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
             # Compare maps
 
-            input_map = hp.read_map(
-                os.path.join(testdir, "input_map.fits"), field=None, nest=True
-            )
+            if self.make_plots:
+                plot_healpix_maps(
+                    hitfile=toast_hit_path,
+                    mapfile=toast_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+                plot_healpix_maps(
+                    hitfile=madam_hit_path,
+                    mapfile=madam_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+
             toast_map = hp.read_map(toast_map_path, field=None, nest=True)
             madam_map = hp.read_map(madam_map_path, field=None, nest=True)
 
-            # Set madam unhit pixels to zero
+            good = madam_hits > 0
+            bad = np.logical_not(good)
+            diff_map = toast_map - madam_map
+            diff_map[:, bad] = np.nan
+
             for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
-                mask = hp.mask_bad(madam_map[stokes])
-                madam_map[stokes][mask] = 0.0
-                input_map[stokes][mask] = 0.0
-                diff_map = toast_map[stokes] - madam_map[stokes]
-                madam_diff_truth = madam_map[stokes] - input_map[stokes]
-                toast_diff_truth = toast_map[stokes] - input_map[stokes]
-
-                print("diff map {} has rms {}".format(ststr, np.std(diff_map)))
-                print(
-                    "toast-truth map {} has rms {}".format(
-                        ststr, np.std(toast_diff_truth)
-                    )
-                )
-                print(
-                    "madam-truth map {} has rms {}".format(
-                        ststr, np.std(madam_diff_truth)
-                    )
-                )
-
-                outfile = os.path.join(testdir, "madam_map_{}.png".format(ststr))
-                hp.mollview(madam_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "toast_map_{}.png".format(ststr))
-                hp.mollview(toast_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
-                hp.mollview(diff_map, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "madam_diff_truth_{}.png".format(ststr))
-                hp.mollview(madam_diff_truth, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "toast_diff_truth_{}.png".format(ststr))
-                hp.mollview(toast_diff_truth, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
+                if self.make_plots:
+                    outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
+                    hp.gnomview(diff_map[stokes], xsize=1600, nest=True)
+                    plt.savefig(outfile)
+                    plt.close()
 
                 if not np.allclose(
-                    toast_map[stokes], madam_map[stokes], atol=0.1, rtol=0.05
+                    toast_map[stokes][good],
+                    madam_map[stokes][good],
+                    atol=0.1,
+                    rtol=0.05,
                 ):
+                    print(f"FAIL on diag pre {ststr}", flush=True)
                     fail = True
 
         if data.comm.comm_world is not None:
@@ -852,24 +1109,22 @@ class MapmakerTest(MPITestCase):
 
         # Set up template matrix with just an offset template.
 
-        # Use 1/10 of an observation as the baseline length.  Make it not evenly
-        # divisible in order to test handling of the final amplitude.
-        ob_time = (
-            data.obs[0].shared[defaults.times][-1]
-            - data.obs[0].shared[defaults.times][0]
-        )
-        # step_seconds = float(int(ob_time / 10.0))
-        step_seconds = 5.0
+        step_seconds = 2.0
+        dbg_dir = None
+        if self.make_plots and self.extra_debug:
+            dbg_dir = testdir
         tmpl = templates.Offset(
             times=defaults.times,
             noise_model=default_model.noise_model,
             step_time=step_seconds * u.second,
             use_noise_prior=True,
             precond_width=10,
-            # debug_plots=testdir,
+            debug_plots=dbg_dir,
         )
 
         tmatrix = ops.TemplateMatrix(templates=[tmpl])
+
+        ops.Copy(detdata=[(defaults.det_data, "input_signal")]).apply(data)
 
         gt = GlobalTimers.get()
         gt.stop_all()
@@ -877,18 +1132,25 @@ class MapmakerTest(MPITestCase):
 
         # Map maker
         mapper = ops.MapMaker(
-            name="toastmap",
+            name="toast",
             det_data=defaults.det_data,
             binning=binner,
             template_matrix=tmatrix,
             solve_rcond_threshold=1.0e-4,
             map_rcond_threshold=1.0e-4,
             iter_max=50,
+            output_dir=testdir,
             write_hits=False,
             write_map=False,
             write_cov=False,
             write_rcond=False,
             keep_final_products=True,
+            write_solver_products=True,
+            save_cleaned=True,
+            overwrite_cleaned=False,
+            copy_groups=2,
+            purge_det_data=True,
+            restore_det_data=True,
         )
 
         # Make the map
@@ -900,8 +1162,8 @@ class MapmakerTest(MPITestCase):
             dump_timers(alltimers, out)
 
         # Outputs
-        toast_hits = "toastmap_hits"
-        toast_map = "toastmap_map"
+        toast_hits = "toast_hits"
+        toast_map = "toast_map"
 
         # Write map to disk so we can load the whole thing on one process.
 
@@ -917,7 +1179,7 @@ class MapmakerTest(MPITestCase):
         pars = {}
         pars["kfirst"] = "T"
         pars["basis_order"] = 0
-        pars["iter_max"] = 50
+        pars["iter_max"] = 100
         pars["base_first"] = step_seconds
         pars["fsample"] = sample_rate
         pars["nside_map"] = pixels.nside
@@ -948,6 +1210,7 @@ class MapmakerTest(MPITestCase):
             pixel_pointing=pixels,
             stokes_weights=weights,
             noise_model="noise_model",
+            det_out="madam_cleaned",
         )
 
         # Generate persistent pointing
@@ -962,6 +1225,82 @@ class MapmakerTest(MPITestCase):
 
         fail = False
 
+        # Compare local destriped TOD on every process
+
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                input_signal = ob.detdata["input_signal"][det]
+                madam_signal = ob.detdata["madam_cleaned"][det]
+                toast_signal = ob.detdata["toast_cleaned"][det]
+                madam_base = input_signal - madam_signal
+                toast_base = input_signal - toast_signal
+                diff_base = madam_base - toast_base
+                in_rms = np.std(input_signal)
+
+                if self.make_plots:
+                    set_matplotlib_backend()
+                    import matplotlib.pyplot as plt
+
+                    dbg_root = os.path.join(
+                        testdir, f"base_{ob.name}_{data.comm.world_rank}_{det}"
+                    )
+                    if self.extra_debug:
+                        np.savetxt(f"{dbg_root}_signal.txt", input_signal)
+                        np.savetxt(f"{dbg_root}_madam.txt", madam_base)
+                        np.savetxt(f"{dbg_root}_toast.txt", toast_base)
+                        np.savetxt(f"{dbg_root}_diff.txt", diff_base)
+
+                    fig = plt.figure(figsize=(12, 12), dpi=72)
+                    ax = fig.add_subplot(2, 1, 1, aspect="auto")
+                    ax.plot(
+                        np.arange(len(input_signal)),
+                        input_signal,
+                        c="black",
+                        label="Input",
+                    )
+                    ax.plot(
+                        np.arange(len(madam_base)),
+                        madam_base,
+                        c="green",
+                        label="Madam",
+                    )
+                    ax.plot(
+                        np.arange(len(toast_base)),
+                        toast_base,
+                        c="red",
+                        label="Toast",
+                    )
+                    ax.legend(loc=1)
+
+                    ax = fig.add_subplot(2, 1, 2, aspect="auto")
+                    ax.plot(
+                        np.arange(len(madam_base)),
+                        madam_base,
+                        c="green",
+                        label="Madam",
+                    )
+                    ax.plot(
+                        np.arange(len(toast_base)),
+                        toast_base,
+                        c="red",
+                        label="Toast",
+                    )
+                    ax.legend(loc=1)
+
+                    plt.title("Baseline Comparison")
+                    savefile = f"{dbg_root}.pdf"
+                    plt.savefig(savefile)
+                    plt.close()
+
+                if not np.allclose(
+                    toast_base, madam_base, rtol=0.2, atol=1.0e-2 * in_rms
+                ):
+                    msg = f"FAIL: {det} diff : in_rms = {in_rms}, "
+                    msg += f"PtP = {np.ptp(diff_base)}, "
+                    msg += f"mean = {np.mean(diff_base)}"
+                    print(msg, flush=True)
+                    fail = True
+
         if data.comm.world_rank == 0:
             set_matplotlib_backend()
             import matplotlib.pyplot as plt
@@ -972,59 +1311,68 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
-            outfile = os.path.join(testdir, "madam_hits.png")
-            hp.mollview(madam_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "toast_hits.png")
-            hp.mollview(toast_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
-            outfile = os.path.join(testdir, "diff_hits.png")
-            hp.mollview(diff_hits, xsize=1600, nest=True)
-            plt.savefig(outfile)
-            plt.close()
+            if self.make_plots:
+                outfile = os.path.join(testdir, "madam_hits.png")
+                hp.mollview(madam_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "toast_hits.png")
+                hp.mollview(toast_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
+                outfile = os.path.join(testdir, "diff_hits.png")
+                hp.mollview(diff_hits, xsize=1600, nest=True)
+                plt.savefig(outfile)
+                plt.close()
 
             # Compare maps
 
-            input_map = hp.read_map(
-                os.path.join(testdir, "input_map.fits"), field=None, nest=True
-            )
+            if self.make_plots:
+                plot_healpix_maps(
+                    hitfile=toast_hit_path,
+                    mapfile=toast_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+                plot_healpix_maps(
+                    hitfile=madam_hit_path,
+                    mapfile=madam_map_path,
+                    truth=skyfile,
+                    range_I=(-0.05, 0.05),
+                    range_Q=(-0.005, 0.005),
+                    range_U=(-0.005, 0.005),
+                    gnomview=True,
+                    gnomres=3.0,
+                    image_format="png",
+                )
+
             toast_map = hp.read_map(toast_map_path, field=None, nest=True)
             madam_map = hp.read_map(madam_map_path, field=None, nest=True)
-            # Set madam unhit pixels to zero
+
+            good = madam_hits > 0
+            bad = np.logical_not(good)
+            diff_map = toast_map - madam_map
+            diff_map[:, bad] = np.nan
+
             for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
-                mask = hp.mask_bad(madam_map[stokes])
-                madam_map[stokes][mask] = 0.0
-                input_map[stokes][mask] = 0.0
-                diff_map = toast_map[stokes] - madam_map[stokes]
-                madam_diff_truth = madam_map[stokes] - input_map[stokes]
-                toast_diff_truth = toast_map[stokes] - input_map[stokes]
-                # print("diff map {} has rms {}".format(ststr, np.std(diff_map)))
-                outfile = os.path.join(testdir, "madam_map_{}.png".format(ststr))
-                hp.mollview(madam_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "toast_map_{}.png".format(ststr))
-                hp.mollview(toast_map[stokes], xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
-                hp.mollview(diff_map, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "madam_diff_truth_{}.png".format(ststr))
-                hp.mollview(madam_diff_truth, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
-                outfile = os.path.join(testdir, "toast_diff_truth_{}.png".format(ststr))
-                hp.mollview(toast_diff_truth, xsize=1600, nest=True)
-                plt.savefig(outfile)
-                plt.close()
+                if self.make_plots:
+                    outfile = os.path.join(testdir, "diff_map_{}.png".format(ststr))
+                    hp.gnomview(diff_map[stokes], xsize=1600, nest=True)
+                    plt.savefig(outfile)
+                    plt.close()
 
                 if not np.allclose(
-                    toast_map[stokes], madam_map[stokes], atol=0.1, rtol=0.05
+                    toast_map[stokes][good],
+                    madam_map[stokes][good],
+                    atol=0.1,
+                    rtol=0.05,
                 ):
+                    print(f"FAIL on band pre {ststr}", flush=True)
                     fail = True
 
         if data.comm.comm_world is not None:

--- a/src/toast/tests/ops_signal_diff_noise.py
+++ b/src/toast/tests/ops_signal_diff_noise.py
@@ -1,16 +1,15 @@
-# Copyright (c) 2024 by the parties listed in the AUTHORS file.
+# Copyright (c) 2024-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
-import sys
 
 import numpy as np
 from astropy import units as u
 
-from .. import ops as ops
-from ..data import Data
 from ..mpi import MPI
+from ..observation import default_values as defaults
+from .. import ops as ops
 from .helpers import close_data, create_ground_data, create_outdir
 from .mpi import MPITestCase
 
@@ -21,16 +20,9 @@ class SignalDiffNoiseTest(MPITestCase):
         self.outdir = create_outdir(self.comm, subdir=fixture_name)
 
     def test_diff_noise(self):
-        rank = 0
-        if self.comm is not None:
-            rank = self.comm.rank
-
         # Create fake observing of a small patch
-        data = create_ground_data(self.comm, sample_rate=100 * u.Hz, fknee=1e-3 * u.Hz)
-
-        # Simple detector pointing
-        detpointing_azel = ops.PointingDetectorSimple(
-            boresight="boresight_azel", quats="quats_azel"
+        data = create_ground_data(
+            self.comm, sample_rate=100 * u.Hz, fknee=1e-3 * u.Hz
         )
 
         # Create a noise model from focalplane detector properties
@@ -47,14 +39,19 @@ class SignalDiffNoiseTest(MPITestCase):
 
         # Check that the last frequency bin of analytic and measured
         # noise agrees
+        fail = 0
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                psd0 = ob["analytic_noise"].psd(det)
+                psd1 = ob["measured_noise"].psd(det)
+                if np.abs((psd0[-1] - psd1[-1]) / psd0[-1]) > 5e-2:
+                    msg = f"{ob.name}:{det} final PSD value disagrees "
+                    msg += f"({psd0[-3:-1]} != {psd1[-3:-1]})"
+                    print(msg, flush=True)
+                    fail = 1
 
-        dets = data.obs[0].local_detectors
-        det = dets[0]
-        # freq0 = data.obs[0]["analytic_noise"].freq(det)
-        psd0 = data.obs[0]["analytic_noise"].psd(det)
-        # freq1 = data.obs[0]["measured_noise"].freq(det)
-        psd1 = data.obs[0]["measured_noise"].psd(det)
-
-        assert np.abs((psd0[-1] - psd1[-1]) / psd0[-1]) < 1e-2
+        if data.comm.comm_world is not None:
+            data.comm.comm_world.allreduce(fail, op=MPI.SUM)
+        self.assertTrue(fail == 0)
 
         close_data(data)


### PR DESCRIPTION


- In the Offset template, change the way that the noise
  prior is computed / handled:
  
  - If noise prior is enabled, baselines are forced to be
    contiguous and fixed-length.  View is used only for 
    cutting samples.  If noise prior is not enabled, view
    is used to start / truncate offset sample ranges
    
  - Restore toast-2 spacing of high-resolution offset PSD
    frequencies for evaluation.
    
  - When building the offset PSD, better document the typo
    in the Madam paper and actually implement the fix.
    
  - Do not overwrite solver flag values- make a copy.
  
  - Dynamically changed the banded preconditioner width if
    needed.

- Fix memory bug in compiled offset template code where
  amplitudes are indexed.

- In mapmaker tests:

  - Add ground based offset test
  
  - Avoid debug files and plots when running in CI
  
  - Also compare solved baselines between madam and toast
    when running with a banded preconditioner.

- Add destriping test that works with demodulated data.

- Reset template matrix during initialization.

- Other unrelated cleanups.
