### PR TITLE
Longer turnarounds

### DIFF
--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -1943,6 +1943,8 @@ class FilterBin(Operator):
             "rightleft_interval",
             "poly_filter_order",
             "poly_filter_view",
+            "poly_filter_view_crop_start",
+            "poly_filter_view_crop_end",
             "precomputed_templates",
             "precomputed_template_view",
         ]:

--- a/src/toast/ops/filterbin.py
+++ b/src/toast/ops/filterbin.py
@@ -482,6 +482,14 @@ class FilterBin(Operator):
         "throw", allow_none=True, help="Intervals for polynomial filtering"
     )
 
+    poly_filter_view_crop_start = Float(
+        0, help="Crop beginning of each interval [seconds]",
+    )
+
+    poly_filter_view_crop_end = Float(
+        0, help="Crop end of each interval [seconds]",
+    )
+
     write_obs_matrix = Bool(False, help="Write the observation matrix")
 
     nskip = Int(
@@ -1419,23 +1427,31 @@ class FilterBin(Operator):
         else:
             shared_flags = np.copy(obs.shared[self.shared_flags].data)
         bad = (shared_flags & self.shared_flag_mask) != 0
+        not_filtered = np.ones(shared_flags.size, dtype=bool)
+
+        # See if we are using full intervals
+        fsample = obs.telescope.focalplane.sample_rate.to_value(u.Hz)
+        crop_start = int(self.poly_filter_view_crop_start * fsample)
+        crop_end = int(self.poly_filter_view_crop_end * fsample)
 
         # Since the intervals are common to all processes in a column of
         # the process grid, this block of code will produce identical
         # outputs across all those processes (including updates to the
         # shared flags).
         for i, ival in enumerate(intervals):
-            istart = ival.first
-            istop = ival.last
+            istart = ival.first + crop_start
+            istop = ival.last - crop_end
             # Trim flagged samples from both ends
             while istart < istop and bad[istart]:
                 istart += 1
             while istop - 1 > istart and bad[istop - 1]:
                 istop -= 1
             if istop - istart < nfilter:
-                # Not enough samples to filter, flag this interval
-                shared_flags[ival.first : ival.last] |= self.filter_flag_mask
+                # Not enough samples to filter
                 continue
+            # This interval will be filtered
+            not_filtered[istart : istop] = False
+            # Build the templates for this interval
             wbin = 2 / (istop - istart)
             phase = (np.arange(istop - istart) + 0.5) * wbin - 1
             ltemplates = np.zeros([nfilter, phase.size])
@@ -1447,6 +1463,9 @@ class FilterBin(Operator):
 
         # Save polynomial intervals for reference
         templates.meta["poly_intervals"] = intervals.data
+
+        # Flag all samples that are not filtered by the polynomials
+        shared_flags[not_filtered] |= self.filter_flag_mask
 
         if self.shared_flags is not None:
             # Update the flags.  The input is ignored on all processes except the

--- a/src/toast/tests/ops_filterbin.py
+++ b/src/toast/tests/ops_filterbin.py
@@ -36,6 +36,138 @@ class FilterBinTest(MPITestCase):
         self.outdir = create_outdir(self.comm, subdir=fixture_name)
         self.nside = 64
 
+    def test_extend_turnaround(self):
+        # Create a fake ground data set for testing
+        data = create_ground_data(self.comm, turnarounds_invalid=True, schedule_hours=1)
+
+        nside = 256
+
+        # Create some detector pointing matrices
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=nside,
+            create_dist="pixel_dist",
+            detector_pointing=detpointing,
+        )
+        weights = ops.StokesWeights(
+            mode="I",  # "IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise from this model
+        sim_noise = ops.SimNoise(noise_model="noise_model", out=defaults.det_data)
+        sim_noise.apply(data)
+
+        # Add a strong gradient that should be filtered out completely
+        for obs in data.obs:
+            grad = np.arange(obs.n_local_samples)
+            for det in obs.local_detectors:
+                obs.detdata[defaults.det_data][det] += grad
+
+        # Make fake flags
+        fake_flags(data)
+
+        binning = ops.BinMap(
+            pixel_dist="pixel_dist",
+            covariance="covariance",
+            det_data=sim_noise.det_data,
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+            sync_type="allreduce",
+            shared_flags=defaults.shared_flags,
+            shared_flag_mask=defaults.shared_mask_nonscience,
+            det_flags=defaults.det_flags,
+            det_flag_mask=defaults.det_mask_invalid,
+        )
+
+        # Copy the signal
+        ops.Copy(
+            shared=[(defaults.shared_flags, "shared_flags_copy")],
+            detdata=[
+                (defaults.det_data, "signal_copy"),
+                (defaults.det_flags, "det_flags_copy"),
+            ],
+        ).apply(data)
+
+        name = "filterbin_turnaround_ref"
+        filterbin_ref = ops.FilterBin(
+            name=name,
+            det_data=defaults.det_data,
+            det_flags=defaults.det_flags,
+            det_flag_mask=defaults.det_mask_nonscience,
+            shared_flags=defaults.shared_flags,
+            shared_flag_mask=defaults.shared_mask_nonscience,
+            binning=binning,
+            poly_filter_view="scanning",
+            poly_filter_order=1,
+            output_dir=self.outdir,
+            write_binmap=True,
+            write_map=True,
+            write_hits=True,
+            write_hdf5=True,
+        )
+        filterbin_ref.apply(data)
+
+        name = "filterbin_turnaround"
+        filterbin = ops.FilterBin(
+            name=name,
+            det_data="signal_copy",
+            det_flags="det_flags_copy",
+            det_flag_mask=defaults.det_mask_nonscience,
+            shared_flags="shared_flags_copy",
+            shared_flag_mask=defaults.shared_mask_nonscience,
+            binning=binning,
+            poly_filter_view="scanning",
+            poly_filter_order=1,
+            poly_filter_view_crop_start=1,
+            poly_filter_view_crop_end=1,
+            output_dir=self.outdir,
+            write_binmap=True,
+            write_map=True,
+            write_hits=True,
+            write_hdf5=True,
+        )
+        filterbin.apply(data)
+
+        if data.comm.world_rank == 0:
+            # Check that the number of hits drops
+
+            fname_hits_ref = os.path.join(
+                self.outdir, f"{filterbin_ref.name}_filtered_hits.h5"
+            )
+            fname_hits = os.path.join(
+                self.outdir, f"{filterbin.name}_filtered_hits.h5"
+            )
+            hits_ref = read_healpix(fname_hits_ref)
+            hits = read_healpix(fname_hits)
+
+            assert np.sum(hits) < 0.9 * np.sum(hits_ref)
+
+            # Check that filtering is still effective
+
+            fname_binned = os.path.join(
+                self.outdir, f"{filterbin.name}_unfiltered_map.h5"
+            )
+            fname_filtered = os.path.join(
+                self.outdir, f"{filterbin.name}_filtered_map.h5"
+            )
+            binned = np.atleast_2d(read_healpix(fname_binned, None))
+            filtered = np.atleast_2d(read_healpix(fname_filtered, None))
+
+            good = binned != 0
+            rms1 = np.std(binned[good])
+            rms2 = np.std(filtered[good])
+
+            assert rms2 < 1e-3 * rms1
+
+        close_data(data)
+
     def test_filterbin_with_config(self):
         if "CIBUILDWHEEL" in os.environ:
             print(f"WARNING:  Skipping test_filterbin_with_config during wheel tests")


### PR DESCRIPTION
This PR adds traits to the FilterBin operator to truncate the science scan views.  We are using the operator to allow using different truncation parameters to different observations. If the optimal truncation turns out to be static, then the truncation should be done in preprocessing, not in FilterBin.