### PR TITLE
Update the way that detector splits are implemented in mapmaking

### DIFF
--- a/src/toast/data.py
+++ b/src/toast/data.py
@@ -170,7 +170,7 @@ class Data(MutableMapping):
                 ob.select_local_detectors(selection=selection, flagmask=flagmask)
             )
 
-            local_splits = dict()
+            local_splits = {}
             for k, v in local_groups.items():
                 for d in v:
                     if d in dets:

--- a/src/toast/ops/arithmetic.py
+++ b/src/toast/ops/arithmetic.py
@@ -107,7 +107,8 @@ class Combine(Operator):
                 scale_first = unit_conversion(first_units, result_units)
                 scale_second = 1.0
             else:
-                # We are creating a new field for the output.  Use units of first field.
+                # We are storing the output in a separate field.  Create if needed,
+                # and use units of first field.
                 result_units = first_units
                 scale_first = 1.0
                 scale_second = unit_conversion(second_units, result_units)
@@ -120,24 +121,24 @@ class Combine(Operator):
                 )
             if self.op == "add":
                 for d in dets:
-                    ob.detdata[self.result][d, :] = (
-                        scale_first * ob.detdata[self.first][d, :]
-                    ) + (scale_second * ob.detdata[self.second][d, :])
+                    ob.detdata[self.result][d][:] = (
+                        scale_first * ob.detdata[self.first][d]
+                    ) + (scale_second * ob.detdata[self.second][d])
             elif self.op == "subtract":
                 for d in dets:
-                    ob.detdata[self.result][d, :] = (
-                        scale_first * ob.detdata[self.first][d, :]
-                    ) - (scale_second * ob.detdata[self.second][d, :])
+                    ob.detdata[self.result][d][:] = (
+                        scale_first * ob.detdata[self.first][d]
+                    ) - (scale_second * ob.detdata[self.second][d])
             elif self.op == "multiply":
                 for d in dets:
-                    ob.detdata[self.result][d, :] = (
-                        scale_first * ob.detdata[self.first][d, :]
-                    ) * (scale_second * ob.detdata[self.second][d, :])
+                    ob.detdata[self.result][d][:] = (
+                        scale_first * ob.detdata[self.first][d]
+                    ) * (scale_second * ob.detdata[self.second][d])
             elif self.op == "divide":
                 for d in dets:
-                    ob.detdata[self.result][d, :] = (
-                        scale_first * ob.detdata[self.first][d, :]
-                    ) / (scale_second * ob.detdata[self.second][d, :])
+                    ob.detdata[self.result][d][:] = (
+                        scale_first * ob.detdata[self.first][d]
+                    ) / (scale_second * ob.detdata[self.second][d])
 
     def _finalize(self, data, **kwargs):
         return None

--- a/src/toast/ops/copy.py
+++ b/src/toast/ops/copy.py
@@ -142,7 +142,7 @@ class Copy(Operator):
                         )
                     # Copy detector data
                     for d in dets:
-                        ob.detdata[out_key][d, :] = ob.detdata[in_key][d, :]
+                        ob.detdata[out_key][d][:] = ob.detdata[in_key][d]
         return
 
     def _finalize(self, data, **kwargs):

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -193,6 +193,8 @@ class MapMaker(Operator):
 
     report_memory = Bool(False, help="Report memory throughout the execution")
 
+    _log_prefix = "MapMaker"
+
     @traitlets.validate("map_binning")
     def _check_map_binning(self, proposal):
         bin = proposal["value"]
@@ -251,7 +253,8 @@ class MapMaker(Operator):
             else:
                 fname = os.path.join(self.output_dir, f"{rootname}_{product}.fits")
             if self.mc_mode and not force and os.path.isfile(fname):
-                log.info_rank(f"Skipping existing file: {fname}", comm=self._comm)
+                msg = f"{self._log_prefix} Skipping existing file: {fname}"
+                log.info_rank(msg, comm=self._comm)
             else:
                 self._data[prod_key].write(
                     fname,
@@ -260,7 +263,9 @@ class MapMaker(Operator):
                     report_memory=self.report_memory,
                     extra_header=extra_header,
                 )
-            log.info_rank(f"Wrote {fname} in", comm=self._comm, timer=wtimer)
+            log.info_rank(
+                f"{self._log_prefix} Wrote {fname} in", comm=self._comm, timer=wtimer
+            )
 
         if not self.keep_final_products and not self.mc_mode:
             if prod_key in self._data:
@@ -353,7 +358,6 @@ class MapMaker(Operator):
 
         self._log = Logger.get()
         self._timer = Timer()
-        self._log_prefix = "MapMaker"
 
         self._mc_root = self.name
         if self.mc_mode:
@@ -414,9 +418,7 @@ class MapMaker(Operator):
             reset_pix_dist=self.reset_pix_dist,
             report_memory=self.report_memory,
         )
-        amplitudes_solve.apply(
-            self._data, use_accel=self._use_accel
-        )
+        amplitudes_solve.apply(self._data, use_accel=self._use_accel)
         template_amplitudes = amplitudes_solve.amplitudes
 
         self._log.info_rank(
@@ -468,9 +470,7 @@ class MapMaker(Operator):
             )
             # We intentionally build the pixel distribution with all detectors,
             # so that it will be valid for any subsets.
-            pix_dist.apply(
-                self._data, detectors=None, use_accel=self._use_accel
-            )
+            pix_dist.apply(self._data, detectors=None, use_accel=self._use_accel)
             self._log.info_rank(
                 f"{self._log_prefix}  finished build of pixel distribution in",
                 comm=self._comm,
@@ -516,9 +516,7 @@ class MapMaker(Operator):
             save_pointing=map_binning.full_pointing,
         )
 
-        final_cov.apply(
-            self._data, use_accel=self._use_accel
-        )
+        final_cov.apply(self._data, use_accel=self._use_accel)
 
         self._log.info_rank(
             f"{self._log_prefix}  finished build of final covariance in",
@@ -552,9 +550,7 @@ class MapMaker(Operator):
             f"{self._log_prefix} begin map binning",
             comm=self._comm,
         )
-        map_binning.apply(
-            self._data, use_accel=self._use_accel
-        )
+        map_binning.apply(self._data, use_accel=self._use_accel)
         self._log.info_rank(
             f"{self._log_prefix}  finished binning in",
             comm=self._comm,
@@ -601,9 +597,7 @@ class MapMaker(Operator):
                 template_matrix=self.template_matrix,
                 output=out_cleaned,
             )
-            amplitudes_apply.apply(
-                self._data, use_accel=self._use_accel
-            )
+            amplitudes_apply.apply(self._data, use_accel=self._use_accel)
 
             if not self.keep_solver_products:
                 del self._data[template_amplitudes]
@@ -637,9 +631,7 @@ class MapMaker(Operator):
         map_binning.binned = self.map_name
 
         # Do the final binning
-        map_binning.apply(
-            self._data, use_accel=self._use_accel
-        )
+        map_binning.apply(self._data, use_accel=self._use_accel)
 
         self._log.info_rank(
             f"{self._log_prefix}  finished final binning in",
@@ -702,7 +694,6 @@ class MapMaker(Operator):
 
         del self._log
         del self._timer
-        del self._log_prefix
         del self._mc_root
         del self._data
         del self._use_accel
@@ -783,12 +774,14 @@ class MapMaker(Operator):
                 self.name = f"{self._save_split_name}_{safe_split}"
             n_split_dets = len(split_dets)
             if n_split_dets == 0:
+                msg = f"{self._log_prefix} Detector split '{split_key}' "
+                msg += "has no dets, skipping"
                 log.info_rank(
-                    f"Detector split '{split_key}' has no dets, skipping",
+                    msg,
                     comm=data.comm.comm_world,
                 )
             else:
-                msg = f"Running det split '{split_key}' with "
+                msg = f"{self._log_prefix} Running det split '{split_key}' with "
                 msg += f"{n_split_dets} dets"
                 log.info_rank(msg, comm=data.comm.comm_world)
 
@@ -799,13 +792,13 @@ class MapMaker(Operator):
                 map_binning.det_mask,
             )
 
-            msg = f"After selection, split '{split_key}' has "
+            msg = f"{self._log_prefix} After selection, split '{split_key}' has "
             msg += f"{len(selected_dets)} dets"
             log.info_rank(msg, comm=data.comm.comm_world)
 
             extra_header = self._get_extra_header(selected_dets)
 
-            self._memreport.prefix = "Start of mapmaking"
+            self._memreport.prefix = f"{self._log_prefix} Start of mapmaking"
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
             template_amplitudes = self._fit_templates()
@@ -829,7 +822,7 @@ class MapMaker(Operator):
 
             self._write_maps(extra_header=extra_header)
 
-            self._memreport.prefix = "End of mapmaking"
+            self._memreport.prefix = f"{self._log_prefix} End of mapmaking"
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
             # Restore detector flags

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -156,6 +156,8 @@ class MapMaker(Operator):
 
     write_rcond = Bool(True, help="If True, write the reciprocal condition numbers.")
 
+    write_float64 = Bool(False, help="If True, write the map data in double precision.")
+
     write_solver_products = Bool(
         False, help="If True, write out equivalent solver products."
     )
@@ -231,10 +233,6 @@ class MapMaker(Operator):
         """Write data object to file and delete it from cache"""
         log = Logger.get()
 
-        # FIXME:  This I/O technique assumes "known" types of pixel representations.
-        # Instead, we should associate read / write functions to a particular pixel
-        # class.
-
         if self.map_binning is not None and self.map_binning.enabled:
             map_binning = self.map_binning
         else:
@@ -259,7 +257,7 @@ class MapMaker(Operator):
                 self._data[prod_key].write(
                     fname,
                     force_serial=self.write_hdf5_serial,
-                    single_precision=True,
+                    single_precision=(not self.write_float64),
                     report_memory=self.report_memory,
                     extra_header=extra_header,
                 )
@@ -395,7 +393,7 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _fit_templates(self):
+    def _fit_templates(self, detectors):
         """Solve for template amplitudes"""
 
         amplitudes_solve = SolveAmplitudes(
@@ -418,7 +416,9 @@ class MapMaker(Operator):
             reset_pix_dist=self.reset_pix_dist,
             report_memory=self.report_memory,
         )
-        amplitudes_solve.apply(self._data, use_accel=self._use_accel)
+        amplitudes_solve.apply(
+            self._data, detectors=detectors, use_accel=self._use_accel
+        )
         template_amplitudes = amplitudes_solve.amplitudes
 
         self._log.info_rank(
@@ -481,7 +481,7 @@ class MapMaker(Operator):
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
     @function_timer
-    def _build_pixel_covariance(self, map_binning):
+    def _build_pixel_covariance(self, map_binning, detectors):
         """Accumulate hits and pixel covariance"""
 
         if map_binning.covariance in self._data and self.mc_mode:
@@ -516,7 +516,7 @@ class MapMaker(Operator):
             save_pointing=map_binning.full_pointing,
         )
 
-        final_cov.apply(self._data, use_accel=self._use_accel)
+        final_cov.apply(self._data, detectors=detectors, use_accel=self._use_accel)
 
         self._log.info_rank(
             f"{self._log_prefix}  finished build of final covariance in",
@@ -537,7 +537,7 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _bin_and_write_raw_signal(self, map_binning, extra_header=None):
+    def _bin_and_write_raw_signal(self, map_binning, detectors, extra_header=None):
         """Optionally bin and save an undestriped map"""
 
         if not self.write_binmap:
@@ -550,7 +550,7 @@ class MapMaker(Operator):
             f"{self._log_prefix} begin map binning",
             comm=self._comm,
         )
-        map_binning.apply(self._data, use_accel=self._use_accel)
+        map_binning.apply(self._data, detectors=detectors, use_accel=self._use_accel)
         self._log.info_rank(
             f"{self._log_prefix}  finished binning in",
             comm=self._comm,
@@ -570,7 +570,7 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _clean_signal(self, template_amplitudes):
+    def _clean_signal(self, template_amplitudes, detectors):
         if (
             self.template_matrix is None
             or self.template_matrix.n_enabled_templates == 0
@@ -597,7 +597,9 @@ class MapMaker(Operator):
                 template_matrix=self.template_matrix,
                 output=out_cleaned,
             )
-            amplitudes_apply.apply(self._data, use_accel=self._use_accel)
+            amplitudes_apply.apply(
+                self._data, detectors=detectors, use_accel=self._use_accel
+            )
 
             if not self.keep_solver_products:
                 del self._data[template_amplitudes]
@@ -614,7 +616,7 @@ class MapMaker(Operator):
         return out_cleaned
 
     @function_timer
-    def _bin_cleaned_signal(self, map_binning, out_cleaned):
+    def _bin_cleaned_signal(self, map_binning, detectors, out_cleaned):
         """Bin and save a map of the destriped signal"""
 
         self._log.info_rank(
@@ -631,7 +633,7 @@ class MapMaker(Operator):
         map_binning.binned = self.map_name
 
         # Do the final binning
-        map_binning.apply(self._data, use_accel=self._use_accel)
+        map_binning.apply(self._data, detectors=detectors, use_accel=self._use_accel)
 
         self._log.info_rank(
             f"{self._log_prefix}  finished final binning in",
@@ -780,6 +782,7 @@ class MapMaker(Operator):
                     msg,
                     comm=data.comm.comm_world,
                 )
+                continue
             else:
                 msg = f"{self._log_prefix} Running det split '{split_key}' with "
                 msg += f"{n_split_dets} dets"
@@ -801,22 +804,24 @@ class MapMaker(Operator):
             self._memreport.prefix = f"{self._log_prefix} Start of mapmaking"
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
-            template_amplitudes = self._fit_templates()
+            template_amplitudes = self._fit_templates(selected_dets)
 
             self._prepare_binning(map_binning)
 
-            self._build_pixel_covariance(map_binning)
+            self._build_pixel_covariance(map_binning, selected_dets)
 
-            self._bin_and_write_raw_signal(map_binning, extra_header=extra_header)
+            self._bin_and_write_raw_signal(
+                map_binning, selected_dets, extra_header=extra_header
+            )
 
-            out_cleaned = self._clean_signal(template_amplitudes)
+            out_cleaned = self._clean_signal(template_amplitudes, selected_dets)
 
             if (
                 self.write_noiseweighted_map
                 or self.write_map
                 or self.keep_final_products
             ):
-                self._bin_cleaned_signal(map_binning, out_cleaned)
+                self._bin_cleaned_signal(map_binning, selected_dets, out_cleaned)
 
             self._purge_cleaned_tod()  # Potentially frees memory for writing maps
 

--- a/src/toast/ops/mapmaker.py
+++ b/src/toast/ops/mapmaker.py
@@ -270,10 +270,85 @@ class MapMaker(Operator):
         self._memreport.prefix = f"After writing/deleting {prod_key}"
         self._memreport.apply(self._data, use_accel=self._use_accel)
 
-        return
+    @function_timer
+    def _select_detectors(self, input_dets, flagmask):
+        """Select a subset of detectors and disable others.
+
+        This function combines information from multiple sources to choose
+        the current active set of detectors.  Other detectors are temporarily
+        flagged as invalid.
+
+        Note that detector selection happens independently from re-use or
+        clearing of the pixel distribution.  This is intentional, since often
+        the pixel distribution is computed once and is expensive.  And then
+        this distribution can be re-used for multiple detector splits.
+
+        The starting point is a list of global detectors.  A user-specified
+        regex pattern is optionally applied.
+
+        Args:
+            input_dets (list):  The list of input detectors from the calling
+                code (or None).
+            flagmask (int):  The det flagmask to use.  This comes from an
+                input binning operator.
+
+        Returns:
+            (set):  The total set of globally selected detectors across all obs.
+
+        """
+        if self.pattern is not None:
+            det_pat = re.compile(self.pattern)
+
+        self._save_data_obs_flags = {}
+        global_selected = set()
+        for ob in self._data.obs:
+            # Start with existing flags
+            new_flags = dict(ob.local_detector_flags)
+
+            # Save a copy before modifying
+            self._save_data_obs_flags[ob.uid] = dict(new_flags)
+
+            # Initial detector selection for this obs
+            starting_dets = ob.select_local_detectors(flagmask=flagmask)
+
+            # Restrict to the global input list
+            check = set(input_dets)
+            split_dets = set()
+            for det in starting_dets:
+                if det in check:
+                    split_dets.add(det)
+
+            # Apply any pattern match
+            if self.pattern is None:
+                selected = split_dets
+            else:
+                selected = set()
+                for det in split_dets:
+                    if det_pat.match(det) is not None:
+                        selected.add(det)
+
+            # Create new flags
+            for det in ob.local_detectors:
+                if det not in selected:
+                    new_flags[det] |= defaults.det_mask_invalid
+                else:
+                    global_selected.add(det)
+            ob.set_local_detector_flags(new_flags)
+        return global_selected
 
     @function_timer
-    def _setup(self, data, detectors, use_accel):
+    def _unselect_detectors(self):
+        """Restore original detector flags.
+
+        Undo the temporary flagging of detectors for purposes of detector
+        selection.
+
+        """
+        for ob in self._data.obs:
+            ob.set_local_detector_flags(self._save_data_obs_flags[ob.uid])
+
+    @function_timer
+    def _setup(self, data, use_accel):
         """Set up convenience members used in the _exec() method"""
 
         self._log = Logger.get()
@@ -288,7 +363,6 @@ class MapMaker(Operator):
                 self._mc_root += f"_{self.mc_index:05d}"
 
         self._data = data
-        self._detectors = detectors
         self._use_accel = use_accel
         self._memreport = MemoryCounter()
         if not self.report_memory:
@@ -311,28 +385,6 @@ class MapMaker(Operator):
         self.binmap_name = f"{self.name}_binmap"
         self.map_name = f"{self.name}_map"
         self.noiseweighted_map_name = f"{self.name}_noiseweighted_map"
-
-        self._pattern_flags = None
-        # If we are selecting detectors with a pattern, save the per-detector
-        # flags and temporarily modify those to mark other dets as invalid.
-        if self.pattern is not None:
-            self._pattern_flags = dict()
-            self._save_detectors = self._detectors
-            self._detectors = set()
-            det_pat = re.compile(self.pattern)
-            for ob in self._data.obs:
-                # Make a copy of the original
-                self._pattern_flags[ob.uid] = dict(ob.local_detector_flags)
-                cutdets = dict()
-                for det in ob.local_detectors:
-                    if det_pat.match(det) is None:
-                        # Cut this det
-                        cutdets[det] = defaults.det_mask_invalid
-                    else:
-                        # Keep this det
-                        self._detectors.add(det)
-                ob.update_local_detector_flags(cutdets)
-            self._detectors = list(sorted(self._detectors))
 
         self._timer.start()
 
@@ -363,7 +415,7 @@ class MapMaker(Operator):
             report_memory=self.report_memory,
         )
         amplitudes_solve.apply(
-            self._data, detectors=self._detectors, use_accel=self._use_accel
+            self._data, use_accel=self._use_accel
         )
         template_amplitudes = amplitudes_solve.amplitudes
 
@@ -379,15 +431,9 @@ class MapMaker(Operator):
         return template_amplitudes
 
     @function_timer
-    def _prepare_binning(self):
+    def _prepare_binning(self, map_binning):
         """Set up the final map binning"""
 
-        # Map binning operator
-        if self.map_binning is not None and self.map_binning.enabled:
-            map_binning = self.map_binning
-        else:
-            # Use the same binning used in the solver.
-            map_binning = self.binning
         map_binning.pre_process = None
         map_binning.covariance = self.cov_name
 
@@ -412,7 +458,7 @@ class MapMaker(Operator):
 
         if map_binning.pixel_dist not in self._data:
             self._log.info_rank(
-                f"{self._log_prefix} Caching pixel distribution",
+                f"{self._log_prefix} Caching pixel distribution with all dets",
                 comm=self._comm,
             )
             pix_dist = BuildPixelDistribution(
@@ -420,8 +466,10 @@ class MapMaker(Operator):
                 pixel_pointing=map_binning.pixel_pointing,
                 save_pointing=map_binning.full_pointing,
             )
+            # We intentionally build the pixel distribution with all detectors,
+            # so that it will be valid for any subsets.
             pix_dist.apply(
-                self._data, detectors=self._detectors, use_accel=self._use_accel
+                self._data, detectors=None, use_accel=self._use_accel
             )
             self._log.info_rank(
                 f"{self._log_prefix}  finished build of pixel distribution in",
@@ -431,8 +479,6 @@ class MapMaker(Operator):
 
             self._memreport.prefix = "After pixel distribution"
             self._memreport.apply(self._data, use_accel=self._use_accel)
-
-        return map_binning
 
     @function_timer
     def _build_pixel_covariance(self, map_binning):
@@ -471,7 +517,7 @@ class MapMaker(Operator):
         )
 
         final_cov.apply(
-            self._data, detectors=self._detectors, use_accel=self._use_accel
+            self._data, use_accel=self._use_accel
         )
 
         self._log.info_rank(
@@ -507,7 +553,7 @@ class MapMaker(Operator):
             comm=self._comm,
         )
         map_binning.apply(
-            self._data, detectors=self._detectors, use_accel=self._use_accel
+            self._data, use_accel=self._use_accel
         )
         self._log.info_rank(
             f"{self._log_prefix}  finished binning in",
@@ -556,7 +602,7 @@ class MapMaker(Operator):
                 output=out_cleaned,
             )
             amplitudes_apply.apply(
-                self._data, detectors=self._detectors, use_accel=self._use_accel
+                self._data, use_accel=self._use_accel
             )
 
             if not self.keep_solver_products:
@@ -592,7 +638,7 @@ class MapMaker(Operator):
 
         # Do the final binning
         map_binning.apply(
-            self._data, detectors=self._detectors, use_accel=self._use_accel
+            self._data, use_accel=self._use_accel
         )
 
         self._log.info_rank(
@@ -654,19 +700,11 @@ class MapMaker(Operator):
     def _closeout(self):
         """Explicitly delete members used by the _exec() method"""
 
-        # Restore detector flags, if we modified them.
-        if self._pattern_flags is not None:
-            self._detectors = self._save_detectors
-            for ob in self._data.obs:
-                orig = self._pattern_flags[ob.uid]
-                ob.set_local_detector_flags(orig)
-
         del self._log
         del self._timer
         del self._log_prefix
         del self._mc_root
         del self._data
-        del self._detectors
         del self._use_accel
         del self._memreport
         del self._comm
@@ -675,15 +713,25 @@ class MapMaker(Operator):
         return
 
     @function_timer
-    def _get_extra_header(self, data, detectors):
-        """Extract useful information from the data object to record in
-        map headers"""
+    def _get_extra_header(self, selected_dets):
+        """Extract useful information from the data object.
+
+        This takes the set of globally selected detectors used across all
+        observations.  Various metadata is collected for writing to the
+        output map headers.
+
+        Args:
+            selected_dets (set):  The global detector list used to create outputs.
+
+        Returns:
+            (None)
+
+        """
         extra_header = {}
         start = 1e100
         stop = -1e100
-        all_dets = set()
-        good_dets = set()
-        for ob in data.obs:
+        all_dets = self._data.all_detectors()
+        for ob in self._data.obs:
             times = ob.shared[self.times].data
             if start is None:
                 start = times[0]
@@ -693,30 +741,21 @@ class MapMaker(Operator):
                 stop = times[-1]
             else:
                 stop = max(stop, times[-1])
-            all_dets.update(ob.select_local_detectors(detectors))
-            good_dets.update(
-                ob.select_local_detectors(
-                    detectors,
-                    flagmask=self.binning.det_mask,
-                )
-            )
         if self._comm is not None:
             start = self._comm.allreduce(start, op=MPI.MIN)
             stop = self._comm.allreduce(stop, op=MPI.MAX)
-            all_dets_list = self._comm.allgather(all_dets)
-            good_dets_list = self._comm.allgather(good_dets)
-            all_dets.update(*all_dets_list)
-            good_dets.update(*good_dets_list)
         extra_header["START"] = (start, "Dataset start time")
         extra_header["STOP"] = (stop, "Dataset stop time")
         extra_header["NDET"] = (len(all_dets), "Total number of detectors")
-        extra_header["NGOOD"] = (len(good_dets), "Total number of usable detectors")
+        extra_header["NGOOD"] = (len(selected_dets), "Total number of usable detectors")
         extra_header["OPERATOR"] = ("TOAST MapMaker", "Generating code")
 
         return extra_header
 
     @function_timer
     def _exec(self, data, detectors=None, use_accel=None, **kwargs):
+        log = Logger.get()
+
         # First confirm that there is at least one valid detector
 
         if self.map_binning is not None and self.map_binning.enabled:
@@ -740,23 +779,38 @@ class MapMaker(Operator):
         for split_key, split_dets in splits.items():
             if split_key != "ALL":
                 safe_split = re.sub(r"\s", "", str(split_key))
-                self._save_reset_state = self.reset_pix_dist
-                self.reset_pix_dist = True
                 self._save_split_name = self.name
                 self.name = f"{self._save_split_name}_{safe_split}"
-            if split_dets is None:
-                split_dets = detectors
+            n_split_dets = len(split_dets)
+            if n_split_dets == 0:
+                log.info_rank(
+                    f"Detector split '{split_key}' has no dets, skipping",
+                    comm=data.comm.comm_world,
+                )
+            else:
+                msg = f"Running det split '{split_key}' with "
+                msg += f"{n_split_dets} dets"
+                log.info_rank(msg, comm=data.comm.comm_world)
 
-            self._setup(data, split_dets, use_accel)
+            self._setup(data, use_accel)
 
-            extra_header = self._get_extra_header(data, detectors)
+            selected_dets = self._select_detectors(
+                split_dets,
+                map_binning.det_mask,
+            )
+
+            msg = f"After selection, split '{split_key}' has "
+            msg += f"{len(selected_dets)} dets"
+            log.info_rank(msg, comm=data.comm.comm_world)
+
+            extra_header = self._get_extra_header(selected_dets)
 
             self._memreport.prefix = "Start of mapmaking"
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
             template_amplitudes = self._fit_templates()
 
-            map_binning = self._prepare_binning()
+            self._prepare_binning(map_binning)
 
             self._build_pixel_covariance(map_binning)
 
@@ -778,10 +832,12 @@ class MapMaker(Operator):
             self._memreport.prefix = "End of mapmaking"
             self._memreport.apply(self._data, use_accel=self._use_accel)
 
+            # Restore detector flags
+            self._unselect_detectors()
+
             self._closeout()
 
             if split_key != "ALL":
-                self.reset_pix_dist = self._save_reset_state
                 self.name = self._save_split_name
 
         return

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -164,33 +164,36 @@ class BuildHitMap(Operator):
                 # Nothing to do for this observation
                 continue
 
-            # The pixels and weights view for this observation
-            pix = ob.view[self.view].detdata[self.pixels]
-            if self.det_flags is not None:
-                flgs = ob.view[self.view].detdata[self.det_flags]
-            else:
-                flgs = [None for x in pix]
-            if self.shared_flags is not None:
-                shared_flgs = ob.view[self.view].shared[self.shared_flags]
-            else:
-                shared_flgs = [None for x in pix]
+            views = ob.intervals[self.view]
 
             for det in dets:
                 # Process every data view
-                for pview, fview, shared_fview in zip(pix, flgs, shared_flgs):
+                for iview, view in enumerate(views):
+                    nsample = view.last - view.first
+                    vslice = slice(view.first, view.last)
+
+                    pix = ob.detdata[self.pixels][det][vslice]
+                    if self.shared_flags is not None:
+                        flgs = (
+                            ob.shared[self.shared_flags].data[vslice]
+                            & self.shared_flag_mask
+                        )
+                    else:
+                        flgs = np.zeros(nsample, dtype=np.uint8)
+                    if self.det_flags is not None:
+                        flgs |= (
+                            ob.detdata[self.det_flags][det][vslice] & self.det_flag_mask
+                        )
+
                     # Get local submap and pixels
-                    local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
+                    local_sm, local_pix = dist.global_pixel_to_submap(pix)
 
                     # Samples with telescope pointing problems are already flagged in
                     # the pointing operators by setting the pixel numbers to a negative
                     # value.  Here we optionally apply detector flags to the local
                     # pixel numbers to flag more samples.
 
-                    # Apply the flags if needed
-                    if self.det_flags is not None:
-                        local_pix[(fview[det] & self.det_flag_mask) != 0] = -1
-                    if self.shared_flags is not None:
-                        local_pix[(shared_fview & self.shared_flag_mask) != 0] = -1
+                    local_pix[flgs != 0] = -1
 
                     cov_accum_diag_hits(
                         dist.n_local_submap,
@@ -421,14 +424,16 @@ class BuildInverseCovariance(Operator):
             if data.comm.comm_world is not None:
                 weight_nnz = data.comm.comm_world.allreduce(weight_nnz, op=MPI.MAX)
             if weight_nnz == 0:
-                msg = f"No valid detectors. Could not infer the pointing matrix "
-                msg += f"dimensions from the data."
+                msg = "No valid detectors. Could not infer the pointing matrix "
+                msg += "dimensions from the data."
                 raise RuntimeError(msg)
             cov_nnz = int(weight_nnz * (weight_nnz + 1) // 2)
             data[self.inverse_covariance] = PixelData(
                 dist, np.float64, n_value=cov_nnz, units=invcov_units
             )
             invcov = data[self.inverse_covariance]
+
+        check_nnz = None
 
         for ob in data.obs:
             # Get the detectors we are using for this observation
@@ -447,42 +452,44 @@ class BuildInverseCovariance(Operator):
                 # Nothing to do for this observation
                 continue
 
-            noise = ob[self.noise_model]
+            # We require that the pointing matrix has the same number of
+            # non-zero elements for every detector and every observation.
+            # We check that here.
+            if len(ob.detdata[self.weights].detector_shape) == 1:
+                check_nnz = 1
+            else:
+                check_nnz = ob.detdata[self.weights].detector_shape[1]
+            if check_nnz != weight_nnz:
+                msg = f"observation '{ob.name}', detector '{det}', "
+                msg += f"pointing weights '{self.weights}' has {check_nnz} nnz, "
+                msg += f"not {weight_nnz}"
+                raise RuntimeError(msg)
 
-            # The pixels and weights view for this observation
-            pix = ob.view[self.view].detdata[self.pixels]
-            wts = ob.view[self.view].detdata[self.weights]
-            if self.det_flags is not None:
-                flgs = ob.view[self.view].detdata[self.det_flags]
-            else:
-                flgs = [None for x in wts]
-            if self.shared_flags is not None:
-                shared_flgs = ob.view[self.view].shared[self.shared_flags]
-            else:
-                shared_flgs = [None for x in wts]
+            noise = ob[self.noise_model]
+            views = ob.intervals[self.view]
 
             for det in dets:
                 # Process every data view
-                for pview, wview, fview, shared_fview in zip(
-                    pix, wts, flgs, shared_flgs
-                ):
-                    # We require that the pointing matrix has the same number of
-                    # non-zero elements for every detector and every observation.
-                    # We check that here.
+                for iview, view in enumerate(views):
+                    nsample = view.last - view.first
+                    vslice = slice(view.first, view.last)
 
-                    check_nnz = None
-                    if len(wview.detector_shape) == 1:
-                        check_nnz = 1
-                    else:
-                        check_nnz = wview.detector_shape[1]
-                    if check_nnz != weight_nnz:
-                        msg = "observation '{}', detector '{}', pointing weights '{}' has {} nnz, not {}".format(
-                            ob.name, det, self.weights, check_nnz, weight_nnz
+                    pix = ob.detdata[self.pixels][det][vslice]
+                    wts = ob.detdata[self.weights][det][vslice]
+                    if self.shared_flags is not None:
+                        flgs = (
+                            ob.shared[self.shared_flags].data[vslice]
+                            & self.shared_flag_mask
                         )
-                        raise RuntimeError(msg)
+                    else:
+                        flgs = np.zeros(nsample, dtype=np.uint8)
+                    if self.det_flags is not None:
+                        flgs |= (
+                            ob.detdata[self.det_flags][det][vslice] & self.det_flag_mask
+                        )
 
                     # Get local submap and pixels
-                    local_sm, local_pix = dist.global_pixel_to_submap(pview[det])
+                    local_sm, local_pix = dist.global_pixel_to_submap(pix)
 
                     # Get the detector weight from the noise model.
                     detweight = noise.detector_weight(det)
@@ -492,11 +499,7 @@ class BuildInverseCovariance(Operator):
                     # value.  Here we optionally apply detector flags to the local
                     # pixel numbers to flag more samples.
 
-                    # Apply the flags if needed
-                    if self.det_flags is not None:
-                        local_pix[(fview[det] & self.det_flag_mask) != 0] = -1
-                    if self.shared_flags is not None:
-                        local_pix[(shared_fview & self.shared_flag_mask) != 0] = -1
+                    local_pix[flgs != 0] = -1
 
                     # Accumulate
                     cov_accum_diag_invnpp(
@@ -505,7 +508,7 @@ class BuildInverseCovariance(Operator):
                         weight_nnz,
                         local_sm.astype(np.int64),
                         local_pix.astype(np.int64),
-                        wview[det].reshape(-1),
+                        wts.reshape(-1),
                         detweight.to_value(invcov_units),
                         invcov.raw,
                         impl=implementation,

--- a/src/toast/ops/mapmaker_utils/mapmaker_utils.py
+++ b/src/toast/ops/mapmaker_utils/mapmaker_utils.py
@@ -1151,7 +1151,7 @@ class CovarianceAndHits(Operator):
                 pixel_pointing=self.pixel_pointing,
                 save_pointing=self.save_pointing,
             )
-            pix_dist.apply(data)
+            pix_dist.apply(data, detectors=detectors)
 
         # Check if map domain products exist and are consistent.  The hits
         # and inverse covariance accumulation operators support multiple

--- a/src/toast/ops/pipeline.py
+++ b/src/toast/ops/pipeline.py
@@ -145,7 +145,7 @@ class Pipeline(Operator):
                 self._exec_operator(
                     op,
                     data,
-                    detectors=None,
+                    detectors=detectors,
                     pipe_accel=pipe_accel,
                 )
         elif len(self.detector_sets) == 1 and self.detector_sets[0] == "SINGLE":

--- a/src/toast/ops/stokes_hwp.py
+++ b/src/toast/ops/stokes_hwp.py
@@ -14,19 +14,24 @@ from ..utils import Logger
 from .operator import Operator
 
 
-def get_group_a_detectors(focalplane, pair_group, tol_deg=1.0):
+def get_group_a_detectors(data, pair_group, tol_deg=1.0):
     """Return the global A detector names for the given pair_group.
 
-    Parameters
-    ----------
-    focalplane : Focalplane
-    pair_group : str, '0-90' or '45-135'
-    tol_deg : float, tolerance in degrees
+    This function will only work with focalplanes that have detector
+    orientation ("gamma") angles arranged in orthogonal pairs of
+    horizontal / vertical and rotated by 45 degrees.  It also assumes
+    that a given detector name has the same gamma angle across observations.
 
-    Returns
-    -------
-    list of str
+    Args:
+        data (Data):  The Data.
+        pair_group (str):  The group of angles ('0-90' or '45-135').
+        tol_deg (float):  Tolerance in degrees.
+
+    Returns:
+        (list):  The list of detector names.
+
     """
+
     tol = np.deg2rad(tol_deg)
     if pair_group == "0-90":
         gamma_a_target = 0.0
@@ -35,16 +40,23 @@ def get_group_a_detectors(focalplane, pair_group, tol_deg=1.0):
     else:
         raise ValueError(f"Unknown pair_group: '{pair_group}'")
 
-    result = []
-    for d in focalplane.detectors:
-        g = focalplane[d]["gamma"].to_value(u.rad) % (2.0 * np.pi)
+    all_groups = data.all_detector_groups(
+        column="gamma", flagmask=defaults.det_mask_nonscience
+    )
+
+    # Go through the sorted detector keys (which are floating point gamma angles) and
+    # combine all groups whose values are within the tolerance.
+
+    result = set()
+    for gamma_raw, dets in all_groups.items():
+        g_rad = gamma_raw.to_value(u.rad) % (2 * np.pi)
         if (
-            abs(g - gamma_a_target) < tol
-            or abs(g - gamma_a_target + 2.0 * np.pi) < tol
-            or abs(g - gamma_a_target - 2.0 * np.pi) < tol
+            abs(g_rad - gamma_a_target) < tol
+            or abs(g_rad - gamma_a_target + 2.0 * np.pi) < tol
+            or abs(g_rad - gamma_a_target - 2.0 * np.pi) < tol
         ):
-            result.append(d)
-    return result
+            result.update(dets)
+    return list(sorted(result))
 
 
 def stokes_weights_hwp_model_nominal(
@@ -590,25 +602,18 @@ class StokesWeightsHWP(Operator):
         for ob in data.obs:
             # Get the detectors we are using for this observation
             dets = ob.select_local_detectors(
-                detectors, flagmask=self.detector_pointing.det_mask
+                selection=detectors, flagmask=self.detector_pointing.det_mask
             )
 
             focalplane = ob.telescope.focalplane
 
             if self.mode == "pair_diff":
-                all_local_dets = ob.select_local_detectors(
-                    None, flagmask=self.detector_pointing.det_mask
-                )
-                a_dets, pairs = self._get_pair_dets(all_local_dets, focalplane)
-                weight_dets = a_dets
-
+                a_dets, pairs = self._get_pair_dets(dets, focalplane)
                 if len(pairs) == 0:
                     log.verbose(
                         f"ob {ob.name}: no local pairs for "
                         f"pair_group='{self.pair_group}'."
                     )
-            else:
-                weight_dets = dets
 
             # Check that our view is fully covered by detector pointing.  If the
             # detector_pointing view is None, then it has all samples.  If our own
@@ -632,7 +637,7 @@ class StokesWeightsHWP(Operator):
                 self.weights,
                 sample_shape=(self.nnz,),
                 dtype=np.float32 if self.single_precision else np.float64,
-                detectors=weight_dets,
+                detectors=dets,
                 accel=use_accel,
             )
 
@@ -642,30 +647,33 @@ class StokesWeightsHWP(Operator):
                 if data.comm.group_rank == 0:
                     msg = (
                         f"Group {data.comm.group}, ob {ob.name}, Stokes weights "
-                        f"already computed for {weight_dets}"
+                        f"already computed for {dets}"
                     )
                     log.verbose(msg)
                 continue
 
-            if self.mode == "pair_diff":
-                quat_indx = ob.detdata[quats_name].indices(all_local_dets)
-                weight_indx = ob.detdata[self.weights].indices(a_dets)
-                det_data_indx = ob.detdata[self.det_data].indices(all_local_dets)
+            if len(dets) == 0:
+                continue
 
-                det_epsilon = np.zeros(len(all_local_dets), dtype=np.float64)
+            if self.mode == "pair_diff":
+                quat_indx = ob.detdata[quats_name].indices(dets)
+                weight_indx = ob.detdata[self.weights].indices(a_dets)
+                det_data_indx = ob.detdata[self.det_data].indices(dets)
+
+                det_epsilon = np.zeros(len(dets), dtype=np.float64)
                 if "pol_leakage" in focalplane.detector_data.colnames:
-                    for idet, d in enumerate(all_local_dets):
+                    for idet, d in enumerate(dets):
                         det_epsilon[idet] = focalplane[d]["pol_leakage"]
 
                 if self.cal is None:
-                    cal = np.ones(len(all_local_dets), dtype=np.float64)
+                    cal = np.ones(len(dets), dtype=np.float64)
                 else:
                     cal = np.array(
-                        [ob[self.cal][x] for x in all_local_dets], dtype=np.float64
+                        [ob[self.cal][x] for x in dets], dtype=np.float64
                     )
 
                 det_gamma = np.array(
-                    [focalplane[d]["gamma"].to_value(u.rad) for d in all_local_dets],
+                    [focalplane[d]["gamma"].to_value(u.rad) for d in dets],
                     dtype=np.float64,
                 )
                 hwp_data = ob.shared[self.hwp_angle].data

--- a/src/toast/scripts/toast_healpix_coadd.py
+++ b/src/toast/scripts/toast_healpix_coadd.py
@@ -45,7 +45,7 @@ def load_map(fname, prefix="", cache=None, dtype=np.float64):
     else:
         log.info(prefix + f"Loading {fname}")
         try:
-            m = read_healpix(fname, None, nest=True, dtype=dtype)
+            m = read_healpix(fname, field=None, nest=True, dtype=dtype)
         except Exception as e:
             msg = prefix + f"Failed to load HEALPix map: {e}"
             raise RuntimeError(msg)
@@ -273,12 +273,12 @@ def parse_input_maps(args, comm, weights):
 
 
 def main(
-        opts=None,
-        comm=None,
-        cache=None,
-        result=None,
-        prefix=None,
-        weights=None,
+    opts=None,
+    comm=None,
+    cache=None,
+    result=None,
+    prefix=None,
+    weights=None,
 ):
     """Coadd the specified HEALPix maps
 
@@ -449,8 +449,7 @@ def main(
                         if pix in map_set:
                             keep_hits[i] = True
                     good_hits = good_hits[keep_hits]
-                    hits = hits[keep_hits]
-                    raise RuntimeError(msg)
+                    hits = hits[:, keep_hits]
                 if np.any(good_hits != good):
                     raise RuntimeError("Map and hits disagree on nonzeros")
             else:
@@ -497,7 +496,7 @@ def main(
         invcov_sum[:, good] += invcov
         if have_hits:
             hits_sum[:, good] += hits
-        log.info_rank(prefix + f"Co-added maps in", timer=timer1, comm=None)
+        log.info_rank(prefix + "Co-added maps in", timer=timer1, comm=None)
 
         del hits
         del invcov

--- a/src/toast/tests/arithmetic.py
+++ b/src/toast/tests/arithmetic.py
@@ -1,0 +1,262 @@
+# Copyright (c) 2026-2026 by the parties listed in the AUTHORS file.
+# All rights reserved.  Use of this source code is governed by
+# a BSD-style license that can be found in the LICENSE file.
+
+import os
+
+import numpy as np
+
+from .. import ops
+from .helpers import (
+    close_data,
+    create_outdir,
+    create_satellite_empty,
+    create_satellite_data,
+)
+from .mpi import MPITestCase
+
+
+class ArithmeticTest(MPITestCase):
+    def setUp(self):
+        fixture_name = os.path.splitext(os.path.basename(__file__))[0]
+        self.outdir = create_outdir(self.comm, subdir=fixture_name)
+        self.shapes = [(1,), (4,), (3, 2)]
+        self.types = {
+            "f64": np.float64,
+            "f32": np.float32,
+            "i64": np.int64,
+            "u64": np.uint64,
+            "i32": np.int32,
+            "u32": np.uint32,
+            "i16": np.int16,
+            "u16": np.uint16,
+            "i8": np.int8,
+            "u8": np.uint8,
+        }
+
+    def field_list(self, root):
+        fields = []
+        for ishp, shp in enumerate(self.shapes):
+            for tstr, dtype in self.types.items():
+                fields.append(f"{root}_{ishp}_{tstr}")
+        return fields
+
+    def create_data(self):
+        rng = np.random.default_rng(seed=12345)
+        data = create_satellite_empty(self.comm, obs_per_group=1, samples=10)
+        for obs in data.obs:
+            n_samp = obs.n_local_samples
+            dets = obs.local_detectors
+            for ishp, shp in enumerate(self.shapes):
+                smplen = np.prod(shp)
+                if smplen == 1:
+                    fullshp = (n_samp,)
+                else:
+                    fullshp = (n_samp,) + shp
+                flatlen = np.prod(fullshp)
+                for tstr, dtype in self.types.items():
+                    dname = f"signal_{ishp}_{tstr}"
+                    obs.detdata.create(
+                        dname, sample_shape=shp, dtype=dtype, detectors=None
+                    )
+                    for d in dets:
+                        if tstr == "f64" or tstr == "f32":
+                            flat = rng.random(size=flatlen, dtype=dtype)
+                        else:
+                            flat = rng.integers(
+                                low=0, high=64, size=flatlen, dtype=dtype
+                            )
+                        obs.detdata[dname][d] = flat.reshape(fullshp)
+        return data
+
+    def test_movement(self):
+        data = self.create_data()
+
+        orig_fields = self.field_list("signal")
+        cp_fields = self.field_list("copy")
+
+        # Store a separate copy of all arrays for comparison
+        input = {}
+        for obs in data.obs:
+            input[obs.uid] = {}
+            for fld in orig_fields:
+                input[obs.uid][fld] = {}
+                for d in obs.local_detectors:
+                    input[obs.uid][fld][d] = np.copy(obs.detdata[fld][d])
+
+        ops.Copy(detdata=[(x, y) for x, y in zip(orig_fields, cp_fields)]).apply(data)
+
+        ops.Reset(detdata=orig_fields).apply(data)
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    if np.any(obs.detdata[fld][d]):
+                        print(f"Failed to reset {obs.name}:{fld}:{d}", flush=True)
+                        self.assertTrue(False)
+
+        ops.Copy(detdata=[(x, y) for x, y in zip(cp_fields, orig_fields)]).apply(data)
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    if not np.array_equal(obs.detdata[fld][d], input[obs.uid][fld][d]):
+                        print(f"Failed to restore {obs.name}:{fld}:{d}", flush=True)
+                        self.assertTrue(False)
+
+        close_data(data)
+
+    def test_math(self):
+        data = self.create_data()
+
+        orig_fields = self.field_list("signal")
+        temp1_fields = self.field_list("temp1")
+        temp2_fields = self.field_list("temp2")
+
+        # Store a separate copy of all arrays for comparison
+        input = {}
+        for obs in data.obs:
+            input[obs.uid] = {}
+            for fld in orig_fields:
+                input[obs.uid][fld] = {}
+                for d in obs.local_detectors:
+                    input[obs.uid][fld][d] = np.copy(obs.detdata[fld][d])
+
+        # Test out-of-place operations
+
+        # temp1 = signal
+        ops.Copy(detdata=[(x, y) for x, y in zip(orig_fields, temp1_fields)]).apply(
+            data
+        )
+
+        # temp2 = signal + temp1
+        for ffirst, fsecond, fresult in zip(orig_fields, temp1_fields, temp2_fields):
+            ops.Combine(op="add", first=ffirst, second=fsecond, result=fresult).apply(
+                data
+            )
+
+        for obs in data.obs:
+            for fld, ofld in zip(temp2_fields, orig_fields):
+                for d in obs.local_detectors:
+                    dvals = obs.detdata[fld][d]
+                    if not np.allclose(dvals, 2 * input[obs.uid][ofld][d]):
+                        print(
+                            f"Failed out-of-place sum {obs.name}:{fld}:{d}", flush=True
+                        )
+                        bad = dvals != 0
+                        indx = np.arange(obs.n_local_samples, dtype=np.int64)[bad]
+                        for isamp, badval in zip(indx, dvals[bad]):
+                            print(f"  {isamp}:  {badval}", flush=True)
+                        self.assertTrue(False)
+
+        # signal = 0
+        ops.Reset(detdata=orig_fields).apply(data)
+
+        # signal = temp2 - temp1
+        for ffirst, fsecond, fresult in zip(temp2_fields, temp1_fields, orig_fields):
+            ops.Combine(
+                op="subtract", first=ffirst, second=fsecond, result=fresult
+            ).apply(data)
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    dvals = obs.detdata[fld][d]
+                    if not np.allclose(dvals, input[obs.uid][fld][d]):
+                        print(
+                            f"Failed out-of-place diff {obs.name}:{fld}:{d}", flush=True
+                        )
+                        bad = dvals != 0
+                        indx = np.arange(obs.n_local_samples, dtype=np.int64)[bad]
+                        for isamp, badval in zip(indx, dvals[bad]):
+                            print(f"  {isamp}:  {badval}", flush=True)
+                        self.assertTrue(False)
+
+        # Restore signal
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    obs.detdata[fld][d] = input[obs.uid][fld][d]
+
+        # Test in-place operations
+
+        # temp1 = signal
+        ops.Copy(detdata=[(x, y) for x, y in zip(orig_fields, temp1_fields)]).apply(
+            data
+        )
+
+        # signal += temp1
+        for ffirst, fsecond, fresult in zip(orig_fields, temp1_fields, orig_fields):
+            ops.Combine(op="add", first=ffirst, second=fsecond, result=fresult).apply(
+                data
+            )
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    dvals = obs.detdata[fld][d]
+                    if not np.allclose(dvals, 2 * input[obs.uid][fld][d]):
+                        print(
+                            f"Failed in-place sum {obs.name}:{fld}:{d}", flush=True
+                        )
+                        bad = dvals != 0
+                        indx = np.arange(obs.n_local_samples, dtype=np.int64)[bad]
+                        for isamp, badval in zip(indx, dvals[bad]):
+                            print(f"  {isamp}:  {badval}", flush=True)
+                        self.assertTrue(False)
+
+        # signal -= temp1
+        for ffirst, fsecond, fresult in zip(orig_fields, temp1_fields, orig_fields):
+            ops.Combine(
+                op="subtract", first=ffirst, second=fsecond, result=fresult
+            ).apply(data)
+
+        for obs in data.obs:
+            for fld in orig_fields:
+                for d in obs.local_detectors:
+                    dvals = obs.detdata[fld][d]
+                    if not np.allclose(dvals, input[obs.uid][fld][d]):
+                        print(
+                            f"Failed in-place diff {obs.name}:{fld}:{d}", flush=True
+                        )
+                        bad = dvals != 0
+                        indx = np.arange(obs.n_local_samples, dtype=np.int64)[bad]
+                        for isamp, badval in zip(indx, dvals[bad]):
+                            print(f"  {isamp}:  {badval}", flush=True)
+                        self.assertTrue(False)
+
+        close_data(data)
+
+    def test_pipeline(self):
+        data = create_satellite_data(self.comm, obs_per_group=1)
+
+        model = ops.DefaultNoiseModel()
+        sim_noise1 = ops.SimNoise()
+        copy1 = ops.Copy(detdata=[("signal", "nse1")])
+        sim_noise2 = ops.SimNoise()
+        copy2 = ops.Copy(detdata=[("signal", "nse2")])
+        diff1 = ops.Combine(op="subtract", first="nse2", second="nse1", result="diff")
+        check = ops.Combine(op="add", first="nse1", second="diff", result="signal")
+
+        ops.Pipeline(
+            operators=[
+                model,
+                sim_noise1,
+                copy1,
+                sim_noise2,
+                copy2,
+                diff1,
+                check,
+            ]
+        ).apply(data)
+
+        for obs in data.obs:
+            for d in obs.local_detectors:
+                if not np.allclose(obs.detdata["signal"][d], obs.detdata["nse2"][d]):
+                    print(
+                        f"Failed pipeline check {obs.name}:{d}", flush=True
+                    )
+                    self.assertTrue(False)
+
+        close_data(data)

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -1082,6 +1082,147 @@ class MapmakerTest(MPITestCase):
 
         close_data(data)
 
+    def test_exec_detectors(self):
+        if sys.platform.lower() == "darwin":
+            print("WARNING:  Skipping test_single_pixels on MacOS")
+            return
+
+        testdir = os.path.join(self.outdir, "exec_detectors")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create a data set for testing
+
+        data = create_satellite_data(
+            self.comm,
+            freqs=[90.0 * u.GHz, 150.0 * u.GHz],
+        )
+
+        # Create some sky signal timestreams.
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=64,
+            create_dist="pixel_dist",
+            detector_pointing=detpointing,
+        )
+        pixels.apply(data)
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+        weights.apply(data)
+
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_map.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
+            det_data=defaults.det_data,
+        )
+
+        # Now clear the pointing and reset things for use with the mapmaking test later
+        delete_pointing = ops.Delete(
+            detdata=[detpointing.quats, pixels.pixels, weights.weights],
+            meta=["pixel_dist"],
+        )
+        delete_pointing.apply(data)
+        pixels.create_dist = None
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(
+            noise_model=default_model.noise_model, det_data=defaults.det_data
+        )
+        sim_noise.apply(data)
+
+        # Copy the data for later use
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        # Split the data into 2 groups
+        alldets = data.all_detectors(flagmask=defaults.det_mask_invalid)
+        group1 = []
+        group2 = []
+        for idet, det in enumerate(alldets):
+            if idet % 2 == 0:
+                group1.append(det)
+            else:
+                group2.append(det)
+
+        # Set up binning operator for solving
+        binner = ops.BinMap(
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="mapmaker",
+            det_data=defaults.det_data,
+            binning=binner,
+            map_rcond_threshold=1.0e-6,
+            write_hits=True,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=False,
+            keep_final_products=False,
+            output_dir=testdir,
+        )
+
+        # Make total map
+        mapper.apply(data)
+
+        # Make first group
+        mapper.reset_pix_dist = True
+        mapper.name = "mapmaker_group1"
+        mapper.apply(data, detectors=group1)
+
+        # Make second group
+        mapper.name = "mapmaker_group2"
+        mapper.apply(data, detectors=group2)
+
+        # Compare hit maps
+
+        if data.comm.world_rank == 0:
+            # Total map
+            hit_total_file = os.path.join(testdir, "mapmaker_hits.fits")
+            hit_total = hp.read_map(hit_total_file, field=None, nest=True)
+
+            # Accumulate the per-pixel hit maps
+            hit_accum = np.zeros_like(hit_total)
+            for split_name in ["group1", "group2"]:
+                hit_split_file = os.path.join(
+                    testdir, f"mapmaker_{split_name}_hits.fits"
+                )
+                hit_split = hp.read_map(hit_split_file, field=None, nest=True)
+                hit_accum += hit_split
+
+            bad = hit_accum < 3
+            good = np.logical_not(bad)
+            good_idx = np.arange(len(hit_accum), dtype=np.int64)[good]
+            if not np.array_equal(hit_total[good], hit_accum[good]):
+                for idx, tot, haccum in zip(good_idx, hit_total[good], hit_accum[good]):
+                    msg = f"pix {idx}: Accum = {haccum}, Total = {tot}"
+                    print(msg, flush=True)
+                self.assertTrue(False)
+
+        close_data(data)
+
     def test_compare_madam_noprior(self):
         if not ops.madam.available():
             print("libmadam not available, skipping destriping comparison")

--- a/src/toast/tests/ops_mapmaker.py
+++ b/src/toast/tests/ops_mapmaker.py
@@ -902,7 +902,6 @@ class MapmakerTest(MPITestCase):
             name="mapmaker",
             det_data=defaults.det_data,
             binning=binner,
-            template_matrix=tmatrix,
             solve_rcond_threshold=1.0e-6,
             map_rcond_threshold=1.0e-6,
             iter_max=5,
@@ -915,8 +914,137 @@ class MapmakerTest(MPITestCase):
             output_dir=testdir,
         )
 
-        # Make the map separately for different frequencies
-        mapper.focalplane_key = "bandcenter"
+        # Test both with and without destriping
+        for mname, tmat in [("none", None), ("offset", tmatrix)]:
+            mapper.name = f"mapmaker_{mname}"
+            mapper.template_matrix = tmat
+            # Make the map separately for different frequencies
+            mapper.focalplane_key = "bandcenter"
+            mapper.apply(data)
+
+            # Make a total map
+            mapper.focalplane_key = None
+            mapper.apply(data)
+
+            # Compare hit maps
+
+            if data.comm.world_rank == 0:
+                hit_A_file = os.path.join(testdir, f"{mapper.name}_90.0GHz_hits.fits")
+                hit_B_file = os.path.join(testdir, f"{mapper.name}_150.0GHz_hits.fits")
+                hit_total_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
+                hit_A = hp.read_map(hit_A_file, field=None, nest=True)
+                hit_B = hp.read_map(hit_B_file, field=None, nest=True)
+                hit_total = hp.read_map(hit_total_file, field=None, nest=True)
+                bad = np.logical_or(
+                    hit_A < 3,
+                    hit_B < 3,
+                )
+                good = np.logical_not(bad)
+                good_idx = np.arange(len(hit_A), dtype=np.int64)[good]
+                if not np.array_equal(hit_total[good], hit_A[good] + hit_B[good]):
+                    for idx, tot, hA, hB in zip(
+                        good_idx, hit_total[good], hit_A[good], hit_B[good]
+                    ):
+                        msg = f"{mname} pix {idx}: A = {hA}, B = {hB}, Total = {tot}"
+                        print(msg, flush=True)
+                    self.assertTrue(False)
+
+        close_data(data)
+
+    def test_single_pixels(self):
+        if sys.platform.lower() == "darwin":
+            print("WARNING:  Skipping test_single_pixels on MacOS")
+            return
+
+        testdir = os.path.join(self.outdir, "single_pixels")
+        if self.comm is None or self.comm.rank == 0:
+            os.makedirs(testdir)
+
+        # Create a data set for testing
+
+        data = create_satellite_data(
+            self.comm,
+            freqs=[90.0 * u.GHz, 150.0 * u.GHz],
+        )
+
+        # Create some sky signal timestreams.
+        detpointing = ops.PointingDetectorSimple()
+        pixels = ops.PixelsHealpix(
+            nside=64,
+            create_dist="pixel_dist",
+            detector_pointing=detpointing,
+        )
+        pixels.apply(data)
+        weights = ops.StokesWeights(
+            mode="IQU",
+            hwp_angle=defaults.hwp_angle,
+            detector_pointing=detpointing,
+        )
+        weights.apply(data)
+
+        # Create fake polarized sky signal
+        skyfile = os.path.join(testdir, "input_map.fits")
+        map_key = "fake_map"
+        create_fake_healpix_scanned_tod(
+            data,
+            pixels,
+            weights,
+            skyfile,
+            "pixel_dist",
+            map_key=map_key,
+            fwhm=30.0 * u.arcmin,
+            lmax=3 * pixels.nside,
+            I_scale=0.01,
+            Q_scale=0.001,
+            U_scale=0.001,
+            det_data=defaults.det_data,
+        )
+
+        # Now clear the pointing and reset things for use with the mapmaking test later
+        delete_pointing = ops.Delete(
+            detdata=[detpointing.quats, pixels.pixels, weights.weights],
+            meta=["pixel_dist"],
+        )
+        delete_pointing.apply(data)
+        pixels.create_dist = None
+
+        # Create an uncorrelated noise model from focalplane detector properties
+        default_model = ops.DefaultNoiseModel(noise_model="noise_model")
+        default_model.apply(data)
+
+        # Simulate noise and accumulate to signal
+        sim_noise = ops.SimNoise(
+            noise_model=default_model.noise_model, det_data=defaults.det_data
+        )
+        sim_noise.apply(data)
+
+        # Copy the data for later use
+        ops.Copy(detdata=[(defaults.det_data, "input")]).apply(data)
+
+        # Set up binning operator for solving
+        binner = ops.BinMap(
+            pixel_pointing=pixels,
+            stokes_weights=weights,
+            noise_model=default_model.noise_model,
+        )
+
+        # Map maker
+        mapper = ops.MapMaker(
+            name="mapmaker",
+            det_data=defaults.det_data,
+            binning=binner,
+            map_rcond_threshold=1.0e-6,
+            write_hits=True,
+            write_map=True,
+            write_cov=False,
+            write_rcond=False,
+            keep_solver_products=False,
+            keep_final_products=False,
+            output_dir=testdir,
+        )
+
+        # Make the map separately for each pixel
+        mapper.focalplane_key = "pixel"
         mapper.apply(data)
 
         # Make a total map
@@ -925,24 +1053,30 @@ class MapmakerTest(MPITestCase):
 
         # Compare hit maps
 
+        splits = data.all_detector_groups(
+            column="pixel", flagmask=defaults.det_mask_invalid
+        )
+
         if data.comm.world_rank == 0:
-            hit_A_file = os.path.join(testdir, "mapmaker_90.0GHz_hits.fits")
-            hit_B_file = os.path.join(testdir, "mapmaker_150.0GHz_hits.fits")
-            hit_total_file = os.path.join(testdir, "mapmaker_hits.fits")
-            hit_A = hp.read_map(hit_A_file, field=None, nest=True)
-            hit_B = hp.read_map(hit_B_file, field=None, nest=True)
+            # Total map
+            hit_total_file = os.path.join(testdir, f"{mapper.name}_hits.fits")
             hit_total = hp.read_map(hit_total_file, field=None, nest=True)
-            bad = np.logical_or(
-                hit_A < 3,
-                hit_B < 3,
-            )
+
+            # Accumulate the per-pixel hit maps
+            hit_accum = np.zeros_like(hit_total)
+            for split_name in splits.keys():
+                hit_split_file = os.path.join(
+                    testdir, f"{mapper.name}_{split_name}_hits.fits"
+                )
+                hit_split = hp.read_map(hit_split_file, field=None, nest=True)
+                hit_accum += hit_split
+
+            bad = hit_accum < 3
             good = np.logical_not(bad)
-            good_idx = np.arange(len(hit_A), dtype=np.int64)[good]
-            if not np.array_equal(hit_total[good], hit_A[good] + hit_B[good]):
-                for idx, tot, hA, hB in zip(
-                    good_idx, hit_total[good], hit_A[good], hit_B[good]
-                ):
-                    msg = f"pix {idx}: A = {hA}, B = {hB}, Total = {tot}"
+            good_idx = np.arange(len(hit_accum), dtype=np.int64)[good]
+            if not np.array_equal(hit_total[good], hit_accum[good]):
+                for idx, tot, haccum in zip(good_idx, hit_total[good], hit_accum[good]):
+                    msg = f"pix {idx}: Accum = {haccum}, Total = {tot}"
                     print(msg, flush=True)
                 self.assertTrue(False)
 

--- a/src/toast/tests/ops_mapmaker_utils.py
+++ b/src/toast/tests/ops_mapmaker_utils.py
@@ -65,12 +65,19 @@ class MapmakerUtilsTest(MPITestCase):
         # Manual check
         check_hits = PixelData(data["pixel_dist"], np.int64, n_value=1)
         for ob in data.obs:
-            for det in ob.select_local_detectors(flagmask=defaults.det_mask_invalid):
+            shflags = (
+                ob.shared[defaults.shared_flags].data & defaults.shared_mask_nonscience
+            )
+            ob_dets = ob.select_local_detectors(flagmask=defaults.det_mask_nonscience)
+            for det in ob_dets:
                 local_sm, local_pix = data["pixel_dist"].global_pixel_to_submap(
                     ob.detdata["pixels"][det]
                 )
+                detflags = (
+                    ob.detdata[defaults.det_flags][det] & defaults.det_mask_nonscience
+                ) | shflags
                 for i in range(ob.n_local_samples):
-                    if local_pix[i] >= 0:
+                    if local_pix[i] >= 0 and not detflags[i]:
                         check_hits.data[local_sm[i], local_pix[i], 0] += 1
         check_hits.sync_allreduce()
 
@@ -78,6 +85,14 @@ class MapmakerUtilsTest(MPITestCase):
             hmap = hits[stype]
             comm = hmap.distribution.comm
             failed = not np.all(np.equal(hmap.data, check_hits.data))
+            if failed:
+                for ism, sm in enumerate(check_hits.data):
+                    for ipix, val in enumerate(sm):
+                        if val != hmap.data[ism, ipix]:
+                            print(
+                                f"  {ism}:{ipix} {val} {hmap.data[ism, ipix]}",
+                                flush=True,
+                            )
             if comm is not None:
                 failed = comm.allreduce(failed, op=MPI.LOR)
             self.assertFalse(failed)

--- a/src/toast/tests/ops_stokes_hwp.py
+++ b/src/toast/tests/ops_stokes_hwp.py
@@ -3,10 +3,11 @@
 # a BSD-style license that can be found in the LICENSE file.
 
 import os
+import re
 
-import healpy as hp # pyright: ignore[reportMissingImports]
-import numpy as np # pyright: ignore[reportMissingImports]
-from astropy import units as u # pyright: ignore[reportMissingImports]
+import healpy as hp  # pyright: ignore[reportMissingImports]
+import numpy as np  # pyright: ignore[reportMissingImports]
+from astropy import units as u  # pyright: ignore[reportMissingImports]
 
 from .. import ops as ops
 from ..observation import default_values as defaults
@@ -80,7 +81,7 @@ class StokesWeightsHWPTest(MPITestCase):
         return data
 
     def plot_results(self, file_root, nnz):
-        import matplotlib.pyplot as plt # pyright: ignore[reportMissingModuleSource]
+        import matplotlib.pyplot as plt  # pyright: ignore[reportMissingModuleSource]
 
         hit_file = f"{file_root}_hits.fits"
         rcond_file = f"{file_root}_rcond.fits"
@@ -405,12 +406,18 @@ class StokesWeightsHWPTest(MPITestCase):
             detector_pointing=detpointing,
         )
 
-        file_roots = []
-        for i, pair_group in enumerate(["0-90", "45-135"]):
-            a_dets = get_group_a_detectors( # Compute A detectors globally so the mapmaker only processes them
-                data.obs[0].telescope.focalplane, pair_group
-            )
+        # Get the full list of "A" detectors
+        all_dets = data.all_detectors(
+            selection=None, flagmask=defaults.det_mask_nonscience
+        )
+        a_dets = set()
+        pat = re.compile(r"D.*A.*")
+        for det in all_dets:
+            if pat.match(det) is not None:
+                a_dets.add(det)
 
+        file_roots = []
+        for pair_group in ["0-90", "45-135"]:
             weights = ops.StokesWeightsHWP(
                 mode="pair_diff",
                 detector_pointing=detpointing,
@@ -427,6 +434,9 @@ class StokesWeightsHWPTest(MPITestCase):
                 noise_model="noise_model",
             )
 
+            # Compute the global set of "A" detectors.
+            group_a_dets = get_group_a_detectors(data, pair_group)
+
             mapper = ops.MapMaker(
                 name=f"mapmaker_pair_diff_{pair_group}",
                 det_data=defaults.det_data,
@@ -438,12 +448,11 @@ class StokesWeightsHWPTest(MPITestCase):
                 write_invcov=True,
                 write_rcond=True,
                 output_dir=testdir,
-                # Rebuild pixel dist for every group except the first
-                reset_pix_dist=(i > 0),
+                reset_pix_dist=True,
             )
 
-             # Pass only A dets, mapmaker ignores B dets
-            mapper.apply(data, detectors=a_dets)
+            # Pass only A dets, mapmaker ignores B dets
+            mapper.apply(data, detectors=group_a_dets)
             file_roots.append(os.path.join(testdir, mapper.name))
 
         close_data(data)

--- a/src/toast/tests/runner.py
+++ b/src/toast/tests/runner.py
@@ -12,6 +12,7 @@ from ..mpi import MPI, use_mpi
 from ..spt3g import available as spt3g_available
 from ..vis import set_matplotlib_backend
 from . import accelerator as test_accelerator
+from . import arithmetic as test_arithmetic
 from . import config as test_config
 from . import covariance as test_covariance
 from . import dist as test_dist
@@ -195,6 +196,7 @@ def test(name=None, verbosity=2):
         suite.addTest(loader.loadTestsFromModule(test_observation))
         suite.addTest(loader.loadTestsFromModule(test_dist))
         suite.addTest(loader.loadTestsFromModule(test_config))
+        suite.addTest(loader.loadTestsFromModule(test_arithmetic))
 
         suite.addTest(loader.loadTestsFromModule(test_ops_azimuth_intervals))
         suite.addTest(loader.loadTestsFromModule(test_ops_sim_satellite))


### PR DESCRIPTION
    
- Add functions to select and de-select detectors across all
      observations using temporary per-detector flags.  This ensures
      that even for a combination of regex matching and focalplane
      splits, the correct detectors are used.
    
- Simplify some of the setup functions in the mapmaker.
    
- Add another unit test for making per-focalplane-pixel maps.