### PR TITLE
Support optional jinja2 templating in yaml config files

### DIFF
--- a/src/toast/config/yaml.py
+++ b/src/toast/config/yaml.py
@@ -18,6 +18,12 @@ from ..trait_utils import string_to_trait, trait_to_string
 from ..utils import Environment, Logger
 from .utils import merge_config
 
+try:
+    from jinja2 import Template
+    have_jinja = True
+except ImportError:
+    have_jinja = False
+
 yaml = YAML()
 
 
@@ -172,8 +178,14 @@ def load_yaml(file, input=None, comm=None):
     """
     raw = None
     if comm is None or comm.rank == 0:
-        with open(file, "r") as f:
-            raw = yaml.load(f)
+        if have_jinja:
+            with open(file, "r") as f:
+                template = Template(f.read())
+                rendered = template.render()
+                raw = yaml.load(rendered)
+        else:
+            with open(file, "r") as f:
+                raw = yaml.load(f)
     if comm is not None:
         raw = comm.bcast(raw, root=0)
 

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -741,3 +741,35 @@ class ConfigTest(MPITestCase):
         ]
 
         run_main(opts=opts, comm=self.comm)
+
+    def test_jinja2(self):
+        try:
+            from jinja2 import Template
+        except ImportError:
+            if self.comm is None or self.comm.rank == 0:
+                print("Skipping jinja2 tests- not importable", flush=True)
+            return
+        testdir = os.path.join(self.outdir, "jinja")
+        input_file = os.path.join(testdir, "test.yml")
+        output_file = os.path.join(testdir, "check.yml")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+            with open(input_file, "w") as f:
+                f.write("""
+{% set data_names = ["satp1", "satp2", "satp3", "lat"] %}
+{% set n_realization = 5 %}
+operators:
+
+  {% for real in range(n_realization) %}
+  {% set real_str = '{0:02d}'.format(real) %}
+  sim_noise_{{ real_str }}:
+    name: sim_noise_{{ real_str }}
+    class: toast.ops.sim_tod_noise.SimNoise
+    realization: {{ real }}
+
+  {% endfor %}
+"""
+                )
+        conf = load_config(input_file, comm=self.comm)
+        dump_config(output_file, conf, comm=self.comm)
+

--- a/src/toast/tests/config.py
+++ b/src/toast/tests/config.py
@@ -756,7 +756,6 @@ class ConfigTest(MPITestCase):
             os.makedirs(testdir)
             with open(input_file, "w") as f:
                 f.write("""
-{% set data_names = ["satp1", "satp2", "satp3", "lat"] %}
 {% set n_realization = 5 %}
 operators:
 


### PR DESCRIPTION
In some cases we resort to writing shell scripts to generate yaml files, when the jinja2 package can already do extensive python-like control structures in the yaml.  If jinja2 is importable, pass yaml files through that when loading.