### PR TITLE
Detector grouping is global, not local

### DIFF
--- a/src/toast/instrument.py
+++ b/src/toast/instrument.py
@@ -952,15 +952,19 @@ class Focalplane(object):
             (dict):  The detector names grouped by unique column values.
 
         """
-        if column not in self.detector_data.colnames:
+        if column is None:
+            # Return all detectors
+            detgroups = {"ALL": self.detectors}
+        elif column not in self.detector_data.colnames:
             raise RuntimeError(f"'{column}' is not a valid det data column")
-        detgroups = dict()
-        for d in self.detectors:
-            indx = self._det_to_row[d]
-            val = self.detector_data[column][indx]
-            if val not in detgroups:
-                detgroups[val] = list()
-            detgroups[val].append(d)
+        else:
+            detgroups = dict()
+            for d in self.detectors:
+                indx = self._det_to_row[d]
+                val = self.detector_data[column][indx]
+                if val not in detgroups:
+                    detgroups[val] = list()
+                detgroups[val].append(d)
         return detgroups
 
     def __repr__(self):

--- a/src/toast/ops/noise_model.py
+++ b/src/toast/ops/noise_model.py
@@ -690,12 +690,7 @@ class FlagNoiseFit(Operator):
 
             _ = obs.detdata.ensure(self.det_flags, dtype=np.uint8, detectors=local_dets)
 
-            if self.focalplane_key is not None:
-                all_groups = obs.telescope.focalplane.detector_groups(
-                    self.focalplane_key
-                )
-            else:
-                all_groups = {"ALL": local_dets}
+            all_groups = obs.telescope.focalplane.detector_groups(self.focalplane_key)
             if self.focalplane_value is not None:
                 if self.focalplane_value not in all_groups:
                     msg = f"Focalplane column '{self.focalplane_key}' has no "


### PR DESCRIPTION
The recent modifications to this code broke the detector counting. If noise cuts were done in detector groups, those groups were extracted from the Focalplane and were global. However, if the cuts were done over all detectors, the list of detectors was limited to the local detectors.

This PR handles `focalplane_key == None` through the same function as any valid key and produces consistent results.