### PR TITLE
Ensure proper functioning when some processes have no data

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     steps:
       - name: Configure pages
         uses: actions/configure-pages@v6
@@ -26,51 +26,45 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Setup Conda Base
-        run: |
-          sudo rm -rf /usr/share/miniconda \
-            && sudo rm -rf /usr/local/miniconda \
-            && curl -SL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
-            && bash miniforge.sh -b -f -p ~/conda \
-            && source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && conda update -n base --yes conda
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          channels: conda-forge
+          channel-priority: strict
+          conda-remove-defaults: true
+          auto-update-conda: true
+          auto-activate: true
+          activate-environment:  # Disable creation of the 'test' env
 
       - name: Check Conda Config
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && conda info \
-            && conda list \
-            && conda config --show-sources \
-            && conda config --show
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
 
       - name: Create Conda Env
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && ./conda_setup.sh -e docs -p 3.13 \
+          ./conda_setup.sh -e docs -p 3.13
 
       - name: Install TOAST
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate docs \
-            && pip install -v .
+          conda activate docs
+          pip install -v .
 
       - name: Install Doc Dependencies
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate docs \
-            && pip install -r docs/doc_requirements.txt
+          conda activate docs
+          pip install -r docs/doc_requirements.txt
 
       - name: Build Docs
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate docs \
-            && pushd docs \
-            && ./run_notebooks.sh ./docs \
-            && ./build.sh \
-            && popd
+          conda activate docs
+          pushd docs
+          ./run_notebooks.sh ./docs
+          ./build.sh
+          popd
 
       - name: Upload Docs
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,10 @@ jobs:
         run: |
           ./conda_setup.sh -e toast -p ${{ matrix.python }} -x
           conda activate toast
-          python3 -m pip install 'spt3g==1.0.0'
+        # FIXME: re-enable once we migrate the toast.spt3g submodule
+        # to use the latest API rather than the one we are stuck with
+        # in so3g.
+        #conda install spt3g
 
       - name: Install
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
@@ -63,53 +63,48 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Setup Conda Base
-        run: |
-          sudo rm -rf /usr/share/miniconda \
-            && sudo rm -rf /usr/local/miniconda \
-            && curl -SL -o miniforge.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${{ matrix.arch }}.sh \
-            && bash miniforge.sh -b -f -p ~/conda \
-            && source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && conda update -n base --yes conda
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniforge-version: latest
+          channels: conda-forge
+          channel-priority: strict
+          conda-remove-defaults: true
+          auto-update-conda: true
+          auto-activate: true
+          activate-environment:  # Disable creation of the 'test' env
 
       - name: Check Conda Config
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && conda info \
-            && conda list \
-            && conda config --show-sources \
-            && conda config --show
+          conda info
+          conda list
+          conda config --show-sources
+          conda config --show
 
       - name: Create Conda Env
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate base \
-            && ./conda_setup.sh -e toast -p ${{ matrix.python }} -x \
-            && python3 -m pip install 'spt3g==1.0.0'
+          ./conda_setup.sh -e toast -p ${{ matrix.python }} -x
+          conda activate toast
+          python3 -m pip install 'spt3g==1.0.0'
 
       - name: Install
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate toast \
-            && pip install -v .
+          conda activate toast
+          pip install -v .
 
       - name: Run Serial Tests
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate toast \
-            && export OMP_NUM_THREADS=2 \
-            && export MPI_DISABLE=1 \
-            && python3 -c 'import toast.tests; toast.tests.run()' \
-            && unset MPI_DISABLE \
-            && unset OMP_NUM_THREADS
+          conda activate toast
+          export OMP_NUM_THREADS=2
+          export MPI_DISABLE=1
+          python3 -c 'import toast.tests; toast.tests.run()'
+          unset MPI_DISABLE
+          unset OMP_NUM_THREADS
 
       - name: Run MPI Tests
         run: |
-          source ~/conda/etc/profile.d/conda.sh \
-            && conda activate toast \
-            && export OMP_NUM_THREADS=1 \
-            && mpirun -np 2 python -c 'import toast.tests; toast.tests.run()' \
-            && unset OMP_NUM_THREADS
+          conda activate toast
+          export OMP_NUM_THREADS=1
+          mpirun -np 2 python -c 'import toast.tests; toast.tests.run()'
+          unset OMP_NUM_THREADS
 

--- a/src/toast/io/observation_hdf_load.py
+++ b/src/toast/io/observation_hdf_load.py
@@ -202,23 +202,56 @@ def load_hdf5_detdata(obs, file_dets, hgrp, fields, log_prefix, parallel):
             keep_dets[iglobal] = True
     else:
         keep_dets = None
+
     # The MPI distribution passed to flacarray is given in terms of
-    # the detectors in the file, not the ones we are loading.
+    # the detectors in the file, not the ones we are loading.  Also,
+    # this MPI distribution should have first == last for any procs
+    # without data (since last is exclusive).  The MPI distribution
+    # is contiguous between processes (detector are excluded by the
+    # keep array).
+
     if len(dist_dets) == 1:
         mpi_dist = [(0, len(file_dets))]
     else:
         mpi_dist = list()
-        for iproc, dd in enumerate(dist_dets):
-            poff = dd.offset
-            pelem = dd.n_elem
+        # Find the first detector observation index for each process.
+        # We work backwards to more easily deal with processes that
+        # have no detectors.
+        proc_obs_first = list()
+        cur_first = len(obs.all_detectors)
+        for dd in reversed(dist_dets):
+            doff = dd.offset
+            if doff < 0:
+                # This proc has no data
+                proc_obs_first.append(cur_first)
+            else:
+                proc_obs_first.append(doff)
+                cur_first = doff
+        proc_obs_first.reverse()
+
+        nproc = len(proc_obs_first)
+        for iproc in range(nproc):
             if iproc == 0:
                 first = 0
             else:
-                first = int(det_obs_to_file[poff])
-            if iproc == obs.comm.group_size - 1:
+                cur_first = proc_obs_first[iproc]
+                if cur_first == len(obs.all_detectors):
+                    # We are the end of processes with data
+                    first = len(file_dets)
+                else:
+                    # Get the index of this first detector in the file
+                    first = det_obs_to_file[cur_first]
+            if iproc == nproc - 1:
+                # Last proc, distribution always goes to end of file dets
                 last = len(file_dets)
             else:
-                last = int(det_obs_to_file[poff + pelem])
+                # Use the next proc's start as the last
+                next_first = proc_obs_first[iproc + 1]
+                if next_first == len(obs.all_detectors):
+                    # No further processes have data
+                    last = len(file_dets)
+                else:
+                    last = det_obs_to_file[next_first]
             mpi_dist.append((first, last))
 
     cmsg = f"Compressed detdata MPI dist = {dist_dets},\n loading with flacarray"
@@ -339,9 +372,12 @@ def load_hdf5_detdata(obs, file_dets, hgrp, fields, log_prefix, parallel):
         elif serial_load:
             # Uncompressed read and distribute
             for proc, detrange in enumerate(dist_dets):
+                n_local_det = detrange.n_elem
+                if n_local_det <= 0:
+                    # No data on this process
+                    continue
                 first_det = detrange.offset
                 end_det = detrange.offset + detrange.n_elem
-                n_local_det = detrange.n_elem
                 if obs.comm.group_rank == 0:
                     buffer = np.zeros((n_local_det, obs.n_all_samples), dtype=dtype)
                     if det_subset:
@@ -390,16 +426,17 @@ def load_hdf5_detdata(obs, file_dets, hgrp, fields, log_prefix, parallel):
                     del buffer
         else:
             # Uncompressed read in parallel
-            detdata_slice = (slice(0, det_nelem, 1), slice(0, samp_nelem, 1))
-            detdata_slice += post_slice
-            hf_slice = (
-                slice(det_off, det_off + det_nelem, 1),
-                slice(samp_off, samp_off + samp_nelem, 1),
-            )
-            hf_slice += post_slice
-            msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
-            check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
-            ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
+            if det_nelem > 0:
+                detdata_slice = (slice(0, det_nelem, 1), slice(0, samp_nelem, 1))
+                detdata_slice += post_slice
+                hf_slice = (
+                    slice(det_off, det_off + det_nelem, 1),
+                    slice(samp_off, samp_off + samp_nelem, 1),
+                )
+                hf_slice += post_slice
+                msg = f"Detdata field {field} (group rank {obs.comm.group_rank})"
+                check_dataset_buffer_size(msg, hf_slice, dtype, parallel)
+                ds.read_direct(obs.detdata[field].data, hf_slice, detdata_slice)
 
         if obs.comm.comm_group is not None:
             obs.comm.comm_group.barrier()
@@ -559,8 +596,9 @@ def load_instrument(
                             new_ds.append(d)
                     if len(new_ds) > 0:
                         new_detsets.append(new_ds)
-            else:
-                # Must be a dictionary
+            elif isinstance(file_det_sets, dict):
+                # Must be a dictionary.  This is a legacy technique.  All
+                # current detector sets should be list-of-lists.
                 new_detsets = list()
                 for dskey, ds in file_det_sets.items():
                     new_ds = list()

--- a/src/toast/io/observation_hdf_save.py
+++ b/src/toast/io/observation_hdf_save.py
@@ -267,6 +267,11 @@ def save_hdf5_detdata(obs, hgrp, fields, log_prefix, in_place=False):
                     samp_nelem = dist_samps[proc].n_elem
                     det_off = dist_dets[proc].offset
                     det_nelem = dist_dets[proc].n_elem
+
+                    if det_nelem <= 0:
+                        # No detectors on this process
+                        continue
+
                     nflat = det_nelem * samp_nelem
                     shp = (det_nelem, samp_nelem)
                     detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
@@ -308,23 +313,28 @@ def save_hdf5_detdata(obs, hgrp, fields, log_prefix, in_place=False):
                 det_off = dist_dets[obs.comm.group_rank].offset
                 det_nelem = dist_dets[obs.comm.group_rank].n_elem
 
-                detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
-                hf_slice = [
-                    slice(det_off, det_off + det_nelem, 1),
-                    slice(samp_off, samp_off + samp_nelem, 1),
-                ]
-                if dvalshape is not None:
-                    detdata_slice.extend([slice(0, x) for x in dvalshape])
-                    hf_slice.extend([slice(0, x) for x in dvalshape])
-                detdata_slice = tuple(detdata_slice)
-                hf_slice = tuple(hf_slice)
-                msg = f"Detector data field {field} (group rank {obs.comm.group_rank})"
-                check_dataset_buffer_size(msg, hf_slice, ddtype, True)
+                if det_nelem <= 0:
+                    do_write = False
+                else:
+                    do_write = True
+                    detdata_slice = [slice(0, det_nelem, 1), slice(0, samp_nelem, 1)]
+                    hf_slice = [
+                        slice(det_off, det_off + det_nelem, 1),
+                        slice(samp_off, samp_off + samp_nelem, 1),
+                    ]
+                    if dvalshape is not None:
+                        detdata_slice.extend([slice(0, x) for x in dvalshape])
+                        hf_slice.extend([slice(0, x) for x in dvalshape])
+                    detdata_slice = tuple(detdata_slice)
+                    hf_slice = tuple(hf_slice)
+                    msg = f"Detector data field {field} (group rank {obs.comm.group_rank})"
+                    check_dataset_buffer_size(msg, hf_slice, ddtype, True)
 
                 with hdata.collective:
-                    hdata.write_direct(
-                        local_data.data.astype(ddtype), detdata_slice, hf_slice
-                    )
+                    if do_write:
+                        hdata.write_direct(
+                            local_data.data.astype(ddtype), detdata_slice, hf_slice
+                        )
             del hdata
             log.verbose_rank(
                 f"{log_prefix}  Detdata finished {field} serial write in",
@@ -359,11 +369,15 @@ def save_hdf5_detdata(obs, hgrp, fields, log_prefix, in_place=False):
                 if quanta is None and precision is None:
                     msg = "When compressing floating point data, you"
                     msg += " must specify the quanta or precision."
-                    raise RuntimeError("You must specify the quanta")
+                    raise RuntimeError(msg)
 
             # We flatten all the per-sample data when compressing
+            if local_n_det == 0:
+                flatdata = local_data.data.astype(hdtype)
+            else:
+                flatdata = local_data.data.astype(hdtype).reshape((local_n_det, -1))
             flacarray.hdf5.write_array(
-                local_data.data.astype(hdtype).reshape((local_n_det, -1)),
+                flatdata,
                 fgrp,
                 level=level,
                 quanta=quanta,
@@ -378,19 +392,20 @@ def save_hdf5_detdata(obs, hgrp, fields, log_prefix, in_place=False):
                 det_nelem = dist_dets[obs.comm.group_rank].n_elem
                 mpi_dist = [(x.offset, x.offset + x.n_elem) for x in dist_dets]
 
-                flcdata = (
-                    flacarray.hdf5.read_array(
-                        fgrp,
-                        keep=None,
-                        stream_slice=None,
-                        keep_indices=False,
-                        mpi_comm=comm,
-                        mpi_dist=mpi_dist,
-                        use_threads=False,
-                    )
-                    .astype(ddtype)
-                    .reshape(local_data.shape)
-                )
+                raw = flacarray.hdf5.read_array(
+                    fgrp,
+                    keep=None,
+                    stream_slice=None,
+                    keep_indices=False,
+                    mpi_comm=comm,
+                    mpi_dist=mpi_dist,
+                    use_threads=False,
+                ).astype(ddtype)
+                if local_n_det == 0:
+                    flcdata = raw
+                else:
+                    flcdata = raw.reshape(local_data.shape)
+
                 for idet, det in enumerate(local_data.detectors):
                     local_data.data[idet] = flcdata[idet]
                 del flcdata

--- a/src/toast/noise.py
+++ b/src/toast/noise.py
@@ -331,7 +331,7 @@ class Noise(object):
                 for det in pdets:
                     if det in gdets:
                         msg = f"Multiple processes have detector '{det}'.  "
-                        msg += f"Are you using the grid column communicator?"
+                        msg += "Are you using the grid column communicator?"
                         raise RuntimeError(msg)
                     gdets.add(det)
                     out["mix"][det] = dict()
@@ -400,6 +400,7 @@ class Noise(object):
                 all_weights = comm.bcast(props["weights"], root=0)
             else:
                 all_weights = comm.bcast(None, root=0)
+
             self._detweights = dict()
             for d in self._dets:
                 self._detweights[d] = all_weights[d]
@@ -719,7 +720,10 @@ class Noise(object):
             # The rank zero process should always be writing
             if handle is None:
                 raise RuntimeError("HDF5 group is not open on the root process")
-        _ = self.detector_weight(self.detectors[0])
+        # If the local process has any detectors, trigger caching of the detector
+        # weights before saving.
+        if len(self.detectors) > 0:
+            _ = self.detector_weight(self.detectors[0])
         self._save_hdf5(handle, obs, **kwargs)
 
     @function_timer
@@ -807,7 +811,7 @@ class Noise(object):
                 if rank == 0:
                     freq = pds[0]
                     for key, indx, psdrow in zip(psd_keys, psd_indices, pds[1:]):
-                        props["indices"][key] = int(indx)
+                        props["indices"][key] = indx
                         props["freqs"][key] = u.Quantity(freq, u.Hz)
                         props["psds"][key] = u.Quantity(psdrow, psd_units)
                 del pds
@@ -848,8 +852,12 @@ class Noise(object):
         self._load_hdf5(handle, obs, **kwargs)
 
     def __repr__(self):
-        mix_min = np.min([len(y) for x, y in self._mixmatrix.items()])
-        mix_max = np.max([len(y) for x, y in self._mixmatrix.items()])
+        if len(self._dets) == 0:
+            mix_min = 0
+            mix_max = 0
+        else:
+            mix_min = np.min([len(y) for x, y in self._mixmatrix.items()])
+            mix_max = np.max([len(y) for x, y in self._mixmatrix.items()])
         value = f"<Noise model with {len(self._dets)} detectors each built from "
         value += f"between {mix_min} and {mix_max} independent streams"
         value += ">"
@@ -858,13 +866,19 @@ class Noise(object):
     def __eq__(self, other):
         log = Logger.get()
         fail = 0
+        if len(self._dets) == 0 and len(other._dets) == 0:
+            return True
+
         if set(self._dets) != set(other._dets):
             log.verbose(f"Noise __eq__:  dets {set(self._dets)} != {set(other._dets)}")
             fail = 1
         elif set(self._keys) != set(other._keys):
             log.verbose(f"Noise __eq__:  keys {set(self._keys)} != {set(other._keys)}")
             fail = 1
-        elif self._rates != other._rates:
+        elif not np.allclose(
+            np.array([x.to_value(u.Hz) for x in self._rates.values()]),
+            np.array([x.to_value(u.Hz) for x in other._rates.values()]),
+        ):
             log.verbose(f"Noise __eq__:  rates {self._rates} != {other._rates}")
             fail = 1
         elif self._indices != other._indices:

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -107,7 +107,7 @@ class DetectorData(AcceleratorObject):
                 msg += f" than constructor shape ({self.shape[0]})"
                 log.error(msg)
                 raise RuntimeError(msg)
-            if self._shape[1:] != view_data[0].shape:
+            if self._shape[0] > 0 and self._shape[1:] != view_data[0].shape:
                 msg = f"view data sample shape ({view_data[0].shape})"
                 msg += f" does not match constructor sample shape ({self._shape[1:]})"
                 log.error(msg)

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -94,9 +94,6 @@ class DetectorData(AcceleratorObject):
 
         self._fullsize = 0
         self._memsize = 0
-        self._raw = None
-        self._flatdata = None
-        self._data = None
 
         if view_data is None:
             # Allocate the data
@@ -162,29 +159,24 @@ class DetectorData(AcceleratorObject):
             self.accel_delete()
 
         # Delete existing wrapper and buffer
-        if self._data is not None:
+        if hasattr(self, "_data"):
             del self._data
-        if self._flatdata is not None:
+        if hasattr(self, "_flatdata"):
             del self._flatdata
-        if self._raw is not None:
+        if hasattr(self, "_raw"):
             self._raw.clear()
             del self._raw
 
         # Allocate new host buffer
-        if self._fullsize > 0:
-            self._raw = self._storage_class.zeros(self._fullsize)
-            # Wrap _raw
-            self._flatdata = self._raw.array()[: self._flatshape]
-            self._data = self._flatdata.reshape(self._shape)
-            # Restore device buffer if needed
-            if create_accel:
-                self._accel_create(zero_out=True)
-            if on_accel:
-                self.accel_used(True)
-        else:
-            self._raw = None
-            self._flatdata = None
-            self._data = None
+        self._raw = self._storage_class.zeros(self._fullsize)
+        # Wrap _raw
+        self._flatdata = self._raw.array()[: self._flatshape]
+        self._data = self._flatdata.reshape(self._shape)
+        # Restore device buffer if needed
+        if create_accel:
+            self._accel_create(zero_out=True)
+        if on_accel:
+            self.accel_used(True)
 
     @property
     def detectors(self):
@@ -233,7 +225,7 @@ class DetectorData(AcceleratorObject):
 
     @property
     def data(self):
-        if (not hasattr(self, "_data")) or self._data is None:
+        if not hasattr(self, "_data"):
             raise RuntimeError("Cannot use DetectorData object after clearing memory")
         if self._is_view:
             msg = "DetectorData view is not guaranteed to be contiguous.  "
@@ -243,7 +235,7 @@ class DetectorData(AcceleratorObject):
 
     @property
     def flatdata(self):
-        if (not hasattr(self, "_flatdata")) or self._flatdata is None:
+        if not hasattr(self, "_flatdata"):
             raise RuntimeError("Cannot use DetectorData object after clearing memory")
         if self._is_view:
             raise RuntimeError("DetectorData view has no flat shape")
@@ -349,16 +341,12 @@ class DetectorData(AcceleratorObject):
         # then apply clear
         if hasattr(self, "_data"):
             del self._data
-            self._data = None
         if hasattr(self, "_is_view") and not self._is_view:
             if hasattr(self, "_flatdata"):
                 del self._flatdata
-                self._flatdata = None
             if hasattr(self, "_raw"):
-                if self._raw is not None:
-                    self._raw.clear()
-                    del self._raw
-                    self._raw = None
+                self._raw.clear()
+                del self._raw
 
     def reset(self, dets=None):
         """Zero the current memory.
@@ -376,13 +364,11 @@ class DetectorData(AcceleratorObject):
         if self.accel_in_use():
             self.accel_reset()
         elif dets is None:
-            if self._data is not None:
-                # Zero the whole thing
-                self._data[:] = 0
+            # Zero the whole thing
+            self._data[:] = 0
         else:
-            if self._data is not None:
-                for d in dets:
-                    self[d, :] = 0
+            for d in dets:
+                self[d, :] = 0
 
     def __del__(self):
         self.clear()
@@ -570,7 +556,7 @@ class DetectorData(AcceleratorObject):
         return not self.__eq__(other)
 
     def _accel_exists(self):
-        if self._raw is None:
+        if self._is_view:
             # We have a view.
             # FIXME: eventually we could check the state of the underlying
             # object and use that.
@@ -866,7 +852,7 @@ class DetDataManager(MutableMapping):
                         # We need to convert jax array back to numpy
                         self.accel_update_host(name)
                     else:
-                        msg = f"Should never get here: newly created detdata "
+                        msg = "Should never get here: newly created detdata "
                         msg += "using neither openmp nor jax"
                         raise RuntimeError(msg)
         return existing
@@ -1005,7 +991,7 @@ class DetDataManager(MutableMapping):
             return
         if not self._internal[key].accel_exists():
             msg = f"Detector data '{key}' type = {type(self._internal[key])} "
-            msg += f"is not present on device, cannot delete"
+            msg += "is not present on device, cannot delete"
             log.error(msg)
             raise RuntimeError(msg)
         log.verbose(f"DetDataMgr {key} type = {type(self._internal[key])} accel_delete")
@@ -1026,7 +1012,7 @@ class DetDataManager(MutableMapping):
             return
         if not self._internal[key].accel_exists():
             msg = f"Detector data '{key}' type = {type(self._internal[key])} "
-            msg += f"is not present on device, cannot reset"
+            msg += "is not present on device, cannot reset"
             log.error(msg)
             raise RuntimeError(msg)
         log.verbose(f"DetDataMgr {key} type = {type(self._internal[key])} accel_reset")

--- a/src/toast/observation_data.py
+++ b/src/toast/observation_data.py
@@ -545,11 +545,12 @@ class DetectorData(AcceleratorObject):
             # print(msg)
             return False
         # Compare array values
-        check = array_equal(
-            self.data, other.data, f32=approx, log_prefix="DetectorData"
-        )
-        if not check:
-            return False
+        if len(self.detectors) > 0:
+            check = array_equal(
+                self.data, other.data, f32=approx, log_prefix="DetectorData"
+            )
+            if not check:
+                return False
         return True
 
     def __ne__(self, other):

--- a/src/toast/observation_dist.py
+++ b/src/toast/observation_dist.py
@@ -112,27 +112,31 @@ class DistDetSamp(object):
             # the det sets.
             new_dets = list()
             detsets = list()
-            detectors_set = set(self.detectors)
+            detector_check = set(self.detectors)
             if isinstance(self.detector_sets, list):
                 # We have a list of lists
                 for ds in self.detector_sets:
+                    dset = list()
                     for d in ds:
-                        if d not in detectors_set:
+                        if d not in detector_check:
                             raise RuntimeError(
                                 f"detector {d} in a detset but not in detector list"
                             )
                         new_dets.append(d)
-                    detsets.append(list(ds))
+                        dset.append(d)
+                    detsets.append(dset)
             elif isinstance(self.detector_sets, dict):
                 # We have a detector group dictionary
-                for ds in self.detector_sets.values():
+                for dgroup, ds in self.detector_sets.items():
+                    dset = list()
                     for d in ds:
-                        if d not in detectors_set:
+                        if d not in detector_check:
                             raise RuntimeError(
                                 f"detector {d} in a detset but not in detector list"
                             )
                         new_dets.append(d)
-                    detsets.append(list(ds))
+                        dset.append(d)
+                    detsets.append(dset)
             else:
                 raise RuntimeError("detector_sets should be a list or dict")
 
@@ -141,6 +145,9 @@ class DistDetSamp(object):
             # distribution code.
             self.detectors = new_dets
             self.detector_sets = detsets
+        else:
+            # Create the trivial detsets which consist of one detector per set
+            self.detector_sets = [[x] for x in self.detectors]
 
         # Detector name to index
         self.det_index = {y: x for x, y in enumerate(self.detectors)}
@@ -177,6 +184,9 @@ class DistDetSamp(object):
                 dfirst = self.det_index[ds[0]]
                 dlast = self.det_index[ds[-1]]
                 self.det_indices.append(DistRange(dfirst, dlast - dfirst + 1))
+            else:
+                # No detectors for this process
+                self.det_indices.append(DistRange(-1, -1))
 
         if self.comm.group_rank == 0:
             # check that all processes have some data, otherwise print warning

--- a/src/toast/ops/common_mode_noise.py
+++ b/src/toast/ops/common_mode_noise.py
@@ -193,8 +193,8 @@ class CommonModeNoise(Operator):
 
                 # Draw coupling strengths and record them in the mixing matrix
                 for det in dets:
-                    key1 = noise_uid + obs.telescope.uid * 3956215
-                    key2 = obs_id
+                    key1 = int(noise_uid) + int(obs.telescope.uid) * 3956215
+                    key2 = int(obs_id)
                     counter1 = realization
                     counter2 = focalplane[det]["uid"]
                     gaussian = rng.random(

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -320,7 +320,9 @@ class SimConviqt(Operator):
         my_dets = set()
         for obs in data.obs:
             # Get the detectors we are using for this observation
-            obs_dets = obs.select_local_detectors(detectors, flagmask=self.det_mask)
+            obs_dets = obs.select_local_detectors(
+                selection=detectors, flagmask=self.det_mask
+            )
             for det in obs_dets:
                 my_dets.add(det)
             # Make sure detector data output exists
@@ -449,7 +451,8 @@ class SimConviqt(Operator):
         all_psi_beam = []
         all_hwp_angle = []
         for obs in data.obs:
-            if det not in obs.local_detectors:
+            good_dets = set(obs.select_local_detectors(flagmask=self.det_mask))
+            if det not in good_dets:
                 continue
             focalplane = obs.telescope.focalplane
             # Loop over views
@@ -608,7 +611,8 @@ class SimConviqt(Operator):
         timer.start()
         offset = 0
         for obs in data.obs:
-            if det not in obs.local_detectors:
+            good_dets = set(obs.select_local_detectors(flagmask=self.det_mask))
+            if det not in good_dets:
                 continue
             focalplane = obs.telescope.focalplane
             epsilon = self._get_epsilon(focalplane, det)
@@ -633,7 +637,8 @@ class SimConviqt(Operator):
         offset = 0
         scale = unit_conversion(u.K, self.units)
         for obs in data.obs:
-            if det not in obs.local_detectors:
+            good_dets = set(obs.select_local_detectors(flagmask=self.det_mask))
+            if det not in good_dets:
                 continue
             # Loop over views
             views = obs.view[self.view]

--- a/src/toast/ops/crosslinking.py
+++ b/src/toast/ops/crosslinking.py
@@ -29,6 +29,122 @@ class UniformNoise:
 
 
 @trait_docs
+class CrossLinkingWeights(Operator):
+    """Helper operator to compute the crosslinking weights.
+    """
+
+    # Class traits
+
+    API = Int(0, help="Internal interface version for this operator")
+
+    detector_pointing = Instance(
+        klass=Operator,
+        allow_none=True,
+        help="Operator that translates boresight pointing into detector frame",
+    )
+
+    weights = Unicode(
+        "crosslinking_weights", help="Observation detdata key for output weights"
+    )
+
+    temporary_signal = Unicode(
+        "crosslinking_temp", help="Observation detdata key for temp signal"
+    )
+
+    det_data_units = Unit(
+        defaults.det_data_units, help="Output units if creating detector data"
+    )
+
+    @traitlets.validate("detector_pointing")
+    def _check_detector_pointing(self, proposal):
+        detpointing = proposal["value"]
+        if detpointing is not None:
+            if not isinstance(detpointing, Operator):
+                raise traitlets.TraitError(
+                    "detector_pointing should be an Operator instance"
+                )
+            # Check that this operator has the traits we expect
+            for trt in [
+                "det_mask",
+                "quats",
+            ]:
+                if not detpointing.has_trait(trt):
+                    msg = f"detector_pointing operator should have a '{trt}' trait"
+                    raise traitlets.TraitError(msg)
+        return detpointing
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    @function_timer
+    def _exec(self, data, detectors=None, use_accel=None, **kwargs):
+
+        # Compute the detector quaternions
+        self.detector_pointing.apply(data, detectors=detectors)
+        quats_name = self.detector_pointing.quats
+
+        for obs in data.obs:
+            dets = obs.select_local_detectors(
+                detectors, flagmask=self.detector_pointing.det_mask
+            )
+            exists_signal = obs.detdata.ensure(
+                self.temporary_signal, detectors=dets, create_units=self.det_data_units
+            )
+            exists_weights = obs.detdata.ensure(
+                self.weights, sample_shape=(3,), detectors=dets
+            )
+
+            for det in dets:
+                signal = obs.detdata[self.temporary_signal][det]
+                signal[:] = 1
+                weights = obs.detdata[self.weights][det]
+                quat = obs.detdata[quats_name][det]
+
+                # Measure the scan direction wrt the local meridian for each sample
+                theta, phi, _ = qa.to_iso_angles(quat)
+                theta = np.pi / 2 - theta
+
+                # Scan direction across the reference sample
+                dphi = np.roll(phi, -1) - np.roll(phi, 1)
+                dtheta = np.roll(theta, -1) - np.roll(theta, 1)
+
+                # Except first and last sample
+                for dx, x in (dphi, phi), (dtheta, theta):
+                    dx[0] = x[1] - x[0]
+                    dx[-1] = x[-1] - x[-2]
+
+                # Scale dphi to on-sky
+                dphi *= np.cos(theta)
+
+                # Avoid overflows
+                tiny = np.abs(dphi) < 1e-30
+                if np.any(tiny):
+                    ang = np.zeros(signal.size)
+                    ang[tiny] = np.sign(dtheta[tiny]) * np.sign(dphi[tiny]) * np.pi / 2
+                    not_tiny = np.logical_not(tiny)
+                    ang[not_tiny] = np.arctan(dtheta[not_tiny] / dphi[not_tiny])
+                else:
+                    ang = np.arctan(dtheta / dphi)
+
+                weights[:] = np.vstack(
+                    [np.ones(signal.size), np.cos(2 * ang), np.sin(2 * ang)]
+                ).T
+
+    def _finalize(self, data, **kwargs):
+        return
+
+    def _requires(self):
+        req = self.detector_pointing.requires()
+        return req
+
+    def _provides(self):
+        prov = self.detector_pointing.provides()
+        prov["detdata"].append(self.temporary_signal)
+        prov["detdata"].append(self.weights)
+        return prov
+
+
+@trait_docs
 class CrossLinking(Operator):
     """Evaluate an ACT-style crosslinking map
 
@@ -89,18 +205,21 @@ class CrossLinking(Operator):
         help="Write output data products to this directory",
     )
 
+    crosslinking_map = Unicode(
+        "crosslinking_map",
+        help="The output Data object for the crosslinking map",
+    )
+
+    noise_model = Unicode(
+        "uniform_noise_weights",
+        help="The output noise model with uniform weights",
+    )
+
     sync_type = Unicode(
         "alltoallv", help="Communication algorithm: 'allreduce' or 'alltoallv'"
     )
 
     save_pointing = Bool(False, help="If True, do not clear pixel numbers after use")
-
-    # FIXME: these should be made into traits and also placed in _provides().
-
-    signal = "dummy_signal"
-    weights = "crosslinking_weights"
-    crosslinking_map = "crosslinking_map"
-    noise_model = "uniform_noise_weights"
 
     @traitlets.validate("det_mask")
     def _check_det_mask(self, proposal):
@@ -142,58 +261,6 @@ class CrossLinking(Operator):
         super().__init__(**kwargs)
 
     @function_timer
-    def _get_weights(self, obs_data, det):
-        """Evaluate the special pointing matrix"""
-
-        obs = obs_data.obs[0]
-        exists_signal = obs.detdata.ensure(
-            self.signal, detectors=[det], create_units=self.det_data_units
-        )
-        exists_weights = obs.detdata.ensure(
-            self.weights, sample_shape=(3,), detectors=[det]
-        )
-
-        signal = obs.detdata[self.signal][det]
-        signal[:] = 1
-        weights = obs.detdata[self.weights][det]
-        # Compute the detector quaternions
-        self.pixel_pointing.detector_pointing.apply(obs_data, detectors=[det])
-        quat = obs.detdata[self.pixel_pointing.detector_pointing.quats][det]
-        # measure the scan direction wrt the local meridian for each sample
-        theta, phi, _ = qa.to_iso_angles(quat)
-        theta = np.pi / 2 - theta
-        # scan direction across the reference sample
-        dphi = np.roll(phi, -1) - np.roll(phi, 1)
-        dtheta = np.roll(theta, -1) - np.roll(theta, 1)
-        # except first and last sample
-        for dx, x in (dphi, phi), (dtheta, theta):
-            dx[0] = x[1] - x[0]
-            dx[-1] = x[-1] - x[-2]
-        # scale dphi to on-sky
-        dphi *= np.cos(theta)
-        # Avoid overflows
-        tiny = np.abs(dphi) < 1e-30
-        if np.any(tiny):
-            ang = np.zeros(signal.size)
-            ang[tiny] = np.sign(dtheta[tiny]) * np.sign(dphi[tiny]) * np.pi / 2
-            not_tiny = np.logical_not(tiny)
-            ang[not_tiny] = np.arctan(dtheta[not_tiny] / dphi[not_tiny])
-        else:
-            ang = np.arctan(dtheta / dphi)
-
-        weights[:] = np.vstack(
-            [np.ones(signal.size), np.cos(2 * ang), np.sin(2 * ang)]
-        ).T
-
-        return
-
-    def _purge_weights(self, obs):
-        """Discard special pointing matrix and dummy signal"""
-        del obs.detdata[self.signal]
-        del obs.detdata[self.weights]
-        return
-
-    @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
 
@@ -205,13 +272,16 @@ class CrossLinking(Operator):
         if data.comm.world_rank == 0:
             os.makedirs(self.output_dir, exist_ok=True)
 
+        # When pipelining our operations below, ensure that detector pointing
+        # uses the same mask that the user requested in this operator.
+        save_pointing_det_mask = self.pixel_pointing.detector_pointing.det_mask
+
         # Establish uniform noise weights
         noise_model = UniformNoise()
         for obs in data.obs:
             obs[self.noise_model] = noise_model
 
         # To accumulate, we need the pixel distribution.
-
         if self.pixel_dist not in data:
             pix_dist = BuildPixelDistribution(
                 pixel_dist=self.pixel_dist,
@@ -223,17 +293,23 @@ class CrossLinking(Operator):
             log.info_rank("Caching pixel distribution", comm=data.comm.comm_world)
             pix_dist.apply(data)
 
-        # Accumulation operator
+        # Weights
+        cross_weights = CrossLinkingWeights(
+            detector_pointing=self.pixel_pointing.detector_pointing,
+            det_data_units=self.det_data_units,
+        )
 
+        # Accumulation operator
         build_zmap = BuildNoiseWeighted(
             pixel_dist=self.pixel_dist,
             zmap=self.crosslinking_map,
             view=self.pixel_pointing.view,
             pixels=self.pixel_pointing.pixels,
-            weights=self.weights,
+            weights=cross_weights.weights,
             noise_model=self.noise_model,
-            det_data=self.signal,
+            det_data=cross_weights.temporary_signal,
             det_data_units=self.det_data_units,
+            det_mask=self.det_mask,
             det_flags=self.det_flags,
             det_flag_mask=self.det_flag_mask,
             shared_flags=self.shared_flags,
@@ -241,34 +317,37 @@ class CrossLinking(Operator):
             sync_type=self.sync_type,
         )
 
-        for obs in data.obs:
-            obs_data = data.select(obs_uid=obs.uid)
-            dets = obs.select_local_detectors(detectors, flagmask=self.det_flag_mask)
-            for det in dets:
-                # Pointing weights
-                self._get_weights(obs_data, det)
-                # Pixel numbers
-                self.pixel_pointing.apply(obs_data, detectors=[det])
-                # Accumulate
-                build_zmap.exec(obs_data, detectors=[det])
+        # Cleanup
+        cleanup = Delete(
+            detdata=[cross_weights.weights, cross_weights.temporary_signal],
+        )
 
-        build_zmap.finalize(data)
+        # Our accumulation pipeline
+        accum_pipe = Pipeline(
+            detector_sets=["SINGLE"],
+            operators=[
+                cross_weights,
+                self.pixel_pointing,
+                build_zmap,
+                cleanup,
+            ]
+        )
+        accum_pipe.apply(data, detectors=detectors)
+
+        # Restore detector pointing mask if it was different
+        self.pixel_pointing.detector_pointing.det_mask = save_pointing_det_mask
+
+    def _finalize(self, data, **kwargs):
+        log = Logger.get()
 
         # Write out the results
-
         fname = os.path.join(self.output_dir, f"{self.name}.fits")
         data[self.crosslinking_map].write(fname)
         log.info_rank(f"Wrote crosslinking to {fname}", comm=data.comm.comm_world)
+
+        # Cleanup
         data[self.crosslinking_map].clear()
         del data[self.crosslinking_map]
-
-        for obs in data.obs:
-            self._purge_weights(obs)
-
-        return
-
-    def _finalize(self, data, **kwargs):
-        return
 
     def _requires(self):
         req = self.pixel_pointing.detector_pointing.requires()

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -298,7 +298,7 @@ class Demodulate(Operator):
             n_local = len(obs.local_detectors)
             n_local_good = np.sum(
                 [
-                    1 for x, y in obs.local_detector_flags.items() 
+                    1 for x, y in obs.local_detector_flags.items()
                     if y & self.det_mask == 0
                 ]
             )

--- a/src/toast/ops/gainscrambler.py
+++ b/src/toast/ops/gainscrambler.py
@@ -72,8 +72,12 @@ class GainScrambler(Operator):
             focalplane = obs.telescope.focalplane
 
             # key1 = realization * 2^32 + telescope * 2^16 + component
-            key1 = self.realization * 4294967296 + telescope * 65536 + self.component
-            key2 = sindx
+            key1 = (
+                int(self.realization) * 4294967296
+                + int(telescope) * 65536
+                + int(self.component)
+            )
+            key2 = int(sindx)
             counter1 = 0
             counter2 = 0
 

--- a/src/toast/ops/mapmaker_solve.py
+++ b/src/toast/ops/mapmaker_solve.py
@@ -643,8 +643,7 @@ def solve(
     # The proposal
     # d = s
     for k, v in proposal.items():
-        if v.local is not None:
-            v.local[:] = precond[k].local
+        v.local[:] = precond[k].local
 
     # Set LHS amplitude inputs to this proposal
     lhs_op.template_matrix.amplitudes = proposal_key
@@ -681,8 +680,7 @@ def solve(
         # x += alpha * d
         temp.reset()
         for k, v in temp.items():
-            if v.local is not None:
-                v.local[:] = proposal[k].local
+            v.local[:] = proposal[k].local
         temp *= alpha
         result += temp
         # print(f"{comm.rank} LHS {iter}:  new result = {result}", flush=True)
@@ -691,8 +689,7 @@ def solve(
         # r -= alpha * q
         temp.reset()
         for k, v in temp.items():
-            if v.local is not None:
-                v.local[:] = lhs_out[k].local
+            v.local[:] = lhs_out[k].local
         temp *= alpha
         residual -= temp
         # print(f"{comm.rank} LHS {iter}:  new residual = {residual}", flush=True)

--- a/src/toast/ops/scan_alm.py
+++ b/src/toast/ops/scan_alm.py
@@ -19,8 +19,7 @@ from .. import qarray as qa
 from ..observation import default_values as defaults
 from ..pixels import PixelData, PixelDistribution
 from ..timing import Timer, function_timer
-from ..traits import (Bool, Instance, Int, List, Quantity, Unicode, Unit,
-                      trait_docs)
+from ..traits import Bool, Instance, Int, List, Quantity, Unicode, Unit, trait_docs
 from ..utils import Logger
 from .operator import Operator
 from .pipeline import Pipeline
@@ -143,29 +142,79 @@ class ScanAlm(Operator):
         return weights
 
     def _get_sorted_dets(self, data, detectors=None):
+        """Pass through the data, grouping valid detectors.
+
+        For each observation, group valid detectors according to one or more
+        focalplane column values.  In the calling code, we must collectively
+        iterate over unique combinations of these values.  To make that
+        easier, we group things by a top-level key that is a combination of
+        these values.  The syntax of the returned value is:
+
+        {
+            <unique fp value combination string>: {
+                "key_value": <fp key / values as a dict>,
+                "obs": {
+                    <obs UID>: <list of detectors>,
+                    <obs UID>: <list of detectors>,
+                    ...
+                }
+            },
+            ...
+        }
+
+        """
+        dets_sorted = dict()
+
         if self.focalplane_keys is None:
-            dets_sorted = [ [], [] ]
+            dets_sorted["ALL"] = {"key_value": None, "obs": dict()}
             for ob in data.obs:
-                dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
-                for det in dets:
-                    dets_sorted[-2].append(ob.name)
-                    dets_sorted[-1].append(det)
-            dets_sorted = sorted(zip(*dets_sorted))
+                dets = ob.select_local_detectors(
+                    selection=detectors, flagmask=self.det_mask
+                )
+                dets_sorted["ALL"]["obs"][ob.uid] = [str(x) for x in dets]
         else:
-            dets_sorted = [[] for i in range(2 + len(self.focalplane_keys.split(",")))]
-            # Loop over all observations and local detectors, sort dets according to focalplane_keys
+            fp_keys = self.focalplane_keys.split(",")
             for ob in data.obs:
                 focalplane = ob.telescope.focalplane
-                dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
+                dets = ob.select_local_detectors(
+                    selection=detectors, flagmask=self.det_mask
+                )
                 for det in dets:
-                    for ikey, key in enumerate(self.focalplane_keys.split(",")):
+                    key_seq = []
+                    key_value = {}
+                    for ikey, key in enumerate(fp_keys):
                         if key not in focalplane.detector_data.keys():
                             msg = f"{key} is not in the focalplane during {ob.name}"
                             raise KeyError(msg)
-                        dets_sorted[ikey].append(str(focalplane[det][key]))
-                    dets_sorted[-2].append(ob.name)
-                    dets_sorted[-1].append(det)
-            dets_sorted = sorted(zip(*dets_sorted))
+                        key_seq.append(key)
+                        key_value[key] = str(focalplane[det][key])
+                    key_str = ":".join(key_seq)
+                    if key_str not in dets_sorted:
+                        dets_sorted[key_str] = {"key_value": key_value, "obs": dict()}
+                    if ob.uid not in dets_sorted[key_str]["obs"]:
+                        dets_sorted[key_str]["obs"][ob.uid] = list()
+                    dets_sorted[key_str]["obs"][ob.uid].append(str(det))
+
+        # Find the global set of key / value strings
+        if data.comm.comm_world is None:
+            all_key_str = list(sorted(dets_sorted.keys()))
+        else:
+            local_key_str = list(dets_sorted.keys())
+            proc_key_str = data.comm.comm_world.gather(local_key_str, root=0)
+            all_key_str = None
+            if data.comm.world_rank == 0:
+                all_key_str = set()
+                for pdata in proc_key_str:
+                    for kstr in pdata:
+                        all_key_str.add(kstr)
+                all_key_str = list(sorted(all_key_str))
+            all_key_str = data.comm.comm_world.bcast(all_key_str, root=0)
+
+        # Ensure we have the same top-level keys on all processes
+        for kstr in all_key_str:
+            if kstr not in dets_sorted:
+                dets_sorted[kstr] = {"key_value": {}, "obs": dict()}
+
         return dets_sorted
 
     def _parse_alm(self):
@@ -185,17 +234,24 @@ class ScanAlm(Operator):
 
     @function_timer
     def _load_alm(self, data, file_name, focalplane_key_value=None):
-        """Load, broadcast and save sky a_lm in shared memory"""
+        """Load, broadcast and save sky a_lm in shared memory.
+
+        This operation is collective on the world communicator.  All process groups
+        must work with the same sky a_lm at the same time.
+
+        """
 
         world_comm = data.comm.comm_world
         world_rank = data.comm.world_rank
 
-        #for file_name in self.file_names:
+        # for file_name in self.file_names:
         dtype = complex  # totalconvolve requires dtype=complex
         if self.focalplane_keys is not None:
             # When self.focalplane_keys is set, each group may process
-            # differnt input maps. Therefore the alms can't be shared.
-            self.alm = hp.read_alm(file_name.format(**focalplane_key_value), hdu=(1, 2, 3)).astype(dtype)
+            # different input maps. Therefore the alms can't be shared.
+            self.alm = hp.read_alm(
+                file_name.format(**focalplane_key_value), hdu=(1, 2, 3)
+            ).astype(dtype)
             alm_shape = self.alm.shape
             lmax = hp.Alm.getlmax(self.alm[0].size)
         else:
@@ -274,7 +330,7 @@ class ScanAlm(Operator):
                 msg = f"Unsupported Stokes component: {stokes}"
                 raise RuntimeError(msg)
 
-            phi[phi<0] += 2*np.pi
+            phi[phi < 0] += 2 * np.pi
             pointing = np.vstack([theta, phi, psi]).T
             signal += interpolator.interpol(pointing).ravel() * stokes_weights
 
@@ -282,7 +338,12 @@ class ScanAlm(Operator):
 
     @function_timer
     def _cache_blm(self, data):
-        """Derive polarized and unpolarized beam expansions"""
+        """Derive polarized and unpolarized beam expansions.
+
+        This operation is collective on the world communicator.  All process groups
+        must work with the same beam a_lm at the same time.
+
+        """
 
         world_comm = data.comm.comm_world
         world_rank = data.comm.world_rank
@@ -345,13 +406,19 @@ class ScanAlm(Operator):
         self.interpolators = []
         for file_name in self.file_names:
             self._load_alm(data, file_name, focalplane_key_value)
+
             if self._blm_I is None:
+                # Cache the constant beam a_lm globally
                 self._cache_blm(data)
+
             interpolators = {}
             for stokes in "I", "QU":
                 if stokes == "I":
                     kmax = 0  # Symmetric, unpolarized beam
-                    if focalplane_key_value is None and data.comm.comm_world is not None:
+                    if (
+                        focalplane_key_value is None
+                        and data.comm.comm_world is not None
+                    ):
                         alm_ref = np.atleast_2d(self.alm.data[0])
                     else:
                         alm_ref = np.atleast_2d(self.alm[0])
@@ -361,7 +428,10 @@ class ScanAlm(Operator):
                         blm = self._blm_I
                 elif stokes == "QU":
                     kmax = 2  # Symmetric, polarized beams
-                    if focalplane_key_value is None and data.comm.comm_world is not None:
+                    if (
+                        focalplane_key_value is None
+                        and data.comm.comm_world is not None
+                    ):
                         alm_ref = self.alm.data
                     else:
                         alm_ref = self.alm
@@ -382,7 +452,6 @@ class ScanAlm(Operator):
             if focalplane_key_value is None and data.comm.comm_world is not None:
                 self.alm.close()
             del self.alm
-        return
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -390,7 +459,6 @@ class ScanAlm(Operator):
     @function_timer
     def _exec(self, data, detectors=None, **kwargs):
         log = Logger.get()
-        gcomm = data.comm.comm_group
 
         if not ducc_available:
             msg = "ScanAlm requires ducc0"
@@ -403,15 +471,19 @@ class ScanAlm(Operator):
 
         self._parse_alm()
         self._parse_detdata_keys()
-        self._blm_I = None
+
+        # lmax will be set by the first sky a_lm that is loaded.
         self.lmax = None
 
-        dets_sorted = self._get_sorted_dets(data, detectors)
-        if self.focalplane_keys is None:
-            self._cache_interpolators(data)
+        # Mark beam a_lm as not yet loaded, so that it can be loaded after the
+        # first sky a_lm is loaded.  This way the lmax is known.
+        self._blm_I = None
 
+        # Ensure that our output detector data exists.
         for ob in data.obs:
-            dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
+            dets = ob.select_local_detectors(
+                selection=detectors, flagmask=self.det_mask
+            )
             for key in self.det_data_keys:
                 # If our output detector data does not yet exist, create it
                 exists_data = ob.detdata.ensure(
@@ -420,44 +492,39 @@ class ScanAlm(Operator):
                 if self.zero:
                     ob.detdata[key].reset()
 
-        # Loop over all observations and local detectors, sampling each alm
-        timer = Timer()
-        timer.start()
-        ndet = len(dets_sorted)
-        prev_fp = None
-        for idet, fp_ob_det in enumerate(dets_sorted):
-            ob_name = fp_ob_det[-2]
-            ob_data = data.select(obs_name=ob_name)
-            ob = ob_data.obs[0]
-            det = fp_ob_det[-1]
-            fp = fp_ob_det[:-2]
-            if self.focalplane_keys is not None and fp != prev_fp:
-                # Clean up the interpolators
-                if prev_fp is not None:
-                    log.info(f"Group {data.comm.group:4} : Done detectors with {focalplane_key_value}")
-                    del self.interpolators
-                focalplane_key_value = {}
-                for ikey, key in enumerate(self.focalplane_keys.split(",")):
-                    focalplane_key_value[key] = fp_ob_det[ikey]
-                self._cache_interpolators(data, focalplane_key_value)
-                prev_fp = fp
-                log.info(f"Group {data.comm.group:4} : Done building interpolator with {focalplane_key_value}")
+        # Get the list of all valid detectors for each observation, organized
+        # by focalplane values.
+        dets_sorted = self._get_sorted_dets(data, detectors=detectors)
 
-            theta, phi, weights = self._get_pointing(ob_data, det)
-            for ialm in range(len(self.file_names)):
-                if len(self.det_data_keys) == 1:
-                    det_data_key = self.det_data_keys[0]
-                else:
-                    det_data_key = self.det_data_keys[ialm]
-                interpolators = self.interpolators[ialm]
-                sig = self._scan_alms(interpolators, theta, phi, weights)
-                if self.subtract:
-                    ob.detdata[det_data_key][det] -= sig
-                else:
-                    ob.detdata[det_data_key][det] += sig
-                del interpolators, sig, theta, phi, weights
-            if idet % 1000 == 0:
-                log.debug(f"Group {data.comm.group:4} : {idet}/{ndet} detectors finished")
+        # Loop over unique focalplane key / value combinations.  All processes
+        # Do this loop collectively, even if they have no observations or detectors
+        # that match this combination.
+        for key_val_str, props in dets_sorted.items():
+            self._cache_interpolators(data, focalplane_key_value=props["key_value"])
+
+            # Loop over all observations and local detectors, sampling each alm.
+            for obs_uid, det_list in props["obs"].items():
+                ob_data = data.select(obs_uid=obs_uid)
+                the_obs = ob_data.obs[0]
+                for idet, det in enumerate(det_list):
+                    theta, phi, weights = self._get_pointing(ob_data, det)
+                    for ialm in range(len(self.file_names)):
+                        if len(self.det_data_keys) == 1:
+                            det_data_key = self.det_data_keys[0]
+                        else:
+                            det_data_key = self.det_data_keys[ialm]
+                        interpolators = self.interpolators[ialm]
+                        sig = self._scan_alms(interpolators, theta, phi, weights)
+                        if self.subtract:
+                            the_obs.detdata[det_data_key][det] -= sig
+                        else:
+                            the_obs.detdata[det_data_key][det] += sig
+                        del interpolators, sig, theta, phi, weights
+                # Report progress after each observation for each key_value combination.
+                # this is collective on the group communicator- remember each group is
+                # working on the same observation list.
+                msg = f"ScanAlm: finished {key_val_str} for {the_obs.name}"
+                log.debug_rank(msg, comm=data.comm.comm_group)
 
         # Clean up
         del self.interpolators
@@ -465,12 +532,12 @@ class ScanAlm(Operator):
             del self._blm_I
             del self._blm_P
         else:
-            self._blm_I.close()
+            if self._blm_I is not None:
+                self._blm_I.close()
             del self._blm_I
-            self._blm_P.close()
+            if self._blm_P is not None:
+                self._blm_P.close()
             del self._blm_P
-
-        return
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/ops/sim_cosmic_rays.py
+++ b/src/toast/ops/sim_cosmic_rays.py
@@ -162,7 +162,7 @@ class InjectCosmicRays(Operator):
 
             obstime_seconds = size / samplerate
             n_events_expected = self.eventrate * obstime_seconds
-            key1 = self.realization * 4294967296 + telescope * 65536
+            key1 = int(self.realization) * 4294967296 + int(telescope) * 65536
             counter2 = 0
 
             for kk, det in enumerate(dets):

--- a/src/toast/ops/sim_gaindrifts.py
+++ b/src/toast/ops/sim_gaindrifts.py
@@ -121,7 +121,7 @@ class GainDrifter(Operator):
         for ob in data.obs:
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(detectors)
-            
+
             comm = ob.comm.comm_group
             rank = ob.comm.group_rank
             # Make sure detector data output exists
@@ -141,7 +141,9 @@ class GainDrifter(Operator):
 
             if self.drift_mode == "linear_drift":
                 key1 = (
-                    self.realization * 4294967296 + telescope * 65536 + self.component
+                    int(self.realization) * 4294967296
+                    + int(telescope) * 65536
+                    + int(self.component)
                 )
                 counter2 = 0
 
@@ -195,9 +197,9 @@ class GainDrifter(Operator):
                     # only if the mismatch !=0
                     if self.detector_mismatch != 0:
                         key1 = (
-                            self.realization * 429496123345
-                            + telescope * 6512345
-                            + self.component
+                            int(self.realization) * 429496123345
+                            + int(telescope) * 6512345
+                            + int(self.component)
                         )
                         counter1 = detindx
                         counter2 = 0

--- a/src/toast/ops/sim_hwp.py
+++ b/src/toast/ops/sim_hwp.py
@@ -172,8 +172,8 @@ class PerturbHWP(Operator):
             ntotal = obs.n_all_samples
 
             # Get an RNG seed
-            key1 = self.realization * 1543343 + obs.telescope.uid
-            key2 = obs.session.uid
+            key1 = int(self.realization) * 1543343 + int(obs.telescope.uid)
+            key2 = int(obs.session.uid)
             counter1 = 0
 
             # The times and hwp_angle are shared among columns of the process

--- a/src/toast/ops/sim_tod_atm.py
+++ b/src/toast/ops/sim_tod_atm.py
@@ -420,7 +420,9 @@ class SimAtmosphere(Operator):
                 raise RuntimeError(msg)
 
             # Get the detectors we are using for this observation
-            dets = ob.select_local_detectors(detectors, flagmask=self.det_mask)
+            dets = ob.select_local_detectors(
+                selection=detectors, flagmask=self.det_mask
+            )
 
             tmr = Timer()
             tmr.start()
@@ -434,10 +436,6 @@ class SimAtmosphere(Operator):
                 detectors=dets,
                 create_units=self.det_data_units,
             )
-
-            if len(dets) == 0:
-                # Nothing to do for this observation
-                continue
 
             # Check that our view is fully covered by detector pointing.  If the
             # detector_pointing view is None, then it has all samples.  If our own
@@ -520,10 +518,6 @@ class SimAtmosphere(Operator):
         weather = obs.telescope.site.weather
         bandpass = obs.telescope.focalplane.bandpass
 
-        if absorption_key is None and loading_key is None:
-            # Nothing to do
-            return
-
         generate_absorption = False
         if absorption_key is not None:
             if absorption_key in obs:
@@ -533,6 +527,9 @@ class SimAtmosphere(Operator):
                         break
             else:
                 generate_absorption = True
+
+        if comm is not None:
+            generate_absorption = comm.allreduce(generate_absorption, op=MPI.LOR)
 
         generate_loading = False
         if loading_key is not None:
@@ -544,9 +541,8 @@ class SimAtmosphere(Operator):
             else:
                 generate_loading = True
 
-        if (not generate_loading) and (not generate_absorption):
-            # Nothing to do for these detectors
-            return
+        if comm is not None:
+            generate_loading = comm.allreduce(generate_loading, op=MPI.LOR)
 
         if generate_loading:
             if loading_key in obs:
@@ -563,13 +559,23 @@ class SimAtmosphere(Operator):
         # The focalplane likely has groups of detectors whose bandpass spans
         # the same frequency range.  First we build this grouping.
 
-        freq_groups = dict()
+        local_freq_groups = dict()
         for det in dets:
             dfmin, dfmax = bandpass.get_range(det=det)
             fkey = f"{dfmin} {dfmax}"
-            if fkey not in freq_groups:
-                freq_groups[fkey] = list()
-            freq_groups[fkey].append(det)
+            if fkey not in local_freq_groups:
+                local_freq_groups[fkey] = list()
+            local_freq_groups[fkey].append(det)
+        if comm is None:
+            freq_groups = local_freq_groups
+        else:
+            proc_groups = comm.gather(local_freq_groups, root=0)
+            freq_groups = None
+            if comm.rank == 0:
+                freq_groups = dict()
+                for pgroup in proc_groups:
+                    freq_groups.update(pgroup)
+            freq_groups = comm.bcast(freq_groups, root=0)
 
         # Work on each frequency group of detectors.  Collectively use the
         # processes in the group to do the calculation.

--- a/src/toast/ops/sim_tod_atm_generate.py
+++ b/src/toast/ops/sim_tod_atm_generate.py
@@ -370,7 +370,7 @@ class GenerateAtmosphere(Operator):
             f"{log_prefix}Will simulate atmosphere in {ncone} concentric cones. "
             f"Scale factor between cones is {scale}. "
             f"First cone ranges from R={rmin_tot}m to R={rmin_tot * scale}m. "
-            f"Last cone ranges from R={rmin_tot * scale**(ncone-1)}m to R={rmax_tot}. "
+            f"Last cone ranges from R={rmin_tot * scale ** (ncone - 1)}m to R={rmax_tot}. "
             f"Smallest volume element: {xstep_min} x {ystep_min} x {zstep_min}. "
             f"Largest volume element: {self.xstep} x {self.ystep} x {self.zstep}. ",
             comm=comm,
@@ -485,10 +485,12 @@ class GenerateAtmosphere(Operator):
         session = obs.session.uid
 
         # site UID in higher bits, telescope UID in lower bits
-        key1 = site * 2**32 + telescope
+        key1 = int(site) * 2**32 + int(telescope)
 
         # Observation UID in higher bits, realization and component in lower bits
-        key2 = session * 2**32 + self.realization * 2**16 + self.component
+        key2 = (
+            int(session) * 2**32 + int(self.realization) * 2**16 + int(self.component)
+        )
 
         # This tracks the number of cones simulated due to the wind speed.
         counter1 = 0
@@ -558,8 +560,10 @@ class GenerateAtmosphere(Operator):
                 while istop < len(times) and times[istop] < tmax:
                     istop += 1
                 # Extend the scan to the next turnaround, if we have them
-                if self.turnaround_interval is not None \
-                   and len(obs.intervals[self.turnaround_interval]) > 0:
+                if (
+                    self.turnaround_interval is not None
+                    and len(obs.intervals[self.turnaround_interval]) > 0
+                ):
                     iturn = 0
                     while iturn < len(obs.intervals[self.turnaround_interval]) - 1 and (
                         times[istop]
@@ -803,7 +807,7 @@ class GenerateAtmosphere(Operator):
 
         if self.debug_snapshots:
             fn = os.path.join(
-                outdir, f"atm_{obsname}_{rank}_" f"t_{int(tmin)}_{int(tmax)}.pck"
+                outdir, f"atm_{obsname}_{rank}_t_{int(tmin)}_{int(tmax)}.pck"
             )
             with open(fn, "wb") as fout:
                 pickle.dump([azgrid, elgrid, my_snapshots], fout)

--- a/src/toast/ops/sss.py
+++ b/src/toast/ops/sss.py
@@ -152,8 +152,10 @@ class SimScanSynchronousSignal(Operator):
         telescope = obs.telescope.uid
         site = obs.telescope.site.uid
         sindx = obs.session.uid
-        key1 = self.realization * 2**32 + telescope * 2**16 + self.component
-        key2 = site * 2**16 + sindx
+        key1 = (
+            int(self.realization) * 2**32 + int(telescope) * 2**16 + int(self.component)
+        )
+        key2 = int(site) * 2**16 + int(sindx)
         counter1 = 0
         counter2 = 0
         return key1, key2, counter1, counter2

--- a/src/toast/ops/time_constant.py
+++ b/src/toast/ops/time_constant.py
@@ -113,7 +113,7 @@ class TimeConstant(Operator):
             # randomize tau in a reproducible manner
             counter1 = obs.session.uid
             counter2 = self.realization
-            key1 = focalplane[det]["uid"]
+            key1 = int(focalplane[det]["uid"])
             key2 = 123456
 
             x = rng.random(

--- a/src/toast/ops/yield_cut.py
+++ b/src/toast/ops/yield_cut.py
@@ -99,18 +99,18 @@ class YieldCut(Operator):
             exists = obs.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=dets)
             new_flags = dict()
             for det in dets:
-                key1 = obs.telescope.uid
+                key1 = int(obs.telescope.uid)
                 if self.fixed:
                     key2 = 0
                     counter1 = 0
                 else:
-                    key2 = self.realization
-                    counter1 = obs.session.uid
+                    key2 = int(self.realization)
+                    counter1 = int(obs.session.uid)
                 if self.focalplane_key is not None:
                     value = focalplane[det][self.focalplane_key]
-                    counter2 = name_UID(value)
+                    counter2 = int(name_UID(value))
                 else:
-                    counter2 = focalplane[det]["UID"]
+                    counter2 = int(focalplane[det]["UID"])
                 x = rng.random(
                     1,
                     sampler="uniform_01",

--- a/src/toast/pixels_io_healpix.py
+++ b/src/toast/pixels_io_healpix.py
@@ -216,9 +216,9 @@ def read_healpix(filename, *args, **kwargs):
         header = dict(dset.attrs)
         if "ORDERING" not in header or header["ORDERING"] not in ["NESTED", "RING"]:
             raise RuntimeError("Cannot determine pixel ordering")
-        if header["ORDERING"] == "NESTED" and nest == False:
+        if header["ORDERING"] == "NESTED" and not nest:
             mapdata = hp.reorder(mapdata, n2r=True)
-        elif header["ORDERING"] == "RING" and nest == True:
+        elif header["ORDERING"] == "RING" and nest:
             mapdata = hp.reorder(mapdata, r2n=True)
         f.close()
 
@@ -228,7 +228,7 @@ def read_healpix(filename, *args, **kwargs):
         if mapdata.shape[0] == 1:
             mapdata = mapdata[0]
 
-        if "h" in kwargs and kwargs["h"] == True:
+        if "h" in kwargs and kwargs["h"]:
             result = mapdata, header
         else:
             result = mapdata
@@ -272,7 +272,7 @@ def write_healpix(filename, mapdata, nside_submap=16, *args, **kwargs):
         n_pix_submap = 12 * nside_submap**2
 
         mode = "w-"
-        if "overwrite" in kwargs and kwargs["overwrite"] == True:
+        if "overwrite" in kwargs and kwargs["overwrite"]:
             mode = "w"
         elif os.path.isfile(filename):
             raise FileExistsError(f"'{filename}' exists and `overwrite` is False")
@@ -291,7 +291,7 @@ def write_healpix(filename, mapdata, nside_submap=16, *args, **kwargs):
             raise ValueError("HDF5 does not support column_names")
 
         ordering = "RING"
-        if "nest" in kwargs and kwargs["nest"] == True:
+        if "nest" in kwargs and kwargs["nest"]:
             ordering = "NESTED"
 
         coord = None
@@ -303,7 +303,7 @@ def write_healpix(filename, mapdata, nside_submap=16, *args, **kwargs):
             units = kwargs["column_units"]
             # Only one units attribute is supported
             if not isinstance(units, str):
-                msg = f"ERROR: HDF5 map units must be a single string, "
+                msg = "ERROR: HDF5 map units must be a single string, "
                 msg += f"not {units}"
                 raise RuntimeError(msg)
 

--- a/src/toast/pixels_io_healpix.py
+++ b/src/toast/pixels_io_healpix.py
@@ -228,7 +228,7 @@ def read_healpix(filename, *args, **kwargs):
         if mapdata.shape[0] == 1:
             mapdata = mapdata[0]
 
-        if "h" in kwargs and kwargs["h"]:
+        if "h" in kwargs and kwargs["h"] == True:  #noqa
             result = mapdata, header
         else:
             result = mapdata

--- a/src/toast/spt3g/spt3g_export.py
+++ b/src/toast/spt3g/spt3g_export.py
@@ -242,18 +242,18 @@ class export_obs_meta(object):
         # Construct observation frame
         ob = c3g.G3Frame(c3g.G3FrameType.Observation)
         ob["observation_name"] = c3g.G3String(obs.name)
-        ob["observation_uid"] = c3g.G3Int(obs.uid)
+        ob["observation_uid"] = c3g.G3Int(int(obs.uid))
         ob["observation_detector_sets"] = c3g.G3VectorVectorString(
             obs.all_detector_sets
         )
         ob["observation_detector_flags"] = json.dumps(obs.local_detector_flags)
         ob["telescope_name"] = c3g.G3String(obs.telescope.name)
         ob["telescope_class"] = c3g.G3String(object_fullname(obs.telescope.__class__))
-        ob["telescope_uid"] = c3g.G3Int(obs.telescope.uid)
+        ob["telescope_uid"] = c3g.G3Int(int(obs.telescope.uid))
         site = obs.telescope.site
         ob["site_name"] = c3g.G3String(site.name)
         ob["site_class"] = c3g.G3String(object_fullname(site.__class__))
-        ob["site_uid"] = c3g.G3Int(site.uid)
+        ob["site_uid"] = c3g.G3Int(int(site.uid))
         if isinstance(site, GroundSite):
             ob["site_lat_deg"] = c3g.G3Double(site.earthloc.lat.to_value(u.degree))
             ob["site_lon_deg"] = c3g.G3Double(site.earthloc.lon.to_value(u.degree))
@@ -268,7 +268,7 @@ class export_obs_meta(object):
                     else:
                         ob["site_weather_max_pwv"] = c3g.G3Double(site.weather.max_pwv)
                     ob["site_weather_time"] = to_g3_time(site.weather.time.timestamp())
-                    ob["site_weather_uid"] = c3g.G3Int(site.weather.site_uid)
+                    ob["site_weather_uid"] = c3g.G3Int(int(site.weather.site_uid))
                     ob["site_weather_use_median"] = c3g.G3Bool(
                         site.weather.median_weather
                     )
@@ -276,7 +276,7 @@ class export_obs_meta(object):
         if session is not None:
             ob["session_name"] = c3g.G3String(session.name)
             ob["session_class"] = c3g.G3String(object_fullname(session.__class__))
-            ob["session_uid"] = c3g.G3Int(session.uid)
+            ob["session_uid"] = c3g.G3Int(int(session.uid))
             if session.start is None:
                 ob["session_start"] = c3g.G3String("NONE")
             else:

--- a/src/toast/templates/amplitudes.py
+++ b/src/toast/templates/amplitudes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 by the parties listed in the AUTHORS file.
+# Copyright (c) 2015-2026 by the parties listed in the AUTHORS file.
 # All rights reserved.  Use of this source code is governed by
 # a BSD-style license that can be found in the LICENSE file.
 
@@ -20,8 +20,6 @@ from ..accelerator import (
 )
 from ..mpi import MPI
 from ..utils import (
-    AlignedF32,
-    AlignedF64,
     AlignedI32,
     AlignedU8,
     Logger,
@@ -159,24 +157,16 @@ class Amplitudes(AcceleratorObject):
             self._global_last = self._local_indices[-1]
 
         # Allocate memory
-        if self._n_local == 0:
-            self._raw = None
-            self.local = None
-        else:
-            self._raw = self._storage_class.zeros(self._n_local)
-            self.local = self._raw.array()
+        self._raw = self._storage_class.zeros(self._n_local)
+        self.local = self._raw.array()
 
         # Support flagging of template amplitudes.  This can be used to flag some
         # amplitudes if too many timestream samples contributing to the amplitude value
         # are bad.  We will be passing these flags to compiled code, and there
         # is no way easy way to do this using numpy bool and C++ bool.  So we waste
         # a bit of memory and use a whole byte per amplitude.
-        if self._n_local == 0:
-            self._raw_flags = None
-            self.local_flags = None
-        else:
-            self._raw_flags = AlignedU8.zeros(self._n_local)
-            self.local_flags = self._raw_flags.array()
+        self._raw_flags = AlignedU8.zeros(self._n_local)
+        self.local_flags = self._raw_flags.array()
 
     def clear(self):
         """Delete the underlying memory.
@@ -190,20 +180,14 @@ class Amplitudes(AcceleratorObject):
             self.accel_delete()
         if hasattr(self, "local"):
             del self.local
-            self.local = None
         if hasattr(self, "local_flags"):
             del self.local_flags
-            self.local_flags = None
         if hasattr(self, "_raw"):
-            if self._raw is not None:
-                self._raw.clear()
+            self._raw.clear()
             del self._raw
-            self._raw = None
         if hasattr(self, "_raw_flags"):
-            if self._raw_flags is not None:
-                self._raw_flags.clear()
+            self._raw_flags.clear()
             del self._raw_flags
-            self._raw_flags = None
 
     def __del__(self):
         self.clear()
@@ -219,7 +203,7 @@ class Amplitudes(AcceleratorObject):
             oval = value.local
         else:
             oval = value
-        if self.local is None:
+        if self._n_local == 0:
             if oval is None:
                 return True
             else:
@@ -231,43 +215,40 @@ class Amplitudes(AcceleratorObject):
     # have been zeroed out.
 
     @staticmethod
-    def _math_validate(local, other):
+    def _math_validate(cur, other):
         if isinstance(other, Amplitudes):
-            if local is None and other.local is not None:
-                msg = f"Cannot combine non-None Amplitudes {other}"
-                raise RuntimeError(msg)
-            if local is not None and other.local is None:
-                msg = f"Cannot combine None Amplitudes {other}"
+            if cur._n_local != other._n_local:
+                msg = "Cannot combine amplitudes with different n_local"
                 raise RuntimeError(msg)
             return other.local
         else:
             # Arithmetic with numeric values
-            if local is not None and other is None:
+            if cur._n_local > 0 and other is None:
                 msg = "Cannot combine with None value"
                 raise RuntimeError(msg)
             return other
 
     def __iadd__(self, other):
-        oval = self._math_validate(self.local, other)
-        if self.local is not None:
+        oval = self._math_validate(self, other)
+        if self._n_local > 0:
             self.local[:] += oval
         return self
 
     def __isub__(self, other):
-        oval = self._math_validate(self.local, other)
-        if self.local is not None:
+        oval = self._math_validate(self, other)
+        if self._n_local > 0:
             self.local[:] -= oval
         return self
 
     def __imul__(self, other):
-        oval = self._math_validate(self.local, other)
-        if self.local is not None:
+        oval = self._math_validate(self, other)
+        if self._n_local > 0:
             self.local[:] *= oval
         return self
 
     def __itruediv__(self, other):
-        oval = self._math_validate(self.local, other)
-        if self.local is not None:
+        oval = self._math_validate(self, other)
+        if self._n_local > 0:
             self.local[:] /= oval
         return self
 
@@ -293,7 +274,7 @@ class Amplitudes(AcceleratorObject):
 
     def reset(self):
         """Set all amplitude values to zero."""
-        if self.local is None:
+        if self._n_local == 0:
             return
         self.local[:] = 0
         if self.accel_exists():
@@ -301,7 +282,7 @@ class Amplitudes(AcceleratorObject):
 
     def reset_flags(self):
         """Set all flag values to zero."""
-        if self.local_flags is None:
+        if self._n_local == 0:
             return
         self.local_flags[:] = 0
         if self.accel_exists():
@@ -327,9 +308,8 @@ class Amplitudes(AcceleratorObject):
             # not used inside the solver loop.
             self.accel_update_host()
             restore = True
-        if self.local is not None:
+        if self._n_local > 0:
             ret.local[:] = self.local
-        if self.local_flags is not None:
             ret.local_flags[:] = self.local_flags
         if restore:
             self.accel_update_device()
@@ -354,7 +334,7 @@ class Amplitudes(AcceleratorObject):
     @property
     def n_local_flagged(self):
         """The number of local amplitudes that are flagged."""
-        if self.local_flags is None:
+        if self._n_local == 0:
             return 0
         else:
             return np.count_nonzero(self.local_flags)
@@ -436,7 +416,7 @@ class Amplitudes(AcceleratorObject):
                 send_buffer[:] = 0
                 if (
                     (self._global_last >= comm_offset)
-                    and self.local is not None
+                    and self._n_local > 0
                     and (self._global_first < comm_offset + n_comm)
                 ):
                     # We have some overlap
@@ -525,7 +505,7 @@ class Amplitudes(AcceleratorObject):
             else:
                 if (
                     (self._global_last >= comm_offset)
-                    and self.local is not None
+                    and self._n_local > 0
                     and (self._global_first < comm_offset + n_comm)
                 ):
                     self.local[local_selected] = recv_buffer[buffer_selected]
@@ -580,7 +560,7 @@ class Amplitudes(AcceleratorObject):
         if (self._local_ranges is None) and (self._local_indices is None):
             # Every process has a unique set of amplitudes.  Reduce the local
             # dot products.
-            if self.local is None:
+            if self._n_local == 0:
                 local_result = 0
             else:
                 local_result = np.dot(
@@ -621,7 +601,7 @@ class Amplitudes(AcceleratorObject):
 
             if (
                 (self._global_last >= comm_offset)
-                and self.local is not None
+                and self._n_local > 0
                 and (self._global_first < comm_offset + n_comm)
             ):
                 # We have some overlap
@@ -704,7 +684,7 @@ class Amplitudes(AcceleratorObject):
 
             if (
                 (self._global_last >= comm_offset)
-                and self.local is not None
+                and self._n_local > 0
                 and (self._global_first < comm_offset + n_comm)
             ):
                 # Compute local dot product of just our assigned, unflagged elements
@@ -741,7 +721,7 @@ class Amplitudes(AcceleratorObject):
         return result
 
     def _accel_exists(self):
-        if self.local is None:
+        if self._n_local == 0:
             return False
         if use_accel_omp:
             return accel_data_present(
@@ -755,7 +735,7 @@ class Amplitudes(AcceleratorObject):
             return False
 
     def _accel_create(self, zero_out=False):
-        if self.local is None:
+        if self._n_local == 0:
             return
         if use_accel_omp:
             _ = accel_data_create(self._raw, name=self._accel_name, zero_out=zero_out)
@@ -767,7 +747,7 @@ class Amplitudes(AcceleratorObject):
             self.local_flags = accel_data_create(self.local_flags, zero_out=zero_out)
 
     def _accel_update_device(self):
-        if self.local is None:
+        if self._n_local == 0:
             return
         if use_accel_omp:
             _ = accel_data_update_device(self._raw, name=self._accel_name)
@@ -777,7 +757,7 @@ class Amplitudes(AcceleratorObject):
             self.local_flags = accel_data_update_device(self.local_flags)
 
     def _accel_update_host(self):
-        if self.local is None:
+        if self._n_local == 0:
             return
         if use_accel_omp:
             _ = accel_data_update_host(self._raw, name=self._accel_name)
@@ -787,7 +767,7 @@ class Amplitudes(AcceleratorObject):
             self.local_flags = accel_data_update_host(self.local_flags)
 
     def _accel_delete(self):
-        if self.local is None:
+        if self._n_local == 0:
             return
         if use_accel_omp:
             _ = accel_data_delete(self._raw, name=self._accel_name)
@@ -797,7 +777,7 @@ class Amplitudes(AcceleratorObject):
             self.local_flags = accel_data_delete(self.local_flags)
 
     def _accel_reset_local(self):
-        if self.local is None:
+        if self._n_local == 0:
             return
         # if not self.accel_in_use():
         #     return
@@ -807,7 +787,7 @@ class Amplitudes(AcceleratorObject):
             accel_data_reset(self.local)
 
     def _accel_reset_local_flags(self):
-        if self.local is None:
+        if self._n_local == 0:
             return
         # if not self.accel_in_use():
         #     return
@@ -1010,7 +990,7 @@ class AmplitudesMap(MutableMapping, AcceleratorObject):
             return False
         elif result != len(self._internal):
             log = Logger.get()
-            msg = f"Only some of the Amplitudes exist on device"
+            msg = "Only some of the Amplitudes exist on device"
             log.error(msg)
             raise RuntimeError(msg)
         return True

--- a/src/toast/templates/offset/offset.py
+++ b/src/toast/templates/offset/offset.py
@@ -735,6 +735,7 @@ class Offset(Template):
         implementation, use_accel = self.select_kernels(use_accel=use_accel)
 
         amp_offset = self._det_start[detector]
+
         for iob, ob in enumerate(self.data.obs):
             if detector not in self._obs_dets[iob]:
                 continue
@@ -1129,20 +1130,26 @@ class Offset(Template):
         for iob, ob in enumerate(self.data.obs):
             if ob.name not in obs_det_amps:
                 # There were no good amplitudes in this observation
-                continue
-            obs_local_amps = obs_det_amps[ob.name]
-            if self.data.comm.group_size == 1:
-                all_obs_amps = [obs_local_amps]
+                obs_local_amps = dict()
             else:
-                all_obs_amps = self.data.comm.comm_group.gather(obs_local_amps, root=0)
+                obs_local_amps = obs_det_amps[ob.name]
+            if self.data.comm.group_size == 1:
+                proc_obs_amps = [obs_local_amps]
+            else:
+                proc_obs_amps = self.data.comm.comm_group.gather(obs_local_amps, root=0)
 
             if self.data.comm.group_rank == 0:
                 out_file = f"{out}_{ob.name}.h5"
                 det_names = set()
-                for pdata in all_obs_amps:
-                    for k in pdata.keys():
-                        if k != "bounds":
-                            det_names.add(k)
+                all_obs_amps = list()
+                for pdata in proc_obs_amps:
+                    if len(pdata) > 0:
+                        for k in pdata.keys():
+                            if k != "bounds":
+                                det_names.add(k)
+                        all_obs_amps.append(pdata)
+                if len(all_obs_amps) == 0:
+                    continue
                 det_names = list(sorted(det_names))
                 n_det = len(det_names)
                 amp_first = all_obs_amps[0]["bounds"]["amp_first"]

--- a/src/toast/templates/periodic.py
+++ b/src/toast/templates/periodic.py
@@ -205,14 +205,6 @@ class Periodic(Template):
 
         # Now we know the total number of local amplitudes.
 
-        if offset == 0:
-            # This means that no observations included the shared key
-            # we are using.
-            msg = f"Data has no observations with key '{self.key}'."
-            msg += "  You should disable this template."
-            log.error(msg)
-            raise RuntimeError(msg)
-
         self._n_local = offset
         if new_data.comm.comm_world is None:
             self._n_global = self._n_local
@@ -491,6 +483,8 @@ class Periodic(Template):
             with h5py.File(out, "w") as hf:
                 for obname, obamps in obs_det_amps.items():
                     n_det = len(obamps)
+                    if n_det == 0:
+                        continue
                     det_list = list(sorted(obamps.keys()))
                     det_indx = {y: x for x, y in enumerate(det_list)}
                     indx_to_det = {det_indx[x]: x for x in det_list}

--- a/src/toast/tests/helpers/ground.py
+++ b/src/toast/tests/helpers/ground.py
@@ -94,6 +94,7 @@ def create_ground_data(
     single_group=False,
     flagged_pixels=True,
     flagged_obs=True,
+    flagged_proc=True,
     schedule_hours=2,
 ):
     """Create a data object with a simple ground sim.
@@ -213,6 +214,18 @@ def create_ground_data(
     if flagged_obs:
         for iob, ob in enumerate(data.obs):
             if iob % 2 != 0:
+                det_flags = dict()
+                for det in ob.local_detectors:
+                    det_flags[det] = defaults.det_mask_invalid
+                ob.update_local_detector_flags(det_flags)
+
+    if flagged_proc and toastcomm.group_size > 1:
+        # Take the last process and flag all its detectors
+        for ob in data.obs:
+            if ob.comm.group_rank == ob.comm.group_size - 1:
+                msg = f"{ob.name} g{ob.comm.group}:p{ob.comm.group_rank} "
+                msg += "cutting all dets"
+                print(msg, flush=True)
                 det_flags = dict()
                 for det in ob.local_detectors:
                     det_flags[det] = defaults.det_mask_invalid

--- a/src/toast/tests/helpers/ground.py
+++ b/src/toast/tests/helpers/ground.py
@@ -95,6 +95,7 @@ def create_ground_data(
     flagged_pixels=True,
     flagged_obs=True,
     flagged_proc=True,
+    flagged_proc_first=False,
     schedule_hours=2,
 ):
     """Create a data object with a simple ground sim.
@@ -220,12 +221,13 @@ def create_ground_data(
                 ob.update_local_detector_flags(det_flags)
 
     if flagged_proc and toastcomm.group_size > 1:
-        # Take the last process and flag all its detectors
+        if flagged_proc_first:
+            flag_rank = 0
+        else:
+            flag_rank = ob.comm.group_size - 1
+        # Take the one process and flag all its detectors
         for ob in data.obs:
-            if ob.comm.group_rank == ob.comm.group_size - 1:
-                msg = f"{ob.name} g{ob.comm.group}:p{ob.comm.group_rank} "
-                msg += "cutting all dets"
-                print(msg, flush=True)
+            if ob.comm.group_rank == flag_rank:
                 det_flags = dict()
                 for det in ob.local_detectors:
                     det_flags[det] = defaults.det_mask_invalid

--- a/src/toast/tests/helpers/space.py
+++ b/src/toast/tests/helpers/space.py
@@ -127,6 +127,8 @@ def create_satellite_data(
     width=5.0 * u.degree,
     single_group=False,
     flagged_pixels=True,
+    flagged_obs=True,
+    flagged_proc=True,
     freqs=None,
 ):
     """Create a data object with a simple satellite sim.
@@ -152,6 +154,10 @@ def create_satellite_data(
     if flagged_pixels:
         # We are going to flag half the pixels
         pixel_per_process *= 2
+
+    if flagged_obs:
+        # We are going to flag all detectors in half the observations
+        obs_per_group *= 2
 
     tele = create_space_telescope(
         toastcomm.group_size,
@@ -201,6 +207,23 @@ def create_satellite_data(
                 if idet % 2 != 0:
                     det_flags[det] = defaults.det_mask_invalid
             ob.update_local_detector_flags(det_flags)
+
+    if flagged_obs:
+        for iob, ob in enumerate(data.obs):
+            if iob % 2 != 0:
+                det_flags = dict()
+                for det in ob.local_detectors:
+                    det_flags[det] = defaults.det_mask_invalid
+                ob.update_local_detector_flags(det_flags)
+
+    if flagged_proc and toastcomm.group_size > 1:
+        # Take the last process and flag all its detectors
+        for ob in data.obs:
+            if ob.comm.group_rank == ob.comm.group_size - 1:
+                det_flags = dict()
+                for det in ob.local_detectors:
+                    det_flags[det] = defaults.det_mask_invalid
+                ob.update_local_detector_flags(det_flags)
 
     return data
 
@@ -270,7 +293,7 @@ def create_satellite_data_big(
     # angles to achieve a more compact hit map.
     sim_sat = ops.SimSatellite(
         name="sim_sat",
-        telescope=tele,
+        telescope=new_telescope,
         schedule=sch,
         hwp_angle=defaults.hwp_angle,
         hwp_rpm=10.0,

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -14,6 +14,7 @@ from ..config import build_config
 from ..data import Data
 from ..io import load_hdf5, save_hdf5, VolumeIndex
 from ..noise import Noise
+from ..observation import default_values as defaults
 from ..utils import replace_byte_arrays, array_equal
 from ..weather import Weather
 from .helpers import (
@@ -191,6 +192,8 @@ class IoHdf5Test(MPITestCase):
                 pixel_per_process=ppp,
                 split=split,
                 sample_rate=2.0 * u.Hz,
+                hwp_rpm=5.0,
+                schedule_hours=2,
                 **kwargs,
             )
 
@@ -412,6 +415,109 @@ class IoHdf5Test(MPITestCase):
         del check_data
 
         close_data(data)
+
+    def test_save_load_demod(self):
+        rank = 0
+        if self.comm is not None:
+            rank = self.comm.rank
+
+        toptestdir = os.path.join(self.outdir, "save_load_demod")
+        if rank == 0:
+            os.makedirs(toptestdir)
+        if self.comm is not None:
+            self.comm.barrier()
+
+        for opt, ddir in [(False, "flag_last"), (True, "flag_first")]:
+            datadir = os.path.join(toptestdir, ddir)
+
+            # We use a single group, so that even when running on 2 processes
+            # of the processes will have all detectors flagged.
+            data, config = self.create_data(
+                split=True,
+                single_group=True,
+                flagged_proc=True,
+                flagged_proc_first=opt,
+            )
+
+            # Pointing model for demodulation
+            detpointing_azel = ops.PointingDetectorSimple(
+                boresight=defaults.boresight_radec,
+                shared_flag_mask=0,
+            )
+            demod_weights_in = ops.StokesWeights(
+                weights="demod_weights_in",
+                mode="IQU",
+                hwp_angle=defaults.hwp_angle,
+                detector_pointing=detpointing_azel,
+            )
+
+            # Purge all but one noise model before demodulation
+            ops.Delete(meta=["noise_model", "alt_noise_model"]).apply(data)
+
+            # Demodulate the data.  The resulting detdata object will be empty
+            # for processes that have no good detectors in the input.  This way
+            # we can test save / load of data where a process has no detectors
+            # at all (not just detectors that are all flagged).
+            ops.Demodulate(
+                stokes_weights=demod_weights_in,
+                mode="IQU",
+                hwp_angle=defaults.hwp_angle,
+                noise_model="el_weighted",
+                in_place=True,
+            ).apply(data)
+
+            # Index for later comparison
+            original = dict()
+            for iob, ob in enumerate(data.obs):
+                original[ob.name] = iob
+
+            for tdir, comp, detdata_fields in zip(
+                ["nocomp", "comp"],
+                ["No", "Yes"],
+                [
+                    ["signal", "flags"],
+                    [
+                        ("signal", {"quanta": 1.0e-12}),
+                        ("flags", {}),
+                    ],
+                ],
+            ):
+                volume = os.path.join(datadir, tdir)
+                if rank == 0:
+                    os.makedirs(volume)
+                if self.comm is not None:
+                    self.comm.barrier()
+
+                saver = ops.SaveHDF5(
+                    volume=volume,
+                    detdata=detdata_fields,
+                    volume_index=None,
+                    verify=True,
+                )
+                saver.apply(data)
+
+                if data.comm.comm_world is not None:
+                    data.comm.comm_world.barrier()
+
+                check_data = Data(data.comm)
+                loader = ops.LoadHDF5(volume=volume)
+                loader.apply(check_data)
+
+                # Verify
+                for ob in check_data.obs:
+                    orig = data.obs[original[ob.name]]
+                    if not orig.__eq__(ob, approx=True):
+                        print(f"FAIL on demodulated roundtrip, comp={comp}", flush=True)
+                        print(
+                            f"-------- Proc {data.comm.world_rank} ---------\n{orig}\n{ob}"
+                        )
+                        self.assertTrue(False)
+                del check_data
+
+                if data.comm.comm_world is not None:
+                    data.comm.comm_world.barrier()
+
+            close_data(data)
 
     def test_save_load_session_dirs(self):
         rank = 0

--- a/src/toast/tests/io_hdf5.py
+++ b/src/toast/tests/io_hdf5.py
@@ -13,6 +13,7 @@ from .. import ops as ops
 from ..config import build_config
 from ..data import Data
 from ..io import load_hdf5, save_hdf5, VolumeIndex
+from ..noise import Noise
 from ..utils import replace_byte_arrays, array_equal
 from ..weather import Weather
 from .helpers import (
@@ -228,6 +229,15 @@ class IoHdf5Test(MPITestCase):
         # Create a noise model from focalplane detector properties
         default_model = ops.DefaultNoiseModel()
         default_model.apply(data)
+
+        # Make a copy of the noise model to a base Noise object, in order
+        # to test roundtrip of that object.
+        for ob in data.obs:
+            ob["alt_noise_model"] = Noise(
+                detectors=ob["noise_model"].detectors,
+                freqs=ob["noise_model"]._freqs,
+                psds=ob["noise_model"]._psds,
+            )
 
         if space:
             # Simulate noise and accumulate to signal
@@ -557,7 +567,11 @@ class IoHdf5Test(MPITestCase):
         # Version 1 did not save per-detector flags in the observation to HDF5,
         # so we disable them for this test.
         data, config = self.create_data(
-            split=True, no_meta=True, flagged_pixels=False, flagged_obs=False
+            split=True,
+            no_meta=True,
+            flagged_pixels=False,
+            flagged_obs=False,
+            flagged_proc=False,
         )
         det_data_names = ["signal", "flags", "alt_signal"]
         det_data_fields = [

--- a/src/toast/tests/observation.py
+++ b/src/toast/tests/observation.py
@@ -505,12 +505,6 @@ class ObservationTest(MPITestCase):
             dets = obs.local_detectors
             n_det = len(dets)
 
-            # Delete some problematic intervals that prevent us from getting a
-            # round-trip result that matches the original
-            del obs.intervals["throw_leftright"]
-            del obs.intervals["throw_rightleft"]
-            del obs.intervals["throw"]
-
             # Create some shared objects over the whole comm
             local_array = None
             if obs.comm.group_rank == 0:

--- a/src/toast/tests/ops_extend_flags.py
+++ b/src/toast/tests/ops_extend_flags.py
@@ -124,9 +124,10 @@ class FlagGapsTest(MPITestCase):
             import matplotlib.pyplot as plt
 
             for ob in data.obs:
-                det = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)[
-                    0
-                ]
+                dets = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)
+                if len(dets) == 0:
+                    continue
+                det = dets[0]
                 n_all_samp = ob.n_all_samples
                 n_plot = 2
                 fig_height = 6 * n_plot
@@ -230,9 +231,10 @@ class FlagGapsTest(MPITestCase):
             import matplotlib.pyplot as plt
 
             for ob in data.obs:
-                det = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)[
-                    0
-                ]
+                dets = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)
+                if len(dets) == 0:
+                    continue
+                det = dets[0]
                 n_all_samp = ob.n_all_samples
                 n_plot = 2
                 fig_height = 6 * n_plot

--- a/src/toast/tests/ops_madam.py
+++ b/src/toast/tests/ops_madam.py
@@ -35,7 +35,7 @@ class MadamTest(MPITestCase):
             return
 
         # Create a fake satellite data set for testing
-        data = create_satellite_data(self.comm)
+        data = create_satellite_data(self.comm, flagged_proc=False)
 
         # Create some detector pointing matrices
         detpointing = ops.PointingDetectorSimple()

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -25,7 +25,7 @@ from .helpers import (
     create_satellite_data,
     create_ground_data,
 )
-from .mpi import MPITestCase
+from .mpi import MPITestCase, MPI
 
 
 class MapmakerTest(MPITestCase):
@@ -959,7 +959,10 @@ class MapmakerTest(MPITestCase):
 
         # Create a fake satellite data set for testing
         data = create_satellite_data(
-            self.comm, obs_per_group=self.obs_per_group, obs_time=10.0 * u.minute
+            self.comm,
+            obs_per_group=self.obs_per_group,
+            obs_time=10.0 * u.minute,
+            flagged_proc=False,
         )
 
         # Create some sky signal timestreams.
@@ -1196,6 +1199,10 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
+            if np.any(diff_hits):
+                print("FAIL on band pre hits", flush=True)
+                fail = True
+
             if self.make_plots:
                 outfile = os.path.join(testdir, "madam_hits.png")
                 hp.mollview(madam_hits, xsize=1600, nest=True)
@@ -1241,8 +1248,11 @@ class MapmakerTest(MPITestCase):
 
             good = madam_hits > 0
             bad = np.logical_not(good)
+            unseen = madam_map == hp.UNSEEN
+            toast_map[unseen] = 0
+            madam_map[unseen] = 0
             diff_map = toast_map - madam_map
-            diff_map[:, bad] = np.nan
+            diff_map[:, bad] = 0
 
             for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
                 if self.make_plots:
@@ -1262,7 +1272,7 @@ class MapmakerTest(MPITestCase):
                     fail = True
 
         if data.comm.comm_world is not None:
-            fail = data.comm.comm_world.bcast(fail, root=0)
+            fail = data.comm.comm_world.allreduce(fail, op=MPI.LOR)
 
         self.assertFalse(fail)
 
@@ -1279,7 +1289,10 @@ class MapmakerTest(MPITestCase):
 
         # Create a fake satellite data set for testing
         data = create_satellite_data(
-            self.comm, obs_per_group=self.obs_per_group, obs_time=10.0 * u.minute
+            self.comm,
+            obs_per_group=self.obs_per_group,
+            obs_time=10.0 * u.minute,
+            flagged_proc=False,
         )
 
         # Create some sky signal timestreams.
@@ -1543,6 +1556,10 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
+            if np.any(diff_hits):
+                print("FAIL on band pre hits", flush=True)
+                fail = True
+
             if self.make_plots:
                 outfile = os.path.join(testdir, "madam_hits.png")
                 hp.mollview(madam_hits, xsize=1600, nest=True)
@@ -1588,8 +1605,11 @@ class MapmakerTest(MPITestCase):
 
             good = madam_hits > 0
             bad = np.logical_not(good)
+            unseen = madam_map == hp.UNSEEN
+            toast_map[unseen] = 0
+            madam_map[unseen] = 0
             diff_map = toast_map - madam_map
-            diff_map[:, bad] = np.nan
+            diff_map[:, bad] = 0
 
             for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
                 if self.make_plots:
@@ -1608,7 +1628,7 @@ class MapmakerTest(MPITestCase):
                     fail = True
 
         if data.comm.comm_world is not None:
-            fail = data.comm.comm_world.bcast(fail, root=0)
+            fail = data.comm.comm_world.allreduce(fail, op=MPI.LOR)
 
         self.assertFalse(fail)
 
@@ -1627,7 +1647,10 @@ class MapmakerTest(MPITestCase):
 
         # Create a fake satellite data set for testing
         data = create_satellite_data(
-            self.comm, obs_per_group=self.obs_per_group, obs_time=10.0 * u.minute
+            self.comm,
+            obs_per_group=self.obs_per_group,
+            obs_time=10.0 * u.minute,
+            flagged_proc=False,
         )
 
         # Create some sky signal timestreams.
@@ -1762,7 +1785,7 @@ class MapmakerTest(MPITestCase):
         pars = {}
         pars["kfirst"] = "T"
         pars["basis_order"] = 0
-        pars["iter_max"] = 100
+        pars["iter_max"] = 50
         pars["base_first"] = step_seconds
         pars["fsample"] = sample_rate
         pars["nside_map"] = pixels.nside
@@ -1894,6 +1917,10 @@ class MapmakerTest(MPITestCase):
             madam_hits = hp.read_map(madam_hit_path, field=None, nest=True)
             diff_hits = toast_hits - madam_hits
 
+            if np.any(diff_hits):
+                print("FAIL on band pre hits", flush=True)
+                fail = True
+
             if self.make_plots:
                 outfile = os.path.join(testdir, "madam_hits.png")
                 hp.mollview(madam_hits, xsize=1600, nest=True)
@@ -1939,8 +1966,12 @@ class MapmakerTest(MPITestCase):
 
             good = madam_hits > 0
             bad = np.logical_not(good)
+            unseen = madam_map == hp.UNSEEN
+            toast_map[unseen] = 0
+            madam_map[unseen] = 0
+
             diff_map = toast_map - madam_map
-            diff_map[:, bad] = np.nan
+            diff_map[:, bad] = 0
 
             for stokes, ststr in zip(range(3), ["I", "Q", "U"]):
                 if self.make_plots:
@@ -1949,6 +1980,8 @@ class MapmakerTest(MPITestCase):
                     plt.savefig(outfile)
                     plt.close()
 
+                diff_stokes = diff_map[stokes][good]
+                rel_stokes = diff_stokes / madam_map[stokes][good]
                 if not np.allclose(
                     toast_map[stokes][good],
                     madam_map[stokes][good],
@@ -1956,10 +1989,12 @@ class MapmakerTest(MPITestCase):
                     rtol=0.05,
                 ):
                     print(f"FAIL on band pre {ststr}", flush=True)
+                    print(f"Max diff = {np.amax(np.absolute(diff_stokes))}", flush=True)
+                    print(f"Max rel = {np.amax(np.absolute(rel_stokes))}", flush=True)
                     fail = True
 
         if data.comm.comm_world is not None:
-            fail = data.comm.comm_world.bcast(fail, root=0)
+            fail = data.comm.comm_world.allreduce(fail, op=MPI.LOR)
 
         self.assertFalse(fail)
 

--- a/src/toast/tests/ops_mapmaker_binning.py
+++ b/src/toast/tests/ops_mapmaker_binning.py
@@ -135,7 +135,7 @@ class MapmakerBinningTest(MPITestCase):
 
         np.random.seed(123456)
         # Create a fake satellite data set for testing
-        data = create_satellite_data(self.comm)
+        data = create_satellite_data(self.comm, flagged_proc=False)
 
         # Create an uncorrelated noise model from focalplane detector properties
         default_model = ops.DefaultNoiseModel(noise_model="noise_model")

--- a/src/toast/tests/ops_mapmaker_solve.py
+++ b/src/toast/tests/ops_mapmaker_solve.py
@@ -113,7 +113,7 @@ class MapmakerSolveTest(MPITestCase):
         check_binned = data[binner.binned]
 
         # Verify that the binned map elements agree
-        np.testing.assert_allclose(rhs_binned.raw.array(), check_binned.raw.array())
+        np.testing.assert_allclose(rhs_binned.data, check_binned.data)
 
         # Scan the binned map and subtract from the original detector data.
         pixels.apply(data)

--- a/src/toast/tests/ops_pointing_detector.py
+++ b/src/toast/tests/ops_pointing_detector.py
@@ -51,7 +51,7 @@ class PointingDetectorTest(MPITestCase):
 
         for ob in data.obs:
             np.testing.assert_array_equal(
-                ob.detdata[defaults.quats], ob.detdata["pyquat"]
+                ob.detdata[defaults.quats].data, ob.detdata["pyquat"].data
             )
 
         rank = 0

--- a/src/toast/tests/ops_polyfilter.py
+++ b/src/toast/tests/ops_polyfilter.py
@@ -278,7 +278,10 @@ class PolyFilterTest(MPITestCase):
         for obs in data.obs:
             fp = obs.telescope.focalplane.detector_data
             ndet = len(fp)
-            fp.add_column(Column(name="wafer", length=ndet, dtype=int))
+            if "wafer" in fp.colnames:
+                fp.replace_column("wafer", Column(name="wafer", length=ndet, dtype=int))
+            else:
+                fp.add_column(Column(name="wafer", length=ndet, dtype=int))
             for idet, det in enumerate(fp["name"]):
                 fp[idet]["wafer"] = det.endswith("A")
 

--- a/src/toast/tests/ops_sim_tod_conviqt.py
+++ b/src/toast/tests/ops_sim_tod_conviqt.py
@@ -321,8 +321,6 @@ class SimConviqtTest(MPITestCase):
         toast_hits_path = os.path.join(self.outdir, "toast_hits.fits")
         data[cov_and_hits.hits].write(toast_hits_path)
 
-        fail = False
-
         if self.rank == 0:
             hitsfile = os.path.join(self.outdir, "toast_hits.fits")
 
@@ -453,7 +451,6 @@ class SimConviqtTest(MPITestCase):
         toast_hits_path = os.path.join(self.outdir, "toast_hits.fits")
         data[cov_and_hits.hits].write(toast_hits_path)
 
-        fail = False
         if self.rank == 0:
             mapfile = os.path.join(self.outdir, f"toast_bin.{key1}.fits")
             mdata = hp.read_map(mapfile, field=range(3))
@@ -569,7 +566,6 @@ class SimConviqtTest(MPITestCase):
         toast_hits_path = os.path.join(self.outdir, "toast_hits.fits")
         data[cov_and_hits.hits].write(toast_hits_path)
 
-        fail = False
         if self.rank == 0:
             import matplotlib.pyplot as plt
 
@@ -769,7 +765,7 @@ class SimConviqtTest(MPITestCase):
         data_wo_hwp[cov_and_hits_wo_hwp.hits].write(toast_hits_path)
         toast_hits_path = os.path.join(self.outdir, "toast_hits_w_hwp.fits")
         data_w_hwp[cov_and_hits_w_hwp.hits].write(toast_hits_path)
-        fail = False
+
         if self.rank == 0:
             import matplotlib.pyplot as plt
 

--- a/src/toast/tests/ops_time_constant.py
+++ b/src/toast/tests/ops_time_constant.py
@@ -65,7 +65,7 @@ class TimeConstantTest(MPITestCase):
         for ob in data.obs:
             nsamp = ob.n_local_samples
             mid = nsamp // 2
-            for det in ob.local_detectors:
+            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
                 sig = ob.detdata[defaults.det_data][det]
                 peak = np.amax(sig)
                 peak_loc = np.argmax(sig)

--- a/src/toast/tests/template_fourier2d.py
+++ b/src/toast/tests/template_fourier2d.py
@@ -46,8 +46,7 @@ class TemplateFourier2DTest(MPITestCase):
 
         # Project.
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.add_to_signal(det, amps)
+            tmpl.add_to_signal(det, amps)
 
         # Verify
         if self.comm is None or self.comm.rank == 0:
@@ -58,8 +57,7 @@ class TemplateFourier2DTest(MPITestCase):
 
         # Accumulate amplitudes
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.project_signal(det, amps)
+            tmpl.project_signal(det, amps)
 
         # Verify
         # FIXME...

--- a/src/toast/tests/template_offset.py
+++ b/src/toast/tests/template_offset.py
@@ -55,9 +55,9 @@ class TemplateOffsetTest(MPITestCase):
         amps.local[:] = 1.0
 
         # Project.
+        ops.Reset(detdata=[defaults.det_data]).apply(data)
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.add_to_signal(det, amps)
+            tmpl.add_to_signal(det, amps)
 
         # Verify
         for ob in data.obs:
@@ -66,8 +66,7 @@ class TemplateOffsetTest(MPITestCase):
 
         # Accumulate amplitudes
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.project_signal(det, amps)
+            tmpl.project_signal(det, amps)
 
         # Verify
         for ob in data.obs:
@@ -143,13 +142,11 @@ class TemplateOffsetTest(MPITestCase):
 
         # Project.
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.add_to_signal(det, amps, use_accel=True)
+            tmpl.add_to_signal(det, amps, use_accel=True)
 
         # Accumulate amplitudes
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.project_signal(det, amps, use_accel=True)
+            tmpl.project_signal(det, amps, use_accel=True)
 
         data.accel_update_host(data_names)
         amps.accel_update_host()
@@ -343,24 +340,20 @@ class TemplateOffsetTest(MPITestCase):
 
         # Project.
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.add_to_signal(det, amps)
+            tmpl.add_to_signal(det, amps)
         for det in pytmpl.detectors():
-            for ob in data.obs:
-                pytmpl.add_to_signal(det, pyamps)
+            pytmpl.add_to_signal(det, pyamps)
 
         for ob in data.obs:
             np.testing.assert_allclose(
-                ob.detdata[defaults.det_data], ob.detdata["pydata"]
+                ob.detdata[defaults.det_data].data, ob.detdata["pydata"].data
             )
 
         # Accumulate amplitudes
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.project_signal(det, amps)
+            tmpl.project_signal(det, amps)
         for det in pytmpl.detectors():
-            for ob in data.obs:
-                pytmpl.project_signal(det, pyamps)
+            pytmpl.project_signal(det, pyamps)
 
         # Verify
         np.testing.assert_allclose(amps.local, pyamps.local)

--- a/src/toast/tests/template_periodic.py
+++ b/src/toast/tests/template_periodic.py
@@ -523,8 +523,11 @@ class TemplatePeriodicTest(MPITestCase):
         if data.comm.world_rank == 0 and self.make_plots:
             perplot(pfile, out_root=pplot_root)
             for ob in data.obs:
+                amp_file = f"{oroot}_{ob.name}.h5"
+                if not os.path.isfile(amp_file):
+                    continue
                 offplot(
-                    f"{oroot}_{ob.name}.h5",
+                    amp_file,
                     compare={x: ob.detdata["input"][x, :] for x in ob.local_detectors},
                     out=f"{oroot}_{ob.name}",
                 )
@@ -724,8 +727,11 @@ class TemplatePeriodicTest(MPITestCase):
         if data.comm.world_rank == 0 and self.make_plots:
             perplot(pfile, out_root=pplot_root)
             for ob in data.obs:
+                amp_file = f"{oroot}_{ob.name}.h5"
+                if not os.path.isfile(amp_file):
+                    continue
                 offplot(
-                    f"{oroot}_{ob.name}.h5",
+                    amp_file,
                     compare={x: ob.detdata["input"][x, :] for x in ob.local_detectors},
                     out=f"{oroot}_{ob.name}",
                 )

--- a/src/toast/tests/template_subharmonic.py
+++ b/src/toast/tests/template_subharmonic.py
@@ -46,8 +46,7 @@ class TemplateSubHarmonicTest(MPITestCase):
 
         # Project.
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.add_to_signal(det, amps)
+            tmpl.add_to_signal(det, amps)
 
         # Verify
         if self.comm is None or self.comm.rank == 0:
@@ -58,8 +57,7 @@ class TemplateSubHarmonicTest(MPITestCase):
 
         # Accumulate amplitudes
         for det in tmpl.detectors():
-            for ob in data.obs:
-                tmpl.project_signal(det, amps)
+            tmpl.project_signal(det, amps)
 
         # Verify
         # FIXME...

--- a/src/toast/utils.py
+++ b/src/toast/utils.py
@@ -642,19 +642,13 @@ def name_UID(name, int64=False):
     try:
         ind = int.from_bytes(bdet, byteorder="little")
         if int64:
-            uid = int(ind & 0x7FFFFFFFFFFFFFFF)
+            uid = np.uint64(ind & 0x7FFFFFFFFFFFFFFF)
         else:
-            # FIXME:  This commented out line is the correct thing to use
-            # for signed integers.  However it will change the random seed
-            # values everywhere.  Make this change sometime when it is less
-            # disruptive.
-            # uid = int(ind & 0x7FFFFFFF)
-            uid = int(ind & 0xFFFFFFFF)
-    except:
-        raise RuntimeError(
-            "Cannot convert detector name {} to a unique integer-\
-            maybe it is too long?".format(name)
-        )
+            uid = np.uint32(ind & 0x7FFFFFFF)
+    except Exception:
+        msg = f"Cannot convert name string {name} to a unique "
+        msg += "integer- maybe it is too long?"
+        raise RuntimeError(msg)
     return uid
 
 


### PR DESCRIPTION
When working with real or simulated data with many detectors that are cut, a frequent scenario is that some processes will have zero good detectors for a given observation.

- Add options to the unit test helper functions for generating satellite and ground data to enable flagging of all detectors on the last process in a group.  Enabled by default.

- When working with template data in the Amplitude class and TODs in the DetectorData class, use zero-length array when a process has no local data.  This is less clunky than setting the local data array to None and then checking for None all over the place.

- In SimAtmosphere, remove shortcut where processes with no dets would return.  All processes later participate in communication, so this caused a deadlock.

- Fix ScanAlm operator, which used collective operations that only worked in specific situations.

- Linting of pixels_io_healpix.py

- In Offset template writing, handle case where some processes have no data.

- In Periodic template writing, handle case where some processes have no data.

- In HDF5 I/O tests, add a base Noise class in addition to the AnalyticNoise instance.

- Disable all-dets-flagged on a process for tests involving Madam, which does not support that case.

- Refactor the CrossLinking operator, which was basically manually running a Pipeline without using one.

- Various small cleanups