### PR TITLE
ops/ScanAlm: Add focalplane_keys option

### DIFF
--- a/src/toast/ops/scan_alm.py
+++ b/src/toast/ops/scan_alm.py
@@ -50,6 +50,8 @@ class ScanAlm(Operator):
         None,
         allow_none=True,
         help="Path to a_lm FITS file.  Use ';' if providing multiple files.  "
+        "Any focalplane key listed in `focalplane_keys` can be used here and even "
+        "formatted. For example: {psi_pol:.0f}"
         "If set, `alms` must be empty.",
     )
 
@@ -76,6 +78,13 @@ class ScanAlm(Operator):
     det_mask = Int(
         defaults.det_mask_invalid,
         help="Bit mask value for per-detector flagging",
+    )
+
+    focalplane_keys = Unicode(
+        None,
+        allow_none=True,
+        help="Comma-separated list of keys to retrieve from the focalplane.  "
+        "Used to expand map file names.",
     )
 
     subtract = Bool(
@@ -143,10 +152,39 @@ class ScanAlm(Operator):
                     raise traitlets.TraitError(msg)
         return weights
 
+    def _get_sorted_dets(self, data, detectors=None):
+        if self.focalplane_keys is None:
+            dets_sorted = [ [], [] ]
+            for ob in data.obs:
+                dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
+                for det in dets:
+                    dets_sorted[-2].append(ob.name)
+                    dets_sorted[-1].append(det)
+            dets_sorted = sorted(zip(*dets_sorted))
+        else:
+            dets_sorted = [[] for i in range(2 + len(self.focalplane_keys.split(",")))]
+            # Loop over all observations and local detectors, sort dets according to focalplane_keys
+            for ob in data.obs:
+                focalplane = ob.telescope.focalplane
+                dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
+                for det in dets:
+                    for ikey, key in enumerate(self.focalplane_keys.split(",")):
+                        if key not in focalplane.detector_data.keys():
+                            msg = f"{key} is not in the focalplane during {ob.name}"
+                            raise KeyError(msg)
+                        dets_sorted[ikey].append(str(focalplane[det][key]))
+                    dets_sorted[-2].append(ob.name)
+                    dets_sorted[-1].append(det)
+            dets_sorted = sorted(zip(*dets_sorted))
+        return dets_sorted
+
     def _parse_alm(self):
         if self.file is None:
             if len(self.alms) == 0:
                 msg = "You must set either the `file` or `alms` trait"
+                raise RuntimeError(msg)
+            if self.focalplane_keys is not None:
+                msg = "You must **unset** `alms` and  set `file` when using `focalplane_keys`"
                 raise RuntimeError(msg)
             # Maps are pre-loaded
             nalm = len(self.alms)
@@ -170,7 +208,7 @@ class ScanAlm(Operator):
         return
 
     @function_timer
-    def _load_alm(self, data):
+    def _load_alm(self, data, focalplane_key_value=None):
         """Load, broadcast and save sky a_lm in shared memory"""
 
         world_comm = data.comm.comm_world
@@ -183,7 +221,10 @@ class ScanAlm(Operator):
         for file_name in self.file_names:
             dtype = complex  # totalconvolve requires dtype=complex
             if world_rank == 0:
-                alm = hp.read_alm(file_name, hdu=(1, 2, 3)).astype(dtype)
+                if self.focalplane_keys is None:
+                    alm = hp.read_alm(file_name, hdu=(1, 2, 3)).astype(dtype)
+                else:
+                    alm = hp.read_alm(file_name.format(**focalplane_key_value), hdu=(1, 2, 3)).astype(dtype)
                 alm_shape = alm.shape
                 lmax = hp.Alm.getlmax(alm[0].size)
             else:
@@ -321,17 +362,13 @@ class ScanAlm(Operator):
 
         self._parse_alm()
         self._parse_detdata_keys()
-        self._load_alm(data)
-        self._cache_blm()
-        self._cache_interpolators()
+        dets_sorted = self._get_sorted_dets(data, detectors)
+        if self.focalplane_keys is None:
+            self._load_alm(data)
+            self._cache_blm()
+            self._cache_interpolators()
 
-        # Loop over all observations and local detectors, sampling each alm
-
-        timer = Timer()
-        timer.start()
-        nob = len(data.obs)
-        for iob,ob in enumerate(data.obs):
-            # Get the detectors we are using for this observation
+        for ob in data.obs:
             dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
             for key in self.det_data_keys:
                 # If our output detector data does not yet exist, create it
@@ -341,22 +378,47 @@ class ScanAlm(Operator):
                 if self.zero:
                     ob.detdata[key].reset()
 
-            ob_data = data.select(obs_name=ob.name)
-            for det in dets:
-                theta, phi, weights = self._get_pointing(ob_data, det)
-                for ialm, alm in enumerate(self.alms):
-                    if len(self.det_data_keys) == 1:
-                        det_data_key = self.det_data_keys[0]
-                    else:
-                        det_data_key = self.det_data_keys[ialm]
-                    ref = ob.detdata[det_data_key][det]
-                    interpolators = self.interpolators[ialm]
-                    sig = self._scan_alms(interpolators, theta, phi, weights)
-                    if self.subtract:
-                        ref -= sig
-                    else:
-                        ref += sig
-            log.debug_rank(f"{iob}/{nob} observation finished in", timer=timer, comm=gcomm)
+        # Loop over all observations and local detectors, sampling each alm
+        timer = Timer()
+        timer.start()
+        ndet = len(dets_sorted)
+        prev_focalplane_keys = None
+        for idet, key_ob_det in enumerate(dets_sorted):
+            ob_name = key_ob_det[-2]
+            ob_data = data.select(obs_name=ob_name)
+            ob = ob_data.obs[0]
+            det = key_ob_det[-1]
+            focalplane_keys = key_ob_det[:-2]
+            if self.focalplane_keys is not None and focalplane_keys != prev_focalplane_keys:
+                # Clean up our alm, if needed
+                if not self.save_alm:
+                    for alm in self.alms:
+                        alm.close()
+                    self.alms = []
+                focalplane_key_value = {}
+                for ikey, key in enumerate(self.focalplane_keys.split(",")):
+                    focalplane_key_value[key] = key_ob_det[ikey]
+                self._load_alm(data, focalplane_key_value)
+                self._cache_blm()
+                self._cache_interpolators()
+                prev_focalplane_keys = focalplane_keys
+                log.info_rank(f"Group {data.comm.group:4} : Start detectors with {focalplane_key_value}", timer=timer, comm=gcomm)
+
+            theta, phi, weights = self._get_pointing(ob_data, det)
+            for ialm, alm in enumerate(self.alms):
+                if len(self.det_data_keys) == 1:
+                    det_data_key = self.det_data_keys[0]
+                else:
+                    det_data_key = self.det_data_keys[ialm]
+                ref = ob.detdata[det_data_key][det]
+                interpolators = self.interpolators[ialm]
+                sig = self._scan_alms(interpolators, theta, phi, weights)
+                if self.subtract:
+                    ref -= sig
+                else:
+                    ref += sig
+            if idet % 100 == 0:
+                log.debug_rank(f"Group {data.comm.group:4} : {idet}/{ndet} detectors finished in", timer=timer, comm=gcomm)
 
         # Clean up our alm, if needed
         if not self.save_alm:

--- a/src/toast/tests/ops_scan_alm.py
+++ b/src/toast/tests/ops_scan_alm.py
@@ -31,7 +31,16 @@ class ScanAlmTest(MPITestCase):
     def test_scan_IQU(self):
         self._test_scan(mode="IQU")
 
-    def _test_scan(self, mode):
+    def test_scan_I_det(self):
+        self._test_scan(mode="I", focalplane_keys=True)
+
+    def test_scan_QU_det(self):
+        self._test_scan(mode="QU", focalplane_keys=True)
+
+    def test_scan_IQU_det(self):
+        self._test_scan(mode="IQU", focalplane_keys=True)
+
+    def _test_scan(self, mode, focalplane_keys=False):
         if not ops.scan_alm.ducc_available:
             print("ducc0.totalconvolve is not available skipping tests")
             return
@@ -63,35 +72,42 @@ class ScanAlmTest(MPITestCase):
             else:
                 scales.append(0.0)
 
-        hpix_file = os.path.join(self.outdir, f"fake_{mode}.fits")
-        map_key = "fake_map"
-        create_fake_healpix_scanned_tod(
-            data,
-            pixels,
-            weights_scan,
-            hpix_file,
-            "pixel_dist",
-            map_key=map_key,
-            fwhm=30.0 * u.degree,
-            lmax=3 * pixels.nside,
-            I_scale=scales[0],
-            Q_scale=scales[1],
-            U_scale=scales[2],
-            det_data=defaults.det_data,
-        )
+        if focalplane_keys:
+            pixel_names = np.unique(data.obs[0].telescope.focalplane.detector_data["pixel"])
+        else:
+            pixel_names = ["none"]
+
+        hpix_file = os.path.join(self.outdir, f"fake_{mode}_{{pixel}}.fits")
+        for i, pixel in enumerate(pixel_names):
+            map_key = f"fake_map_{pixel}"
+            create_fake_healpix_scanned_tod(
+                data,
+                pixels,
+                weights_scan,
+                hpix_file.format(pixel=pixel),
+                "pixel_dist",
+                map_key=map_key,
+                fwhm=30.0 * u.degree,
+                lmax=3 * pixels.nside,
+                I_scale=scales[0],
+                Q_scale=scales[1],
+                U_scale=scales[2],
+                det_data=f"det_data_{pixel}",
+            )
 
         # Expand the input map in spherical harmonics on root process
 
         alm_file = hpix_file.replace(".fits", ".alm.fits")
 
         if data.comm.comm_world is None or data.comm.comm_world.rank == 0:
-            m = hp.read_map(hpix_file, None)
-            nside = hp.get_nside(m)
-            lmax = 2 * nside
-            alm = hp.map2alm(m, lmax=lmax, iter=0, pol=True)
-            if hpix_file == alm_file:
-                raise RuntimeError("Failed to synthesize an alm file name")
-            hp.write_alm(alm_file, alm, out_dtype=np.complex64, lmax=lmax)
+            for i, pixel in enumerate(pixel_names):
+                m = hp.read_map(hpix_file.format(pixel=pixel), None)
+                nside = hp.get_nside(m)
+                lmax = 2 * nside
+                alm = hp.map2alm(m, lmax=lmax, iter=0, pol=True)
+                if hpix_file == alm_file:
+                    raise RuntimeError("Failed to synthesize an alm file name")
+                hp.write_alm(alm_file.format(pixel=pixel), alm, out_dtype=np.complex64, lmax=lmax)
 
         if data.comm.comm_world is not None:
             data.comm.comm_world.Barrier()
@@ -106,10 +122,11 @@ class ScanAlmTest(MPITestCase):
         )
 
         scan_alm = ops.ScanAlm(
-            file=alm_file,
+            file=alm_file.format(pixel=pixel),
             det_data="interp_data",
             detector_pointing=detpointing,
             stokes_weights=weights_alm,
+            focalplane_keys="pixel,psi_pol" if focalplane_keys else None,
         )
         scan_alm.apply(data)
 
@@ -117,7 +134,11 @@ class ScanAlmTest(MPITestCase):
 
         for ob in data.obs:
             for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
-                sig1 = ob.detdata[defaults.det_data][det]
+                if focalplane_keys:
+                    pixel = data.obs[0].telescope.focalplane[det]["pixel"]
+                else:
+                    pixel = 'none'
+                sig1 = ob.detdata[f"det_data_{pixel}"][det]
                 sig2 = ob.detdata["interp_data"][det]
                 rms1 = np.std(sig1)
                 rms2 = np.std(sig2)


### PR DESCRIPTION
A Comma-separated list of keys to retrieve from the focalplane. Used to expand map file names.

To avoid calculate interpolators repeatedly, we first sort all detectors according to focalplane_keys. We only recalculate interpolators when current detector focalplane_keys and previous one are different, such that they will have different input files.