### PR TITLE
Add precomputed templates to the destriper

### DIFF
--- a/src/toast/instrument_sim.py
+++ b/src/toast/instrument_sim.py
@@ -1058,6 +1058,7 @@ def plot_focalplane(
     xieta=False,
     show_centers=False,
     show_gamma=False,
+    hide_pol=False,
 ):
     """Visualize a projected Focalplane.
 
@@ -1088,6 +1089,7 @@ def plot_focalplane(
             boresight X/Y/Z.
         show_centers (bool):  If True, label the pixel centers.
         show_gamma (bool):  If True, show gamma angle (for debugging).
+        hide_pol (bool):  If True, hide the polarization vectors.
 
     Returns:
         (Figure):  The figure.
@@ -1243,18 +1245,19 @@ def plot_focalplane(
                     ec="gray",
                     length_includes_head=True,
                 )
-            ax.arrow(
-                xtail,
-                ytail,
-                dx,
-                dy,
-                width=0.1 * detradius,
-                head_width=0.3 * detradius,
-                head_length=0.3 * detradius,
-                fc=detcolor,
-                ec=detcolor,
-                length_includes_head=True,
-            )
+            if not hide_pol:
+                ax.arrow(
+                    xtail,
+                    ytail,
+                    dx,
+                    dy,
+                    width=0.1 * detradius,
+                    head_width=0.3 * detradius,
+                    head_length=0.3 * detradius,
+                    fc=detcolor,
+                    ec=detcolor,
+                    length_includes_head=True,
+                )
 
     # Draw a "mini" coordinate axes for reference
     xmini = -0.8 * half_width

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -20,6 +20,7 @@ from ...observation import default_values as defaults
 from ...timing import GlobalTimers, Timer, function_timer
 from ...traits import Bool, Dict, Instance, Int, Quantity, Unicode, UseEnum, trait_docs
 from ...utils import AlignedF64, AlignedU8, Environment, Logger, dtype_to_aligned
+from ..demodulation import Lowpass
 from ..operator import Operator
 from .kernels import filter_poly2D, filter_polynomial
 
@@ -713,6 +714,18 @@ class CommonModeFilter(Operator):
         help="If True, plot regression coefficients",
     )
 
+    lowpass = Quantity(
+        None,
+        allow_none=True,
+        help="Optionally low pass filter the common mode",
+    )
+
+    template_save_key = Unicode(
+        None,
+        allow_none=True,
+        help="Save the templates to this observation key instead of filtering",
+    )
+
     @traitlets.validate("det_mask")
     def _check_det_mask(self, proposal):
         check = proposal["value"]
@@ -890,6 +903,18 @@ class CommonModeFilter(Operator):
             nsample = temp_ob.n_local_samples
             ndet = len(temp_ob.local_detectors)
 
+            lp = None
+            lp_buffer = 0
+            if self.lowpass is not None:
+                lp = Lowpass(
+                    self.lowpass,
+                    obs.telescope.focalplane.sample_rate,
+                )
+                lp_buffer = 4 * int(
+                    obs.telescope.focalplane.sample_rate.to_value(u.Hz) / 
+                    self.lowpass.to_value(u.Hz)
+                )
+
             # Loop over all values of the focalplane key
             for value in values:
                 local_dets = []
@@ -940,8 +965,27 @@ class CommonModeFilter(Operator):
                     comm.Allreduce(MPI.IN_PLACE, template, op=MPI.SUM)
                     comm.Allreduce(MPI.IN_PLACE, hits, op=MPI.SUM)
 
-                if self.regress:
+                if self.lowpass is not None:
+                    template = lp(template)
+                    template[:lp_buffer] = 0
+                    template[-lp_buffer:] = 0
+                    for det in local_dets:
+                        temp_ob.detdata[self.det_flags][det][:lp_buffer] |= defaults.det_mask_invalid
+                        temp_ob.detdata[self.det_flags][det][-lp_buffer:] |= defaults.det_mask_invalid
+
+                if self.template_save_key is not None:
+                    # Save this template to the observation dictionary for
+                    # later use.
+                    if self.template_save_key not in obs:
+                        obs[self.template_save_key] = dict()
+                        obs[self.template_save_key]["det_to_key"] = dict()
+                    obs[self.template_save_key][value] = template
+                    for det in local_dets:
+                        obs[self.template_save_key]["det_to_key"][det] = value
+                elif self.regress:
                     good = hits != 0
+                    good[:lp_buffer] = 0
+                    good[-lp_buffer:] = 0
                     ngood = np.sum(good)
                     mean_template = template.copy()
                     mean_template[good] /= hits[good]

--- a/src/toast/templates/__init__.py
+++ b/src/toast/templates/__init__.py
@@ -9,5 +9,6 @@ from .fourier2d import Fourier2D
 from .gaintemplate import GainTemplate
 from .offset import Offset
 from .periodic import Periodic
+from .precomputed import PreComputed
 from .subharmonic import SubHarmonic
 from .template import Template

--- a/src/toast/templates/precomputed.py
+++ b/src/toast/templates/precomputed.py
@@ -75,7 +75,7 @@ class PreComputed(Template):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def _initialize(self, new_data):
+    def _initialize(self, new_data, detectors=None):
         log = Logger.get()
         if self.obs_key is None:
             msg = "You must set the obs_key before initializing"
@@ -116,7 +116,9 @@ class PreComputed(Template):
                 det_pat = re.compile(self.pattern)
             self._obs_dets[ob.uid] = list()
             ddets = set(ob.detdata[self.det_data].detectors)
-            for d in ob.select_local_detectors(flagmask=self.det_mask):
+            for d in ob.select_local_detectors(
+                selection=detectors, flagmask=self.det_mask
+            ):
                 if d not in ddets:
                     continue
                 if det_pat is not None and det_pat.match(d) is None:
@@ -239,9 +241,7 @@ class PreComputed(Template):
             # Accumulate to timestream
             for ivw, vw in enumerate(self._obs_views[ob.uid]):
                 vslc = slice(vw.first, vw.last, 1)
-                ob.detdata[self.det_data][detector][vslc] += (
-                    amps[ivw] * template[vslc]
-                )
+                ob.detdata[self.det_data][detector][vslc] += amps[ivw] * template[vslc]
 
     def _project_signal(self, detector, amplitudes, **kwargs):
         if detector not in self._all_dets:

--- a/src/toast/templates/precomputed.py
+++ b/src/toast/templates/precomputed.py
@@ -1,0 +1,466 @@
+# Copyright (c) 2026-2026 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import ast
+import json
+import re
+from collections import OrderedDict
+
+import h5py
+import numpy as np
+
+from ..data import Data
+from ..mpi import MPI
+from ..observation import default_values as defaults
+from ..timing import function_timer
+from ..traits import Bool, Float, Instance, Int, Unicode, trait_docs
+from ..utils import Logger
+from ..vis import set_matplotlib_backend
+from .amplitudes import Amplitudes
+from .template import Template
+
+
+@trait_docs
+class PreComputed(Template):
+    """This template represents amplitudes of precomputed timestream contributions.
+
+    Given a constant, pre-computed, time-domain array, this class represents
+    amplitudes which are coefficients used to project that array into detector
+    timestreams.  The amplitudes are solved per-detector and optionally per-interval.
+
+    If `select_view` is not None, it is a set of intervals used to group sample
+    ranges for independent estimation of the template amplitudes.  These intervals
+    are taken with the intersection of the solving view passed from the template
+    matrix.
+
+    The templates themselves must be in a specific format:
+
+    - The `obs_key` must point to a template dictionary.
+
+    - Within this template dictionary, the `det_to_key` lookup table maps detector
+      names to a corresponding template key.
+
+    - The templates must have exactly the same length as the number of samples
+      in the detector data.
+
+    """
+
+    # Notes:  The TraitConfig base class defines a "name" attribute.  The Template
+    # class (derived from TraitConfig) defines the following traits already:
+    #    data             : The Data instance we are working with
+    #    view             : The timestream view we are using
+    #    det_data         : The detector data key with the timestreams
+    #    det_data_units   : The units of the detector data
+    #    det_mask         : Bitmask for per-detector flagging
+    #    det_flags        : Optional detector solver flags
+    #    det_flag_mask    : Bit mask for detector solver flags
+    #
+
+    obs_key = Unicode(
+        None, allow_none=True, help="Observation key for timestream templates"
+    )
+
+    select_view = Unicode(
+        None,
+        allow_none=True,
+        help="Intervals to use for breaking up regions with independent amplitudes",
+    )
+
+    good_fraction = Float(
+        0.2,
+        help="Fraction of unflagged samples needed to keep a given amplitude estimate",
+    )
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def _initialize(self, new_data):
+        log = Logger.get()
+        if self.obs_key is None:
+            msg = "You must set the obs_key before initializing"
+            raise RuntimeError(msg)
+
+        # Use this as an "Ordered Set".  We want the unique detectors on this process,
+        # but sorted in order of occurrence.
+        # FIXME: not needed once accum_load branch merged
+        self._all_dets = OrderedDict()
+
+        # Good detectors to use for each observation
+        self._obs_dets = dict()
+
+        # The views for each observation
+        self._obs_views = dict()
+        self._obs_nview = dict()
+
+        # Go through the data and find the intersection of the solver intervals and
+        # the intervals we are using to estimate amplitudes.
+
+        for ob in new_data.obs:
+            if self.obs_key not in ob:
+                # No templates in this observation
+                continue
+
+            # The total intervals we are using for projection
+            if self.select_view is not None:
+                self._obs_views[ob.uid] = (
+                    ob.intervals[self.view] & ob.intervals[self.select_view]
+                )
+            else:
+                self._obs_views[ob.uid] = ob.intervals[self.view]
+            self._obs_nview[ob.uid] = len(self._obs_views[ob.uid])
+
+            # Build up detector list
+            det_pat = None
+            if self.pattern is not None:
+                det_pat = re.compile(self.pattern)
+            self._obs_dets[ob.uid] = list()
+            ddets = set(ob.detdata[self.det_data].detectors)
+            for d in ob.select_local_detectors(flagmask=self.det_mask):
+                if d not in ddets:
+                    continue
+                if det_pat is not None and det_pat.match(d) is None:
+                    continue
+                self._obs_dets[ob.uid].append(d)
+                self._all_dets[d] = None
+
+        # Go through the data and compute the offsets into the amplitudes for each
+        # observation and detector.
+
+        self._det_start = dict()
+        offset = 0
+        for ob in new_data.obs:
+            if ob.uid not in self._obs_dets:
+                continue
+            det_list = self._obs_dets[ob.uid]
+            self._det_start[ob.uid] = dict()
+            for det in det_list:
+                self._det_start[ob.uid][det] = offset
+                offset += self._obs_nview[ob.uid]
+
+        # Now we know the total number of amplitudes.
+
+        self._n_local = offset
+        if new_data.comm.comm_world is None:
+            self._n_global = self._n_local
+        else:
+            self._n_global = new_data.comm.comm_world.allreduce(
+                self._n_local, op=MPI.SUM
+            )
+
+        # Now that we know the number of amplitudes, we go through the solver flags
+        # and determine what amplitudes, if any, are poorly constrained.
+
+        # Boolean flags
+        self._amp_flags = np.zeros(self._n_local, dtype=bool)
+
+        # The relative weights for each amplitude, used in preconditioning
+        self._amp_weights = np.zeros(self._n_local, dtype=np.float32)
+
+        # The amplitude covariance.  For each amplitude representing a sample slice
+        # of a time-domain template T, this is just:
+        #
+        # (T * transpose(T))^-1.
+        #
+        # This is a scalar.
+        self._amp_cov = np.zeros(self._n_local, dtype=np.float64)
+
+        for ob in new_data.obs:
+            if ob.uid not in self._obs_dets:
+                continue
+            det_list = self._obs_dets[ob.uid]
+            for det in det_list:
+                template_key = ob[self.obs_key]["det_to_key"][det]
+                det_templates = ob[self.obs_key][template_key]
+                if isinstance(det_templates, dict):
+                    if len(det_templates.keys()) > 1:
+                        msg = f"Det {det} has templates {det_templates.keys()}. "
+                        msg += " Only one template per det is supported"
+                        raise NotImplementedError(msg)
+                    template = list(det_templates.values())[0]
+                else:
+                    template = det_templates
+                offset = self._det_start[ob.uid][det]
+                if self.det_flags is not None:
+                    flags = ob.detdata[self.det_flags][det] & self.det_flag_mask
+                else:
+                    flags = np.zeros(ob.n_local_samples, dtype=np.uint8)
+                for ivw, vw in enumerate(self._obs_views[ob.uid]):
+                    vsamp = vw.last - vw.first
+                    vslc = slice(vw.first, vw.last, 1)
+                    vflags = flags[vslc]
+                    vtemp = template[vslc]
+                    amp_idx = offset + ivw
+
+                    good = vflags == 0
+                    ngood = np.count_nonzero(good)
+                    good_frac = ngood / vsamp
+                    if good_frac < self.good_fraction:
+                        self._amp_flags[amp_idx] = 1
+                        self._amp_cov[amp_idx] = 0.0
+                    else:
+                        self._amp_weights[amp_idx] = good_frac
+                        dot_temp = np.dot(vtemp[good], vtemp[good])
+                        if dot_temp == 0:
+                            msg = f"Obs {ob.name}, det {det}, interval {ivw}"
+                            msg += " has a template of all zeros"
+                            raise RuntimeError(msg)
+                        self._amp_cov[amp_idx] = 1.0 / dot_temp
+
+    def _detectors(self):
+        return self._all_dets
+
+    def _zeros(self):
+        z = Amplitudes(self.data.comm, self._n_global, self._n_local)
+        if z.local_flags is not None:
+            z.local_flags[:] = np.where(self._amp_flags, 1, 0)
+        return z
+
+    def _add_to_signal(self, detector, amplitudes, **kwargs):
+        if detector not in self._all_dets:
+            # This must have been cut by per-detector flags during initialization
+            return
+
+        for ob in self.data.obs:
+            if ob.uid not in self._obs_dets:
+                continue
+            if detector not in self._det_start[ob.uid]:
+                continue
+            amp_offset = self._det_start[ob.uid][detector]
+            amps = amplitudes.local[amp_offset : amp_offset + self._obs_nview[ob.uid]]
+
+            template_key = ob[self.obs_key]["det_to_key"][detector]
+            det_templates = ob[self.obs_key][template_key]
+            if isinstance(det_templates, dict):
+                template = list(det_templates.values())[0]
+            else:
+                template = det_templates
+
+            # Accumulate to timestream
+            for ivw, vw in enumerate(self._obs_views[ob.uid]):
+                vslc = slice(vw.first, vw.last, 1)
+                ob.detdata[self.det_data][detector][vslc] += (
+                    amps[ivw] * template[vslc]
+                )
+
+    def _project_signal(self, detector, amplitudes, **kwargs):
+        if detector not in self._all_dets:
+            # This must have been cut by per-detector flags during initialization
+            return
+
+        for ob in self.data.obs:
+            if ob.uid not in self._obs_dets:
+                continue
+            if detector not in self._det_start[ob.uid]:
+                continue
+            amp_offset = self._det_start[ob.uid][detector]
+            amps = amplitudes.local[amp_offset : amp_offset + self._obs_nview[ob.uid]]
+
+            if self.det_flags is not None:
+                flags = ob.detdata[self.det_flags][detector] & self.det_flag_mask
+            else:
+                flags = np.zeros(ob.n_local_samples, dtype=np.uint8)
+
+            template_key = ob[self.obs_key]["det_to_key"][detector]
+            det_templates = ob[self.obs_key][template_key]
+            if isinstance(det_templates, dict):
+                template = list(det_templates.values())[0]
+            else:
+                template = det_templates
+
+            # Accumulate to amplitudes
+            for ivw, vw in enumerate(self._obs_views[ob.uid]):
+                vslc = slice(vw.first, vw.last, 1)
+                amp_idx = amp_offset + ivw
+                vflags = flags[vslc]
+                good = vflags == 0
+                vtemp = template[vslc]
+                vdata = ob.detdata[self.det_data][detector][vslc]
+                val = self._amp_cov[amp_idx] * np.dot(vtemp[good], vdata[good])
+                amps[ivw] += val
+
+    def _add_prior(self, amplitudes_in, amplitudes_out, **kwargs):
+        # No prior for this template, nothing to accumulate to output.
+        return
+
+    def _apply_precond(self, amplitudes_in, amplitudes_out, **kwargs):
+        # Apply weights based on the number of samples hitting each
+        # amplitude bin.
+        for ob in self.data.obs:
+            if ob.uid not in self._obs_dets:
+                continue
+            for det, amp_offset in self._det_start[ob.uid].items():
+                for ivw, vw in enumerate(self._obs_views[ob.uid]):
+                    amp_idx = amp_offset + ivw
+                    amp_in = amplitudes_in.local[amp_idx]
+                    amplitudes_out.local[amp_idx] = amp_in * self._amp_weights[amp_idx]
+
+
+#     @function_timer
+#     def write(self, amplitudes, out):
+#         """Write out amplitude values.
+
+#         This stores the amplitudes to a file for debugging / plotting.
+
+#         Args:
+#             amplitudes (Amplitudes):  The amplitude data.
+#             out (str):  The output file.
+
+#         Returns:
+#             None
+
+#         """
+#         # By definition, when solving for something that is periodic for
+#         # a given detector in a single observation, we (should) have many
+#         # fewer template amplitudes than timestream samples.  Because of
+#         # this we assume we can make several copies for extracting the
+#         # amplitudes and gathering them for writing.
+
+#         obs_det_amps = dict()
+
+#         for det in self._all_dets:
+#             amp_offset = self._det_offset[det]
+#             for iob, ob in enumerate(self.data.obs):
+#                 if det not in self._obs_dets[iob]:
+#                     continue
+#                 if self.is_detdata_key:
+#                     if self.key not in ob.detdata:
+#                         continue
+#                 else:
+#                     if self.key not in ob.shared:
+#                         continue
+#                 if ob.name not in obs_det_amps:
+#                     obs_det_amps[ob.name] = dict()
+#                 nbins = self._obs_nbins[iob]
+#                 amp_data = amplitudes.local[amp_offset : amp_offset + nbins]
+#                 amp_hits = self._amp_hits[amp_offset : amp_offset + nbins]
+#                 amp_flags = self._amp_flags[amp_offset : amp_offset + nbins]
+#                 obs_det_amps[ob.name][det] = {
+#                     "amps": amp_data,
+#                     "hits": amp_hits,
+#                     "flags": amp_flags,
+#                     "min": self._obs_min[iob],
+#                     "max": self._obs_max[iob],
+#                     "incr": self._obs_incr[iob],
+#                 }
+#                 amp_offset += nbins
+
+#         if self.data.comm.world_size == 1:
+#             all_obs_dets_amps = [obs_det_amps]
+#         else:
+#             all_obs_dets_amps = self.data.comm.comm_world.gather(obs_det_amps, root=0)
+
+#         if self.data.comm.world_rank == 0:
+#             obs_det_amps = dict()
+#             for pdata in all_obs_dets_amps:
+#                 for obname in pdata.keys():
+#                     if obname not in obs_det_amps:
+#                         obs_det_amps[obname] = dict()
+#                     obs_det_amps[obname].update(pdata[obname])
+#             del all_obs_dets_amps
+#             with h5py.File(out, "w") as hf:
+#                 for obname, obamps in obs_det_amps.items():
+#                     n_det = len(obamps)
+#                     det_list = list(sorted(obamps.keys()))
+#                     det_indx = {y: x for x, y in enumerate(det_list)}
+#                     indx_to_det = {det_indx[x]: x for x in det_list}
+#                     n_amp = len(obamps[det_list[0]]["amps"])
+#                     amp_min = [obamps[x]["min"] for x in det_list]
+#                     amp_max = [obamps[x]["max"] for x in det_list]
+#                     amp_incr = [obamps[x]["incr"] for x in det_list]
+
+#                     # Create datasets for this observation
+#                     hg = hf.create_group(obname)
+#                     hg.attrs["detectors"] = json.dumps(det_list)
+#                     hg.attrs["min"] = json.dumps(amp_min)
+#                     hg.attrs["max"] = json.dumps(amp_max)
+#                     hg.attrs["incr"] = json.dumps(amp_incr)
+#                     hamps = hg.create_dataset(
+#                         "amplitudes",
+#                         (n_det, n_amp),
+#                         dtype=np.float64,
+#                     )
+#                     hhits = hg.create_dataset(
+#                         "hits",
+#                         (n_det, n_amp),
+#                         dtype=np.int32,
+#                     )
+#                     hflags = hg.create_dataset(
+#                         "flags",
+#                         (n_det, n_amp),
+#                         dtype=np.uint8,
+#                     )
+
+#                     # Write data
+#                     for idet in range(n_det):
+#                         det = indx_to_det[idet]
+#                         dprops = obamps[det]
+#                         hslice = (slice(idet, idet + 1, 1), slice(0, n_amp, 1))
+#                         dslice = (slice(0, n_amp, 1),)
+#                         hamps.write_direct(dprops["amps"], dslice, hslice)
+#                         hhits.write_direct(dprops["hits"], dslice, hslice)
+#                         hflags.write_direct(dprops["flags"], dslice, hslice)
+
+
+# def plot(amp_file, out_root=None):
+#     """Plot an amplitude dump file.
+
+#     This loads an amplitude file and makes a set of plots.
+
+#     Args:
+#         amp_file (str):  The path to the input file of amplitudes.
+#         out_root (str):  The root of the output files.
+
+#     Returns:
+#         None
+
+#     """
+
+#     if out_root is not None:
+#         set_matplotlib_backend(backend="pdf")
+
+#     import matplotlib.pyplot as plt
+
+#     figdpi = 100
+
+#     with h5py.File(amp_file, "r") as hf:
+#         for obname, obgrp in hf.items():
+#             det_list = json.loads(obgrp.attrs["detectors"])
+#             amp_min = list(ast.literal_eval(obgrp.attrs["min"]))
+#             amp_max = list(ast.literal_eval(obgrp.attrs["max"]))
+#             amp_incr = list(ast.literal_eval(obgrp.attrs["incr"]))
+
+#             hamps = np.array(obgrp["amplitudes"])
+#             hhits = np.array(obgrp["hits"])
+#             hflags = np.array(obgrp["flags"])
+#             n_bin = hamps.shape[1]
+#             bad = hflags != 0
+#             hamps[bad] = np.nan
+
+#             for idet, det in enumerate(det_list):
+#                 outfile = f"{out_root}_{obname}_{det}.pdf"
+#                 xdata = amp_min[idet] + amp_incr[idet] * np.arange(
+#                     n_bin, dtype=np.float64
+#                 )
+#                 fig = plt.figure(dpi=figdpi, figsize=(8, 12))
+#                 ax = fig.add_subplot(3, 1, 1)
+#                 ax.step(xdata, hamps[idet], where="post", label=f"{det}")
+#                 ax.set_xlabel("Shared Data Value")
+#                 ax.set_ylabel("Amplitude")
+#                 ax.legend(loc="best")
+#                 ax = fig.add_subplot(3, 1, 2)
+#                 ax.step(xdata, hflags[idet], where="post", label=f"{det}")
+#                 ax.set_xlabel("Shared Data Value")
+#                 ax.set_ylabel("Flags")
+#                 ax.legend(loc="best")
+#                 ax = fig.add_subplot(3, 1, 3)
+#                 ax.step(xdata, hhits[idet], where="post", label=f"{det}")
+#                 ax.set_xlabel("Shared Data Value")
+#                 ax.set_ylabel("Hits")
+#                 ax.legend(loc="best")
+#                 if out_root is None:
+#                     # Interactive
+#                     plt.show()
+#                 else:
+#                     plt.savefig(outfile, dpi=figdpi, bbox_inches="tight", format="pdf")
+#                     plt.close()

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -848,8 +848,6 @@ class DemodulateTest(MPITestCase):
             det_data=defaults.det_data,
         )
 
-        print(data.obs[0].detdata["signal"], flush=True)
-
         ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
 
         ops.SimAtmosphere(
@@ -858,17 +856,11 @@ class DemodulateTest(MPITestCase):
             zmax=200 * u.m,
         ).apply(data)
 
-        print(data.obs[0].detdata["signal"], flush=True)
-
         ops.SimNoise(noise_model="noise_model").apply(data)
-
-        print(data.obs[0].detdata["signal"], flush=True)
 
         hwpss_scale = 20.0
         tod_rms = np.std(data.obs[0].detdata["input"][0])
         hwpss_coeff = fake_hwpss(data, defaults.det_data, hwpss_scale * tod_rms)
-
-        print(data.obs[0].detdata["signal"], flush=True)
 
         ops.Delete(
             detdata=[

--- a/src/toast/tests/ops_demodulate.py
+++ b/src/toast/tests/ops_demodulate.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2015-2025 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
+import re
 import os
 
 import healpy as hp
@@ -18,6 +19,7 @@ from .helpers import (
     create_ground_data,
     create_outdir,
     create_overdistributed_data,
+    fake_hwpss,
 )
 from .mpi import MPITestCase
 
@@ -187,7 +189,7 @@ class DemodulateTest(MPITestCase):
         # Pointing operators
 
         detpointing_azel = ops.PointingDetectorSimple(
-            boresight=defaults.boresight_radec,
+            boresight=defaults.boresight_azel,
             shared_flag_mask=0,
         )
         detpointing_radec = ops.PointingDetectorSimple(
@@ -498,7 +500,7 @@ class DemodulateTest(MPITestCase):
         # Pointing operators
 
         detpointing_azel = ops.PointingDetectorSimple(
-            boresight=defaults.boresight_radec,
+            boresight=defaults.boresight_azel,
             shared_flag_mask=0,
         )
 
@@ -583,7 +585,7 @@ class DemodulateTest(MPITestCase):
         # Pointing operators
 
         detpointing_azel = ops.PointingDetectorSimple(
-            boresight=defaults.boresight_radec,
+            boresight=defaults.boresight_azel,
             shared_flag_mask=0,
         )
         detpointing_radec = ops.PointingDetectorSimple(
@@ -793,3 +795,347 @@ class DemodulateTest(MPITestCase):
     def test_destripe_QU(self):
         data = create_ground_data(self.comm)
         self._test_destripe(weight_mode="QU", data=data, suffix="_destripe")
+
+    def test_destripe_precomputed(self):
+        testdir = os.path.join(self.outdir, "precomputed")
+        if self.comm is None or self.comm.rank == 0:
+            if not os.path.isdir(testdir):
+                os.mkdir(testdir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        data = create_ground_data(self.comm, schedule_hours=2)
+        nside = 128
+
+        # Simulation
+
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        detpointing_azel = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_azel,
+            shared_flag_mask=0,
+        )
+        detpointing_radec = ops.PointingDetectorSimple(
+            boresight=defaults.boresight_radec,
+            shared_flag_mask=0,
+        )
+
+        pixels = ops.PixelsHealpix(
+            nside=nside,
+            detector_pointing=detpointing_radec,
+        )
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing_radec,
+        )
+
+        sky_file = os.path.join(testdir, "fake_sky.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            sky_file,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=1.0 * u.deg,
+            lmax=3 * nside,
+            I_scale=0.001,
+            Q_scale=0.0001,
+            U_scale=0.0001,
+            det_data=defaults.det_data,
+        )
+
+        print(data.obs[0].detdata["signal"], flush=True)
+
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        ops.SimAtmosphere(
+            detector_pointing=detpointing_azel,
+            gain=1.0e-6,
+            zmax=200 * u.m,
+        ).apply(data)
+
+        print(data.obs[0].detdata["signal"], flush=True)
+
+        ops.SimNoise(noise_model="noise_model").apply(data)
+
+        print(data.obs[0].detdata["signal"], flush=True)
+
+        hwpss_scale = 20.0
+        tod_rms = np.std(data.obs[0].detdata["input"][0])
+        hwpss_coeff = fake_hwpss(data, defaults.det_data, hwpss_scale * tod_rms)
+
+        print(data.obs[0].detdata["signal"], flush=True)
+
+        ops.Delete(
+            detdata=[
+                detpointing_azel.quats,
+                detpointing_radec.quats,
+                pixels.pixels,
+                weights.weights,
+            ]
+        )
+
+        # Data Processing
+
+        # Estimate noise.  We want to get an estimate of the 1/f spectrum prior to
+        # demodulation.  The demodulation operator will modify the input noise model
+        # appropriately.  We copy the data to a temporary location and filter the
+        # HWPSS in order to estimate noise on that TOD.
+
+        ops.Copy(detdata=[(defaults.det_data, "temp")]).apply(data)
+        ops.HWPFilter(
+            trend_order=1,
+            filter_order=7,
+            detrend=True,
+            det_data="temp",
+        ).apply(data)
+
+        ops.NoiseEstim(
+            out_model="raw_noise_model",
+            lagmax=10000,
+            view="scanning",
+            nbin_psd=64,
+            nsum=1,
+            naverage=1,
+            det_data="temp",
+        ).apply(data)
+
+        ops.FitNoiseModel(
+            noise_model="raw_noise_model",
+            out_model="noise_model",
+        ).apply(data)
+
+        ops.Delete(detdata=["temp"]).apply(data)
+
+        # Demodulate.  We intentionally leave in the HWPSS, which will be an added
+        # constant in the band-passed 4f data.
+
+        demod_weights_in = ops.StokesWeights(
+            weights="demod_weights_in",
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing_azel,
+        )
+
+        downsample = 3
+        demod = ops.Demodulate(
+            stokes_weights=demod_weights_in,
+            nskip=downsample,
+            purge=False,
+            mode="IQU",
+            noise_model="noise_model",
+        )
+        demod_data = demod.apply(data)
+
+        demod_weights = ops.StokesWeightsDemod(
+            detector_pointing_in=detpointing_azel,
+            detector_pointing_out=detpointing_radec,
+            mode="IQU",
+        )
+
+        # Add T->P leakage based on the lowpassed intensity TOD.  This
+        # demod0 data should be primarily low-passed atmosphere.
+
+        for ob in demod_data.obs:
+            coeff = dict()
+            I_templates = dict()
+            det_to_key = dict()
+            pat = re.compile(r"demod0_(.*)")
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_nonscience):
+                mat = pat.match(det)
+                if mat is not None:
+                    base = mat.group(1)
+                    cf = np.random.uniform(low=0.02, high=0.1, size=2)
+                    qdet = f"demod4r_{base}"
+                    udet = f"demod4i_{base}"
+                    coeff[det] = 0.0
+                    coeff[qdet] = cf[0]
+                    coeff[udet] = cf[1]
+                    imean = np.mean(ob.detdata[defaults.det_data][det])
+                    I_templates[base] = ob.detdata[defaults.det_data][det] - imean
+                    det_to_key[qdet] = base
+                    det_to_key[udet] = base
+                    ob.detdata[defaults.det_data][qdet] += (
+                        coeff[qdet] * I_templates[base]
+                    )
+                    ob.detdata[defaults.det_data][udet] += (
+                        coeff[udet] * I_templates[base]
+                    )
+            I_templates["det_to_key"] = det_to_key
+            ob["templates"] = I_templates
+            ob["template_coeff"] = coeff
+
+        # Destriping templates.  For the intensity data, we use standard baseline
+        # offsets to model the remaining 1/f in the low-passed data (which is mainly
+        # atmosphere).  For the polarization data, we use both baseline offsets and
+        # also the precomputed intensity templates.
+
+        tmpl_I_offset = templates.Offset(
+            name="offset_I",
+            noise_model="noise_model",
+            step_time=1.0 * u.second,
+            use_noise_prior=False,
+            pattern="demod0.*",
+            view="scanning",
+        )
+        tmpl_P_offset = templates.Offset(
+            name="offset_P",
+            noise_model="noise_model",
+            step_time=1000.0 * u.second,  # Will be truncated to one baseline per scan
+            use_noise_prior=False,
+            pattern="demod4.*",
+            view="scanning",
+        )
+        tmpl_T2P = templates.PreComputed(
+            name="T2P",
+            obs_key="templates",
+            pattern="demod4.*",
+            view="scanning",
+        )
+
+        tmpl = templates.Offset(
+            name="offset",
+            noise_model="noise_model",
+            step_time=1000.0 * u.second,  # Will be truncated to one baseline per scan
+            use_noise_prior=False,
+            view="scanning",
+        )
+
+        tmatrix = ops.TemplateMatrix(
+            templates=[tmpl_I_offset, tmpl_P_offset, tmpl_T2P],
+            #templates=[tmpl_I_offset, tmpl_P_offset],
+            #templates=[tmpl],
+        )
+
+        binner = ops.BinMap(
+            pixel_pointing=pixels,
+            stokes_weights=demod_weights,
+            noise_model="noise_model",
+        )
+
+        mapper = ops.MapMaker(
+            name="mapmaker",
+            det_data=defaults.det_data,
+            binning=binner,
+            template_matrix=tmatrix,
+            write_hits=True,
+            write_map=True,
+            write_cov=True,
+            write_invcov=True,
+            write_rcond=True,
+            keep_solver_products=True,
+            keep_final_products=False,
+            output_dir=testdir,
+            solve_rcond_threshold=1e-3,
+            map_rcond_threshold=1e-3,
+            reset_pix_dist=True,
+        )
+        mapper.apply(demod_data)
+
+        # if data.comm.world_rank == 0:
+        #     set_matplotlib_backend()
+        #     import matplotlib.pyplot as plt
+
+        #     fname_mod = os.path.join(
+        #         self.outdir, f"modulated_{weight_mode}{suffix}_map.fits"
+        #     )
+        #     fname_demod = os.path.join(
+        #         self.outdir, f"demodulated_{weight_mode}{suffix}_map.fits"
+        #     )
+        #     fname_hits = os.path.join(
+        #         self.outdir, f"demodulated_{weight_mode}{suffix}_hits.fits"
+        #     )
+
+        #     map_mod = hp.read_map(fname_mod, None)
+        #     map_demod = np.atleast_2d(hp.read_map(fname_demod, None))
+        #     hits = hp.read_map(fname_hits)
+        #     map_input = np.atleast_2d(hp.read_map(sky_file, None))
+
+        #     # Develop a comparison mask that excludes poorly observed pixels
+        #     sorted_hits = np.sort(hits[hits != 0])
+        #     nhit = len(sorted_hits)
+        #     hit_min = sorted_hits[int(0.1 * nhit)]  # worst 10% of hit pixels
+        #     rms_mask = hits > hit_min
+
+        #     fig = plt.figure(figsize=[18, 12])
+        #     nrow, ncol = 3, 3
+        #     rot = [42, -42]
+        #     reso = 1
+        #     xsize = 800
+
+        #     amp = 1e-5
+        #     for i, m in enumerate(map_mod):
+        #         # Modulated map is full IQU
+        #         value = map_input[i]
+        #         good = m != 0
+        #         rms = np.sqrt(np.mean((m - value)[rms_mask] ** 2))
+        #         m[m == 0] = hp.UNSEEN
+        #         stokes = "IQU"[i]
+        #         hp.gnomview(
+        #             m,
+        #             sub=[nrow, ncol, 1 + i],
+        #             reso=reso,
+        #             xsize=xsize,
+        #             rot=rot,
+        #             title=f"Modulated {stokes} : rms = {rms}",
+        #             min=np.amin(value[good]) - amp,
+        #             max=np.amax(value[good]) + amp,
+        #             cmap="coolwarm",
+        #         )
+
+        #     all_good = True
+        #     for stokes, m in zip(weight_mode, map_demod):
+        #         # Demodulated map only has the prescribed components
+        #         i = "IQU".index(stokes)
+        #         value = map_input[i]
+        #         good = m != 0
+        #         rms0 = np.sqrt(np.mean(value[rms_mask] ** 2))
+        #         rms = np.sqrt(np.mean(m[rms_mask] ** 2))
+        #         rms1 = np.sqrt(np.mean((m - value)[rms_mask] ** 2))
+        #         m[m == 0] = hp.UNSEEN
+        #         hp.gnomview(
+        #             m,
+        #             sub=[nrow, ncol, ncol + i + 1],
+        #             reso=reso,
+        #             xsize=xsize,
+        #             rot=rot,
+        #             title=f"Demodulated {stokes} : rms = {rms / rms0:.3f} x rms(in)",
+        #             min=np.amin(value[good]) - amp,
+        #             max=np.amax(value[good]) + amp,
+        #             cmap="coolwarm",
+        #         )
+        #         resid = m - value
+        #         resid[m == 0] = hp.UNSEEN
+        #         hp.gnomview(
+        #             resid,
+        #             sub=[nrow, ncol, 2 * ncol + i + 1],
+        #             reso=reso,
+        #             xsize=xsize,
+        #             rot=rot,
+        #             title=f"Residual {stokes} : resid rms = {rms1 / rms0:.3f} x rms(in)",
+        #             min=np.amin(value[good]) - amp,
+        #             max=np.amax(value[good]) + amp,
+        #             cmap="coolwarm",
+        #         )
+        #         if rms1 / rms0 > 0.3:
+        #             print(
+        #                 f"input - demodulated map RMS = {rms1}, (input RMS = {rms0})",
+        #                 flush=True,
+        #             )
+        #             all_good = False
+
+        #     outfile = os.path.join(
+        #         self.outdir, f"map_comparison.{weight_mode}{suffix}.png"
+        #     )
+        #     fig.savefig(outfile)
+        #     self.assertTrue(all_good)
+
+        if self.comm is not None:
+            self.comm.barrier()
+
+        close_data(demod_data)
+        close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -96,6 +96,7 @@ from . import template_fourier2d as test_template_fourier2d
 from . import template_gain as test_template_gain
 from . import template_offset as test_template_offset
 from . import template_periodic as test_template_periodic
+from . import template_precomputed as test_template_precomputed
 from . import template_subharmonic as test_template_subharmonic
 from . import timing as test_timing
 from . import weather as test_weather
@@ -260,6 +261,7 @@ def test(name=None, verbosity=2):
 
         suite.addTest(loader.loadTestsFromModule(test_template_amplitudes))
         suite.addTest(loader.loadTestsFromModule(test_template_periodic))
+        suite.addTest(loader.loadTestsFromModule(test_template_precomputed))
         suite.addTest(loader.loadTestsFromModule(test_template_offset))
         suite.addTest(loader.loadTestsFromModule(test_template_fourier2d))
         suite.addTest(loader.loadTestsFromModule(test_template_subharmonic))

--- a/src/toast/tests/template_precomputed.py
+++ b/src/toast/tests/template_precomputed.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2026-2026 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+import numpy.testing as nt
+from astropy import units as u
+
+from .. import ops
+from ..observation import default_values as defaults
+from ..templates import PreComputed
+from ..vis import plot_healpix_maps, plot_noise_estim
+from .helpers import (
+    close_data,
+    create_fake_healpix_scanned_tod,
+    create_fake_wcs_scanned_tod,
+    create_ground_data,
+    create_outdir,
+    create_satellite_data,
+)
+from .mpi import MPITestCase
+
+
+class TemplatePrecomputedTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+        self.nside = 64
+        np.random.seed(123456)
+        if (
+            ("CONDA_BUILD" in os.environ)
+            or ("CIBUILDWHEEL" in os.environ)
+            or ("CI" in os.environ)
+        ):
+            self.make_plots = False
+        else:
+            self.make_plots = True
+
+    def fake_templates(self, data, obs_key):
+        # Create fake templates and coadd to detectors with random
+        # coefficients.
+        for ob in data.obs:
+            nsamp = ob.n_local_samples
+            amp_ptp = 0.0
+            coeff = np.random.uniform(low=0.5, high=1.5, size=len(ob.local_detectors))
+            for det in ob.local_detectors:
+                dptp = np.ptp(ob.detdata[defaults.det_data][det])
+                amp_ptp = max(amp_ptp, dptp)
+            tnames = list()
+            index = np.arange(nsamp, dtype=np.int64)
+            templates = dict()
+            for it in range(5):
+                name = f"template_{it:05d}"
+                tnames.append(name)
+                templates[name] = amp_ptp * np.sin(np.pi * (it + 5) * index / nsamp)
+            det_to_key = dict()
+            det_coeff = dict()
+            for idet, det in enumerate(ob.local_detectors):
+                it = idet % 5
+                name = f"template_{it:05d}"
+                det_to_key[det] = name
+                det_coeff[det] = coeff[idet]
+                ob.detdata[defaults.det_data][det] += coeff[idet] * templates[name]
+            templates["det_to_key"] = det_to_key
+            ob[obs_key] = templates
+            ob["template_amp"] = amp_ptp
+            ob["template_coeff"] = det_coeff
+
+    def test_projection_unity(self):
+        # Create a fake satellite data set for testing
+        data = create_satellite_data(self.comm)
+
+        # Create a default noise model
+        noise_model = ops.DefaultNoiseModel()
+        noise_model.apply(data)
+
+        # Simulate some TOD
+        ops.SimNoise(noise_model="noise_model").apply(data)
+
+        ops.Copy(detdata=[("signal", "input")]).apply(data)
+
+        # Create and apply fake templates
+        self.fake_templates(data, "templates")
+
+        ops.Copy(detdata=[("signal", "combined")]).apply(data)
+        ops.Reset(detdata=["signal"]).apply(data)
+
+        # Destriping template
+        tmpl = PreComputed(obs_key="templates")
+
+        # Set the data and initialize
+        tmpl.data = data
+        tmpl.initialize()
+
+        # Get some amplitudes and set to one
+        amps = tmpl.zeros()
+        amps.local[:] = 1.0
+
+        # Project.
+        for det in tmpl.detectors():
+            for ob in data.obs:
+                tmpl.add_to_signal(det, amps)
+
+        # Verify
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                ddata = ob.detdata[defaults.det_data][det]
+                dkey = ob["templates"]["det_to_key"][det]
+                check = ob["templates"][dkey]
+                if not np.allclose(ddata, check):
+                    msg = f"FAIL: {ddata} != {check}"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+
+        amps.reset()
+
+        # Accumulate amplitudes
+        for det in tmpl.detectors():
+            for ob in data.obs:
+                tmpl.project_signal(det, amps)
+
+        # Verify- we have one amplitude per detector per observation
+        offset = 0
+        for ob in data.obs:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+                detamp = amps.local[offset]
+                if not np.allclose(detamp, 1.0):
+                    msg = f"FAIL: {detamp} != 1.0"
+                    print(msg, flush=True)
+                    self.assertTrue(False)
+                offset += 1
+
+        close_data(data)


### PR DESCRIPTION

- Add lowpass support to the CommonModeFilter operator.
      Also add support for saving the template rather than
      regressing it.
    
- Flag dets when the common mode template matrix is
      singular.
    
- Add a new destriping template that uses precomputed arrays.
      Support both simple and dictionary style templates