### PR TITLE
Clean up use of np.array constructor.

### DIFF
--- a/src/toast/ops/azimuth_intervals.py
+++ b/src/toast/ops/azimuth_intervals.py
@@ -151,10 +151,10 @@ class AzimuthIntervals(Operator):
 
             if obs.comm_col_rank == 0:
                 # The azimuth angle
-                azimuth = np.array(obs.shared[self.azimuth].data)
+                azimuth = np.copy(obs.shared[self.azimuth].data)
 
                 # The azimuth flags
-                flags = np.array(obs.shared[self.shared_flags].data)
+                flags = np.copy(obs.shared[self.shared_flags].data)
                 flags &= self.shared_flag_mask
 
                 # Scan velocity
@@ -631,10 +631,10 @@ class AzimuthRanges(Operator):
                 # Compute the good azimuth data along the top process row
 
                 # The azimuth angle
-                azimuth = np.array(obs.shared[self.azimuth].data)
+                azimuth = np.copy(obs.shared[self.azimuth].data)
 
                 # The azimuth flags
-                flags = np.array(obs.shared[self.shared_flags].data)
+                flags = np.copy(obs.shared[self.shared_flags].data)
                 flags &= self.shared_flag_mask
 
                 # The min / max Az range for this time chunk

--- a/src/toast/ops/conviqt.py
+++ b/src/toast/ops/conviqt.py
@@ -462,10 +462,10 @@ class SimConviqt(Operator):
                 flags = None
                 if self.apply_flags:
                     if self.shared_flags is not None:
-                        flags = np.array(views.shared[self.shared_flags][view])
+                        flags = np.copy(views.shared[self.shared_flags][view])
                         flags &= self.shared_flag_mask
                     if self.det_flags is not None:
-                        detflags = np.array(views.detdata[self.det_flags][view][det])
+                        detflags = np.copy(views.detdata[self.det_flags][view][det])
                         detflags &= self.det_flag_mask
                         if flags is not None:
                             flags |= detflags

--- a/src/toast/ops/demodulation.py
+++ b/src/toast/ops/demodulation.py
@@ -864,13 +864,11 @@ class Demodulate(Operator):
                 demod_detectors.append(demod_det)
                 demod_freqs[demod_det] = freq_out
                 demod_psds[demod_det] = psd_out
-                demod_indices[demod_det] = noise.index(det) * n_mode + indexoff
                 demod_weights[demod_det] = invvar / u.K**2
         demod_obs[self.noise_model] = Noise(
             detectors=demod_detectors,
             freqs=demod_freqs,
             psds=demod_psds,
-            indices=demod_indices,
             detweights=demod_weights,
         )
         return

--- a/src/toast/ops/elevation_noise.py
+++ b/src/toast/ops/elevation_noise.py
@@ -236,7 +236,7 @@ class ElevationNoise(Operator):
                 # Get the flags if needed.  Use the same flags as detector pointing.
                 flags = None
                 if self.detector_pointing.shared_flags is not None:
-                    flags = np.array(
+                    flags = np.copy(
                         views.shared[self.detector_pointing.shared_flags][vw]
                     )
                     flags &= self.detector_pointing.shared_flag_mask

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -857,8 +857,11 @@ class FilterBin(Operator):
                 if not success:
                     continue
 
+            # Get the common templates.  This may modify the shared flags.
             common_templates = self._build_common_templates(obs)
+
             if self.shared_flags is not None:
+                # No need for a copy here, since we are not modifying these below.
                 common_flags = obs.shared[self.shared_flags].data
             else:
                 common_flags = np.zeros(obs.n_local_samples, dtype=np.uint8)
@@ -1165,7 +1168,6 @@ class FilterBin(Operator):
             )
             raise RuntimeError(msg)
         hwp_angle = obs.shared[self.hwp_angle].data
-        shared_flags = np.array(obs.shared[self.shared_flags])
 
         nfilter = 2 * self.hwp_filter_order
         if nfilter < 1:
@@ -1195,7 +1197,6 @@ class FilterBin(Operator):
         # polynomial orders not present in the polynomial filter
 
         phase = self._get_phase(ob)
-        shared_flags = np.array(ob.shared[self.shared_flags])
 
         min_order = 0
         if self.poly_filter_order is not None:
@@ -1297,7 +1298,7 @@ class FilterBin(Operator):
 
         # bin numbers are positive by construction.
         # Assign flagged samples to bin = -1
-        shared_flags = np.array(ob.shared[self.shared_flags])
+        shared_flags = ob.shared[self.shared_flags].data
         bad = (shared_flags & self.shared_flag_mask) != 0
         ibin[bad] = -1
 
@@ -1411,12 +1412,18 @@ class FilterBin(Operator):
             return
         nfilter = self.poly_filter_order + 1
         intervals = obs.intervals[self.poly_filter_view]
+
+        # Make a copy of the shared flags, since we will update them
         if self.shared_flags is None:
             shared_flags = np.zeros(obs.n_local_samples, dtype=np.uint8)
         else:
-            shared_flags = np.array(obs.shared[self.shared_flags])
+            shared_flags = np.copy(obs.shared[self.shared_flags].data)
         bad = (shared_flags & self.shared_flag_mask) != 0
 
+        # Since the intervals are common to all processes in a column of
+        # the process grid, this block of code will produce identical
+        # outputs across all those processes (including updates to the
+        # shared flags).
         for i, ival in enumerate(intervals):
             istart = ival.first
             istop = ival.last
@@ -1442,6 +1449,8 @@ class FilterBin(Operator):
         templates.meta["poly_intervals"] = intervals.data
 
         if self.shared_flags is not None:
+            # Update the flags.  The input is ignored on all processes except the
+            # rank 0 process of the column communicator.
             obs.shared[self.shared_flags].set(shared_flags, offset=(0,), fromrank=0)
 
         return
@@ -1528,7 +1537,8 @@ class FilterBin(Operator):
         if self.shared_flags is None:
             shared_flags = np.zeros(nsample, dtype=np.uint8)
         else:
-            shared_flags = np.array(obs.shared[self.shared_flags])
+            # No need for a copy here since we are not modifying the shared flags.
+            shared_flags = obs.shared[self.shared_flags].data
         bad = (shared_flags & self.shared_flag_mask) != 0
 
         # Improve template orthogonality by projecting subscan

--- a/src/toast/ops/flag_intervals.py
+++ b/src/toast/ops/flag_intervals.py
@@ -108,7 +108,7 @@ class FlagIntervals(Operator):
 
             new_flags = None
             if ob.comm_col_rank == 0:
-                new_flags = np.array(ob.shared[self.shared_flags])
+                new_flags = np.copy(ob.shared[self.shared_flags].data)
                 if self.reset:
                     for vname, vmask in self.view_mask:
                         new_flags &= ~vmask

--- a/src/toast/ops/hwpss_model.py
+++ b/src/toast/ops/hwpss_model.py
@@ -813,7 +813,7 @@ class HWPSynchronousModel(Operator):
                 log.verbose(msg)
                 coeff[idet, :, indx] = 0
                 continue
-            sig = np.array(obs.detdata[self.det_data][det, slc])
+            sig = np.copy(obs.detdata[self.det_data][det, slc])
             dc = np.mean(sig[good_samp])
             sig -= dc
 
@@ -900,7 +900,7 @@ class HWPSynchronousModel(Operator):
         if self.shared_flags is None:
             shared_flags = np.zeros(obs.n_local_samples, dtype=np.uint8)
         else:
-            shared_flags = np.array(obs.shared[self.shared_flags].data)
+            shared_flags = np.copy(obs.shared[self.shared_flags].data)
             shared_flags &= self.shared_flag_mask
 
         # Compute flags for samples where the hwp is stopped

--- a/src/toast/ops/noise_estimation.py
+++ b/src/toast/ops/noise_estimation.py
@@ -437,7 +437,7 @@ class NoiseEstim(Operator):
                     unordered_pairs.add(tuple(sorted(pair)))
                 pairs = list(unordered_pairs)
 
-            times = np.array(obs.shared[self.times])
+            times = obs.shared[self.times].data
             nsample = times.size
 
             shared_flags = np.zeros(times.size, dtype=bool)

--- a/src/toast/ops/noise_filter.py
+++ b/src/toast/ops/noise_filter.py
@@ -119,9 +119,8 @@ class NoiseFilter(Operator):
                 if self.shared_flags is not None:
                     # These shared flags will effectively be propagated to
                     # detector flags by this operator
-                    shflg = self.det_flag_mask * np.array(
+                    shflg = self.det_flag_mask * (
                         obs.shared[self.shared_flags].data & self.shared_flag_mask,
-                        dtype=np.uint8,
                     )
                     for detflag in flags:
                         detflag |= shflg

--- a/src/toast/ops/noise_filter.py
+++ b/src/toast/ops/noise_filter.py
@@ -109,21 +109,27 @@ class NoiseFilter(Operator):
             # Sample rate for this observation
             rate = obs.telescope.focalplane.sample_rate.to_value(u.Hz)
 
+            # Shared flags
+            if self.shared_flags is not None:
+                # These shared flags will effectively be propagated to
+                # detector flags by this operator
+                shflg = np.copy(obs.shared[self.shared_flags].data)
+                shflg &= self.shared_flag_mask
+                shflg *= self.det_flag_mask
+            else:
+                shflg = None
+
             # The signal array: this is a list of detector array references.
             signal = obs.detdata[self.det_data][dets, :]
             if self.det_flags is None:
                 flags = None
                 flag_mask = None
             else:
+                # List of references to the detector flags
                 flags = obs.detdata[self.det_flags][dets, :]
-                if self.shared_flags is not None:
-                    # These shared flags will effectively be propagated to
-                    # detector flags by this operator
-                    shflg = self.det_flag_mask * (
-                        obs.shared[self.shared_flags].data & self.shared_flag_mask,
-                    )
+                if shflg is not None:
                     for detflag in flags:
-                        detflag |= shflg
+                        detflag[:] |= shflg
                 flag_mask = self.det_flag_mask
 
             # Construct the N_tt'^-1 kernels for these detectors

--- a/src/toast/ops/polyfilter/polyfilter.py
+++ b/src/toast/ops/polyfilter/polyfilter.py
@@ -462,12 +462,12 @@ class PolyFilter(Operator):
 
     det_flag_mask = Int(
         defaults.det_mask_invalid | defaults.det_mask_processing,
-        help="Bit mask value for detector sample flagging",
+        help="Input bit mask value for detector sample flagging",
     )
 
     poly_flag_mask = Int(
-        defaults.shared_mask_invalid,
-        help="Shared flag bit mask for samples outside of filtering view",
+        defaults.det_mask_invalid,
+        help="Output detector flag bit mask for samples outside of filtering view",
     )
 
     shared_flags = Unicode(
@@ -549,76 +549,48 @@ class PolyFilter(Operator):
             else:
                 shared_flags = np.zeros(obs.n_local_samples, dtype=np.uint8)
 
-            signals = []
-            filter_dets = []
-            last_flags = None
+            # FIXME:  The underlying kernels assume common flags for all detectors.
+            # This will likely never be true and the API should be updated to take
+            # separate flag vectors for each detector.  In the mean time just call
+            # the kernel once per detector.
+
+            # Track whether we are filtering in place (64bit data).
             in_place = True
+            if obs.detdata[self.det_data].dtype != np.dtype(np.float64):
+                in_place = False
+
             for det in dets:
                 # Test the detector pattern
                 if pat.match(det) is None:
                     continue
 
-                ref = obs.detdata[self.det_data][det]
-                if isinstance(ref[0], np.float64):
-                    signal = ref
-                else:
-                    in_place = False
-                    signal = np.array(ref, dtype=np.float64)
                 if self.det_flags is not None:
                     det_flags = obs.detdata[self.det_flags][det] & self.det_flag_mask
                     flags = shared_flags | det_flags
                 else:
                     flags = shared_flags
 
-                if last_flags is None or np.all(last_flags == flags):
-                    filter_dets.append(det)
-                    signals.append(signal)
+                if in_place:
+                    signal = obs.detdata[self.det_data][det]
                 else:
-                    filter_polynomial(
-                        self.order,
-                        last_flags,
-                        signals,
-                        local_starts,
-                        local_stops,
-                        impl=implementation,
-                        use_accel=use_accel,
-                    )
-                    if not in_place:
-                        for fdet, x in zip(filter_dets, signals):
-                            obs.detdata[self.det_data][fdet] = x
-                    signals = [signal]
-                    filter_dets = [det]
-                last_flags = flags.copy()
+                    signal = np.array(obs.detdata[self.det_data][det], dtype=np.float64)
 
-            if len(signals) > 0:
                 filter_polynomial(
                     self.order,
-                    last_flags,
-                    signals,
+                    flags,
+                    [signal],
                     local_starts,
                     local_stops,
                     impl=implementation,
                     use_accel=use_accel,
                 )
                 if not in_place:
-                    for fdet, x in zip(filter_dets, signals):
-                        obs.detdata[self.det_data][fdet] = x
+                    obs.detdata[self.det_data][det] = signal
 
-            # Optionally flag unfiltered data
-            if self.shared_flags is not None and self.poly_flag_mask is not None:
-                if obs.comm_col_rank != 0:
-                    shared_flags = None
-                else:
-                    shared_flags = np.array(obs.shared[self.shared_flags])
-                    not_filtered = np.ones(shared_flags.size, dtype=bool)
-                    for start, stop in zip(local_starts, local_stops):
-                        not_filtered[start : stop] = False
-                    shared_flags[not_filtered] |= self.poly_flag_mask
-                obs.shared[self.shared_flags].set(shared_flags, fromrank=0)
-            if obs.comm.comm_group is not None:
-                obs.comm.comm_group.barrier()
-
-        return
+                # Flag detector samples that were not filtered.
+                if self.det_flags is not None:
+                    bad = np.array(flags != 0, dtype=np.uint8)
+                    obs.detdata[self.det_flags][det] |= self.poly_flag_mask * bad
 
     def _finalize(self, data, **kwargs):
         return

--- a/src/toast/ops/totalconvolve.py
+++ b/src/toast/ops/totalconvolve.py
@@ -503,10 +503,10 @@ class SimTotalconvolve(Operator):
                 flags = None
                 if self.apply_flags:
                     if self.shared_flags is not None:
-                        flags = np.array(views.shared[self.shared_flags][view])
+                        flags = np.copy(views.shared[self.shared_flags][view])
                         flags &= self.shared_flag_mask
                     if self.det_flags is not None:
-                        detflags = np.array(views.detdata[self.det_flags][view][det])
+                        detflags = np.copy(views.detdata[self.det_flags][view][det])
                         detflags &= self.det_flag_mask
                         if flags is not None:
                             flags |= detflags


### PR DESCRIPTION
In some cases the np.array constructor was being used when really np.copy was the desired operation.  Also simplify the 1D poly filter code.